### PR TITLE
iris/prism checkin: pair tool_call/tool_result via parentMessageId (#1787)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -3867,3 +3867,249 @@ describe("#1761: TOOL_HEARTBEAT_INTERVAL_MS — env override", () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// #1787: tool_call / tool_result frames carry parentMessageId
+// ---------------------------------------------------------------------------
+//
+// The pi extension stamps `parentMessageId` (the in-flight assistant message
+// id observed via `message_start`) onto every `tool_call` and `tool_result`
+// frame it writes. This is the field the consumer's secondary-query SQL
+// pushdown (`db.QueryEventsByMessageIDs`) joins on to pair child tool events
+// back to their parent assistant turn for the `iris checkin` / `prism checkin
+// --turns` narrative views.
+//
+// Pre-#1787 the extension did not stamp any parent-message linkage on the
+// wire — the `id` it emitted was the tool-call id (per-invocation UUID), NOT
+// the parent assistant messageId. The DB pushdown silently dropped every
+// production tool_call/tool_result because no row carried `$.messageId`.
+//
+// Regression coverage: a real handshake-completed extension, fed an
+// assistant `message_start` and then `tool_execution_start` /
+// `tool_execution_end`, must produce wire frames where:
+//   - `parentMessageId` is present and non-empty on tool_call,
+//   - `parentMessageId` is present and non-empty on tool_result,
+//   - both values equal the `message.id` from the preceding message_start.
+
+describe("#1787: tool_call/tool_result emit parentMessageId from message_start", () => {
+  it("stamps the assistant message id onto tool_call and tool_result frames", () => {
+    return new Promise<void>((resolve, reject) => {
+      const sockDir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-test-1787-"))
+      const sockPath = path.join(sockDir, "pipe.sock")
+
+      const savedName = process.env.PRISM_SESSION_NAME
+      const savedPipe = process.env.PRISM_HARNESS_PIPE
+      process.env.PRISM_SESSION_NAME = "test@main"
+      process.env.PRISM_HARNESS_PIPE = `unix://${sockPath}`
+
+      const cleanup = () => {
+        process.env.PRISM_SESSION_NAME = savedName
+        process.env.PRISM_HARNESS_PIPE = savedPipe
+        try { fs.rmSync(sockDir, { recursive: true, force: true }) } catch {}
+      }
+
+      const ASSISTANT_MSG_ID = "msg_assistant_abc123"
+      const TOOL_CALL_ID = "tool_call_uuid_xyz"
+
+      // Sidecar responder: completes the hello/hello_ack handshake then
+      // records every frame the extension writes. After we've seen both the
+      // tool_call and tool_result frames, verify their shape.
+      const receivedLines: string[] = []
+      const server = net.createServer((conn) => {
+        attachJsonlReader(conn, (line) => {
+          if (line.length === 0) return
+          receivedLines.push(line)
+          let f: Record<string, unknown>
+          try { f = JSON.parse(line) as Record<string, unknown> } catch { return }
+          if (f.type === "hello") {
+            conn.write(
+              JSON.stringify({
+                type: "hello_ack",
+                protocol_version: 2,
+                session_name: "test@main",
+                session_role: "worker",
+                isolation_mode: "host",
+              }) + "\n",
+            )
+          }
+        })
+      })
+
+      const { pi, trigger } = makeMockPI1554()
+      prismExtension(pi as never)
+
+      server.listen(sockPath, () => {
+        void trigger("session_start", {}, {}).then(async () => {
+          // Wait a tick for the handshake to round-trip.
+          await new Promise((r) => setTimeout(r, 50))
+
+          // Drive the lifecycle: assistant message_start (provides the
+          // parent message id) → tool_execution_start → tool_execution_end.
+          // The mock pi needs an appendEntry no-op for the doom-loop
+          // snapshot path that tool_execution_start calls into.
+          ;(pi as unknown as { appendEntry: () => void }).appendEntry = () => {}
+          await trigger("message_start", {
+            message: { id: ASSISTANT_MSG_ID, role: "assistant" },
+          })
+          await trigger("tool_execution_start", {
+            toolCallId: TOOL_CALL_ID,
+            toolName: "bash",
+            args: { command: "echo hi" },
+          })
+          await trigger("tool_execution_end", {
+            toolCallId: TOOL_CALL_ID,
+            isError: false,
+            result: { content: "hi\n" },
+          })
+
+          // Wait for the frames to flush across the socket.
+          await new Promise((r) => setTimeout(r, 50))
+
+          try {
+            const frames = receivedLines.map((l) => {
+              try { return JSON.parse(l) as Record<string, unknown> } catch { return {} }
+            })
+            const toolCalls = frames.filter((f) => f.type === "tool_call")
+            const toolResults = frames.filter((f) => f.type === "tool_result")
+
+            assert.equal(
+              toolCalls.length, 1,
+              `expected exactly 1 tool_call frame, got ${toolCalls.length}: ${JSON.stringify(frames)}`,
+            )
+            assert.equal(
+              toolResults.length, 1,
+              `expected exactly 1 tool_result frame, got ${toolResults.length}: ${JSON.stringify(frames)}`,
+            )
+
+            // Core AC: parentMessageId is present and non-empty.
+            assert.equal(
+              toolCalls[0].parentMessageId, ASSISTANT_MSG_ID,
+              `tool_call must carry parentMessageId=${ASSISTANT_MSG_ID}, got: ${JSON.stringify(toolCalls[0])}`,
+            )
+            assert.equal(
+              toolResults[0].parentMessageId, ASSISTANT_MSG_ID,
+              `tool_result must carry parentMessageId=${ASSISTANT_MSG_ID}, got: ${JSON.stringify(toolResults[0])}`,
+            )
+
+            // Sanity: id (tool-call id) is still the per-invocation UUID,
+            // distinct from parentMessageId, so the two pairing keys remain
+            // independent on the wire.
+            assert.equal(
+              toolCalls[0].id, TOOL_CALL_ID,
+              "tool_call id must remain the per-invocation tool-call uuid",
+            )
+            assert.equal(
+              toolResults[0].id, TOOL_CALL_ID,
+              "tool_result id must remain the per-invocation tool-call uuid",
+            )
+
+            cleanup()
+            server.close()
+            resolve()
+          } catch (err) {
+            cleanup()
+            server.close()
+            reject(err as Error)
+          }
+        })
+      })
+
+      // Safety timeout in case the handshake or trigger chain stalls.
+      setTimeout(() => {
+        cleanup()
+        server.close()
+        reject(new Error(
+          `timeout: never saw both tool_call and tool_result frames; received: ${JSON.stringify(receivedLines)}`,
+        ))
+      }, 1000).unref()
+    })
+  })
+
+  it("omits parentMessageId entirely when no assistant message_start has been observed", () => {
+    return new Promise<void>((resolve, reject) => {
+      const sockDir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-test-1787-orphan-"))
+      const sockPath = path.join(sockDir, "pipe.sock")
+
+      const savedName = process.env.PRISM_SESSION_NAME
+      const savedPipe = process.env.PRISM_HARNESS_PIPE
+      process.env.PRISM_SESSION_NAME = "test@main"
+      process.env.PRISM_HARNESS_PIPE = `unix://${sockPath}`
+
+      const cleanup = () => {
+        process.env.PRISM_SESSION_NAME = savedName
+        process.env.PRISM_HARNESS_PIPE = savedPipe
+        try { fs.rmSync(sockDir, { recursive: true, force: true }) } catch {}
+      }
+
+      const receivedLines: string[] = []
+      const server = net.createServer((conn) => {
+        attachJsonlReader(conn, (line) => {
+          if (line.length === 0) return
+          receivedLines.push(line)
+          let f: Record<string, unknown>
+          try { f = JSON.parse(line) as Record<string, unknown> } catch { return }
+          if (f.type === "hello") {
+            conn.write(
+              JSON.stringify({
+                type: "hello_ack",
+                protocol_version: 2,
+                session_name: "test@main",
+                session_role: "worker",
+                isolation_mode: "host",
+              }) + "\n",
+            )
+          }
+        })
+      })
+
+      const { pi, trigger } = makeMockPI1554()
+      prismExtension(pi as never)
+
+      server.listen(sockPath, () => {
+        void trigger("session_start", {}, {}).then(async () => {
+          await new Promise((r) => setTimeout(r, 50))
+
+          // Deliberately skip message_start — simulates an extension that
+          // restarted mid-turn or a tool call fired before any assistant
+          // message_start was observed. The mock pi needs an appendEntry
+          // no-op for the doom-loop snapshot path.
+          ;(pi as unknown as { appendEntry: () => void }).appendEntry = () => {}
+          await trigger("tool_execution_start", {
+            toolCallId: "orphan-tool",
+            toolName: "bash",
+            args: { command: "true" },
+          })
+
+          await new Promise((r) => setTimeout(r, 50))
+
+          try {
+            const frames = receivedLines
+              .map((l) => { try { return JSON.parse(l) as Record<string, unknown> } catch { return {} } })
+              .filter((f) => f.type === "tool_call")
+            assert.equal(frames.length, 1, `expected 1 tool_call frame, got ${frames.length}`)
+            // The field must be entirely absent, not present as an empty
+            // string — consumers distinguish "orphan" from "" by absence.
+            assert.equal(
+              Object.prototype.hasOwnProperty.call(frames[0], "parentMessageId"),
+              false,
+              `parentMessageId must be omitted when no assistant message_start was observed; got: ${JSON.stringify(frames[0])}`,
+            )
+            cleanup()
+            server.close()
+            resolve()
+          } catch (err) {
+            cleanup()
+            server.close()
+            reject(err as Error)
+          }
+        })
+      })
+
+      setTimeout(() => {
+        cleanup()
+        server.close()
+        reject(new Error("timeout"))
+      }, 1000).unref()
+    })
+  })
+})

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -2562,6 +2562,19 @@ export default function prismExtension(pi: ExtensionAPI): void {
       name,
       args,
     }
+    // parentMessageId (#1787): the messageId of the in-flight assistant
+    // message that issued this tool call. Tracked via the message_start
+    // hook below — for the lifecycle pi guarantees, the assistant
+    // message_start always fires before any tool_execution_start whose
+    // tool was requested in that assistant turn, so this value is
+    // populated for every tool call issued by a normal assistant turn.
+    // An empty value (e.g. extension restart mid-turn before any
+    // message_start was observed) is omitted so consumers that filter on
+    // the field can detect orphans without confusing them with the
+    // string "".
+    if (currentAssistantMessageId !== "") {
+      frame.parentMessageId = currentAssistantMessageId
+    }
     if (truncated) frame.truncated = true
     writer.write(frame)
 
@@ -2654,6 +2667,17 @@ export default function prismExtension(pi: ExtensionAPI): void {
       success: !isError,
       output,
     }
+    // parentMessageId (#1787): same value emitted on the matching
+    // tool_call frame. Carried through to tool_result so the consumer's
+    // secondary-query pushdown
+    // (`db.QueryEventsByMessageIDs(..., ['tool_call','tool_result',...])`)
+    // can locate both rows by the same assistant-turn id. The value is
+    // taken from currentAssistantMessageId — pi's lifecycle guarantees
+    // tool_execution_end fires inside the same assistant turn as the
+    // matching tool_execution_start, so the id has not yet rotated.
+    if (currentAssistantMessageId !== "") {
+      frame.parentMessageId = currentAssistantMessageId
+    }
     if (truncated) frame.truncated = true
     writer.write(frame)
   })
@@ -2678,6 +2702,18 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // (then cleared) by `message_end` to decide whether to emit a backstop.
   let currentAssistantSawDelta = false
 
+  // The id of the most recently started assistant message. Captured on
+  // message_start (role=assistant) and stamped onto every tool_call /
+  // tool_result frame emitted during that assistant turn as
+  // `parentMessageId` (#1787). This is what restores tool-call pairing
+  // in `prism checkin --turns` / `iris checkin`: the consumer's
+  // secondary query (`db.QueryEventsByMessageIDs`) joins child events
+  // back to their assistant turn via this field. Empty string means
+  // "no assistant message has started in this session yet" — tool
+  // calls in that window are emitted without the field rather than with
+  // an empty value, so consumers can distinguish "orphan" from "".
+  let currentAssistantMessageId = ""
+
   pi.on("message_start", async (event, ctx) => {
     lastCtx = ctx
     const message = (event as { message?: unknown }).message
@@ -2687,6 +2723,8 @@ export default function prismExtension(pi: ExtensionAPI): void {
       (message as { role?: unknown }).role === "assistant"
     ) {
       currentAssistantSawDelta = false
+      const mid = (message as { id?: unknown }).id
+      currentAssistantMessageId = typeof mid === "string" ? mid : ""
     }
   })
 

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -89,21 +89,19 @@ func userPayload(msgID, text string) string {
 	return fmt.Sprintf(`{"messageId":%q,"text":%q}`, msgID, text)
 }
 
-// toolCallPayload returns a tool_call JSON payload combining the
-// post-#1783 pi-extension wire shape ({name, id, args}) with a
-// synthetic `messageId` field carrying the same id.
+// toolCallPayload returns a tool_call JSON payload in the post-#1787
+// pi-extension wire shape: {name, id, parentMessageId, args}.
 //
-// Why the synthetic messageId: `internal/db/events.go::QueryEventsByMessageIDs`
-// uses `JSON_EXTRACT(payload, '$.messageId')` to fetch child events
-// (tool_call/tool_result) for an assistant turn. The pi prism
-// extension does NOT emit a parent-message linkage on its
-// tool_call/tool_result frames — the per-call `id` it emits is the
-// toolCallId, NOT the parent assistant messageId. That mismatch is a
-// pre-existing bug separate from #1783's field-rename scope (see
-// coordinator escalation 2026-05-17). For tests we inject the
-// synthetic field so the SQL pushdown can still locate children;
-// production output is unchanged from its pre-#1783 broken state
-// until the secondary-query path is reworked.
+// `id` is the tool-call id (the per-invocation UUID the pi extension
+// emits, used to pair this tool_call with its tool_result). For
+// fixture simplicity we use the same string for both `id` and
+// `parentMessageId` — the per-test value of msgID stands in for
+// both the assistant-turn id (the pairing key consumed by
+// `db.QueryEventsByMessageIDs`) and the tool-call id (the pairing
+// key consumed by the tui renderer's tool_call ↔ tool_result merge).
+// Real pi sessions have two distinct ids; the test fixtures don't
+// exercise the distinction because the SQL pushdown only cares about
+// `parentMessageId`.
 //
 // The args input is loose — it may be:
 //   - empty ("") — emitted as JSON null;
@@ -124,7 +122,7 @@ func toolCallPayload(msgID, tool, args string) string {
 		b, _ := json.Marshal(args)
 		argsJSON = string(b)
 	}
-	return fmt.Sprintf(`{"name":%q,"id":%q,"messageId":%q,"args":%s}`, tool, msgID, msgID, argsJSON)
+	return fmt.Sprintf(`{"name":%q,"id":%q,"parentMessageId":%q,"args":%s}`, tool, msgID, msgID, argsJSON)
 }
 
 // isJSONValueLiteral returns true when s looks like a JSON value
@@ -149,15 +147,15 @@ func isJSONValueLiteral(s string) bool {
 	return false
 }
 
-// toolResultPayload returns a tool_result JSON payload combining the
-// post-#1783 pi-extension wire shape ({id, success, output}) with a
-// synthetic `messageId` field carrying the same id. See
-// toolCallPayload for the rationale on the synthetic field.
+// toolResultPayload returns a tool_result JSON payload in the
+// post-#1787 pi-extension wire shape: {id, parentMessageId,
+// success, output}. See `toolCallPayload` for the rationale on
+// the shared msgID stand-in.
 // `tool` is accepted for backward-compat with existing call sites
 // but is no longer part of the wire format; it is silently dropped.
 func toolResultPayload(msgID, tool, result string) string {
 	_ = tool
-	return fmt.Sprintf(`{"id":%q,"messageId":%q,"success":true,"output":%q}`, msgID, msgID, result)
+	return fmt.Sprintf(`{"id":%q,"parentMessageId":%q,"success":true,"output":%q}`, msgID, msgID, result)
 }
 
 // permAskPayload returns a minimal permission_ask JSON payload.

--- a/modules/programs/prism/prism/cmd/checkin_tools.go
+++ b/modules/programs/prism/prism/cmd/checkin_tools.go
@@ -20,6 +20,31 @@ func extractMessageID(raw string) string {
 	return p.MessageID
 }
 
+// extractParentMessageID returns the assistant-turn message id that owns a
+// child event (tool_call, tool_result, permission_*, thinking). It prefers
+// the post-#1787 `parentMessageId` field (emitted by the pi prism extension
+// on tool_call/tool_result frames) and falls back to `messageId` for event
+// types that have always carried the parent link on that field
+// (permission_ask, permission_denied, thinking).
+//
+// Returns an empty string for orphan events whose parent assistant turn is
+// not represented in the payload at all — callers should treat that as the
+// "no parent" signal rather than skip silently, so #1787's edge-case AC
+// (orphan rendered as a standalone summary) is honoured.
+func extractParentMessageID(raw string) string {
+	var p struct {
+		ParentMessageID string `json:"parentMessageId"`
+		MessageID       string `json:"messageId"`
+	}
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return ""
+	}
+	if p.ParentMessageID != "" {
+		return p.ParentMessageID
+	}
+	return p.MessageID
+}
+
 // extractBashCommand extracts the command string from bash tool args.
 // The args may be a plain string (the command itself) or a JSON object
 // with a "command" or "cmd" field.

--- a/modules/programs/prism/prism/cmd/checkin_turns.go
+++ b/modules/programs/prism/prism/cmd/checkin_turns.go
@@ -74,12 +74,29 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 	childTypes := []string{"tool_call", "tool_result", "permission_ask", "permission_denied", "thinking"}
 	secondary, serr := d.QueryEventsByMessageIDs(session, messageIDs, childTypes)
 
-	// Organise children by messageId.
+	// Organise children by parent-assistant messageId. tool_call /
+	// tool_result frames emit `parentMessageId` (#1787); permission_* /
+	// thinking frames emit `messageId`. `extractParentMessageID` picks
+	// the right field for each event type.
+	//
+	// Orphans — child events whose parent assistant turn is not in the
+	// queried window — are collected in a separate slice and rendered
+	// as standalone lines after the timeline (#1787 edge-case AC).
 	childrenByMsgID := make(map[string][]childEventItem)
+	assistantMsgIDs := make(map[string]struct{}, len(messageIDs))
+	for _, id := range messageIDs {
+		assistantMsgIDs[id] = struct{}{}
+	}
+	var orphans []childEventItem
 	if serr == nil {
 		for _, e := range secondary {
-			msgID := extractMessageID(e.Payload)
+			msgID := extractParentMessageID(e.Payload)
 			if msgID == "" {
+				orphans = append(orphans, childEventItem{e.Type, e.Payload})
+				continue
+			}
+			if _, ok := assistantMsgIDs[msgID]; !ok {
+				orphans = append(orphans, childEventItem{e.Type, e.Payload})
 				continue
 			}
 			childrenByMsgID[msgID] = append(childrenByMsgID[msgID], childEventItem{e.Type, e.Payload})
@@ -318,6 +335,24 @@ func renderCheckinTurns(session string, d *db.DB, assistantEvents []db.Event, ve
 		}
 		fmt.Println()
 		i++
+	}
+
+	// Orphan child events (no parent assistant turn in the queried
+	// window) are surfaced as standalone summary lines after the
+	// timeline so they aren't silently dropped — #1787 edge-case AC.
+	// In default mode tool_call/tool_result orphans share the same
+	// renderer as the paired path so the visual shape is consistent;
+	// other child types fall back to their verbose form.
+	if len(orphans) > 0 {
+		fmt.Println("orphan tool events (parent turn outside window):")
+		if verbose {
+			for _, child := range orphans {
+				renderChildEventVerbose(child.eventType, child.payload, "")
+			}
+		} else {
+			renderChildEventsDefault(orphans, "")
+		}
+		fmt.Println()
 	}
 
 	fmt.Println("── end of event log ──")

--- a/modules/programs/prism/prism/cmd/iris/checkin.go
+++ b/modules/programs/prism/prism/cmd/iris/checkin.go
@@ -290,11 +290,29 @@ func runCheckinNarrative(w io.Writer, d *db.DB, session string, last int, before
 	childTypes := []string{"tool_call", "tool_result", "permission_ask", "permission_denied", "thinking"}
 	children, _ := d.QueryEventsByMessageIDs(session, messageIDs, childTypes)
 
-	// Bucket children by messageId for fast lookup at render time.
+	// Bucket children by parent-assistant messageId for fast lookup at
+	// render time. tool_call/tool_result expose the link as
+	// `parentMessageId` (#1787); permission_* and thinking continue to
+	// expose it as `messageId`. ExtractParentMessageID prefers the new
+	// field and falls back to the legacy field.
+	//
+	// Children whose parent assistant turn is not in this window are
+	// collected as orphans and rendered after the timeline so the
+	// information isn't silently dropped (#1787 edge-case AC).
+	assistantMsgIDs := make(map[string]struct{}, len(messageIDs))
+	for _, id := range messageIDs {
+		assistantMsgIDs[id] = struct{}{}
+	}
 	childrenByMsgID := make(map[string][]childItem, len(messageIDs))
+	var orphanChildren []childItem
 	for _, e := range children {
-		mid := narrative.ExtractMessageID(e.Payload)
+		mid := narrative.ExtractParentMessageID(e.Payload)
 		if mid == "" {
+			orphanChildren = append(orphanChildren, childItem{eventType: e.Type, payload: e.Payload})
+			continue
+		}
+		if _, ok := assistantMsgIDs[mid]; !ok {
+			orphanChildren = append(orphanChildren, childItem{eventType: e.Type, payload: e.Payload})
 			continue
 		}
 		childrenByMsgID[mid] = append(childrenByMsgID[mid], childItem{eventType: e.Type, payload: e.Payload})
@@ -404,6 +422,16 @@ func runCheckinNarrative(w io.Writer, d *db.DB, session string, last int, before
 			renderChildEvents(w, childrenByMsgID[mid], verbose)
 			fmt.Fprintln(w)
 		}
+	}
+
+	// Surface orphan child events (parent assistant turn outside the
+	// queried window) so they aren't silently dropped — #1787 edge
+	// case. renderChildEvents already handles the "result without a
+	// matching call" path so we can reuse it directly.
+	if len(orphanChildren) > 0 {
+		fmt.Fprintln(w, "orphan tool events (parent turn outside window):")
+		renderChildEvents(w, orphanChildren, verbose)
+		fmt.Fprintln(w)
 	}
 
 	fmt.Fprintln(w, "── end of event log ──")

--- a/modules/programs/prism/prism/cmd/iris/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/iris/checkin_test.go
@@ -93,45 +93,47 @@ func seedAssistantTurn(t *testing.T, iso *iristest.Isolated, sessionName, text, 
 	} else {
 		tcArgs = json.RawMessage(args)
 	}
-	// Inject a synthetic `messageId` alongside the post-#1783 wire
-	// shape so the cmd/iris/checkin secondary-query path
-	// (QueryEventsByMessageIDs) can still locate this child event
-	// during tests. The pi extension does NOT emit messageId on
-	// tool_call — see coordinator escalation 2026-05-17 and the
-	// commentary on toolCallPayload in cmd/checkin_test.go.
+	// Post-#1787: payload.ToolCall now carries ParentMessageID, the
+	// assistant-turn id stamped by the pi prism extension. The
+	// secondary-query SQL pushdown
+	// (`db.QueryEventsByMessageIDs`) matches on `$.parentMessageId`
+	// so this is the canonical pairing field. Fixture uses the
+	// same msgID value for ParentMessageID (the per-turn assistant
+	// id) and ID (the per-call tool-call id) for simplicity — see
+	// commentary on `toolCallPayload` in cmd/checkin_test.go.
 	tcMarshalled, _ := json.Marshal(payload.ToolCall{
-		Name: tool,
-		Args: tcArgs,
-		ID:   msgID,
+		Name:            tool,
+		Args:            tcArgs,
+		ID:              msgID,
+		ParentMessageID: msgID,
 	})
-	tcp := injectSyntheticMessageID(tcMarshalled, msgID)
 	if err := iso.DB.WriteEvent(db.Event{
 		ID:          uuid.NewString(),
 		SessionName: sessionName,
 		Repo:        "iris-test",
 		Worktree:    iso.Root + "/worktree",
 		Type:        "tool_call",
-		Payload:     string(tcp),
+		Payload:     string(tcMarshalled),
 		CreatedAt:   createdAt.Add(1 * time.Millisecond),
 	}); err != nil {
 		t.Fatalf("seedAssistantTurn: write tool_call: %v", err)
 	}
 
-	// Same synthetic-messageId rationale for tool_result, per
-	// `cmd/checkin_test.go::toolResultPayload`'s commentary.
+	// Same #1787 rationale for tool_result: ParentMessageID is the
+	// pairing field consumed by `db.QueryEventsByMessageIDs`.
 	trMarshalled, _ := json.Marshal(payload.ToolResult{
-		ID:      msgID,
-		Success: true,
-		Output:  result,
+		ID:              msgID,
+		ParentMessageID: msgID,
+		Success:         true,
+		Output:          result,
 	})
-	trp := injectSyntheticMessageID(trMarshalled, msgID)
 	if err := iso.DB.WriteEvent(db.Event{
 		ID:          uuid.NewString(),
 		SessionName: sessionName,
 		Repo:        "iris-test",
 		Worktree:    iso.Root + "/worktree",
 		Type:        "tool_result",
-		Payload:     string(trp),
+		Payload:     string(trMarshalled),
 		CreatedAt:   createdAt.Add(2 * time.Millisecond),
 	}); err != nil {
 		t.Fatalf("seedAssistantTurn: write tool_result: %v", err)
@@ -503,32 +505,4 @@ func TestCheckinEndToEnd_ViaCobra(t *testing.T) {
 	}
 }
 
-// injectSyntheticMessageID rewrites a marshalled payload.ToolCall or
-// payload.ToolResult to add a `messageId` field alongside the new
-// `id` field. The pi prism extension does NOT emit messageId on
-// tool_call/tool_result; the field is synthetic-for-tests so the
-// secondary-query SQL pushdown in db.QueryEventsByMessageIDs (which
-// matches on $.messageId) can still locate these child events. See
-// coordinator escalation 2026-05-17 and the matching helper in
-// cmd/checkin_test.go for the full rationale.
-//
-// The rewrite is a simple JSON-object surgery: drops the leading "{"
-// and inserts the synthetic field at the start of the object body.
-// Returns the original input unchanged if the input doesn't parse as
-// a JSON object (defensive — never panics).
-func injectSyntheticMessageID(in []byte, msgID string) []byte {
-	if len(in) < 2 || in[0] != '{' {
-		return in
-	}
-	// Special case: an empty object literal "{}". Replace with
-	// `{"messageId":"..."}`.
-	if len(in) == 2 && in[1] == '}' {
-		return []byte(fmt.Sprintf(`{"messageId":%q}`, msgID))
-	}
-	// Insert `"messageId":"...",` after the opening "{".
-	prefix := fmt.Sprintf(`{"messageId":%q,`, msgID)
-	out := make([]byte, 0, len(prefix)+len(in)-1)
-	out = append(out, prefix...)
-	out = append(out, in[1:]...)
-	return out
-}
+

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -365,11 +365,12 @@ transitions.
 ### 5.3 `tool_call`
 
 ```json
-{"type":"tool_call","id":"call_abc123","name":"bash","args":{"command":"ls -la"}}
+{"type":"tool_call","id":"call_abc123","name":"bash","args":{"command":"ls -la"},"parentMessageId":"msg_assistant_xyz789"}
 ```
 
 - `id` (string, required) — PI's tool-call ID (corresponds to
-  `toolCallId` in PI's `tool_execution_*` events).
+  `toolCallId` in PI's `tool_execution_*` events). Used to pair this
+  `tool_call` with its `tool_result` (see §5.4).
 - `name` (string, required) — the tool name (`bash`, `read`, `edit`, …).
 - `args` (object, required) — the tool arguments. **Truncation:** the
   extension truncates large arg fields per existing prism conventions —
@@ -379,6 +380,18 @@ transitions.
   truncated string fields are replaced with the first 8 KiB followed by
   the literal sentinel `"…[truncated]"`. The sidecar accepts whatever
   arrives without further truncation.
+- `parentMessageId` (string, optional) — the `messageId` of the assistant
+  turn that issued this tool call. Stamped by the extension from the
+  most recent `message_start` event observed with `role="assistant"`.
+  Omitted (field absent, not empty-string) when the extension has not
+  yet observed an assistant `message_start` in this session — e.g. an
+  extension that restarted mid-turn. Issue #1787 added this field so the
+  consumer-side secondary-query SQL pushdown
+  (`db.QueryEventsByMessageIDs`, used by `iris checkin` and
+  `prism checkin --turns`) can pair tool events back to their parent
+  assistant turn. The previous `messageId` field expected by the older
+  Go consumer was never emitted by this extension; renderers therefore
+  silently dropped every production tool_call until the field was added.
 
 The frame maps directly into a `tool_call` row in `agent_events` (existing
 schema). No translation required on the sidecar side beyond promoting
@@ -387,7 +400,7 @@ schema). No translation required on the sidecar side beyond promoting
 ### 5.4 `tool_result`
 
 ```json
-{"type":"tool_result","id":"call_abc123","success":true,"output":"total 48\ndrwxr-xr-x ..."}
+{"type":"tool_result","id":"call_abc123","success":true,"output":"total 48\ndrwxr-xr-x ...","parentMessageId":"msg_assistant_xyz789"}
 ```
 
 - `id` (string, required) — matches the corresponding `tool_call.id`.
@@ -399,6 +412,12 @@ schema). No translation required on the sidecar side beyond promoting
   exceed the cap remain available to PI in full (PI writes them to its
   own `fullOutputPath` if applicable, see PI RPC docs §"bash"); only the
   wire copy delivered to prism is truncated.
+- `parentMessageId` (string, optional) — mirrors the field on `tool_call`
+  (§5.3). Carries the assistant `messageId` of the turn that issued the
+  matching tool call. Stamped by the extension; same omission semantics
+  as on `tool_call`. Both frames carry the same value, so the consumer's
+  secondary-query pushdown can locate both rows under the same
+  assistant-turn join key. Issue #1787.
 
 The frame maps directly into a `tool_result` row in `agent_events`.
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -1265,15 +1265,20 @@ func TestUpsertStatusWithRootAgent_SidecarWins(t *testing.T) {
 }
 
 // TestQueryEventsByMessageIDs verifies the secondary query fetches events
-// keyed by messageId JSON field, filtered by type.
+// keyed by either the post-#1787 `parentMessageId` field
+// (tool_call/tool_result) or the legacy `messageId` field
+// (permission_*, thinking), filtered by type.
 func TestQueryEventsByMessageIDs(t *testing.T) {
 	d := openTestDB(t)
 
 	base := time.Now().Truncate(time.Second)
 
+	// writeE writes a tool_call / tool_result with the post-#1787 wire
+	// shape: parentMessageId is the assistant-turn join key, id is the
+	// per-tool-call id (same value used for both here for simplicity).
 	writeE := func(id, typ, msgID string, offset time.Duration) {
 		t.Helper()
-		payload := `{"messageId":"` + msgID + `","tool":"bash","args":"go test","result":"ok"}`
+		payload := `{"parentMessageId":"` + msgID + `","id":"` + msgID + `","name":"bash","args":{"command":"go test"},"output":"ok"}`
 		e := db.Event{
 			ID:          id,
 			SessionName: "repo@main",
@@ -1328,6 +1333,52 @@ func TestQueryEventsByMessageIDs(t *testing.T) {
 	}
 	if results3 != nil {
 		t.Errorf("empty result: got %v, want nil", results3)
+	}
+}
+
+// TestQueryEventsByMessageIDs_LegacyMessageIdField verifies that the
+// secondary-query pushdown still matches event types that carry the
+// parent-link on the legacy `messageId` field (permission_ask,
+// permission_denied, thinking) — the COALESCE(`$.parentMessageId`,
+// `$.messageId`) clause is the join contract for #1787.
+func TestQueryEventsByMessageIDs_LegacyMessageIdField(t *testing.T) {
+	d := openTestDB(t)
+
+	base := time.Now().Truncate(time.Second)
+	writeLegacy := func(id, typ, msgID string, offset time.Duration) {
+		t.Helper()
+		payload := `{"messageId":"` + msgID + `","tool":"bash","patterns":["*"]}`
+		if err := d.WriteEvent(db.Event{
+			ID:          id,
+			SessionName: "repo@main",
+			Repo:        "repo",
+			Worktree:    "/code/repo/main",
+			Type:        typ,
+			Payload:     payload,
+			CreatedAt:   base.Add(offset),
+		}); err != nil {
+			t.Fatalf("WriteEvent %s: %v", id, err)
+		}
+	}
+
+	writeLegacy("p1", "permission_ask", "msg-X", 0)
+	writeLegacy("p2", "permission_denied", "msg-X", time.Second)
+	writeLegacy("p3", "thinking", "msg-Y", 2*time.Second)
+
+	results, err := d.QueryEventsByMessageIDs("repo@main", []string{"msg-X", "msg-Y"},
+		[]string{"permission_ask", "permission_denied", "thinking"})
+	if err != nil {
+		t.Fatalf("QueryEventsByMessageIDs: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("result count: got %d, want 3", len(results))
+	}
+	gotIDs := []string{results[0].ID, results[1].ID, results[2].ID}
+	wantIDs := []string{"p1", "p2", "p3"}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("results[%d].ID: got %q, want %q", i, gotIDs[i], wantIDs[i])
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/events.go
+++ b/modules/programs/prism/prism/internal/db/events.go
@@ -158,13 +158,28 @@ func (d *DB) QueryEvents(sessionName string, limit int, before, after *string, t
 }
 
 // QueryEventsByMessageIDs returns all events for sessionName whose payload
-// contains a "messageId" field matching one of the provided IDs. Only events
+// joins back to one of the provided assistant-turn message IDs. Only events
 // of the specified types are returned; pass nil for types to return all types.
 // Results are ordered by created_at ASC.
 //
 // This is used by checkin's secondary query to fetch tool_call, tool_result,
 // permission_ask, permission_denied, and thinking events that belong to a set
-// of user message turns retrieved by the primary query.
+// of assistant-message turns retrieved by the primary query.
+//
+// Join field by event type (#1787):
+//
+//   - tool_call / tool_result: matched on `$.parentMessageId`. The pi prism
+//     extension stamps this field with the in-flight assistant messageId on
+//     every tool frame; pre-#1787 these rows had no parent-link field at all
+//     and were silently dropped by the previous `$.messageId` pushdown.
+//   - permission_ask / permission_denied / thinking: matched on `$.messageId`
+//     (the field the plugin has always emitted for these types).
+//
+// To keep the API a single round-trip with one IN clause, the SQL matches a
+// row when *either* JSON path resolves to a value in the provided id set.
+// COALESCE picks whichever path is populated for a given row — since no
+// event type emits both fields, the two paths are mutually exclusive in
+// practice, so the COALESCE never has to choose between competing values.
 func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, types []string) ([]Event, error) {
 	if len(messageIDs) == 0 {
 		return nil, nil
@@ -179,7 +194,9 @@ func (d *DB) QueryEventsByMessageIDs(sessionName string, messageIDs []string, ty
 		idPlaceholders[i] = "?"
 		args = append(args, id)
 	}
-	conditions = append(conditions, "JSON_EXTRACT(payload, '$.messageId') IN ("+strings.Join(idPlaceholders, ",")+")")
+	conditions = append(conditions,
+		"COALESCE(JSON_EXTRACT(payload, '$.parentMessageId'), JSON_EXTRACT(payload, '$.messageId')) IN ("+
+			strings.Join(idPlaceholders, ",")+")")
 
 	if len(types) > 0 {
 		typePlaceholders := make([]string, len(types))

--- a/modules/programs/prism/prism/internal/harness/pi/adapter.go
+++ b/modules/programs/prism/prism/internal/harness/pi/adapter.go
@@ -464,11 +464,21 @@ func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload 
 		// stdio adapter's input shape (snake_case JSONL) is
 		// unchanged — the adapter just translates into the new
 		// canonical struct names.
+		//
+		// Post-#1787: the stdio adapter's piToolCallFrame.MessageID
+		// is PI's parent-assistant message id (the same field that
+		// `msg_assistant` carries as `$.messageId`). It maps to the
+		// new ParentMessageID field so the checkin secondary-query
+		// pushdown can join this row back to its assistant turn.
+		// We also keep it in ID for backward compatibility with any
+		// stdio-path consumer that pairs on ID (the stdio frame
+		// shape never had a distinct tool-call id).
 		p := payload.ToolCall{
-			Name:       f.Tool,
-			Args:       marshalArgs(f.Input),
-			ID:         f.MessageID,
-			DurationMs: f.ElapsedMs,
+			Name:            f.Tool,
+			Args:            marshalArgs(f.Input),
+			ID:              f.MessageID,
+			ParentMessageID: f.MessageID,
+			DurationMs:      f.ElapsedMs,
 		}
 		return "tool_call", p, true
 
@@ -488,11 +498,17 @@ func (a *Adapter) NormaliseFrame(rawLine []byte) (eventType string, normPayload 
 		// input frame, so Success defaults to true. Consumers that
 		// need to detect failures fall back to per-tool result
 		// summarisation heuristics (narrative.ToolResultSummary).
+		//
+		// ParentMessageID mirrors the ToolCall mapping above
+		// (#1787): the stdio frame's `message_id` is the parent
+		// assistant turn id, which is what the secondary-query
+		// pushdown joins on.
 		p := payload.ToolResult{
-			ID:        f.MessageID,
-			Success:   true,
-			Output:    output,
-			Truncated: truncated,
+			ID:              f.MessageID,
+			ParentMessageID: f.MessageID,
+			Success:         true,
+			Output:          output,
+			Truncated:       truncated,
 		}
 		return "tool_result", p, true
 

--- a/modules/programs/prism/prism/internal/iris/narrative/narrative.go
+++ b/modules/programs/prism/prism/internal/iris/narrative/narrative.go
@@ -475,3 +475,26 @@ func ExtractMessageID(raw string) string {
 	}
 	return p.MessageID
 }
+
+// ExtractParentMessageID returns the assistant-turn message id that owns a
+// child event (tool_call, tool_result, permission_*, thinking). It prefers
+// the post-#1787 `parentMessageId` field (emitted by the pi prism extension
+// on tool_call/tool_result frames) and falls back to `messageId` for event
+// types that have always carried the parent link on that field
+// (permission_ask, permission_denied, thinking).
+//
+// Returns an empty string for orphan events whose parent assistant turn is
+// not represented in the payload at all.
+func ExtractParentMessageID(raw string) string {
+	var p struct {
+		ParentMessageID string `json:"parentMessageId"`
+		MessageID       string `json:"messageId"`
+	}
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return ""
+	}
+	if p.ParentMessageID != "" {
+		return p.ParentMessageID
+	}
+	return p.MessageID
+}

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -98,12 +98,25 @@ type MsgAssistant struct {
 // `internal/harness/pi/adapter.go`) which still populates it from
 // `elapsed_ms`. The current prism extension does not emit a duration
 // field; DurationMs is zero in that case.
+//
+// ParentMessageID (issue #1787) is the messageId of the assistant turn
+// that issued this tool call. The pi prism extension stamps it from
+// the `message_start` event observed immediately before the matching
+// `tool_execution_start`, so it always points at the in-flight
+// assistant message at the moment the tool was invoked. Consumers use
+// this to join a tool_call back to its parent msg_assistant row
+// (`db.QueryEventsByMessageIDs` filters on `$.parentMessageId`). An
+// empty value means "orphan" — either the parent message scrolled
+// out of the query window, or the extension started mid-turn and never
+// observed a message_start; renderers fall back to a standalone summary
+// in that case rather than dropping the row.
 type ToolCall struct {
-	Name       string          `json:"name"`
-	Args       json.RawMessage `json:"args,omitempty"`
-	ID         string          `json:"id"`
-	Truncated  bool            `json:"truncated,omitempty"`
-	DurationMs int64           `json:"durationMs,omitempty"`
+	Name            string          `json:"name"`
+	Args            json.RawMessage `json:"args,omitempty"`
+	ID              string          `json:"id"`
+	ParentMessageID string          `json:"parentMessageId,omitempty"`
+	Truncated       bool            `json:"truncated,omitempty"`
+	DurationMs      int64           `json:"durationMs,omitempty"`
 }
 
 // ToolResult is the payload for tool_result events.
@@ -120,11 +133,20 @@ type ToolCall struct {
 //
 // The older PI stdio adapter (Translate path) produces the same
 // shape after #1783; see `internal/harness/pi/adapter.go`.
+//
+// ParentMessageID (issue #1787) mirrors the field on ToolCall and
+// carries the assistant messageId of the turn that issued the matching
+// tool_call. Populated by the pi extension on both frames so the
+// secondary-query pushdown can fetch the pair together. Empty when the
+// extension could not observe the parent message_start; the renderer
+// then surfaces the result as a standalone summary rather than
+// dropping it.
 type ToolResult struct {
-	ID        string `json:"id"`
-	Success   bool   `json:"success"`
-	Output    string `json:"output"`
-	Truncated bool   `json:"truncated,omitempty"`
+	ID              string `json:"id"`
+	Success         bool   `json:"success"`
+	Output          string `json:"output"`
+	ParentMessageID string `json:"parentMessageId,omitempty"`
+	Truncated       bool   `json:"truncated,omitempty"`
 }
 
 // PermissionAsk is the payload for permission_ask events.


### PR DESCRIPTION
## Summary

Restores tool-call narrative rendering in `iris checkin` and `prism checkin --turns`. Pre-#1787 the consumer's secondary-query SQL pushdown (`db.QueryEventsByMessageIDs`) joined child rows on `JSON_EXTRACT($.messageId)`, but the pi prism extension never emitted that field on `tool_call` / `tool_result` frames — the `id` it stamped was the per-call tool-call uuid, not the parent assistant messageId — so every production tool_call/tool_result row was silently dropped in those views.

This PR takes **strategy (A) from the issue** — the producer-side fix:

- The pi extension tracks the in-flight assistant messageId via the `message_start` hook and stamps it as `parentMessageId` on every `tool_call` and `tool_result` frame it writes.
- `payload.ToolCall` / `payload.ToolResult` gain a matching `ParentMessageID string \`json:"parentMessageId,omitempty"\`` field.
- The SQL pushdown now joins on `COALESCE($.parentMessageId, $.messageId)` so both the new tool-frame field and the legacy `messageId` field (still used by `permission_*` / `thinking`) work via the same query.
- The legacy stdio `internal/harness/pi/adapter.go` Translate path is updated to populate `ParentMessageID` from the snake_case `message_id` field on incoming PI frames so that path keeps working too.
- The synthetic-`messageId` fixture hack in `cmd/checkin_test.go` and `cmd/iris/checkin_test.go` is removed; fixtures now use the real `parentMessageId` wire shape (one of the ACs).

## Edge cases handled

- **tool_result without a matching tool_call.** Existing `renderChildEvents` orphan path still renders the result as a standalone `↳ result (orphan): ...` line.
- **tool_call whose parent msg_assistant is outside the queried window.** Surfaced under a new `orphan tool events (parent turn outside window):` header after the main timeline rather than being silently dropped. Both `cmd/checkin_turns.go` and `cmd/iris/checkin.go` honour this.
- **No assistant message_start observed yet** (extension restarted mid-turn, or the very first event in a session is a tool call somehow). The extension omits `parentMessageId` entirely (field absent, not empty-string) so consumers can distinguish 'orphan' from a literal empty string. Verified by a dedicated test.

## Tests

- `internal/db`: `TestQueryEventsByMessageIDs` updated to use the new `parentMessageId` wire shape; new `TestQueryEventsByMessageIDs_LegacyMessageIdField` pins the COALESCE fallback path for permission_*/thinking rows.
- `pi/extensions/prism.test.ts`: new `#1787` suite drives the extension through `message_start` → `tool_execution_start` → `tool_execution_end` against a real socket and asserts `parentMessageId` is present on both wire frames; second test asserts the field is omitted entirely when no `message_start` was observed (covers the AC: "a test that loads a real pi-extension JSONL frame asserts `parentMessageId` is non-empty").
- Existing `iris/cmd` checkin tests continue to assert the rendered output includes the tool one-liner — they now exercise the real `parentMessageId` path because the synthetic `messageId` injection helper was removed.

## Pre-PR self-check

```
go build ./...             ✓
go test ./... -race        ✓ (all packages pass)
tsx --test prism.test.ts   ✓ (74/74 suites pass; my new #1787 suite is the last)
nix build .#prism          ✓
```

Closes #1787