### PR TITLE
dashboard: per-agent status cluster + verdict labels on collapsed review-group row

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/poll.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/session"
 )
@@ -50,6 +51,12 @@ func FetchSessionsFromDB() tea.Msg {
 	// Filter out internal sessions (scratchpad, prism-dashboard).
 	sessions = FilterAgentSessions(sessions)
 
+	// Attach last-assistant messages for per-agent review sessions so the
+	// virtual review-group row can derive per-child verdicts (#1795). We
+	// fetch GroupResults once per unique review group_id — review groups
+	// are bounded in number, so this is a small fixed cost per refresh.
+	attachReviewLastMessages(d, sessions)
+
 	// Collect unique agent paths that need git stat computation.
 	seen := map[string]bool{}
 	var paths []string
@@ -78,6 +85,48 @@ func FetchSessionsFromDB() tea.Msg {
 	wg.Wait()
 
 	return SessionsMsg{Sessions: sessions, GitStats: stats}
+}
+
+// attachReviewLastMessages populates sessions[i].LastMessage for every
+// per-agent review session (i.e. ReviewRoundKey(sessions[i].Name) != "")
+// using db.GroupResults() keyed by group_id. The DB handle is reused; on
+// error the field is left empty (best-effort — the dashboard still renders
+// correctly, just without verdict glyphs / labels until the next refresh).
+//
+// One GroupResults() call per unique review group_id. Review groups are
+// bounded in number, so this is a small fixed cost per FetchSessionsFromDB
+// invocation.
+func attachReviewLastMessages(d *db.DB, sessions []AgentSession) {
+	// Collect unique group_ids belonging to per-agent review sessions.
+	groupIDs := map[string]bool{}
+	for _, s := range sessions {
+		if s.GroupID == nil || *s.GroupID == "" {
+			continue
+		}
+		if ReviewRoundKey(s.Name) == "" {
+			continue
+		}
+		groupIDs[*s.GroupID] = true
+	}
+	if len(groupIDs) == 0 {
+		return
+	}
+	// Fetch GroupResults for each unique group and stash a per-session map.
+	bySession := map[string]string{}
+	for gid := range groupIDs {
+		members, err := d.GroupResults(gid)
+		if err != nil {
+			continue
+		}
+		for name, m := range members {
+			bySession[name] = m.LastMessage
+		}
+	}
+	for i, s := range sessions {
+		if msg, ok := bySession[s.Name]; ok {
+			sessions[i].LastMessage = msg
+		}
+	}
 }
 
 // FetchGitStatsOnly queries the current set of active sessions from the DB

--- a/modules/programs/prism/prism/internal/dashboard/review_summary.go
+++ b/modules/programs/prism/prism/internal/dashboard/review_summary.go
@@ -1,0 +1,396 @@
+package dashboard
+
+// review_summary.go — per-agent review-round status rendering.
+//
+// This file owns:
+//   - the ReviewChildSummary type (one entry per canonical review agent on a
+//     virtual review-group row),
+//   - the verdict-parsing helper (case-insensitive substring match against the
+//     last assistant message, mirroring internal/db/sessions.go::ReviewVerdict),
+//   - the canonical short-name mapping (derived from review.Agents()), and
+//   - the single rendering helper RenderReviewSummary that produces the
+//     coloured glyph cluster, per-agent verdict labels, and progress tail
+//     shown on the collapsed review-group row.
+//
+// The canonical five-agent order is read from review.Agents() in
+// internal/review/agents.go — never duplicated here. See AC for #1795.
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// Verdict values produced by ParseVerdict and stored in ReviewChildSummary.
+const (
+	VerdictPass    = "pass"
+	VerdictFail    = "fail"
+	VerdictRunning = "running" // active / waiting / compacting / reviewing
+	VerdictPending = "pending" // idle / unknown / not yet started
+	VerdictError   = "error"   // errored / startup failure / missing agent
+)
+
+// ReviewChildSummary holds the per-agent rollup used to render one cell of the
+// collapsed review-group row's glyph cluster and label list. One entry per
+// canonical review agent in the order returned by review.Agents().
+type ReviewChildSummary struct {
+	// AgentShortName is the canonical short label (e.g. "goal", "code",
+	// "security" — see ShortAgentName). It is rendered in the per-agent
+	// verdict labels, e.g. "goal:P".
+	AgentShortName string
+	// State is the AgentState string ("active" | "waiting" | "finished" |
+	// "compacting" | "error" | "idle" | ""). Used to decide running vs
+	// pending vs error when no verdict marker is present.
+	State string
+	// Verdict is one of VerdictPass | VerdictFail | VerdictRunning |
+	// VerdictPending | VerdictError. Derived from State + the last
+	// assistant message.
+	Verdict string
+}
+
+// canonicalReviewAgentNames returns the canonical list of review-agent full
+// names (e.g. "review-goal", "review-code", ...) in the order defined by
+// internal/review.Agents(). Centralised here so the dashboard never duplicates
+// the agent list.
+func canonicalReviewAgentNames() []string {
+	agents := review.Agents()
+	out := make([]string, len(agents))
+	for i, a := range agents {
+		out[i] = a.Name
+	}
+	return out
+}
+
+// ShortAgentName maps a full review-agent name (e.g. "review-security") to its
+// short display label (e.g. "sec"). Falls back to the part after the first "-"
+// for any unknown name, and to the full name if there is no "-".
+//
+// The short labels are tuned for column-budget reasons: most agent names are
+// short enough to use as-is, but "review-security" is collapsed to "sec" so
+// the per-agent verdict labels line fits within the dashboard width budget at
+// the common terminal sizes.
+func ShortAgentName(fullName string) string {
+	// Strip the "review-" prefix when present.
+	stripped := strings.TrimPrefix(fullName, "review-")
+	switch stripped {
+	case "security":
+		return "sec"
+	default:
+		return stripped
+	}
+}
+
+// ParseVerdict returns VerdictPass when the last assistant message contains a
+// case-insensitive `<verdict>pass</verdict>` marker, VerdictFail when it
+// contains `<verdict>fail</verdict>`, and "" otherwise.
+//
+// This mirrors the rule used by internal/db/sessions.go::ReviewVerdict
+// rollup — no regex, no XML parsing, just a substring check.
+func ParseVerdict(lastMessage string) string {
+	if lastMessage == "" {
+		return ""
+	}
+	lower := strings.ToLower(lastMessage)
+	if strings.Contains(lower, "<verdict>pass</verdict>") {
+		return VerdictPass
+	}
+	if strings.Contains(lower, "<verdict>fail</verdict>") {
+		return VerdictFail
+	}
+	return ""
+}
+
+// classifyVerdict returns the final Verdict value for a child given its
+// AgentState and the result of ParseVerdict on its LastMessage. The rules:
+//
+//   - error state                              → VerdictError
+//   - parsed verdict pass                      → VerdictPass
+//   - parsed verdict fail                      → VerdictFail
+//   - active / waiting / compacting / reviewing → VerdictRunning
+//   - anything else (idle, "", finished w/o verdict) → VerdictPending
+//
+// Note: a child whose AgentState is "finished" but whose last assistant
+// message has no <verdict> marker is treated as VerdictPending — the rollup
+// only commits to PASS/FAIL when the marker is present.
+func classifyVerdict(state, lastMessage string) string {
+	if state == "error" {
+		return VerdictError
+	}
+	if v := ParseVerdict(lastMessage); v != "" {
+		return v
+	}
+	switch state {
+	case "active", "waiting", "compacting", "reviewing":
+		return VerdictRunning
+	default:
+		return VerdictPending
+	}
+}
+
+// BuildReviewChildSummaries returns one ReviewChildSummary per canonical
+// review agent, in the order defined by review.Agents().
+//
+// `children` is the set of per-agent AgentSessions that belong to the same
+// review-round group. It is matched against the canonical agent list by the
+// suffix of each child's session name: a child "...~review-1-review-goal"
+// matches the canonical agent "review-goal".
+//
+// Agents that have no matching child (e.g. the round was spawned with --only,
+// or an agent failed to start) are rendered as VerdictError so the user can
+// see at a glance that the slot is missing — this matches the AC's intent
+// ("missing agents as ✕").
+func BuildReviewChildSummaries(children []AgentSession) []ReviewChildSummary {
+	names := canonicalReviewAgentNames()
+
+	// Index children by the trailing review-agent name (e.g. "review-goal").
+	byAgent := make(map[string]AgentSession, len(children))
+	for _, ch := range children {
+		// Find the trailing "-review-<name>" component.
+		// The full session name is e.g. "repo@branch~review-N-review-goal".
+		// We extract the substring after the last "~review-N-" boundary by
+		// looking for "review-" anchored after a "-".
+		// Simplest: split on "-" and look for "review-<rest>" suffix.
+		if name := trailingReviewAgent(ch.Name); name != "" {
+			byAgent[name] = ch
+		}
+	}
+
+	out := make([]ReviewChildSummary, len(names))
+	for i, full := range names {
+		ch, ok := byAgent[full]
+		if !ok {
+			out[i] = ReviewChildSummary{
+				AgentShortName: ShortAgentName(full),
+				State:          "",
+				Verdict:        VerdictError,
+			}
+			continue
+		}
+		out[i] = ReviewChildSummary{
+			AgentShortName: ShortAgentName(full),
+			State:          ch.AgentState,
+			Verdict:        classifyVerdict(ch.AgentState, ch.LastMessage),
+		}
+	}
+	return out
+}
+
+// trailingReviewAgent extracts the canonical review-agent name suffix from a
+// per-agent session name. Given "repo@branch~review-3-review-security" it
+// returns "review-security". Returns "" when the name has no such suffix.
+func trailingReviewAgent(sessionName string) string {
+	// ReviewRoundKey returns "" for non-per-agent sessions; we trust it as the
+	// gate. The agent suffix is everything after the round key + "-".
+	rk := ReviewRoundKey(sessionName)
+	if rk == "" {
+		return ""
+	}
+	// rk is e.g. "repo@branch~review-3"; the suffix is sessionName[len(rk)+1:].
+	if len(sessionName) <= len(rk)+1 {
+		return ""
+	}
+	return sessionName[len(rk)+1:]
+}
+
+// ── width budget ─────────────────────────────────────────────────────────────
+
+// reviewSummaryClusterWidth is the rune width of the five-glyph cluster
+// (5 glyphs, no separators). This is the floor — the cluster never collapses.
+const reviewSummaryClusterWidth = 5
+
+// reviewSummaryLabelsWidth returns the rune width of the per-agent verdict
+// labels segment for the given summaries (e.g.
+// "goal:P  code:P  sec:F  qa:◌  context:·"). Used by RenderReviewSummary to
+// decide whether the labels fit in the remaining width budget.
+func reviewSummaryLabelsWidth(summaries []ReviewChildSummary) int {
+	if len(summaries) == 0 {
+		return 0
+	}
+	w := 0
+	for i, s := range summaries {
+		if i > 0 {
+			w += 2 // two-space separator between labels
+		}
+		w += utf8.RuneCountInString(s.AgentShortName) + 1 + 1 // "name" + ":" + letter
+	}
+	return w
+}
+
+// reviewSummaryTailText returns the progress-tail text for the given
+// summaries. Used by RenderReviewSummary and by tests.
+//
+//   - "all pass" when all five terminal verdicts are PASS
+//   - "all fail" when all five terminal verdicts are FAIL
+//   - "N/5 done" otherwise, where N counts PASS, FAIL, or ERROR
+//
+// "Terminal" mirrors the AC: PASS, FAIL, ERROR all count toward N.
+func reviewSummaryTailText(summaries []ReviewChildSummary) string {
+	if len(summaries) == 0 {
+		return ""
+	}
+	var pass, fail, terminal int
+	for _, s := range summaries {
+		switch s.Verdict {
+		case VerdictPass:
+			pass++
+			terminal++
+		case VerdictFail:
+			fail++
+			terminal++
+		case VerdictError:
+			terminal++
+		}
+	}
+	if terminal == 5 && pass == 5 {
+		return "all pass"
+	}
+	if terminal == 5 && fail == 5 {
+		return "all fail"
+	}
+	return fmt.Sprintf("%d/5 done", terminal)
+}
+
+// glyphForVerdict returns the cluster glyph for a verdict.
+func glyphForVerdict(v string) string {
+	switch v {
+	case VerdictPass:
+		return "●"
+	case VerdictFail:
+		return "○"
+	case VerdictRunning:
+		return "◐"
+	case VerdictError:
+		return "✕"
+	default:
+		return "·"
+	}
+}
+
+// letterForVerdict returns the per-agent label letter for a verdict.
+func letterForVerdict(v string) string {
+	switch v {
+	case VerdictPass:
+		return "P"
+	case VerdictFail:
+		return "F"
+	case VerdictRunning:
+		return "◌"
+	case VerdictError:
+		return "✕"
+	default:
+		return "·"
+	}
+}
+
+// colorForVerdict returns the lipgloss colour name for a verdict, used for
+// both glyphs and label letters.
+func colorForVerdict(v string) string {
+	switch v {
+	case VerdictPass:
+		return ColorGreen
+	case VerdictFail:
+		return ColorRed
+	case VerdictRunning:
+		return ColorPrimary
+	case VerdictError:
+		return ColorRed
+	default:
+		return ColorSecondary
+	}
+}
+
+// RenderReviewSummary builds the cluster + per-agent labels + progress tail
+// for a collapsed review-group row. It returns three independently rendered
+// (ANSI-coloured) string fragments so the caller can place gap characters
+// between them and apply its own enclosing styles.
+//
+// The width budget is honoured as follows:
+//
+//   - If `budget` >= cluster + 2 (gap) + labels + 2 (gap) + tail, all three
+//     fragments are returned non-empty.
+//   - If only cluster + 2 + tail fits, the labels fragment is returned empty.
+//   - If only cluster fits, both labels and tail are returned empty.
+//   - If even the cluster does not fit, all three are returned empty (the
+//     caller falls back to its previous render — the floor is preserved as
+//     described in the edge-case AC).
+//
+// Returns the plain rune width consumed by the rendered fragments (excluding
+// the inter-fragment gaps, which the caller is responsible for inserting) so
+// the caller can correctly pad / truncate trailing columns.
+func RenderReviewSummary(summaries []ReviewChildSummary, budget int) (cluster, labels, tail string, plainWidth int) {
+	if len(summaries) == 0 {
+		return "", "", "", 0
+	}
+
+	// Build cluster (always rendered when the budget allows).
+	clusterW := reviewSummaryClusterWidth
+	if budget < clusterW {
+		return "", "", "", 0
+	}
+
+	var clusterB strings.Builder
+	for _, s := range summaries {
+		st := lipgloss.NewStyle().Foreground(lipgloss.Color(colorForVerdict(s.Verdict)))
+		clusterB.WriteString(st.Render(glyphForVerdict(s.Verdict)))
+	}
+	cluster = clusterB.String()
+	plainWidth = clusterW
+
+	// Decide whether labels fit.
+	labelsW := reviewSummaryLabelsWidth(summaries)
+	tailText := reviewSummaryTailText(summaries)
+	tailW := utf8.RuneCountInString(tailText)
+
+	// Try cluster + labels + tail. Each transition costs 2 runes of gap.
+	if budget >= clusterW+2+labelsW+2+tailW {
+		labels = renderLabels(summaries)
+		tail = renderTail(tailText)
+		plainWidth = clusterW + 2 + labelsW + 2 + tailW
+		return
+	}
+	// Try cluster + tail (drop labels first per the AC).
+	if budget >= clusterW+2+tailW && tailW > 0 {
+		tail = renderTail(tailText)
+		plainWidth = clusterW + 2 + tailW
+		return
+	}
+	// Only the cluster fits.
+	return
+}
+
+// renderLabels renders the per-agent verdict labels segment as a single
+// ANSI-coloured string. Format: "goal:P  code:P  sec:F  qa:◌  context:·" —
+// the agent short name in dim, ":" in dim, the verdict letter in the verdict
+// colour.
+func renderLabels(summaries []ReviewChildSummary) string {
+	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
+	var b strings.Builder
+	for i, s := range summaries {
+		if i > 0 {
+			b.WriteString("  ")
+		}
+		b.WriteString(styleDim.Render(s.AgentShortName + ":"))
+		letter := lipgloss.NewStyle().Foreground(lipgloss.Color(colorForVerdict(s.Verdict)))
+		b.WriteString(letter.Render(letterForVerdict(s.Verdict)))
+	}
+	return b.String()
+}
+
+// renderTail renders the progress-tail text. "all pass" is rendered green,
+// "all fail" red, and "N/5 done" dim.
+func renderTail(text string) string {
+	if text == "" {
+		return ""
+	}
+	color := ColorSecondary
+	switch text {
+	case "all pass":
+		color = ColorGreen
+	case "all fail":
+		color = ColorRed
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Render(text)
+}

--- a/modules/programs/prism/prism/internal/dashboard/review_summary_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/review_summary_test.go
@@ -1,0 +1,701 @@
+package dashboard_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// ── ParseVerdict ─────────────────────────────────────────────────────────────
+
+func TestParseVerdict(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"lowercase pass", "summary <verdict>pass</verdict> ok", "pass"},
+		{"uppercase pass", "SUMMARY <VERDICT>PASS</VERDICT> OK", "pass"},
+		{"mixed-case pass", "<Verdict>Pass</Verdict>", "pass"},
+		{"lowercase fail", "<verdict>fail</verdict>", "fail"},
+		{"uppercase fail", "<VERDICT>FAIL</VERDICT>", "fail"},
+		{"no marker", "no verdict here", ""},
+		{"malformed", "<verdict>maybe</verdict>", ""},
+		{"pass wins over fail", "<verdict>pass</verdict> and <verdict>fail</verdict>", "pass"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dashboard.ParseVerdict(tt.in)
+			if got != tt.want {
+				t.Errorf("ParseVerdict(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── ShortAgentName ───────────────────────────────────────────────────────────
+
+func TestShortAgentName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"review-goal", "goal"},
+		{"review-code", "code"},
+		{"review-security", "sec"},
+		{"review-qa", "qa"},
+		{"review-context", "context"},
+		// Future / unknown agents fall through (strip prefix only).
+		{"review-rubric", "rubric"},
+		{"review-arch", "arch"},
+		// Names without the prefix pass through unchanged.
+		{"goal", "goal"},
+	}
+	for _, tt := range tests {
+		got := dashboard.ShortAgentName(tt.in)
+		if got != tt.want {
+			t.Errorf("ShortAgentName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// ── BuildReviewChildSummaries ────────────────────────────────────────────────
+
+// canonicalShortNames mirrors the production mapping for assertions. It is
+// derived from review.Agents() so the test will break (intentionally) if the
+// canonical list changes without updating ShortAgentName.
+func canonicalShortNames() []string {
+	agents := review.Agents()
+	out := make([]string, len(agents))
+	for i, a := range agents {
+		out[i] = dashboard.ShortAgentName(a.Name)
+	}
+	return out
+}
+
+// buildChildren constructs per-agent AgentSessions for every canonical review
+// agent in a single round, with the supplied state and last-message map keyed
+// by full agent name (e.g. "review-goal").
+func buildChildren(round int, states map[string]string, lastMessages map[string]string) []dashboard.AgentSession {
+	agents := review.Agents()
+	out := make([]dashboard.AgentSession, 0, len(agents))
+	for _, a := range agents {
+		name := "repo@branch~review-" + itoaTest(round) + "-" + a.Name
+		out = append(out, dashboard.AgentSession{
+			Name:        name,
+			AgentState:  states[a.Name],
+			LastMessage: lastMessages[a.Name],
+		})
+	}
+	return out
+}
+
+func itoaTest(n int) string {
+	if n < 10 {
+		return string(rune('0' + n))
+	}
+	return "10"
+}
+
+func TestBuildReviewChildSummaries_CanonicalOrder(t *testing.T) {
+	children := buildChildren(1, nil, nil)
+	got := dashboard.BuildReviewChildSummaries(children)
+
+	want := canonicalShortNames()
+	if len(got) != len(want) {
+		t.Fatalf("got %d summaries, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].AgentShortName != w {
+			t.Errorf("summary[%d].AgentShortName = %q, want %q", i, got[i].AgentShortName, w)
+		}
+	}
+}
+
+func TestBuildReviewChildSummaries_AllPass(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "summary <verdict>PASS</verdict>"
+	}
+	got := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	for i, s := range got {
+		if s.Verdict != dashboard.VerdictPass {
+			t.Errorf("summary[%d].Verdict = %q, want pass", i, s.Verdict)
+		}
+	}
+}
+
+func TestBuildReviewChildSummaries_MixedPassFail(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for i, a := range agents {
+		states[a.Name] = "finished"
+		if i%2 == 0 {
+			msgs[a.Name] = "<verdict>pass</verdict>"
+		} else {
+			msgs[a.Name] = "<verdict>fail</verdict>"
+		}
+	}
+	got := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	for i, s := range got {
+		var want string
+		if i%2 == 0 {
+			want = dashboard.VerdictPass
+		} else {
+			want = dashboard.VerdictFail
+		}
+		if s.Verdict != want {
+			t.Errorf("summary[%d].Verdict = %q, want %q", i, s.Verdict, want)
+		}
+	}
+}
+
+func TestBuildReviewChildSummaries_TwoRunning(t *testing.T) {
+	// Three children PASS-finished, two still active (one waiting, one active).
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for i, a := range agents {
+		switch i {
+		case 0:
+			states[a.Name] = "active"
+		case 1:
+			states[a.Name] = "waiting"
+		default:
+			states[a.Name] = "finished"
+			msgs[a.Name] = "<verdict>pass</verdict>"
+		}
+	}
+	got := dashboard.BuildReviewChildSummaries(buildChildren(2, states, msgs))
+	runningCount := 0
+	passCount := 0
+	for _, s := range got {
+		switch s.Verdict {
+		case dashboard.VerdictRunning:
+			runningCount++
+		case dashboard.VerdictPass:
+			passCount++
+		}
+	}
+	if runningCount != 2 {
+		t.Errorf("runningCount = %d, want 2", runningCount)
+	}
+	if passCount != 3 {
+		t.Errorf("passCount = %d, want 3", passCount)
+	}
+}
+
+func TestBuildReviewChildSummaries_AllPending(t *testing.T) {
+	// All children present but idle (no state, no message).
+	got := dashboard.BuildReviewChildSummaries(buildChildren(1, nil, nil))
+	for i, s := range got {
+		if s.Verdict != dashboard.VerdictPending {
+			t.Errorf("summary[%d].Verdict = %q, want pending", i, s.Verdict)
+		}
+	}
+}
+
+func TestBuildReviewChildSummaries_StartupErrorChild(t *testing.T) {
+	// All present; one is in error state. The error must surface as VerdictError.
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>pass</verdict>"
+	}
+	// Force the first canonical agent into error state.
+	states[agents[0].Name] = "error"
+	msgs[agents[0].Name] = ""
+
+	got := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	if got[0].Verdict != dashboard.VerdictError {
+		t.Errorf("summary[0].Verdict = %q, want error", got[0].Verdict)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Verdict != dashboard.VerdictPass {
+			t.Errorf("summary[%d].Verdict = %q, want pass", i, got[i].Verdict)
+		}
+	}
+}
+
+func TestBuildReviewChildSummaries_MissingChildBecomesError(t *testing.T) {
+	// Construct only two of the canonical agents — the other three slots must
+	// render as VerdictError (✕) per the AC ("missing agents as ✕").
+	agents := review.Agents()
+	full0 := agents[0].Name
+	full1 := agents[1].Name
+
+	children := []dashboard.AgentSession{
+		{
+			Name:        "repo@branch~review-1-" + full0,
+			AgentState:  "finished",
+			LastMessage: "<verdict>pass</verdict>",
+		},
+		{
+			Name:        "repo@branch~review-1-" + full1,
+			AgentState:  "active",
+			LastMessage: "",
+		},
+	}
+	got := dashboard.BuildReviewChildSummaries(children)
+	if len(got) != len(agents) {
+		t.Fatalf("got %d summaries, want %d (one per canonical agent)", len(got), len(agents))
+	}
+	if got[0].Verdict != dashboard.VerdictPass {
+		t.Errorf("summary[0].Verdict = %q, want pass", got[0].Verdict)
+	}
+	if got[1].Verdict != dashboard.VerdictRunning {
+		t.Errorf("summary[1].Verdict = %q, want running", got[1].Verdict)
+	}
+	for i := 2; i < len(got); i++ {
+		if got[i].Verdict != dashboard.VerdictError {
+			t.Errorf("summary[%d].Verdict = %q (agent %q), want error", i, got[i].Verdict, got[i].AgentShortName)
+		}
+	}
+}
+
+// ── RenderReviewSummary: width-budget truncation ────────────────────────────
+
+func TestRenderReviewSummary_FullBudgetRendersAll(t *testing.T) {
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, nil, nil))
+	// Plenty of width.
+	cluster, labels, tail, _ := dashboard.RenderReviewSummary(summaries, 200)
+	if cluster == "" {
+		t.Errorf("cluster empty at full budget")
+	}
+	if labels == "" {
+		t.Errorf("labels empty at full budget")
+	}
+	if tail == "" {
+		t.Errorf("tail empty at full budget")
+	}
+}
+
+func TestRenderReviewSummary_NarrowDropsLabels(t *testing.T) {
+	// Budget large enough for cluster + tail but not labels.
+	// cluster=5, gap=2, tail="5/5 done"=8 → need 15 for cluster+tail.
+	// labels for canonical agents = sum of "name:X" + separators.
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, nil, nil))
+	tail := "5/5 done"
+	_ = tail
+	cluster, labels, gotTail, _ := dashboard.RenderReviewSummary(summaries, 20)
+	if cluster == "" {
+		t.Errorf("cluster empty at budget=20")
+	}
+	if labels != "" {
+		t.Errorf("labels should be empty at budget=20, got %q", stripANSI(labels))
+	}
+	if gotTail == "" {
+		t.Errorf("tail should be visible at budget=20, got empty")
+	}
+}
+
+func TestRenderReviewSummary_VeryNarrowKeepsCluster(t *testing.T) {
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, nil, nil))
+	// Cluster is 5 glyphs.
+	cluster, labels, tail, _ := dashboard.RenderReviewSummary(summaries, 5)
+	if cluster == "" {
+		t.Errorf("cluster should be visible at budget=5")
+	}
+	if labels != "" || tail != "" {
+		t.Errorf("labels/tail should be empty at budget=5; labels=%q tail=%q", labels, tail)
+	}
+}
+
+func TestRenderReviewSummary_TooNarrowReturnsEmpty(t *testing.T) {
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, nil, nil))
+	cluster, labels, tail, w := dashboard.RenderReviewSummary(summaries, 4)
+	if cluster != "" || labels != "" || tail != "" {
+		t.Errorf("all fragments must be empty at budget=4; got cluster=%q labels=%q tail=%q", cluster, labels, tail)
+	}
+	if w != 0 {
+		t.Errorf("plainWidth = %d, want 0", w)
+	}
+}
+
+// ── Progress tail text ───────────────────────────────────────────────────────
+
+func TestProgressTail_AllPass(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>pass</verdict>"
+	}
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	_, _, tail, _ := dashboard.RenderReviewSummary(summaries, 200)
+	if !strings.Contains(stripANSI(tail), "all pass") {
+		t.Errorf("tail = %q, want to contain 'all pass'", stripANSI(tail))
+	}
+}
+
+func TestProgressTail_AllFail(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>fail</verdict>"
+	}
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	_, _, tail, _ := dashboard.RenderReviewSummary(summaries, 200)
+	if !strings.Contains(stripANSI(tail), "all fail") {
+		t.Errorf("tail = %q, want to contain 'all fail'", stripANSI(tail))
+	}
+}
+
+func TestProgressTail_PartialCounts(t *testing.T) {
+	// 2 pass, 1 fail, 2 running → terminal count = 3 → "3/5 done"
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for i, a := range agents {
+		switch i {
+		case 0, 1:
+			states[a.Name] = "finished"
+			msgs[a.Name] = "<verdict>pass</verdict>"
+		case 2:
+			states[a.Name] = "finished"
+			msgs[a.Name] = "<verdict>fail</verdict>"
+		case 3, 4:
+			states[a.Name] = "active"
+		}
+	}
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	_, _, tail, _ := dashboard.RenderReviewSummary(summaries, 200)
+	if !strings.Contains(stripANSI(tail), "3/5 done") {
+		t.Errorf("tail = %q, want to contain '3/5 done'", stripANSI(tail))
+	}
+}
+
+func TestProgressTail_ErrorCountsAsTerminal(t *testing.T) {
+	// 1 pass, 1 error, 3 running → terminal count = 2 → "2/5 done"
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for i, a := range agents {
+		switch i {
+		case 0:
+			states[a.Name] = "finished"
+			msgs[a.Name] = "<verdict>pass</verdict>"
+		case 1:
+			states[a.Name] = "error"
+		default:
+			states[a.Name] = "active"
+		}
+	}
+	summaries := dashboard.BuildReviewChildSummaries(buildChildren(1, states, msgs))
+	_, _, tail, _ := dashboard.RenderReviewSummary(summaries, 200)
+	if !strings.Contains(stripANSI(tail), "2/5 done") {
+		t.Errorf("tail = %q, want to contain '2/5 done'", stripANSI(tail))
+	}
+}
+
+// ── Integration: collapsed group row contains cluster + labels + tail ───────
+
+// renderCollapsedReviewRow is a small test helper that constructs a dashboard
+// Shared, populates a single review-round with the supplied per-agent states
+// + last messages, and returns the rendered row (ANSI-stripped) for the
+// collapsed group.
+func renderCollapsedReviewRow(t *testing.T, width int, states map[string]string, msgs map[string]string) string {
+	t.Helper()
+	agents := review.Agents()
+	sessions := []dashboard.AgentSession{
+		{Name: "repo@feature", AgentState: "active", AgentName: "worker"},
+	}
+	for _, a := range agents {
+		// Only include the child if state is set (so we can test the missing-child case).
+		st, hasState := states[a.Name]
+		if !hasState {
+			continue
+		}
+		sessions = append(sessions, dashboard.AgentSession{
+			Name:        "repo@feature~review-1-" + a.Name,
+			AgentState:  st,
+			LastMessage: msgs[a.Name],
+		})
+	}
+	d := dashboard.Shared{
+		Width:    width,
+		Sessions: sessions,
+	}
+	d = dashboard.RefilterShared(d)
+	out := dashboard.DashView(d, "", false)
+	plain := stripANSI(out)
+
+	// Extract the line containing "~review-1".
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "~review-1") {
+			return line
+		}
+	}
+	t.Fatalf("no ~review-1 line in output:\n%s", plain)
+	return ""
+}
+
+func TestCollapsedRow_AllPass(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>pass</verdict>"
+	}
+	row := renderCollapsedReviewRow(t, 200, states, msgs)
+	// Five filled circles.
+	if strings.Count(row, "●") != 5 {
+		t.Errorf("expected 5 ● glyphs in row, got %d; row=%q", strings.Count(row, "●"), row)
+	}
+	if !strings.Contains(row, "all pass") {
+		t.Errorf("row missing 'all pass'; row=%q", row)
+	}
+	// Per-agent labels: every canonical short name appears followed by :P
+	for _, a := range agents {
+		short := dashboard.ShortAgentName(a.Name)
+		want := short + ":P"
+		if !strings.Contains(row, want) {
+			t.Errorf("row missing %q; row=%q", want, row)
+		}
+	}
+}
+
+func TestCollapsedRow_MixedPassFail(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for i, a := range agents {
+		states[a.Name] = "finished"
+		if i%2 == 0 {
+			msgs[a.Name] = "<verdict>pass</verdict>"
+		} else {
+			msgs[a.Name] = "<verdict>fail</verdict>"
+		}
+	}
+	row := renderCollapsedReviewRow(t, 200, states, msgs)
+	// Glyphs: alternating ● and ○.
+	if strings.Count(row, "●") < 1 || strings.Count(row, "○") < 1 {
+		t.Errorf("expected both ● and ○ glyphs; row=%q", row)
+	}
+	// Progress tail: terminal count = 5 (all finished with verdicts) but mixed
+	// → falls into "5/5 done" (because neither all-pass nor all-fail).
+	if !strings.Contains(row, "5/5 done") {
+		t.Errorf("row missing '5/5 done'; row=%q", row)
+	}
+}
+
+func TestCollapsedRow_TwoRunning(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for i, a := range agents {
+		switch i {
+		case 0:
+			states[a.Name] = "active"
+		case 1:
+			states[a.Name] = "waiting"
+		default:
+			states[a.Name] = "finished"
+			msgs[a.Name] = "<verdict>pass</verdict>"
+		}
+	}
+	row := renderCollapsedReviewRow(t, 200, states, msgs)
+	// Two ◐ glyphs (running) and three ●.
+	if strings.Count(row, "◐") != 2 {
+		t.Errorf("expected 2 ◐ glyphs, got %d; row=%q", strings.Count(row, "◐"), row)
+	}
+	if strings.Count(row, "●") != 3 {
+		t.Errorf("expected 3 ● glyphs, got %d; row=%q", strings.Count(row, "●"), row)
+	}
+	if !strings.Contains(row, "3/5 done") {
+		t.Errorf("row missing '3/5 done'; row=%q", row)
+	}
+	// Running letter is ◌ — at least two should be present.
+	if strings.Count(row, "◌") < 2 {
+		t.Errorf("expected >=2 ◌ letters in labels, got %d; row=%q", strings.Count(row, "◌"), row)
+	}
+}
+
+func TestCollapsedRow_AllPending(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "" // idle
+	}
+	row := renderCollapsedReviewRow(t, 200, states, nil)
+	if strings.Count(row, "·") < 5 {
+		t.Errorf("expected at least 5 · in row (5 glyphs + 5 letters), got %d; row=%q",
+			strings.Count(row, "·"), row)
+	}
+	if !strings.Contains(row, "0/5 done") {
+		t.Errorf("row missing '0/5 done'; row=%q", row)
+	}
+}
+
+func TestCollapsedRow_StartupErrorChild(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>pass</verdict>"
+	}
+	// Force the first agent into error.
+	states[agents[0].Name] = "error"
+	msgs[agents[0].Name] = ""
+
+	row := renderCollapsedReviewRow(t, 200, states, msgs)
+	if !strings.Contains(row, "✕") {
+		t.Errorf("expected ✕ (error glyph or letter) in row; row=%q", row)
+	}
+	// Terminal count: 4 pass + 1 error = 5 → not uniform-pass / uniform-fail → "5/5 done"
+	if !strings.Contains(row, "5/5 done") {
+		t.Errorf("row missing '5/5 done'; row=%q", row)
+	}
+}
+
+func TestCollapsedRow_MissingChildren(t *testing.T) {
+	// Only include the first canonical agent; the remaining four slots are
+	// missing → must render as ✕ and the tail must still use /5 as denominator.
+	agents := review.Agents()
+	states := map[string]string{
+		agents[0].Name: "active",
+	}
+	row := renderCollapsedReviewRow(t, 200, states, nil)
+	if strings.Count(row, "✕") < 4 {
+		t.Errorf("expected at least 4 ✕ for missing agents, got %d; row=%q",
+			strings.Count(row, "✕"), row)
+	}
+	if !strings.Contains(row, "/5") {
+		t.Errorf("tail must still use /5 denominator; row=%q", row)
+	}
+}
+
+// ── Narrow-width truncation ──────────────────────────────────────────────────
+
+func TestCollapsedRow_NarrowDropsLabels(t *testing.T) {
+	// At width=80, all the leaf-row columns are present and the session column
+	// is grown to absorb surplus, leaving a small trailing budget that fits
+	// the cluster + tail but not the per-agent labels.
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>pass</verdict>"
+	}
+	row := renderCollapsedReviewRow(t, 80, states, msgs)
+	// Cluster still visible.
+	if strings.Count(row, "●") < 5 {
+		t.Errorf("expected 5 ● in narrow row, got %d; row=%q", strings.Count(row, "●"), row)
+	}
+	// Per-agent labels (look for "goal:") should be absent at narrow widths.
+	if strings.Contains(row, "goal:") {
+		t.Errorf("expected per-agent labels to be dropped at narrow width; row=%q", row)
+	}
+}
+
+func TestCollapsedRow_VeryNarrowKeepsClusterFloor(t *testing.T) {
+	// At very narrow widths, only the original row content (label + state)
+	// remains visible. The cluster never collapses while it fits, but if even
+	// the cluster does not fit, the row still renders without crash.
+	agents := review.Agents()
+	states := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "active"
+	}
+	row := renderCollapsedReviewRow(t, 60, states, nil)
+	// Row must at least contain the group label.
+	if !strings.Contains(row, "~review-1") {
+		t.Errorf("group label must remain visible at narrow width; row=%q", row)
+	}
+}
+
+// ── Expanded state: parent row still shows summary ───────────────────────────
+
+func TestCollapsedRow_ExpandedStillShowsSummary(t *testing.T) {
+	agents := review.Agents()
+	states := map[string]string{}
+	msgs := map[string]string{}
+	for _, a := range agents {
+		states[a.Name] = "finished"
+		msgs[a.Name] = "<verdict>pass</verdict>"
+	}
+
+	sessions := []dashboard.AgentSession{
+		{Name: "repo@feature", AgentState: "active", AgentName: "worker"},
+	}
+	for _, a := range agents {
+		sessions = append(sessions, dashboard.AgentSession{
+			Name:        "repo@feature~review-1-" + a.Name,
+			AgentState:  states[a.Name],
+			LastMessage: msgs[a.Name],
+		})
+	}
+
+	d := dashboard.Shared{
+		Width:           200,
+		Sessions:        sessions,
+		CollapsedGroups: map[string]bool{"repo@feature~review-1": true}, // expanded
+	}
+	d = dashboard.RefilterShared(d)
+	out := stripANSI(dashboard.DashView(d, "", false))
+
+	// Find the group line (the one with "~review-1" but not a per-agent suffix
+	// like "review-1-review-goal").
+	var groupLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "~review-1") && !strings.Contains(line, "~review-1-review-") {
+			groupLine = line
+			break
+		}
+	}
+	if groupLine == "" {
+		t.Fatalf("group line not found in expanded output:\n%s", out)
+	}
+	// Summary must still be present on the parent row when expanded.
+	if strings.Count(groupLine, "●") != 5 {
+		t.Errorf("expanded group row missing cluster; line=%q", groupLine)
+	}
+	if !strings.Contains(groupLine, "all pass") {
+		t.Errorf("expanded group row missing 'all pass' tail; line=%q", groupLine)
+	}
+	// And per-agent child rows must be visible.
+	childCount := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "~review-1-review-") {
+			childCount++
+		}
+	}
+	if childCount == 0 {
+		t.Errorf("no per-agent child rows visible in expanded output:\n%s", out)
+	}
+}
+
+// ── Non-review group rows visually unchanged ─────────────────────────────────
+
+func TestNonReviewRowsUnchanged(t *testing.T) {
+	// A plain top-level + a regular depth-1 child (non-review branch) must not
+	// pick up any cluster glyphs.
+	sessions := []dashboard.AgentSession{
+		{Name: "repo@main", AgentState: "active", AgentName: "coordinator"},
+		{Name: "repo@feature", AgentState: "finished", AgentName: "worker"},
+	}
+	d := dashboard.Shared{Width: 200, Sessions: sessions}
+	d = dashboard.RefilterShared(d)
+	out := stripANSI(dashboard.DashView(d, "", false))
+
+	// None of the cluster glyphs should appear on these rows.
+	for _, glyph := range []string{"●", "○", "◐", "✕"} {
+		if strings.Contains(out, glyph) {
+			t.Errorf("non-review rows should not contain glyph %q; output=\n%s", glyph, out)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -42,6 +42,17 @@ type AgentSession struct {
 	// IsReviewGroup marks a virtual ~review-N group row (not a real session).
 	// Selecting this row in the picker toggles expand/collapse rather than switching.
 	IsReviewGroup bool
+	// LastMessage is the most recent assistant message payload for this
+	// session, when available. It is populated only for per-agent review
+	// sessions (i.e. those with a non-empty ReviewRoundKey) so that
+	// BuildDisplayRows can derive per-child verdicts when constructing the
+	// virtual review-group row. Empty for all other rows. See #1795.
+	LastMessage string
+	// ReviewChildSummaries is populated on virtual IsReviewGroup rows. One
+	// entry per canonical review agent in the order returned by
+	// review.Agents(). Empty on non-group rows. See review_summary.go for
+	// the rendering helpers. See #1795.
+	ReviewChildSummaries []ReviewChildSummary
 }
 
 // StatusToAgentSession converts a db.Status into an AgentSession.
@@ -310,10 +321,11 @@ func BuildDisplayRows(sessions []AgentSession, collapsedGroups map[string]bool, 
 		// Emit the virtual group row.
 		// Use the first child's path/harness for context (or empty).
 		groupRow := AgentSession{
-			Name:          currentGroupKey,
-			AgentState:    esc,
-			AgentPath:     currentChildren[0].AgentPath,
-			IsReviewGroup: true,
+			Name:                 currentGroupKey,
+			AgentState:           esc,
+			AgentPath:            currentChildren[0].AgentPath,
+			IsReviewGroup:        true,
+			ReviewChildSummaries: BuildReviewChildSummaries(currentChildren),
 		}
 		out = append(out, groupRow)
 		if expanded {

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -11,6 +11,13 @@ import (
 // RenderReviewGroupRow renders a virtual review-round group row (collapsed or
 // expanded). treePrefix is the depth-1 connector ("  ├── " or "  └── ").
 // expanded controls whether the ▼ (expanded) or ▶ (collapsed) indicator is shown.
+//
+// When s.ReviewChildSummaries is non-empty, the row also renders the
+// per-agent status cluster (●○◐·✕), the per-agent verdict labels
+// ("goal:P  code:F  …"), and the progress tail ("3/5 done" or "all pass")
+// after the state column, subject to the available width budget. The cluster
+// is the floor — it never collapses while it fits; the per-agent labels are
+// dropped first, the progress tail second. See #1795.
 func RenderReviewGroupRow(
 	d Shared,
 	s AgentSession,
@@ -52,12 +59,42 @@ func RenderReviewGroupRow(
 	}
 	sessionArea := treePrefix + fmt.Sprintf("%-*s", totalSessionW-runeCount, content)
 
+	// Compute the trailing summary fragments (cluster + labels + tail) if
+	// per-child summaries are populated. The width budget is whatever is
+	// left of d.Width after the leading session area + state column + the
+	// fixed gaps. We deliberately budget only against d.Width, not the
+	// other columns rendered by leaf rows — the group row's trailing area
+	// is independent of the leaf rows' type / model / harness / stat / title
+	// columns; it just consumes whatever horizontal space remains.
+	var clusterStr, labelsStr, tailStr string
+	var trailingPlainW int
+	if len(s.ReviewChildSummaries) > 0 && d.Width > 0 {
+		// Bytes consumed so far in the plain (un-styled) layout:
+		//   leading space (1) + dot (2) + sessionArea (totalSessionW) +
+		//   gap (2) + state label (stateW) + gap (2) = consumed.
+		consumed := 1 + 2 + totalSessionW + 2 + stateW + 2
+		budget := d.Width - consumed
+		if budget < 0 {
+			budget = 0
+		}
+		clusterStr, labelsStr, tailStr, trailingPlainW = RenderReviewSummary(s.ReviewChildSummaries, budget)
+	}
+
 	if isSelected && cursorActive {
 		barBg := lipgloss.Color(ColorSecondary)
 		if c, ok := stateStyle(s.AgentState).GetForeground().(lipgloss.Color); ok {
 			barBg = c
 		}
 		plain := fmt.Sprintf(" %s%s  %-*s", dot, sessionArea, stateW, stateLabel(s.AgentState))
+		if clusterStr != "" {
+			// The selected-row bar uses lipgloss.Width(...).Render(plain),
+			// which would strip the cluster colours under the bar. Render
+			// the trailing summary as plain text (no per-glyph colour) when
+			// the row is selected so the bar bg stays uniform and the glyphs
+			// stay readable in foreground/background contrast. The labels
+			// and tail follow the same drop-order rules.
+			plain += "  " + plainSummaryForBudget(s.ReviewChildSummaries, labelsStr != "", tailStr != "")
+		}
 		row := lipgloss.NewStyle().
 			Foreground(lipgloss.Color(ColorBg0)).
 			Background(barBg).
@@ -77,7 +114,51 @@ func RenderReviewGroupRow(
 	labelPart := styleDim.Render(fmt.Sprintf("%-*s", totalSessionW-runeCount, content))
 	prefix := treePart + labelPart
 	row := prefix + styleFg.Render("  ") + stateStr
+	if clusterStr != "" {
+		row += styleFg.Render("  ") + clusterStr
+		if labelsStr != "" {
+			row += styleFg.Render("  ") + labelsStr
+		}
+		if tailStr != "" {
+			row += styleFg.Render("  ") + tailStr
+		}
+	}
+	_ = trailingPlainW
 	return row + "\n"
+}
+
+// plainSummaryForBudget renders the cluster + (optionally) labels +
+// (optionally) tail as a plain (unstyled) string for use inside the
+// selected-row bar, where lipgloss's Width().Render would interact poorly
+// with per-glyph colours. The includeLabels / includeTail flags must match
+// the budget decisions made by RenderReviewSummary so the selected and
+// unselected renders have the same width footprint.
+func plainSummaryForBudget(summaries []ReviewChildSummary, includeLabels, includeTail bool) string {
+	if len(summaries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, sm := range summaries {
+		b.WriteString(glyphForVerdict(sm.Verdict))
+	}
+	if includeLabels {
+		b.WriteString("  ")
+		for i, sm := range summaries {
+			if i > 0 {
+				b.WriteString("  ")
+			}
+			b.WriteString(sm.AgentShortName)
+			b.WriteString(":")
+			b.WriteString(letterForVerdict(sm.Verdict))
+		}
+	}
+	if includeTail {
+		if tail := reviewSummaryTailText(summaries); tail != "" {
+			b.WriteString("  ")
+			b.WriteString(tail)
+		}
+	}
+	return b.String()
 }
 
 // DashView is the shared rendering function for both popup and persistent modes.


### PR DESCRIPTION
Closes #1795

## What changed

The collapsed `~review-N` group row in the dashboard now shows two new visual elements:

- a **five-glyph cluster** (`●○◐·✕`) — one glyph per canonical review agent in the order defined by `internal/review.Agents()`;
- **per-agent verdict labels** (`goal:P  code:F  sec:◌  qa:·  context:✕`) followed by a progress tail (`3/5 done`, or `all pass` / `all fail` when uniform).

### Before
```
  └── ▶ ~review-1   waiting
```

### After (full width)
```
  └── ▶ ~review-1   waiting   ◐◐●●●   goal:◌  code:◌  sec:P  qa:P  context:P   3/5 done
```

### After (narrow width — labels drop, cluster + tail stay)
```
  └── ▶ ~review-1   waiting   ◐◐●●●   3/5 done
```

### After (very narrow — cluster collapses last, label + state remain)
```
  └── ▶ ~review-1   waiting
```

## Data flow

- `db.GroupResults(group_id)` is called once per unique review group per `FetchSessionsFromDB` refresh and the per-child `LastMessage` is attached to the corresponding `AgentSession`. Review groups are bounded in number so this is a small fixed cost per refresh.
- `BuildDisplayRows` aggregates the children into `AgentSession.ReviewChildSummaries` on the virtual group row.
- `RenderReviewGroupRow` renders the cluster / labels / tail when summaries are populated, falling back to today's render when empty (pre-migration and non-review group rows are unaffected).

Verdict detection reuses the same case-insensitive substring match for `<verdict>pass</verdict>` / `<verdict>fail</verdict>` that `internal/db/sessions.go::ReviewVerdict` already uses — no regex, no XML parsing.

## Canonical agent list

The canonical five-agent order is read from `review.Agents()` in `internal/review/agents.go`. The issue body's *example* (`goal`, `code`, `arch`, `security`, `rubric`) is illustrative; the actual canonical list today is `goal`, `code`, `security`, `qa`, `context`. The AC and the implementation note both specify that the dashboard must read this list from `internal/review/agents.go` rather than duplicating it, so the implementation uses the live canonical list. Short labels are derived via `ShortAgentName()` — `review-security` → `sec`; all others strip the `review-` prefix.

## Files

- **New**: `internal/dashboard/review_summary.go` — `ReviewChildSummary` type, `ParseVerdict`, `ShortAgentName`, `BuildReviewChildSummaries`, `RenderReviewSummary`, glyph / letter / colour tables.
- **New**: `internal/dashboard/review_summary_test.go` — all six AC-required cases plus integration tests for collapsed/expanded rendering, narrow-width truncation, and missing children.
- **Modified**: `internal/dashboard/sessions.go` — widened `AgentSession` with `LastMessage` + `ReviewChildSummaries`; `BuildDisplayRows.flush()` populates summaries on the synthetic group row.
- **Modified**: `internal/dashboard/poll.go` — `attachReviewLastMessages` calls `db.GroupResults` per unique review group_id and writes `LastMessage` onto each per-agent session.
- **Modified**: `internal/dashboard/view.go` — `RenderReviewGroupRow` rewritten to render cluster + labels + tail with width-adaptive truncation; selected-row bar uses a plain-text variant to keep the bar background uniform.

## Quality gates

- `go build ./...` — pass
- `go test ./...` — pass (full suite)
- `go vet ./...` — pass
- `nix build .#prism` — pass

## Coordination with #1794 (`prism-nav`)

Per the spawn prompt's coordination note: new types and helpers landed in `internal/dashboard/review_summary.go` (a new file) to minimise rebase risk. The unavoidable edits in `sessions.go` (widening `AgentSession`, populating `ReviewChildSummaries` in `BuildDisplayRows.flush()`) and `view.go` (rewriting `RenderReviewGroupRow`) are tightly scoped — no opportunistic refactors of `SortDisplayed`, `IsDepth2Session`, `Depth2Label`, `ReviewRoundKey`, or the top-level / depth-1 predicates that the nav worker reads.