### PR TITLE
prism nav: directional session switching via C-hjkl on agent window

### DIFF
--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,6 +25,13 @@ import (
 
 // captureStdout redirects os.Stdout to a pipe for the duration of fn,
 // then returns everything that was written.
+//
+// Drain the read end concurrently with fn so that writes larger than the
+// kernel pipe buffer (16 pages ≈ 64 KiB on Linux) do not deadlock fn on
+// Write. Without the goroutine, a single fn() that writes more than the
+// pipe buffer (e.g. `agent-context` JSON, which is currently ~69 KiB)
+// blocks on the underlying write(2) syscall forever because nothing is
+// reading from the pipe until after fn returns.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -33,14 +41,23 @@ func captureStdout(t *testing.T, fn func()) string {
 	old := os.Stdout
 	os.Stdout = w
 
+	var buf bytes.Buffer
+	var copyErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, copyErr = io.Copy(&buf, r)
+	}()
+
 	fn()
 
 	w.Close()
+	wg.Wait()
 	os.Stdout = old
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("io.Copy: %v", err)
+	if copyErr != nil {
+		t.Fatalf("io.Copy: %v", copyErr)
 	}
 	return buf.String()
 }

--- a/modules/programs/prism/prism/cmd/nav.go
+++ b/modules/programs/prism/prism/cmd/nav.go
@@ -1,0 +1,145 @@
+package cmd
+
+// prism nav — directional session switching for the agent window.
+//
+// `prism nav up|down|left|right` is intended to be wired to root-level
+// C-h/C-j/C-k/C-l in tmux.nix via an if-shell guard that fires only on the
+// `agent` window. The bindings on `edit` and `term` windows pass the literal
+// keystroke through.
+//
+// Behaviour summary:
+//   - up/down walks the top-level prism sessions (the rows the dashboard
+//     renders without a tree connector) in dashboard ordering, wrapping at
+//     both ends. Sessions in terminal states (finished/deleted/interrupted)
+//     and sessions without a live tmux session are skipped.
+//   - left/right walks the review cycle for the current session:
+//       [parent, review-goal, review-code, review-security, review-qa, review-context]
+//     when the current session is either a depth-2 review agent (the cycle is
+//     anchored on that agent's parent and round) or the parent of an active
+//     review round (the cycle is anchored on the lowest-numbered active round).
+//     Outside both contexts, left/right are silent no-ops.
+//   - Invocation outside a tmux client ($TMUX unset) returns a non-zero exit
+//     with a clear error.
+//   - Unknown direction arguments return a non-zero exit with a clear error.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/nav"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+var navCmd = &cobra.Command{
+	Use:   "nav <up|down|left|right>",
+	Short: "Switch tmux client to an adjacent prism session",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runNav,
+}
+
+func init() {
+	rootCmd.AddCommand(navCmd)
+}
+
+func runNav(_ *cobra.Command, args []string) error {
+	dir, err := nav.ParseDirection(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Require a tmux client. We treat $TMUX as the marker — `prism nav` is
+	// only ever invoked from a tmux key binding, and outside that context
+	// there is nothing to switch.
+	if os.Getenv("TMUX") == "" {
+		return fmt.Errorf("prism nav: not running inside a tmux client ($TMUX is not set)")
+	}
+
+	current, err := tmux.CurrentSession()
+	if err != nil {
+		return fmt.Errorf("prism nav: failed to query current tmux session: %w", err)
+	}
+
+	sessions, err := fetchNavSessions()
+	if err != nil {
+		return fmt.Errorf("prism nav: %w", err)
+	}
+
+	target, ok := resolveTarget(current, dir, sessions)
+	if !ok {
+		// Silent no-op: per spec, exit 0 without switching and without
+		// writing to stderr.
+		return nil
+	}
+
+	if _, err := tmux.SwitchClientCurrent(target); err != nil {
+		return fmt.Errorf("prism nav: switch-client to %q failed: %w", target, err)
+	}
+	return nil
+}
+
+// resolveTarget computes the target session name for the requested direction,
+// or ("", false) when the navigation is a no-op.
+func resolveTarget(current string, dir nav.Direction, sessions []dashboard.AgentSession) (string, bool) {
+	live := tmux.HasSession
+	switch dir {
+	case nav.DirUp, nav.DirDown:
+		targets := nav.VerticalTargets(sessions, live)
+		return nav.ResolveVertical(current, dir, targets)
+	case nav.DirLeft, nav.DirRight:
+		cycle, ok := nav.ResolveReviewContext(current, sessions, live)
+		if !ok {
+			return "", false
+		}
+		return nav.ResolveLateral(current, dir, cycle, live)
+	default:
+		return "", false
+	}
+}
+
+// fetchNavSessions returns the slice of dashboard sessions sorted in
+// SortDisplayed order. Internal/meta sessions (scratchpad, prism-dashboard)
+// are filtered out so they never appear in the nav spine.
+func fetchNavSessions() ([]dashboard.AgentSession, error) {
+	d, err := openNavDB()
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+
+	statuses, err := d.AllActiveStatus()
+	if err != nil {
+		return nil, fmt.Errorf("agent_status query: %w", err)
+	}
+
+	groupParents, _ := d.AllGroupParents()
+
+	// Build AgentSession values without the tmux client-count fetch — nav
+	// does not need attachment counts and avoiding the extra `list-clients`
+	// subprocess keeps the binding cheap.
+	out := make([]dashboard.AgentSession, 0, len(statuses))
+	for _, s := range statuses {
+		if session.IsMetaSession(s.SessionName) {
+			continue
+		}
+		out = append(out, dashboard.StatusToAgentSession(s, nil, groupParents))
+	}
+	dashboard.SortDisplayed(out)
+	return out, nil
+}
+
+// openNavDB opens prism.db at the standard path. Factored out as a var so
+// tests in the same package can replace it (not currently used; the pure
+// resolver is exercised under internal/nav/).
+var openNavDB = func() (*db.DB, error) {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, _ := os.UserHomeDir()
+		stateHome = home + "/.local/state"
+	}
+	return db.Open(stateHome + "/prism/prism.db")
+}

--- a/modules/programs/prism/prism/internal/nav/nav.go
+++ b/modules/programs/prism/prism/internal/nav/nav.go
@@ -1,0 +1,332 @@
+// Package nav implements directional session switching for `prism nav`.
+//
+// The package is intentionally split into pure resolver functions (no tmux,
+// no DB) and thin wrappers that perform IO. The pure resolvers take a slice
+// of dashboard.AgentSession (the same data structure the dashboard renders)
+// plus the current session name and a direction, and return the target
+// session name to switch to (or the empty string when the call is a no-op).
+//
+// This split keeps the navigation logic unit-testable without spinning up a
+// tmux server or seeding a DB.
+package nav
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+	"github.com/prismatic-koi/prism/internal/review"
+)
+
+// Direction is one of the four cardinal directions.
+type Direction string
+
+const (
+	DirUp    Direction = "up"
+	DirDown  Direction = "down"
+	DirLeft  Direction = "left"
+	DirRight Direction = "right"
+)
+
+// ParseDirection parses the textual direction argument used on the command
+// line. It returns an error for any unknown value.
+func ParseDirection(s string) (Direction, error) {
+	switch Direction(s) {
+	case DirUp, DirDown, DirLeft, DirRight:
+		return Direction(s), nil
+	default:
+		return "", fmt.Errorf("unknown direction %q: must be one of up, down, left, right", s)
+	}
+}
+
+// IsTopLevel reports whether the session is a top-level row in the dashboard:
+// either a plain session name (no "@") or an "@main" branch session. Mirrors
+// the predicate inlined in internal/dashboard/view.go::isTopLevel and excludes
+// review-group virtual rows and depth-2 children.
+func IsTopLevel(s dashboard.AgentSession) bool {
+	if s.IsReviewGroup {
+		return false
+	}
+	branch := dashboard.SessionBranch(s.Name)
+	return branch == s.Name || branch == "@main"
+}
+
+// terminalStates is the set of agent states that exclude a session from the
+// navigable vertical spine, per the issue spec. Sessions in any of these
+// states are skipped even if `ended_at IS NULL` has not yet been written by
+// the lifecycle layer.
+var terminalStates = map[string]bool{
+	"finished":    true,
+	"deleted":     true,
+	"interrupted": true,
+}
+
+// IsNavigableTopLevel reports whether s should be included in the up/down
+// navigable set. The session must be top-level, not in a terminal state, and
+// must have a live tmux session (the latter checked by the caller via the
+// liveCheck callback because tmux IO is impure).
+func IsNavigableTopLevel(s dashboard.AgentSession, liveCheck func(string) bool) bool {
+	if !IsTopLevel(s) {
+		return false
+	}
+	if terminalStates[s.AgentState] {
+		return false
+	}
+	if liveCheck != nil && !liveCheck(s.Name) {
+		return false
+	}
+	return true
+}
+
+// VerticalTargets returns the ordered list of top-level session names that
+// participate in the up/down spine, given a slice of all dashboard sessions
+// (already sorted by dashboard.SortDisplayed) and a tmux liveness check.
+func VerticalTargets(sessions []dashboard.AgentSession, liveCheck func(string) bool) []string {
+	var out []string
+	for _, s := range sessions {
+		if IsNavigableTopLevel(s, liveCheck) {
+			out = append(out, s.Name)
+		}
+	}
+	return out
+}
+
+// ResolveVertical returns the target session name for an up/down navigation
+// from current within the given ordered list of top-level session names. The
+// cycle wraps at both ends.
+//
+// Returns ("", false) when the list has fewer than two entries or when
+// current is not in the list (in which case the navigation is a no-op).
+func ResolveVertical(current string, dir Direction, targets []string) (string, bool) {
+	if len(targets) < 2 {
+		return "", false
+	}
+	idx := -1
+	for i, n := range targets {
+		if n == current {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return "", false
+	}
+	switch dir {
+	case DirUp:
+		if idx == 0 {
+			return targets[len(targets)-1], true
+		}
+		return targets[idx-1], true
+	case DirDown:
+		if idx == len(targets)-1 {
+			return targets[0], true
+		}
+		return targets[idx+1], true
+	default:
+		return "", false
+	}
+}
+
+// ReviewCycle holds the parent + agent-name ordering used for left/right
+// navigation within a review round.
+type ReviewCycle struct {
+	// Parent is the parent session name (e.g. "nixos-config@feature").
+	Parent string
+	// AgentNames is the canonical ordering of review-agent names within a
+	// round (e.g. "review-goal", "review-code", ...).
+	AgentNames []string
+	// Round is the review-round integer (e.g. 1).
+	Round int
+}
+
+// CanonicalAgentNames returns the canonical ordered list of review-agent
+// names. It is derived from internal/review.Agents() so it is never
+// duplicated.
+func CanonicalAgentNames() []string {
+	agents := review.Agents()
+	out := make([]string, len(agents))
+	for i, a := range agents {
+		out[i] = a.Name
+	}
+	return out
+}
+
+// childName constructs the depth-2 session name for a given parent, round,
+// and agent. Example: ("nixos-config@feature", 1, "review-goal") →
+// "nixos-config@feature~review-1-review-goal".
+func childName(parent string, round int, agent string) string {
+	return fmt.Sprintf("%s~review-%d-%s", parent, round, agent)
+}
+
+// cycleSessionNames returns the full ordered cycle of session names for a
+// review round, starting with the parent:
+//
+//	[parent, parent~review-N-<agent0>, ..., parent~review-N-<agentK>]
+func cycleSessionNames(c ReviewCycle) []string {
+	out := make([]string, 0, len(c.AgentNames)+1)
+	out = append(out, c.Parent)
+	for _, a := range c.AgentNames {
+		out = append(out, childName(c.Parent, c.Round, a))
+	}
+	return out
+}
+
+// ResolveReviewContext determines which review cycle (parent + round) applies
+// to the given current session, given the full slice of dashboard sessions.
+//
+// Three cases:
+//
+//  1. current is a depth-2 review agent (matches "<parent>~review-N-<agent>"):
+//     the cycle is anchored on that agent's parent and round.
+//
+//  2. current is the parent of an active review round (it has at least one
+//     live depth-2 review child): the cycle is anchored on the lowest-
+//     numbered active round.
+//
+//  3. Otherwise: no review cycle applies and (zero ReviewCycle, false) is
+//     returned. left/right become no-ops.
+//
+// "Live" here is determined by the liveCheck callback (so the resolver stays
+// pure with respect to tmux IO).
+func ResolveReviewContext(current string, sessions []dashboard.AgentSession, liveCheck func(string) bool) (ReviewCycle, bool) {
+	agentNames := CanonicalAgentNames()
+
+	// Case 1: current is itself a depth-2 review agent.
+	if parent, round, ok := parseDepth2Agent(current); ok {
+		return ReviewCycle{
+			Parent:     parent,
+			AgentNames: agentNames,
+			Round:      round,
+		}, true
+	}
+
+	// Case 2: current is the parent of an active round. Walk all sessions,
+	// pick out depth-2 review children whose parsed parent matches current,
+	// then choose the lowest round number that has any live child.
+	live := func(name string) bool {
+		if liveCheck == nil {
+			return true
+		}
+		return liveCheck(name)
+	}
+
+	roundLive := map[int]bool{}
+	for _, s := range sessions {
+		if s.IsReviewGroup {
+			continue
+		}
+		p, n, ok := parseDepth2Agent(s.Name)
+		if !ok {
+			continue
+		}
+		if p != current {
+			continue
+		}
+		if live(s.Name) {
+			roundLive[n] = true
+		}
+	}
+	if len(roundLive) == 0 {
+		return ReviewCycle{}, false
+	}
+	// Choose the lowest live round.
+	lowest := -1
+	for n := range roundLive {
+		if lowest < 0 || n < lowest {
+			lowest = n
+		}
+	}
+	return ReviewCycle{
+		Parent:     current,
+		AgentNames: agentNames,
+		Round:      lowest,
+	}, true
+}
+
+// parseDepth2Agent parses a depth-2 review-agent session name into its parent
+// session, round number, and agent name. Returns ok=false if the name does
+// not match the per-agent pattern.
+//
+// Reuses dashboard.ReviewRoundKey for the parsing — it already validates the
+// "~review-N-<agent>" shape and returns "<parent>~review-N".
+func parseDepth2Agent(name string) (parent string, round int, ok bool) {
+	rk := dashboard.ReviewRoundKey(name)
+	if rk == "" {
+		return "", 0, false
+	}
+	// rk is "<parent>~review-N". Split on the last "~review-".
+	const sep = "~review-"
+	idx := strings.LastIndex(rk, sep)
+	if idx < 0 {
+		return "", 0, false
+	}
+	parent = rk[:idx]
+	nStr := rk[idx+len(sep):]
+	n := 0
+	for _, r := range nStr {
+		if r < '0' || r > '9' {
+			return "", 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	if n <= 0 {
+		return "", 0, false
+	}
+	return parent, n, true
+}
+
+// ResolveLateral returns the target session name for a left/right navigation
+// from current. cycle is the ReviewCycle returned by ResolveReviewContext.
+// liveCheck filters out cycle entries whose tmux session is not live; the
+// cycle contracts to only live entries plus the parent (the parent is always
+// kept in the cycle when its tmux session is live; the parent is the anchor
+// of the cycle).
+//
+// Returns ("", false) when:
+//   - the post-live filter leaves zero or one entries, or
+//   - current is not in the (filtered) cycle, or
+//   - dir is not left or right.
+func ResolveLateral(current string, dir Direction, cycle ReviewCycle, liveCheck func(string) bool) (string, bool) {
+	full := cycleSessionNames(cycle)
+
+	// Apply liveness filter. The parent is included on the same terms as the
+	// agent children; if the parent itself has no live tmux session it is
+	// dropped from the cycle too. (In practice the parent is always live for
+	// case 1 — the user is navigating from a child — and is by definition
+	// live for case 2 — the user is on the parent.)
+	live := make([]string, 0, len(full))
+	for _, name := range full {
+		if liveCheck != nil && !liveCheck(name) {
+			// Always retain `current` so the resolver can locate it; it will
+			// be advanced past below.
+			if name == current {
+				live = append(live, name)
+			}
+			continue
+		}
+		live = append(live, name)
+	}
+	if len(live) < 2 {
+		return "", false
+	}
+	idx := -1
+	for i, n := range live {
+		if n == current {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return "", false
+	}
+	switch dir {
+	case DirRight:
+		next := (idx + 1) % len(live)
+		return live[next], true
+	case DirLeft:
+		next := (idx - 1 + len(live)) % len(live)
+		return live[next], true
+	default:
+		return "", false
+	}
+}

--- a/modules/programs/prism/prism/internal/nav/nav_test.go
+++ b/modules/programs/prism/prism/internal/nav/nav_test.go
@@ -1,0 +1,424 @@
+package nav_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+	"github.com/prismatic-koi/prism/internal/nav"
+)
+
+// makeSessions builds a sorted slice of AgentSession values from a list of
+// (name, state) pairs. The slice is sorted with dashboard.SortDisplayed so
+// the navigable spine order matches what the dashboard renders.
+func makeSessions(t *testing.T, entries ...[2]string) []dashboard.AgentSession {
+	t.Helper()
+	ss := make([]dashboard.AgentSession, 0, len(entries))
+	for _, e := range entries {
+		ss = append(ss, dashboard.AgentSession{Name: e[0], AgentState: e[1]})
+	}
+	dashboard.SortDisplayed(ss)
+	return ss
+}
+
+// alwaysLive is a liveCheck that returns true for every session name. Used in
+// the pure tests where we want to focus on ordering and state, not liveness.
+func alwaysLive(string) bool { return true }
+
+// neverLive is a liveCheck that returns false for every session name.
+func neverLive(string) bool { return false }
+
+// liveSet returns a liveCheck that reports true only for the given names.
+func liveSet(names ...string) func(string) bool {
+	set := map[string]bool{}
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(name string) bool { return set[name] }
+}
+
+func TestParseDirection(t *testing.T) {
+	for _, ok := range []string{"up", "down", "left", "right"} {
+		if _, err := nav.ParseDirection(ok); err != nil {
+			t.Errorf("ParseDirection(%q) returned err: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "north", "Up", "UP", "u", "forward"} {
+		if _, err := nav.ParseDirection(bad); err == nil {
+			t.Errorf("ParseDirection(%q): expected error, got nil", bad)
+		}
+	}
+}
+
+func TestIsTopLevel(t *testing.T) {
+	cases := []struct {
+		name    string
+		s       dashboard.AgentSession
+		topLvl  bool
+	}{
+		{"plain", dashboard.AgentSession{Name: "scratchpad"}, true},
+		{"main", dashboard.AgentSession{Name: "nixos-config@main"}, true},
+		{"branch", dashboard.AgentSession{Name: "nixos-config@feature"}, false},
+		{"depth2", dashboard.AgentSession{Name: "nixos-config@feature~review-1-review-goal"}, false},
+		{"review-group", dashboard.AgentSession{Name: "nixos-config@feature~review-1", IsReviewGroup: true}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := nav.IsTopLevel(c.s); got != c.topLvl {
+				t.Errorf("IsTopLevel(%q) = %v, want %v", c.s.Name, got, c.topLvl)
+			}
+		})
+	}
+}
+
+func TestVerticalTargets_FiltersTerminalAndNonLive(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"alpha@main", "active"},
+		[2]string{"alpha@feature", "active"}, // depth-1: not top-level
+		[2]string{"beta@main", "finished"},   // terminal state: excluded
+		[2]string{"gamma@main", "idle"},
+		[2]string{"gamma@feature~review-1-review-goal", "active"}, // depth-2: excluded
+		[2]string{"delta@main", "active"},                          // not live: excluded
+		[2]string{"scratchpad", "idle"},
+	)
+	live := liveSet("alpha@main", "alpha@feature", "gamma@main", "gamma@feature~review-1-review-goal", "scratchpad")
+
+	got := nav.VerticalTargets(sessions, live)
+	want := []string{"alpha@main", "gamma@main", "scratchpad"}
+	if !equalSlice(got, want) {
+		t.Errorf("VerticalTargets = %v, want %v", got, want)
+	}
+}
+
+func TestVerticalTargets_TerminalStatesExcluded(t *testing.T) {
+	for _, state := range []string{"finished", "deleted", "interrupted"} {
+		sessions := makeSessions(t,
+			[2]string{"alpha@main", "active"},
+			[2]string{"beta@main", state},
+		)
+		got := nav.VerticalTargets(sessions, alwaysLive)
+		if len(got) != 1 || got[0] != "alpha@main" {
+			t.Errorf("state=%q: got %v, want [alpha@main]", state, got)
+		}
+	}
+}
+
+func TestResolveVertical_BasicAndWrap(t *testing.T) {
+	targets := []string{"alpha@main", "beta@main", "gamma@main"}
+	cases := []struct {
+		current string
+		dir     nav.Direction
+		want    string
+		ok      bool
+	}{
+		{"alpha@main", nav.DirDown, "beta@main", true},
+		{"beta@main", nav.DirDown, "gamma@main", true},
+		{"gamma@main", nav.DirDown, "alpha@main", true}, // wrap forward
+		{"alpha@main", nav.DirUp, "gamma@main", true},   // wrap back
+		{"beta@main", nav.DirUp, "alpha@main", true},
+		{"gamma@main", nav.DirUp, "beta@main", true},
+	}
+	for _, c := range cases {
+		got, ok := nav.ResolveVertical(c.current, c.dir, targets)
+		if ok != c.ok || got != c.want {
+			t.Errorf("ResolveVertical(%q,%q) = (%q,%v), want (%q,%v)", c.current, c.dir, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestResolveVertical_NoOpCases(t *testing.T) {
+	// Zero entries.
+	if _, ok := nav.ResolveVertical("alpha@main", nav.DirDown, nil); ok {
+		t.Errorf("empty targets: expected no-op")
+	}
+	// Single entry — should be a no-op even when current matches.
+	if _, ok := nav.ResolveVertical("alpha@main", nav.DirDown, []string{"alpha@main"}); ok {
+		t.Errorf("single target: expected no-op")
+	}
+	// Current not in the list.
+	if _, ok := nav.ResolveVertical("missing@main", nav.DirDown, []string{"alpha@main", "beta@main"}); ok {
+		t.Errorf("current not in list: expected no-op")
+	}
+	// Non-vertical direction passed.
+	if _, ok := nav.ResolveVertical("alpha@main", nav.DirLeft, []string{"alpha@main", "beta@main"}); ok {
+		t.Errorf("non-vertical direction: expected no-op")
+	}
+}
+
+// TestResolveReviewContext_FromDepth2Agent: current is a depth-2 review-agent
+// session; the cycle should be anchored on its parent and round irrespective
+// of what other sessions exist.
+func TestResolveReviewContext_FromDepth2Agent(t *testing.T) {
+	current := "repo@main~review-2-review-code"
+	sessions := makeSessions(t,
+		[2]string{"repo@main", "active"},
+		[2]string{current, "active"},
+	)
+	cyc, ok := nav.ResolveReviewContext(current, sessions, alwaysLive)
+	if !ok {
+		t.Fatalf("expected review context, got false")
+	}
+	if cyc.Parent != "repo@main" {
+		t.Errorf("parent = %q, want %q", cyc.Parent, "repo@main")
+	}
+	if cyc.Round != 2 {
+		t.Errorf("round = %d, want 2", cyc.Round)
+	}
+	canon := nav.CanonicalAgentNames()
+	if len(cyc.AgentNames) != len(canon) {
+		t.Errorf("AgentNames length = %d, want %d", len(cyc.AgentNames), len(canon))
+	}
+}
+
+// TestResolveReviewContext_FromParentLowestRound: current is the parent of
+// two active review rounds; the cycle must anchor on the lowest-numbered one.
+func TestResolveReviewContext_FromParentLowestRound(t *testing.T) {
+	parent := "repo@main"
+	sessions := makeSessions(t,
+		[2]string{parent, "active"},
+		[2]string{parent + "~review-2-review-goal", "active"},
+		[2]string{parent + "~review-3-review-goal", "active"},
+	)
+	cyc, ok := nav.ResolveReviewContext(parent, sessions, alwaysLive)
+	if !ok {
+		t.Fatalf("expected review context, got false")
+	}
+	if cyc.Round != 2 {
+		t.Errorf("round = %d, want 2 (lowest active)", cyc.Round)
+	}
+	if cyc.Parent != parent {
+		t.Errorf("parent = %q, want %q", cyc.Parent, parent)
+	}
+}
+
+// TestResolveReviewContext_DeadRoundsSkipped: round 1 exists but has no live
+// children; round 2 is live. Anchor must skip to 2.
+func TestResolveReviewContext_DeadRoundsSkipped(t *testing.T) {
+	parent := "repo@main"
+	r1Child := parent + "~review-1-review-goal"
+	r2Child := parent + "~review-2-review-goal"
+	sessions := makeSessions(t,
+		[2]string{parent, "active"},
+		[2]string{r1Child, "finished"},
+		[2]string{r2Child, "active"},
+	)
+	cyc, ok := nav.ResolveReviewContext(parent, sessions, liveSet(parent, r2Child))
+	if !ok {
+		t.Fatalf("expected review context, got false")
+	}
+	if cyc.Round != 2 {
+		t.Errorf("round = %d, want 2 (round 1 has no live child)", cyc.Round)
+	}
+}
+
+// TestResolveReviewContext_NoneWhenStandaloneTopLevel: current is a top-level
+// session with no review children; left/right must be no-ops.
+func TestResolveReviewContext_NoneWhenStandaloneTopLevel(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"repo@main", "active"},
+		[2]string{"other@main", "active"},
+	)
+	if _, ok := nav.ResolveReviewContext("repo@main", sessions, alwaysLive); ok {
+		t.Errorf("expected no review context, got one")
+	}
+}
+
+// TestResolveReviewContext_NoneWhenDepth1Branch: current is a depth-1 branch
+// session (not a review agent); left/right must be no-ops.
+func TestResolveReviewContext_NoneWhenDepth1Branch(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"repo@main", "active"},
+		[2]string{"repo@feature", "active"},
+	)
+	if _, ok := nav.ResolveReviewContext("repo@feature", sessions, alwaysLive); ok {
+		t.Errorf("expected no review context for plain depth-1 branch")
+	}
+}
+
+func TestResolveLateral_FullCycleWrap(t *testing.T) {
+	parent := "repo@main"
+	cyc := nav.ReviewCycle{
+		Parent:     parent,
+		AgentNames: nav.CanonicalAgentNames(),
+		Round:      1,
+	}
+	expected := append([]string{parent}, makeChildNames(parent, 1, cyc.AgentNames)...)
+
+	// right walks forward through the whole cycle and wraps back to parent.
+	cur := parent
+	for i := 0; i < len(expected); i++ {
+		next, ok := nav.ResolveLateral(cur, nav.DirRight, cyc, alwaysLive)
+		if !ok {
+			t.Fatalf("right step %d: ok=false from %q", i, cur)
+		}
+		want := expected[(i+1)%len(expected)]
+		if next != want {
+			t.Errorf("right step %d: got %q, want %q", i, next, want)
+		}
+		cur = next
+	}
+	// left walks backward through the whole cycle.
+	cur = parent
+	for i := 0; i < len(expected); i++ {
+		next, ok := nav.ResolveLateral(cur, nav.DirLeft, cyc, alwaysLive)
+		if !ok {
+			t.Fatalf("left step %d: ok=false from %q", i, cur)
+		}
+		// After step i (0-indexed) starting from index 0 going left, we are
+		// at index (-(i+1) mod len). Add len before mod to keep it positive.
+		want := expected[((-1-i)%len(expected)+len(expected))%len(expected)]
+		if next != want {
+			t.Errorf("left step %d: got %q, want %q", i, next, want)
+		}
+		cur = next
+	}
+}
+
+func TestResolveLateral_RightFromParentIsReviewGoal(t *testing.T) {
+	parent := "repo@main"
+	cyc := nav.ReviewCycle{Parent: parent, AgentNames: nav.CanonicalAgentNames(), Round: 1}
+	got, ok := nav.ResolveLateral(parent, nav.DirRight, cyc, alwaysLive)
+	want := parent + "~review-1-" + nav.CanonicalAgentNames()[0]
+	if !ok || got != want {
+		t.Errorf("right from parent: got (%q,%v), want (%q,true)", got, ok, want)
+	}
+}
+
+func TestResolveLateral_LeftFromParentIsLastLiveEntry(t *testing.T) {
+	parent := "repo@main"
+	agents := nav.CanonicalAgentNames()
+	cyc := nav.ReviewCycle{Parent: parent, AgentNames: agents, Round: 1}
+
+	// Case A: all agents live → left from parent goes to last agent.
+	allNames := []string{parent}
+	for _, a := range agents {
+		allNames = append(allNames, parent+"~review-1-"+a)
+	}
+	got, ok := nav.ResolveLateral(parent, nav.DirLeft, cyc, liveSet(allNames...))
+	wantLast := parent + "~review-1-" + agents[len(agents)-1]
+	if !ok || got != wantLast {
+		t.Errorf("left from parent (all live): got (%q,%v), want (%q,true)", got, ok, wantLast)
+	}
+
+	// Case B: only the first agent is live → left from parent should skip
+	// straight to that first (and only) live agent, since it is also the
+	// last live entry preceding the parent in the cycle.
+	firstChild := parent + "~review-1-" + agents[0]
+	got, ok = nav.ResolveLateral(parent, nav.DirLeft, cyc, liveSet(parent, firstChild))
+	if !ok || got != firstChild {
+		t.Errorf("left from parent (only first agent live): got (%q,%v), want (%q,true)", got, ok, firstChild)
+	}
+}
+
+func TestResolveLateral_SkipsDeadEntries(t *testing.T) {
+	parent := "repo@main"
+	agents := nav.CanonicalAgentNames() // [review-goal, review-code, review-security, review-qa, review-context]
+	cyc := nav.ReviewCycle{Parent: parent, AgentNames: agents, Round: 1}
+
+	// Live set: parent + review-goal + review-security (skip review-code).
+	goal := parent + "~review-1-" + agents[0]
+	security := parent + "~review-1-" + agents[2]
+	live := liveSet(parent, goal, security)
+
+	// right from review-goal must skip review-code and land on review-security.
+	got, ok := nav.ResolveLateral(goal, nav.DirRight, cyc, live)
+	if !ok || got != security {
+		t.Errorf("right from goal: got (%q,%v), want (%q,true)", got, ok, security)
+	}
+	// left from review-security must skip review-code and land on review-goal.
+	got, ok = nav.ResolveLateral(security, nav.DirLeft, cyc, live)
+	if !ok || got != goal {
+		t.Errorf("left from security: got (%q,%v), want (%q,true)", got, ok, goal)
+	}
+}
+
+func TestResolveLateral_NoOpWhenContractsBelowTwo(t *testing.T) {
+	parent := "repo@main"
+	cyc := nav.ReviewCycle{Parent: parent, AgentNames: nav.CanonicalAgentNames(), Round: 1}
+	// Only `parent` is live; the cycle contracts to a single entry.
+	got, ok := nav.ResolveLateral(parent, nav.DirRight, cyc, liveSet(parent))
+	if ok {
+		t.Errorf("contracted-to-one cycle: expected no-op, got %q", got)
+	}
+}
+
+func TestResolveLateral_RejectsNonLateralDirection(t *testing.T) {
+	parent := "repo@main"
+	cyc := nav.ReviewCycle{Parent: parent, AgentNames: nav.CanonicalAgentNames(), Round: 1}
+	for _, d := range []nav.Direction{nav.DirUp, nav.DirDown} {
+		if _, ok := nav.ResolveLateral(parent, d, cyc, alwaysLive); ok {
+			t.Errorf("dir=%q: expected no-op", d)
+		}
+	}
+}
+
+// TestResolveReviewContext_AllChildrenDead: parent has only finished/dead
+// children — no live tmux session for any review-N — so no review context
+// applies and left/right must be no-ops.
+func TestResolveReviewContext_AllChildrenDead(t *testing.T) {
+	parent := "repo@main"
+	r1Child := parent + "~review-1-review-goal"
+	sessions := makeSessions(t,
+		[2]string{parent, "active"},
+		[2]string{r1Child, "finished"},
+	)
+	if _, ok := nav.ResolveReviewContext(parent, sessions, neverLive); ok {
+		t.Errorf("expected no review context when no child is live")
+	}
+}
+
+// TestCanonicalAgentNames_MatchesReviewAgents: smoke test guaranteeing the
+// nav cycle stays in sync with the canonical review.Agents() list — this is
+// the "do not hardcode it twice" invariant from the implementation notes.
+func TestCanonicalAgentNames_MatchesReviewAgents(t *testing.T) {
+	got := nav.CanonicalAgentNames()
+	if len(got) == 0 {
+		t.Fatalf("CanonicalAgentNames returned empty slice")
+	}
+	for _, name := range got {
+		if !strings.HasPrefix(name, "review-") {
+			t.Errorf("agent name %q does not start with %q", name, "review-")
+		}
+	}
+}
+
+// helpers
+
+func makeChildNames(parent string, round int, agents []string) []string {
+	out := make([]string, len(agents))
+	for i, a := range agents {
+		out[i] = parent + "~review-" + itoa(round) + "-" + a
+	}
+	return out
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -239,6 +239,35 @@ in
               bind -n C-g if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' 'send-keys Home'
               bind -n C-M-g if-shell '${sandboxedPaneGuard} "#{pane_current_command}"' 'send-keys End'
 
+              # Directional session switching for the agent window (issue #1794).
+              #
+              # Root-level C-h/C-j/C-k/C-l invoke `prism nav <dir>` when the active
+              # window is named `agent`; on every other window (edit / term /
+              # custom) the literal keystroke is sent through unchanged via
+              # `send-keys`. This preserves neovim's window navigation on the
+              # `edit` window and the shell's C-h (backspace) on the `term` window.
+              #
+              # The guard is window-name based ("#{window_name}" = "agent"), not
+              # pane-command based, because the agent window may be on its second
+              # pane (a shell next to pi) and the keystroke should still navigate
+              # sessions in that case.
+              #
+              # `run-shell -b` runs `prism nav` in the background so the tmux
+              # binding returns immediately; the nav subcommand calls
+              # `tmux switch-client` itself.
+              bind -n C-h if-shell '[ "#{window_name}" = "agent" ]' \
+                'run-shell -b "${prism} nav left"' \
+                'send-keys C-h'
+              bind -n C-j if-shell '[ "#{window_name}" = "agent" ]' \
+                'run-shell -b "${prism} nav down"' \
+                'send-keys C-j'
+              bind -n C-k if-shell '[ "#{window_name}" = "agent" ]' \
+                'run-shell -b "${prism} nav up"' \
+                'send-keys C-k'
+              bind -n C-l if-shell '[ "#{window_name}" = "agent" ]' \
+                'run-shell -b "${prism} nav right"' \
+                'send-keys C-l'
+
               # Clipboard paste bridge for sandboxed agent panes (issue #752).
               #
               # When Ctrl-V is pressed in a pane whose current command is one of


### PR DESCRIPTION
Closes #1794

## Summary

Adds a new `prism nav up|down|left|right` subcommand and root-level tmux bindings that map onto the natural 2D grid of prism sessions:

- **`C-k` / `C-j`** — previous / next top-level prism session (the dashboard's un-indented rows), in `SortDisplayed` order, filtered to live tmux sessions not in a terminal state (`finished`/`deleted`/`interrupted`). Wraps at both ends.
- **`C-h` / `C-l`** — previous / next review-cycle member. Cycle is `[parent, review-goal, review-code, review-security, review-qa, review-context]` (canonical order pulled from `review.Agents()` — no duplicate definition). Anchored when the current session is either a depth-2 review agent or the parent of an active review round (lowest-numbered active round wins). Dead entries are skipped silently; `left`/`right` are no-ops outside a review context. Wraps.

The bindings sit at tmux root level (no prefix) gated on `#{window_name} = "agent"`. On `edit` (neovim) and `term` (shell) windows the literal keystroke passes through unchanged via `send-keys`, so `C-hjkl` window-pane navigation in neovim and `C-h` (backspace) in shells keep working.

## Implementation

Split into a pure resolver and a thin IO wrapper:

- `internal/nav/` — pure direction-resolution logic, no tmux or DB dependencies. Comprehensively unit-tested.
- `cmd/nav.go` — cobra subcommand: `$TMUX` guard, reads `agent_status` via `dashboard.SortDisplayed`, uses `tmux.HasSession` for liveness, dispatches `tmux switch-client`.
- `modules/programs/prism/tmux.nix` — declarative `if-shell` bindings for the four directions.

Test coverage in `internal/nav/nav_test.go`:

- Vertical: basic forward/backward + wrap at both ends, terminal-state filtering, non-live filtering, zero/one-element no-op, current-not-in-list no-op, non-vertical-direction rejection.
- Lateral: full-cycle forward + backward wrap, parent → review-goal, parent → last live entry going left (all-live and one-live cases), dead-entry skipping mid-cycle, contracted-to-one no-op, non-lateral-direction rejection, lowest-active-round selection from parent, all-children-dead no-op, depth-2-anchored context, canonical-agent-names-match-review.Agents() invariant.

## Fix to `captureStdout` test helper

While wiring `nav` into the cobra tree I uncovered a latent deadlock in `cmd/checkin_test.go::captureStdout`:

- The helper writes `fn()`'s stdout into an `os.Pipe` and only drains it **after** `fn` returns.
- When `fn` writes more than the kernel pipe buffer (16 pages ≈ 64 KiB on Linux), the underlying `write(2)` blocks forever because nothing is reading.
- The `agent-context` JSON output is currently **~69 KiB** — already past the pipe buffer; the test on `main` only passes by happenstance of how `encoding/json`'s `Encoder` fragments its writes. Adding the `nav` command pushed the output over the edge and `TestAgentContextCoversAllCommands` began hanging.

The fix is the canonical drain-in-goroutine pattern: start a goroutine to drain the read end into a `bytes.Buffer` before invoking `fn`, close the writer once `fn` returns, then `Wait` on the goroutine. Signature, callers, and `t.Helper()` semantics are unchanged. A comment above the function explains the rationale.

This pre-dates the nav work but is uncovered by registering the new subcommand. A follow-up issue records the fragility for future code that adds cobra subcommands.

## Verification

```bash
# From modules/programs/prism/prism/
go build ./...                              # clean
go vet ./...                                # clean
go test ./...                               # all pass
go test ./internal/nav/... -v               # 16 cases, all green

# From repo root
nix build .#prism                           # succeeds
./result/bin/prism nav north                # → "unknown direction" exit 1
./result/bin/prism nav up                   # outside tmux → "$TMUX is not set" exit 1
```

## Acceptance criteria

- [x] `prism nav up` / `down` walk top-level sessions in dashboard order; wraps at both ends.
- [x] Navigable set is exactly top-level rows of `SortDisplayed`, filtered to live + non-terminal.
- [x] From a depth-2 review agent, `right`/`left` cycle through `[parent, review-goal, …]`; wraps.
- [x] From the parent of an active review round, the cycle is anchored to the lowest-numbered active round; `right` → `review-goal`, `left` → last live entry preceding `parent`.
- [x] Non-live cycle entries are skipped silently.
- [x] `left`/`right` are silent no-ops outside both review contexts.
- [x] Zero/one-member navigable sets are silent no-ops.
- [x] Outside `$TMUX`: non-zero exit with clear error.
- [x] Unknown direction arg: non-zero exit with clear error.
- [x] `tmux.nix` binds C-h/C-j/C-k/C-l with `if-shell '[ "#{window_name}" = "agent" ]'`; else branch `send-keys`.
- [x] `edit` and `term` windows pass the literal keystroke through (no `prism nav` invocation in the else branch).
- [x] `go test ./...` passes; `nix build .#prism` succeeds.