### PR TITLE
prism nav: include depth-1 child sessions in vertical spine

### DIFF
--- a/modules/programs/prism/prism/cmd/nav.go
+++ b/modules/programs/prism/prism/cmd/nav.go
@@ -8,10 +8,11 @@ package cmd
 // keystroke through.
 //
 // Behaviour summary:
-//   - up/down walks the top-level prism sessions (the rows the dashboard
-//     renders without a tree connector) in dashboard ordering, wrapping at
-//     both ends. Sessions in terminal states (finished/deleted/interrupted)
-//     and sessions without a live tmux session are skipped.
+//   - up/down walks every real switchable session in dashboard order
+//     (top-level rows and their depth-1 children), excluding review-group
+//     virtual rows, depth-2 review-agent children, sessions in terminal
+//     states (finished/deleted/interrupted), and sessions without a live
+//     tmux session. The cycle wraps at both ends.
 //   - left/right walks the review cycle for the current session:
 //       [parent, review-goal, review-code, review-security, review-qa, review-context]
 //     when the current session is either a depth-2 review agent (the cycle is

--- a/modules/programs/prism/prism/internal/nav/nav.go
+++ b/modules/programs/prism/prism/internal/nav/nav.go
@@ -39,16 +39,24 @@ func ParseDirection(s string) (Direction, error) {
 	}
 }
 
-// IsTopLevel reports whether the session is a top-level row in the dashboard:
-// either a plain session name (no "@") or an "@main" branch session. Mirrors
-// the predicate inlined in internal/dashboard/view.go::isTopLevel and excludes
-// review-group virtual rows and depth-2 children.
-func IsTopLevel(s dashboard.AgentSession) bool {
+// IsSpineRow reports whether the session is a real switchable row in the
+// dashboard's vertical spine. The spine includes top-level rows AND their
+// depth-1 children (e.g. `nixos-config@dashboard-slim`). It excludes:
+//
+//   - virtual review-group rows (IsReviewGroup == true), and
+//   - depth-2 review-agent children (matching dashboard.IsDepth2Session).
+//
+// This is broader than the original `IsTopLevel` predicate (which only
+// admitted plain or `@main` names) and matches the actual spine the
+// dashboard renders — see issue #1800.
+func IsSpineRow(s dashboard.AgentSession) bool {
 	if s.IsReviewGroup {
 		return false
 	}
-	branch := dashboard.SessionBranch(s.Name)
-	return branch == s.Name || branch == "@main"
+	if dashboard.IsDepth2Session(s.Name) {
+		return false
+	}
+	return true
 }
 
 // terminalStates is the set of agent states that exclude a session from the
@@ -61,12 +69,12 @@ var terminalStates = map[string]bool{
 	"interrupted": true,
 }
 
-// IsNavigableTopLevel reports whether s should be included in the up/down
-// navigable set. The session must be top-level, not in a terminal state, and
-// must have a live tmux session (the latter checked by the caller via the
-// liveCheck callback because tmux IO is impure).
-func IsNavigableTopLevel(s dashboard.AgentSession, liveCheck func(string) bool) bool {
-	if !IsTopLevel(s) {
+// IsNavigableSpine reports whether s should be included in the up/down
+// navigable spine. The session must be a spine row (per IsSpineRow), not in
+// a terminal state, and must have a live tmux session (the latter checked
+// by the caller via the liveCheck callback because tmux IO is impure).
+func IsNavigableSpine(s dashboard.AgentSession, liveCheck func(string) bool) bool {
+	if !IsSpineRow(s) {
 		return false
 	}
 	if terminalStates[s.AgentState] {
@@ -78,13 +86,16 @@ func IsNavigableTopLevel(s dashboard.AgentSession, liveCheck func(string) bool) 
 	return true
 }
 
-// VerticalTargets returns the ordered list of top-level session names that
-// participate in the up/down spine, given a slice of all dashboard sessions
-// (already sorted by dashboard.SortDisplayed) and a tmux liveness check.
+// VerticalTargets returns the ordered list of spine session names that
+// participate in the up/down navigation, given a slice of all dashboard
+// sessions (already sorted by dashboard.SortDisplayed) and a tmux liveness
+// check. Both top-level rows and their depth-1 children are included; the
+// dashboard ordering — `@main` first within each repo, then other branches
+// alphabetically; repos ordered alphabetically — is preserved.
 func VerticalTargets(sessions []dashboard.AgentSession, liveCheck func(string) bool) []string {
 	var out []string
 	for _, s := range sessions {
-		if IsNavigableTopLevel(s, liveCheck) {
+		if IsNavigableSpine(s, liveCheck) {
 			out = append(out, s.Name)
 		}
 	}

--- a/modules/programs/prism/prism/internal/nav/nav_test.go
+++ b/modules/programs/prism/prism/internal/nav/nav_test.go
@@ -50,22 +50,27 @@ func TestParseDirection(t *testing.T) {
 	}
 }
 
-func TestIsTopLevel(t *testing.T) {
+func TestIsSpineRow(t *testing.T) {
 	cases := []struct {
-		name    string
-		s       dashboard.AgentSession
-		topLvl  bool
+		name  string
+		s     dashboard.AgentSession
+		want  bool
 	}{
+		// Top-level rows: included.
 		{"plain", dashboard.AgentSession{Name: "scratchpad"}, true},
 		{"main", dashboard.AgentSession{Name: "nixos-config@main"}, true},
-		{"branch", dashboard.AgentSession{Name: "nixos-config@feature"}, false},
+		// Depth-1 child branches: now included (issue #1800).
+		{"branch", dashboard.AgentSession{Name: "nixos-config@feature"}, true},
+		{"dashboard-slim", dashboard.AgentSession{Name: "nixos-config@dashboard-slim"}, true},
+		// Depth-2 review-agent children: excluded.
 		{"depth2", dashboard.AgentSession{Name: "nixos-config@feature~review-1-review-goal"}, false},
+		// Virtual review-group rows: excluded.
 		{"review-group", dashboard.AgentSession{Name: "nixos-config@feature~review-1", IsReviewGroup: true}, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := nav.IsTopLevel(c.s); got != c.topLvl {
-				t.Errorf("IsTopLevel(%q) = %v, want %v", c.s.Name, got, c.topLvl)
+			if got := nav.IsSpineRow(c.s); got != c.want {
+				t.Errorf("IsSpineRow(%q) = %v, want %v", c.s.Name, got, c.want)
 			}
 		})
 	}
@@ -74,7 +79,7 @@ func TestIsTopLevel(t *testing.T) {
 func TestVerticalTargets_FiltersTerminalAndNonLive(t *testing.T) {
 	sessions := makeSessions(t,
 		[2]string{"alpha@main", "active"},
-		[2]string{"alpha@feature", "active"}, // depth-1: not top-level
+		[2]string{"alpha@feature", "active"}, // depth-1: included (issue #1800)
 		[2]string{"beta@main", "finished"},   // terminal state: excluded
 		[2]string{"gamma@main", "idle"},
 		[2]string{"gamma@feature~review-1-review-goal", "active"}, // depth-2: excluded
@@ -84,9 +89,128 @@ func TestVerticalTargets_FiltersTerminalAndNonLive(t *testing.T) {
 	live := liveSet("alpha@main", "alpha@feature", "gamma@main", "gamma@feature~review-1-review-goal", "scratchpad")
 
 	got := nav.VerticalTargets(sessions, live)
-	want := []string{"alpha@main", "gamma@main", "scratchpad"}
+	want := []string{"alpha@main", "alpha@feature", "gamma@main", "scratchpad"}
 	if !equalSlice(got, want) {
 		t.Errorf("VerticalTargets = %v, want %v", got, want)
+	}
+}
+
+// TestVerticalTargets_Depth1Included_BasicRegression covers the core
+// regression from issue #1800: a fixture with `nixos-config@main` and a
+// depth-1 child `nixos-config@dashboard-slim` (no review groups) must yield
+// both names in dashboard order, and the cycle must connect them.
+func TestVerticalTargets_Depth1Included_BasicRegression(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"nixos-config@main", "active"},
+		[2]string{"nixos-config@dashboard-slim", "active"},
+	)
+	got := nav.VerticalTargets(sessions, alwaysLive)
+	want := []string{"nixos-config@main", "nixos-config@dashboard-slim"}
+	if !equalSlice(got, want) {
+		t.Fatalf("VerticalTargets = %v, want %v", got, want)
+	}
+	if next, ok := nav.ResolveVertical("nixos-config@main", nav.DirDown, got); !ok || next != "nixos-config@dashboard-slim" {
+		t.Errorf("down from @main: got (%q,%v), want (nixos-config@dashboard-slim,true)", next, ok)
+	}
+	if next, ok := nav.ResolveVertical("nixos-config@dashboard-slim", nav.DirDown, got); !ok || next != "nixos-config@main" {
+		t.Errorf("down from @dashboard-slim (wrap): got (%q,%v), want (nixos-config@main,true)", next, ok)
+	}
+	if next, ok := nav.ResolveVertical("nixos-config@main", nav.DirUp, got); !ok || next != "nixos-config@dashboard-slim" {
+		t.Errorf("up from @main (wrap): got (%q,%v), want (nixos-config@dashboard-slim,true)", next, ok)
+	}
+	if next, ok := nav.ResolveVertical("nixos-config@dashboard-slim", nav.DirUp, got); !ok || next != "nixos-config@main" {
+		t.Errorf("up from @dashboard-slim: got (%q,%v), want (nixos-config@main,true)", next, ok)
+	}
+}
+
+// TestVerticalTargets_DashboardOrdering verifies that the spine is ordered
+// per dashboard.SortDisplayed: within each repo `@main` first then other
+// branches alphabetically; repos ordered alphabetically.
+func TestVerticalTargets_DashboardOrdering(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"other-repo@main", "active"},
+		[2]string{"nixos-config@feat-a", "active"},
+		[2]string{"nixos-config@main", "active"},
+	)
+	got := nav.VerticalTargets(sessions, alwaysLive)
+	want := []string{"nixos-config@main", "nixos-config@feat-a", "other-repo@main"}
+	if !equalSlice(got, want) {
+		t.Errorf("VerticalTargets = %v, want %v", got, want)
+	}
+}
+
+// TestVerticalTargets_ExcludesReviewGroupAndDepth2 verifies that review-group
+// virtual rows and depth-2 review-agent children are not part of the up/down
+// spine even though they appear in dashboard rendering.
+func TestVerticalTargets_ExcludesReviewGroupAndDepth2(t *testing.T) {
+	parent := "repo@feature"
+	rgName := parent + "~review-1"
+	d2Name := parent + "~review-1-review-goal"
+	sessions := makeSessions(t,
+		[2]string{"repo@main", "active"},
+		[2]string{parent, "active"},
+		[2]string{d2Name, "active"},
+	)
+	// Inject a virtual review-group row (these are synthesised by the
+	// dashboard layer, not present in the DB; build it directly here).
+	sessions = append(sessions, dashboard.AgentSession{Name: rgName, IsReviewGroup: true, AgentState: "active"})
+	dashboard.SortDisplayed(sessions)
+
+	got := nav.VerticalTargets(sessions, alwaysLive)
+	want := []string{"repo@main", parent}
+	if !equalSlice(got, want) {
+		t.Errorf("VerticalTargets = %v, want %v", got, want)
+	}
+}
+
+// TestVerticalTargets_Depth1OnlyRepo verifies the edge case where a repo has
+// only depth-1 children (no `@main` sibling). Those children must still be
+// rendered in the spine.
+func TestVerticalTargets_Depth1OnlyRepo(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"alpha@main", "active"},
+		[2]string{"orphan@feature-x", "active"},
+		[2]string{"orphan@feature-y", "active"},
+	)
+	got := nav.VerticalTargets(sessions, alwaysLive)
+	// Expect alpha@main, then orphan repo's depth-1 children in alpha order.
+	want := []string{"alpha@main", "orphan@feature-x", "orphan@feature-y"}
+	if !equalSlice(got, want) {
+		t.Errorf("VerticalTargets = %v, want %v", got, want)
+	}
+	// Confirm they cycle.
+	if next, ok := nav.ResolveVertical("orphan@feature-x", nav.DirDown, got); !ok || next != "orphan@feature-y" {
+		t.Errorf("down from orphan@feature-x: got (%q,%v), want (orphan@feature-y,true)", next, ok)
+	}
+}
+
+// TestVerticalTargets_MainOnlyRepo verifies the edge case where a repo has
+// only `@main` and no depth-1 children — unchanged from previous behaviour.
+func TestVerticalTargets_MainOnlyRepo(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"alpha@main", "active"},
+		[2]string{"beta@main", "active"},
+	)
+	got := nav.VerticalTargets(sessions, alwaysLive)
+	want := []string{"alpha@main", "beta@main"}
+	if !equalSlice(got, want) {
+		t.Errorf("VerticalTargets = %v, want %v", got, want)
+	}
+}
+
+// TestVerticalTargets_TerminalStateExcludesDepth1 verifies that depth-1
+// children in terminal states are excluded from the spine, just like
+// top-level rows.
+func TestVerticalTargets_TerminalStateExcludesDepth1(t *testing.T) {
+	for _, state := range []string{"finished", "deleted", "interrupted"} {
+		sessions := makeSessions(t,
+			[2]string{"repo@main", "active"},
+			[2]string{"repo@feature", state},
+		)
+		got := nav.VerticalTargets(sessions, alwaysLive)
+		if len(got) != 1 || got[0] != "repo@main" {
+			t.Errorf("depth-1 state=%q: got %v, want [repo@main]", state, got)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes the `prism nav up`/`down` spine so depth-1 child sessions
(e.g. `nixos-config@dashboard-slim`) are part of the cycle.

## Problem

`internal/nav/nav.go::IsTopLevel` mirrored `internal/dashboard/view.go::isTopLevel`
literally — accepting only plain session names or `@main` branches. But the
dashboard's rendered spine is broader: a non-`@main` session is always a real
switchable row (rendered as depth-1 child when an `@main` sibling exists,
otherwise as a top-level row). Two observable bugs followed:

1. From `<repo>@main`, `C-j` skipped over `<repo>@feature`.
2. From `<repo>@feature`, `C-j`/`C-k` was a silent no-op (the current session
   wasn't in the navigable list, so `ResolveVertical` returned `(\"\", false)`).

## Fix

`internal/nav/nav.go`:
- `IsTopLevel` → `IsSpineRow`. New predicate: `!s.IsReviewGroup && !dashboard.IsDepth2Session(s.Name)`.
- `IsNavigableTopLevel` → `IsNavigableSpine`. Terminal-state and liveness filters unchanged.
- `VerticalTargets` continues to use the renamed predicate; dashboard ordering is
  preserved (via `dashboard.SortDisplayed`).

`cmd/nav.go`:
- Doc comment updated to describe the new (correct) spine.

`internal/nav/nav_test.go`:
- Updated the renamed-predicate test and the `FiltersTerminalAndNonLive`
  fixture (depth-1 `alpha@feature` now expected in the result).
- New regression tests:
  - basic regression: `nixos-config@main` + `nixos-config@dashboard-slim`
    cycle in both directions with wrap;
  - dashboard ordering across repos with `@feat-a` interleaved;
  - virtual review-group rows and depth-2 children excluded;
  - depth-1-only repo edge case (no `@main` sibling);
  - `@main`-only repo edge case (unchanged behaviour);
  - terminal-state exclusion for depth-1 rows.

## Scope

Per the issue's coordination note with #1799, this PR touches only
`internal/nav/nav.go`, `internal/nav/nav_test.go`, and the doc-comment block
in `cmd/nav.go`. No dashboard files modified. `dashboard.IsDepth2Session`
(already exported) is the only cross-package touchpoint.

## Verification

```
# From modules/programs/prism/prism/
go build ./...   # OK
go test ./...    # all packages pass
# From repo root
nix build .#prism  # OK
```

Refs #1794
Closes #1800