### PR TITLE
Configure default cloud ID for Atlassian PI on m4mac

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -27,7 +27,10 @@ in
       prism = {
         profile.default = "anthropic";
         agent.isolation.default = "sandbox-exec";
-        pi.atlassian.enable = true;
+        pi.atlassian = {
+          enable = true;
+          defaultCloudId = "08986a80-a6ed-4480-ae2d-4a439d50d71b";
+        };
         projects.isolationOverrides = {
           "~/Documents/obsidian" = "host";
         };


### PR DESCRIPTION
This change updates the Atlassian PI configuration within the m4mac machine manifest. It explicitly sets the defaultCloudId to ensure proper integration and service routing for the machine.