### PR TITLE
pin bitwarden-cli + harden userscripts (closes #1809)

### DIFF
--- a/modules/programs/qutebrowser/default.nix
+++ b/modules/programs/qutebrowser/default.nix
@@ -146,6 +146,17 @@
             # Linux: use rofi as default dmenu
             export PATH="${pkgs.bitwarden-cli}/bin:$PATH"
 
+            # Load Bitwarden password from sops secret if available and not
+            # already set. Mirrors the Darwin branch above — needed because
+            # qutebrowser launched via .desktop / wayland bindings does not
+            # always inherit environment.sessionVariables.
+            if [ -z "$BITWARDEN_PASSWORD" ]; then
+              BW_SECRET_PATH="${config.sops.secrets.bitwarden_password.path}"
+              if [ -f "$BW_SECRET_PATH" ]; then
+                export BITWARDEN_PASSWORD="$(cat "$BW_SECRET_PATH")"
+              fi
+            fi
+
             # Build arguments array
             ARGS=()
             HAS_DMENU=0

--- a/modules/programs/qutebrowser/userscripts/bitwarden
+++ b/modules/programs/qutebrowser/userscripts/bitwarden
@@ -97,6 +97,36 @@ argument_parser.add_argument(
 
 stderr = functools.partial(print, file=sys.stderr)
 
+# Upstream regression reference: https://github.com/bitwarden/clients/issues/20703
+# When the buggy bitwarden-cli versions (2026.3.0+) are in use, `bw` prompts
+# interactively for the master password even when BW_SESSION is set, because
+# the session token from `bw unlock --raw` is silently rejected. The stderr
+# signature is a line containing "Master password:" — we detect that
+# specifically so we can surface a clear diagnostic instead of a generic error.
+UPSTREAM_ISSUE = "bitwarden/clients#20703"
+BROKEN_SESSION_HINT = (
+    "bw unlock returned a session that does not unlock the vault \u2014 see "
+    + UPSTREAM_ISSUE
+    + " and modules/programs/bitwarden.nix"
+)
+
+
+def _is_broken_session_stderr(err):
+    """Detect the upstream-regression stderr signature.
+
+    `bw` prints `? Master password: [input is hidden]` to stderr when the
+    session token does not unlock the vault.
+    """
+    return err is not None and "Master password:" in err
+
+
+class BwSessionError(Exception):
+    """Raised when `bw` fails in a way that should abort the candidate loop."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
 
 class ExitCodes(enum.IntEnum):
     SUCCESS = 0
@@ -105,6 +135,7 @@ class ExitCodes(enum.IntEnum):
     NO_PASS_CANDIDATES = 2
     COULD_NOT_MATCH_USERNAME = 3
     COULD_NOT_MATCH_PASSWORD = 4
+    BW_SESSION_ERROR = 5
 
 
 def qute_command(command):
@@ -171,32 +202,39 @@ def get_all_vault_items(encoding, password_prompt_invocation, use_cache=True):
         except (json.JSONDecodeError, FileNotFoundError):
             pass  # Fall through to fetch fresh data
     
-    # Fetch fresh data from bitwarden
+    # Fetch fresh data from bitwarden using BW_SESSION env (upstream-recommended
+    # form, matches bitwarden-prefetch).
     session_key = get_session_key(password_prompt_invocation)
+    env = os.environ.copy()
+    env["BW_SESSION"] = session_key
     process = subprocess.run(
-        ["bw", "list", "items", "--session", session_key],
+        ["bw", "list", "items"],
         capture_output=True,
+        env=env,
     )
-    
+
     err = process.stderr.decode(encoding).strip()
     if err:
-        stderr(f"Bitwarden CLI error when fetching all items: {err}")
-        return []
-    
+        if _is_broken_session_stderr(err):
+            raise BwSessionError(BROKEN_SESSION_HINT)
+        raise BwSessionError("Bitwarden CLI error when fetching all items: {}".format(err))
+
     if process.returncode:
-        return []
-    
+        raise BwSessionError(
+            "Bitwarden CLI exited {} when fetching all items".format(process.returncode)
+        )
+
     try:
         items = json.loads(process.stdout.decode(encoding).strip())
-        
+
         # Cache the result
         with open(cache_file, "w", encoding="utf-8") as f:
             json.dump(items, f)
-        
+
         # Update timestamp
         with open(timestamp_file, "w", encoding="utf-8") as f:
             f.write(str(time.time()))
-        
+
         return items
     except json.JSONDecodeError:
         return []
@@ -345,13 +383,22 @@ def main(arguments):
             extract_result.ipv4,
         ],
     ):
-        target_candidates = json.loads(
-            pass_(
-                target,
-                arguments.io_encoding,
-                arguments.password_prompt_invocation,
+        try:
+            target_candidates = json.loads(
+                pass_(
+                    target,
+                    arguments.io_encoding,
+                    arguments.password_prompt_invocation,
+                )
             )
-        )
+        except BwSessionError as e:
+            # `bw` failed in a way that will fail identically for every
+            # remaining candidate (typically the upstream-regression
+            # "Master password:" prompt). Emit exactly one error line and
+            # abort the loop rather than amplifying it into N identical lines.
+            stderr(e.message)
+            return ExitCodes.BW_SESSION_ERROR
+
         if not target_candidates:
             continue
 

--- a/modules/programs/qutebrowser/userscripts/bitwarden-prefetch
+++ b/modules/programs/qutebrowser/userscripts/bitwarden-prefetch
@@ -11,6 +11,14 @@ import json
 import subprocess
 import time
 
+# Upstream regression reference: https://github.com/bitwarden/clients/issues/20703
+# When the buggy bitwarden-cli versions (2026.3.0+) are in use, `bw unlock --raw`
+# returns an 88-char session token that `bw status` / `bw list` silently reject.
+# We defend against re-introduction by validating any freshly minted session via
+# `bw status` before persisting it.
+UPSTREAM_ISSUE = "bitwarden/clients#20703"
+
+
 def get_cache_file_path():
     """Get the path to store the cached vault items."""
     runtime_dir = os.getenv("XDG_RUNTIME_DIR", "/tmp")
@@ -26,31 +34,78 @@ def get_session_file_path():
     runtime_dir = os.getenv("XDG_RUNTIME_DIR", "/tmp")
     return os.path.join(runtime_dir, "bw_session_key")
 
+def session_unlocks_vault(session_key):
+    """Verify that the given session key actually unlocks the vault.
+
+    Runs `bw status` with BW_SESSION=<key> in env and parses the JSON output.
+    Returns True only if status == "unlocked". On parse failure or any other
+    status (including "locked"), returns False.
+    """
+    try:
+        env = os.environ.copy()
+        env["BW_SESSION"] = session_key
+        process = subprocess.run(
+            ["bw", "status"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if process.returncode != 0:
+            return False
+        status_doc = json.loads(process.stdout.strip())
+        return status_doc.get("status") == "unlocked"
+    except (json.JSONDecodeError, ValueError):
+        return False
+    except Exception:
+        return False
+
 def unlock_bitwarden():
-    """Unlock Bitwarden using the password from environment variable."""
+    """Unlock Bitwarden using the password from environment variable.
+
+    Returns a session key only if it is validated as actually unlocking the
+    vault. If validation fails, prints an error referencing the upstream issue
+    and returns None.
+    """
     master_pass = os.getenv("BITWARDEN_PASSWORD")
     if not master_pass:
         return None
 
     try:
         process = subprocess.run(
-            ["bw", "unlock", "--raw"],
-            input=master_pass,
+            ["bw", "unlock", "--raw", "--passwordenv", "BITWARDEN_PASSWORD"],
             capture_output=True,
-            text=True
+            text=True,
         )
 
         if process.returncode != 0:
             print(f"Failed to unlock Bitwarden: {process.stderr.strip()}", file=sys.stderr)
             return None
 
-        return process.stdout.strip()
+        session_key = process.stdout.strip()
+        if not session_key:
+            print(f"bw unlock returned an empty session key (see {UPSTREAM_ISSUE})", file=sys.stderr)
+            return None
+
+        if not session_unlocks_vault(session_key):
+            print(
+                f"bw unlock returned a session that does not unlock the vault "
+                f"(see {UPSTREAM_ISSUE}); refusing to persist bogus key",
+                file=sys.stderr,
+            )
+            return None
+
+        return session_key
     except Exception as e:
         print(f"Error unlocking Bitwarden: {e}", file=sys.stderr)
         return None
 
 def get_session_key():
-    """Get existing session key from file, or create one if BITWARDEN_PASSWORD is set."""
+    """Get existing session key from file, or create one if BITWARDEN_PASSWORD is set.
+
+    A freshly minted key is only written to disk if it has been validated via
+    `bw status` as actually unlocking the vault, so we never overwrite an
+    existing usable key with a bogus one.
+    """
     session_file = get_session_file_path()
 
     # Try to read existing session file
@@ -66,7 +121,7 @@ def get_session_key():
     session_key = unlock_bitwarden()
     if session_key:
         try:
-            # Save the session key for future use
+            # Save the validated session key for future use
             with open(session_file, "w", encoding="utf-8") as f:
                 f.write(session_key)
             print("Created new Bitwarden session", file=sys.stderr)
@@ -79,6 +134,17 @@ def get_session_key():
     # No session available and can't create one
     return None
 
+def run_bw_list_items(session_key):
+    """Run `bw list items` with BW_SESSION=<key> in env."""
+    env = os.environ.copy()
+    env["BW_SESSION"] = session_key
+    return subprocess.run(
+        ["bw", "list", "items"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
 def prefetch_vault_items():
     """Prefetch all vault items and cache them."""
     session_key = get_session_key()
@@ -88,12 +154,8 @@ def prefetch_vault_items():
         return False
 
     try:
-        # Fetch all items
-        process = subprocess.run(
-            ["bw", "list", "items", "--session", session_key],
-            capture_output=True,
-            text=True
-        )
+        # Fetch all items using BW_SESSION env (upstream-recommended form).
+        process = run_bw_list_items(session_key)
 
         if process.returncode != 0:
             error_msg = process.stderr.strip()
@@ -113,11 +175,7 @@ def prefetch_vault_items():
                     return False
 
                 # Retry with fresh session
-                process = subprocess.run(
-                    ["bw", "list", "items", "--session", session_key],
-                    capture_output=True,
-                    text=True
-                )
+                process = run_bw_list_items(session_key)
 
                 if process.returncode != 0:
                     print(f"Bitwarden CLI error after retry: {process.stderr.strip()}", file=sys.stderr)

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -27,6 +27,15 @@ rec {
 
       claude-code = masterPkgs.claude-code;
       discord = masterPkgs.discord;
+
+      # bitwarden-cli: upstream 2026.3.0+ regressed `bw unlock --raw` — the
+      # returned session token is silently rejected by `bw status` / `bw list`,
+      # breaking all non-interactive automation (qutebrowser userscript,
+      # bitwarden-prefetch). Pin to nixpkgs-stable (currently 2025.9.0) which
+      # predates the regression.
+      # See: https://github.com/bitwarden/clients/issues/20703
+      # Remove this override once upstream lands a fix.
+      bitwarden-cli = stablePkgs.bitwarden-cli;
       pi-coding-agent =
         let
           newSrc = prev.fetchFromGitHub {


### PR DESCRIPTION
## Summary

Pins `bitwarden-cli` to a known-good version and adds defence-in-depth in the
qutebrowser bitwarden userscripts so the next upstream regression is loud, not
silent.

Background: upstream `bitwarden-cli` 2026.3.0+ regressed `bw unlock --raw` —
the returned session token is silently rejected by `bw status` / `bw list`,
prompting interactively for the master password and breaking all
non-interactive automation (qutebrowser userscript, `bitwarden-prefetch`).

Upstream tracking: https://github.com/bitwarden/clients/issues/20703

## Changes

1. **Pin** — `overlays/default.nix` overrides `bitwarden-cli` with
   `nixpkgs-stable.bitwarden-cli` (currently 2025.11.0), which predates the
   regression. Comment shape matches the existing `direnv` workaround in the
   same file.

2. **`bitwarden-prefetch` hardening** — after `bw unlock --raw --passwordenv
   BITWARDEN_PASSWORD`, validate the session via `bw status` with
   `BW_SESSION=<key>` in env and parse the JSON. Only if `status == "unlocked"`
   do we persist the key to `$XDG_RUNTIME_DIR/bw_session_key`. If validation
   fails, emit a single error line referencing `bitwarden/clients#20703`, exit
   non-zero, and crucially do **not** overwrite an existing valid key file
   with the bogus one. Subsequent `bw list items` switched to `BW_SESSION`
   env (the upstream-recommended form).

3. **`bitwarden` userscript hardening** — the candidate loop in `main()`
   previously re-invoked `bw` once per candidate (fqdn, top-domain, sub.domain,
   domain, ipv4), amplifying one `bw` failure into four identical stderr
   lines. Now aborts on the first `bw` failure with a single error line.
   When the failure signature is `Master password:` on stderr (the specific
   upstream-regression footprint), the error message names
   `bitwarden/clients#20703` and `modules/programs/bitwarden.nix` directly
   rather than the generic "Bitwarden CLI error". `bw list items` switched
   to `BW_SESSION` env for consistency with the prefetch.

4. **Linux wrapper parity** — `modules/programs/qutebrowser/default.nix` now
   mirrors the Darwin branch in the Linux branch of the
   `bitwarden-userscript` wrapper: if `BITWARDEN_PASSWORD` is unset/empty,
   read it from `config.sops.secrets.bitwarden_password.path` before exec'ing
   the userscript. Fixes qutebrowser instances launched via `.desktop` or
   wayland keybindings, which don't reliably inherit
   `environment.sessionVariables`.

## Validation

- `nix flake check` — passes.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` —
  succeeds, including the `pkgs.writers.writePython3Bin` flake8 lint of
  both userscripts.
- Python syntax validated with `ast.parse`.
- Cannot live-test `bw` from inside the worker sandbox; final functional
  validation will happen on the next `nh switch`.

Closes #1809