### PR TITLE
docs: codify stdout-capture testing convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,17 @@ assertions on profile content are necessary but not sufficient. See
 `modules/programs/prism/prism/docs/sandbox-exec-testing.md` for the full
 convention and helpers (issue #1192).
 
+### stdout-capture testing convention
+
+Any test helper that redirects `os.Stdout` or `os.Stderr` through an
+`os.Pipe` must drain the read end concurrently with the function under test —
+otherwise a single write larger than the kernel pipe buffer (16 pages ≈ 64 KiB
+on Linux) deadlocks the writer until `go test`'s timeout fires. The
+`agent-context` JSON output (~69 KiB) is the current worst offender and the
+reason this gap surfaced. See
+`modules/programs/prism/prism/docs/stdout-capture-testing.md` for the full
+convention and the canonical `captureStdout` helper (issue #1798).
+
 ### File naming and organisation
 
 Names of files and directories should be in lowercase, with dashes between words — kebab case, not camel case.

--- a/modules/programs/prism/prism/cmd/checkin_test.go
+++ b/modules/programs/prism/prism/cmd/checkin_test.go
@@ -32,6 +32,8 @@ import (
 // pipe buffer (e.g. `agent-context` JSON, which is currently ~69 KiB)
 // blocks on the underlying write(2) syscall forever because nothing is
 // reading from the pipe until after fn returns.
+//
+// See modules/programs/prism/prism/docs/stdout-capture-testing.md.
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	r, w, err := os.Pipe()

--- a/modules/programs/prism/prism/docs/stdout-capture-testing.md
+++ b/modules/programs/prism/prism/docs/stdout-capture-testing.md
@@ -1,0 +1,76 @@
+# stdout-capture testing convention
+
+This document codifies the testing pattern for any helper that redirects
+`os.Stdout` (or `os.Stderr`) through an `os.Pipe` in order to capture what a
+command under test writes. It exists because the previous
+`captureStdout` in `cmd/checkin_test.go` drained the read end of the pipe
+**after** the function under test returned, and that pattern is a latent
+deadlock — invisible until the captured output grows past the kernel
+pipe buffer.
+
+The fix shipped in #1797. This convention exists to keep it from
+re-emerging. The paper trail is #1798.
+
+## The kernel-pipe-buffer deadlock class
+
+On Linux, an `os.Pipe` is backed by a kernel ring buffer of 16 pages
+(≈ 64 KiB). Once the buffer fills, the next `write(2)` blocks until a
+reader drains bytes from the read end. If the test helper only starts
+reading **after** the function under test returns, and the function
+writes more than the buffer in a single contiguous burst, the writer
+deadlocks forever — `go test` then hangs until its 10-minute timeout
+fires.
+
+The worst offender in this repo is the `agent-context` JSON document
+emitted by `runAgentContext` (`cmd/agent_context.go`), which is
+currently ~69 KiB on `main`. `TestAgentContextCoversAllCommands`
+previously only passed by happenstance of how `encoding/json`'s
+`Encoder` fragments its writes against the pipe; adding a single
+top-level cobra subcommand was enough to push it over the threshold
+and trigger the hang.
+
+## The convention
+
+> Any test helper that redirects `os.Stdout` or `os.Stderr` through an
+> `os.Pipe` must drain the read end of the pipe **concurrently** with
+> the function under test — typically a `sync.WaitGroup` + goroutine
+> that `io.Copy`s into a `bytes.Buffer` while `fn()` runs, then
+> `w.Close()` + `wg.Wait()` after `fn()` returns. Do not buffer the
+> output by reading only after `fn` returns.
+
+The canonical implementation lives in
+`modules/programs/prism/prism/cmd/checkin_test.go::captureStdout`. New
+helpers should either reuse `captureStdout` (preferred) or follow the
+same drain-in-goroutine shape. Do not duplicate the pre-#1797 pattern
+in a new helper.
+
+## When to re-verify the agent-context test under stress
+
+`agent-context` is the largest stdout-bound command in the tree, so
+its output is the canary for this deadlock class. Whenever its output
+grows substantially — new always-on context fields, deeply nested
+command trees, large embedded help text — re-run
+`TestAgentContextCoversAllCommands` under `-race -count=20` from
+`modules/programs/prism/prism/`:
+
+```
+go test ./cmd/ -run TestAgentContextCoversAllCommands -race -count=20
+```
+
+If the test ever hangs rather than failing cleanly, the helper has
+regressed to the buffered-read pattern.
+
+## Scope
+
+This convention applies to test code only. Production stdout writers
+must not change behaviour for the sake of tests. The fix is always in
+the capture helper, never in the writer.
+
+## References
+
+- #1797 — the PR that fixed `captureStdout` with the drain-in-goroutine
+  pattern.
+- #1798 — this issue: codifies the convention so the fragility class
+  stays visible.
+- `modules/programs/prism/prism/cmd/checkin_test.go::captureStdout` —
+  the canonical example of the correct pattern.


### PR DESCRIPTION
Documentation-only follow-up to #1797. Codifies the kernel-pipe-buffer
deadlock class that was masked by the buffered-read shape of the previous
`captureStdout` helper, so future cobra subcommands (or any new
stdout-redirecting test helper) cannot reintroduce it silently.

## Changes

- **New doc** `modules/programs/prism/prism/docs/stdout-capture-testing.md`
  — explains the ~64 KiB Linux pipe-buffer threshold, names
  `agent-context` (~69 KiB) as the current worst offender, prescribes the
  drain-in-goroutine pattern, and recommends running
  `TestAgentContextCoversAllCommands` under \`-race -count=20\` whenever
  that command's output grows substantially. References #1797 and #1798
  and points to \`cmd/checkin_test.go::captureStdout\` as the canonical
  example.
- **Root \`AGENTS.md\`** — new \"stdout-capture testing convention\"
  subsection, peer of the existing \"sandbox-exec testing convention\",
  linking to the new doc by repo-relative path.
- **\`cmd/checkin_test.go\`** — one-line addition to the existing
  \`captureStdout\` comment cross-referencing the new doc. No code change
  to the helper itself or any other test.

No production code is modified. \`go build ./...\` and
\`go test ./...\` from \`modules/programs/prism/prism/\` pass; \`nixfmt .\`
from the repo root leaves the tree clean.

Closes #1798.