### PR TITLE
pi archive: add bwrap-mode SourcePath branch (#1814)

### DIFF
--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/container"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // piArchiveAdapter implements harness/archive.ArchiveAdapter for PI.
@@ -82,28 +83,22 @@ func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
 // encoded-cwd is derived from p.Worktree in both cases. Bug #1538 fix: only
 // the home base differs for sandbox-exec sessions.
 //
+// For bwrap sessions (IsolationMode == "bwrap"), PI writes into the per-session
+// pi-agent staging directory bind-mounted into the sandbox at
+// $PI_CODING_AGENT_DIR — on the host that resolves to
+// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/. Pi defaults
+// --session-dir to <PI_CODING_AGENT_DIR>/sessions/, so the JSONL lands at
+// <run>/pi-agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl — note there is no
+// ".pi/agent" join under the run dir (the staging dir IS the agent dir). The
+// session-dir hash is computed via session.SessionDirName (sha256 prefix). See
+// bug #1814 for the analysis.
+//
 // See docs/pi-rpc-interface.md Q5 for the authoritative path specification.
 func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, error) {
-	var home string
-
-	if p.IsolationMode == "sandbox-exec" && p.InstanceID != "" {
-		// sandbox-exec: PI writes into the per-session staging HOME, not
-		// the real home directory. Use the same path formula as
-		// container.SandboxExecStagingHomePath.
-		stagingHome, err := container.SandboxExecStagingHomePath(p.InstanceID)
-		if err != nil {
-			return "", fmt.Errorf("pi archive: resolve sandbox-exec staging home: %w", err)
-		}
-		home = stagingHome
-	} else {
-		var err error
-		home, err = os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("pi archive: resolve home: %w", err)
-		}
+	sessionsRoot, err := piSessionsRoot(p)
+	if err != nil {
+		return "", err
 	}
-
-	sessionsRoot := filepath.Join(home, ".pi", "agent", "sessions")
 
 	if p.HarnessSessionID == "" || p.Worktree == "" {
 		// No session ID or no worktree: return sessions root.
@@ -136,6 +131,58 @@ func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, er
 	// No matching file — return a sentinel; Archive's IsNotExist path applies.
 	log.Printf("pi archive: SourcePath: no file matching *%s in %q — session may not have written any data", suffix, cwdDir)
 	return filepath.Join(cwdDir, "session_"+p.HarnessSessionID+".jsonl"), nil
+}
+
+// piSessionsRoot returns the per-mode sessions directory — the directory under
+// which pi creates one subdirectory per encoded CWD. The three branches are:
+//
+//	host         → <home>/.pi/agent/sessions
+//	bwrap        → <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions
+//	sandbox-exec → <stagingHome>/.pi/agent/sessions
+//
+// The bwrap branch falls through to the host branch when SessionName is empty
+// (no way to derive a sessionDirHash), matching the no-op contract used by
+// SourcePath when HarnessSessionID or Worktree is empty.
+func piSessionsRoot(p harnessarchive.SourceParams) (string, error) {
+	switch {
+	case p.IsolationMode == "sandbox-exec" && p.InstanceID != "":
+		// sandbox-exec: PI writes into the per-session staging HOME, not
+		// the real home directory. Use the same path formula as
+		// container.SandboxExecStagingHomePath.
+		stagingHome, err := container.SandboxExecStagingHomePath(p.InstanceID)
+		if err != nil {
+			return "", fmt.Errorf("pi archive: resolve sandbox-exec staging home: %w", err)
+		}
+		return filepath.Join(stagingHome, ".pi", "agent", "sessions"), nil
+
+	case p.IsolationMode == "bwrap" && p.SessionName != "":
+		// bwrap: PI writes into the per-session pi-agent staging dir at
+		// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/.
+		// There is no .pi/agent join — the staging dir IS the agent dir.
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("pi archive: resolve home for bwrap state dir: %w", err)
+			}
+			stateHome = filepath.Join(home, ".local", "state")
+		}
+		return filepath.Join(
+			stateHome, "prism", "run",
+			session.SessionDirName(p.SessionName),
+			"pi-agent", "sessions",
+		), nil
+
+	default:
+		// host (and any fallback — empty IsolationMode, podman, or a
+		// bwrap/sandbox-exec session missing its identifier): use the real
+		// home directory.
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("pi archive: resolve home: %w", err)
+		}
+		return filepath.Join(home, ".pi", "agent", "sessions"), nil
+	}
 }
 
 // Archive copies PI's JSONL session file from srcPath into rawDir/session.jsonl.

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prismatic-koi/prism/internal/harness/pi"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
+	"github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // encodePiCWDForTest mirrors the encodePiCWD logic in archive.go for use in
@@ -82,8 +83,12 @@ func TestArchiveAdapter_SourcePath_HostMode(t *testing.T) {
 // HarnessSessionID is empty (harness failed to start), SourcePath returns the
 // sessions root, which Archive's os.IsNotExist path treats as a no-op.
 func TestArchiveAdapter_SourcePath_EmptyHarnessSessionID(t *testing.T) {
+	// Redirect $HOME so the test does not touch the real home or fail under
+	// /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	a := pi.NewArchiveAdapter()
-	home, _ := os.UserHomeDir()
+	home := fakeHome
 
 	p := harnessarchive.SourceParams{
 		Worktree: "/tmp/test-my-repo",
@@ -101,8 +106,12 @@ func TestArchiveAdapter_SourcePath_EmptyHarnessSessionID(t *testing.T) {
 // TestArchiveAdapter_SourcePath_EmptyWorktree verifies that when Worktree is
 // empty (non-worktree session), SourcePath returns the sessions root.
 func TestArchiveAdapter_SourcePath_EmptyWorktree(t *testing.T) {
+	// Redirect $HOME so the test does not touch the real home or fail under
+	// /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	a := pi.NewArchiveAdapter()
-	home, _ := os.UserHomeDir()
+	home := fakeHome
 
 	p := harnessarchive.SourceParams{
 		HarnessSessionID: "some-uuid",
@@ -122,8 +131,12 @@ func TestArchiveAdapter_SourcePath_EmptyWorktree(t *testing.T) {
 // directory does not exist on disk, SourcePath returns a sentinel path (not an
 // error), and Archive treats it as a no-op via os.IsNotExist.
 func TestArchiveAdapter_SourcePath_NoCWDDir(t *testing.T) {
+	// Redirect $HOME so the test does not touch the real home or fail under
+	// /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	a := pi.NewArchiveAdapter()
-	home, _ := os.UserHomeDir()
+	home := fakeHome
 	const sessionID = "aabbccdd-0000-0000-0000-000000000000"
 	// Use a worktree path unlikely to have a real session directory.
 	const worktree = "/tmp/nonexistent-prism-test-worktree-xyzzy"
@@ -323,8 +336,12 @@ func TestArchiveAdapter_SourcePath_SandboxExec(t *testing.T) {
 // IsolationMode is "sandbox-exec" but InstanceID is empty, SourcePath falls
 // back to the real home directory rather than returning an error.
 func TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID(t *testing.T) {
+	// Redirect $HOME so the test does not touch the real home or fail under
+	// /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	a := pi.NewArchiveAdapter()
-	home, _ := os.UserHomeDir()
+	home := fakeHome
 	const worktree = "/tmp/test-fallback"
 	const sessionID = "some-session-uuid"
 
@@ -347,14 +364,19 @@ func TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID(t *testing.T) {
 }
 
 // TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome verifies that
-// non-sandbox-exec isolation modes (podman, bwrap, host) use the real home
-// directory for the sessions root.
+// non-sandbox-exec, non-bwrap isolation modes (podman, host, "") use the real
+// home directory for the sessions root. The bwrap branch is covered
+// separately by TestArchiveAdapter_SourcePath_Bwrap* below.
 func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome(t *testing.T) {
-	home, _ := os.UserHomeDir()
+	// Redirect $HOME so the test does not touch the real home or fail under
+	// /homeless-shelter in the Nix sandbox CI build.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	home := fakeHome
 	const sessionID = "pi-ses-xyz-nonse"
 	const worktree = "/tmp/test-non-sandbox"
 
-	for _, mode := range []string{"podman", "bwrap", "host", ""} {
+	for _, mode := range []string{"podman", "host", ""} {
 		t.Run("mode="+mode, func(t *testing.T) {
 			a := pi.NewArchiveAdapter()
 			p := harnessarchive.SourceParams{
@@ -444,5 +466,291 @@ func TestArchiveAdapter_EndToEnd_HostMode(t *testing.T) {
 	}
 	if string(got) != sessionContent {
 		t.Errorf("exported session.jsonl: got %q, want %q", got, sessionContent)
+	}
+}
+
+// stageBwrapSession writes a fake pi JSONL file at the bwrap layout path and
+// returns (filePath, content). It assumes $XDG_STATE_HOME has already been
+// redirected to a temp dir by the caller (t.Setenv("XDG_STATE_HOME", t.TempDir())).
+func stageBwrapSession(t *testing.T, stateHome, sessionName, worktree, harnessSessionID string) (string, string) {
+	t.Helper()
+	dirHash := session.SessionDirName(sessionName)
+	encodedCWD := encodePiCWDForTest(worktree)
+	sessDir := filepath.Join(stateHome, "prism", "run", dirHash, "pi-agent", "sessions", encodedCWD)
+	if err := os.MkdirAll(sessDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	filePath := filepath.Join(sessDir, "2026-05-20T07-27-30-806Z_"+harnessSessionID+".jsonl")
+	content := `{"type":"session","version":3,"id":"` + harnessSessionID + `"}` + "\n" +
+		`{"type":"msg_user","content":"hello bwrap"}` + "\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return filePath, content
+}
+
+// TestArchiveAdapter_SourcePath_Bwrap_FindsMatchingFile verifies that under
+// bwrap mode, SourcePath locates the JSONL inside
+// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/
+// and returns the matching file path (AC #1, #2, #5).
+func TestArchiveAdapter_SourcePath_Bwrap_FindsMatchingFile(t *testing.T) {
+	// Redirect both $HOME and $XDG_STATE_HOME so no real-host paths are
+	// touched (works in both dev shell and Nix sandbox).
+	t.Setenv("HOME", t.TempDir())
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const sessionName = "nixos-config@bwrap-test"
+	const worktree = "/tmp/test-bwrap-worktree"
+	const harnessSessionID = "ses_01HQXY7Z8ABCDEFG"
+
+	wantPath, _ := stageBwrapSession(t, stateHome, sessionName, worktree, harnessSessionID)
+
+	a := pi.NewArchiveAdapter()
+	got, err := a.SourcePath(harnessarchive.SourceParams{
+		SessionName:      sessionName,
+		IsolationMode:    "bwrap",
+		HarnessSessionID: harnessSessionID,
+		Worktree:         worktree,
+	})
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+	if got != wantPath {
+		t.Errorf("SourcePath (bwrap): got %q, want %q", got, wantPath)
+	}
+
+	// The path must be under the run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/
+	// layout — not under ~/.pi/agent/sessions/ — and the sessionDirHash must
+	// match session.SessionDirName(sessionName) byte-for-byte.
+	wantPrefix := filepath.Join(
+		stateHome, "prism", "run",
+		session.SessionDirName(sessionName),
+		"pi-agent", "sessions",
+		encodePiCWDForTest(worktree),
+	)
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("SourcePath (bwrap): got %q, expected prefix %q", got, wantPrefix)
+	}
+	// Defensive: must not point into the ~/.pi/agent/ tree.
+	if strings.Contains(got, filepath.Join(".pi", "agent")) {
+		t.Errorf("SourcePath (bwrap) returned path under .pi/agent/: %q", got)
+	}
+}
+
+// TestArchiveAdapter_Archive_Bwrap_EndToEnd verifies that for a staged bwrap
+// session, composing SourcePath then Archive produces rawDir/session.jsonl
+// byte-identical to the source file (AC #8).
+func TestArchiveAdapter_Archive_Bwrap_EndToEnd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const sessionName = "nixos-config@bwrap-e2e"
+	const worktree = "/tmp/test-bwrap-e2e-worktree"
+	const harnessSessionID = "ses_e2e_01HQXY7Z9ABCDEFG"
+
+	srcPath, content := stageBwrapSession(t, stateHome, sessionName, worktree, harnessSessionID)
+
+	a := pi.NewArchiveAdapter()
+	p := harnessarchive.SourceParams{
+		SessionName:      sessionName,
+		IsolationMode:    "bwrap",
+		HarnessSessionID: harnessSessionID,
+		Worktree:         worktree,
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath: %v", err)
+	}
+	if got != srcPath {
+		t.Fatalf("SourcePath: got %q, want %q", got, srcPath)
+	}
+
+	rawDir := t.TempDir()
+	if err := a.Archive(context.Background(), got, rawDir, p); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	dst := filepath.Join(rawDir, "session.jsonl")
+	gotContent, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read rawDir/session.jsonl: %v", err)
+	}
+	if string(gotContent) != content {
+		t.Errorf("rawDir/session.jsonl content mismatch:\n got: %q\nwant: %q", gotContent, content)
+	}
+}
+
+// TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName verifies that when
+// IsolationMode is "bwrap" but SessionName is empty (the bwrap branch cannot
+// compute a sessionDirHash), SourcePath returns a path that Archive treats as
+// a no-op — matching the existing fallback contract for the other modes
+// (AC #6).
+func TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	a := pi.NewArchiveAdapter()
+	p := harnessarchive.SourceParams{
+		SessionName:      "", // empty — bwrap branch cannot compute dirHash
+		IsolationMode:    "bwrap",
+		HarnessSessionID: "ses_01HQXY",
+		Worktree:         "/tmp/test-no-session-name",
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath (bwrap empty SessionName): %v", err)
+	}
+
+	// Archive on that sentinel must be a no-op (the dir does not exist).
+	rawDir := t.TempDir()
+	if err := a.Archive(context.Background(), got, rawDir, p); err != nil {
+		t.Fatalf("Archive on bwrap-empty-SessionName sentinel: %v", err)
+	}
+	entries, _ := os.ReadDir(rawDir)
+	if len(entries) != 0 {
+		t.Errorf("rawDir must be empty after no-op Archive; got %d entry/entries", len(entries))
+	}
+}
+
+// TestArchiveAdapter_SourcePath_Bwrap_NoMatchingFile verifies that when the
+// bwrap encoded-cwd directory exists but contains no file matching
+// *_<HarnessSessionID>.jsonl, SourcePath returns a sentinel path inside the
+// encoded-cwd dir and Archive on that sentinel is a no-op (AC #7).
+func TestArchiveAdapter_SourcePath_Bwrap_NoMatchingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const sessionName = "nixos-config@bwrap-nomatch"
+	const worktree = "/tmp/test-bwrap-nomatch-worktree"
+	const harnessSessionID = "ses_NOTPRESENT"
+
+	// Create the encoded-cwd dir but with a file that does NOT match the
+	// HarnessSessionID suffix — so the scan succeeds but finds no match.
+	dirHash := session.SessionDirName(sessionName)
+	encodedCWD := encodePiCWDForTest(worktree)
+	sessDir := filepath.Join(stateHome, "prism", "run", dirHash, "pi-agent", "sessions", encodedCWD)
+	if err := os.MkdirAll(sessDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(sessDir, "2026-05-20T07-27-30-806Z_some-other-id.jsonl"),
+		[]byte(`{"type":"session"}`+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	a := pi.NewArchiveAdapter()
+	p := harnessarchive.SourceParams{
+		SessionName:      sessionName,
+		IsolationMode:    "bwrap",
+		HarnessSessionID: harnessSessionID,
+		Worktree:         worktree,
+	}
+	got, err := a.SourcePath(p)
+	if err != nil {
+		t.Fatalf("SourcePath (bwrap no match): %v", err)
+	}
+	// The sentinel must live inside the encoded-cwd dir (so future Archive
+	// calls land on a non-existent file path under it).
+	if !strings.HasPrefix(got, sessDir+string(filepath.Separator)) {
+		t.Errorf("SourcePath sentinel must be inside %q; got %q", sessDir, got)
+	}
+	// Archive on the sentinel is a no-op (the file does not exist).
+	rawDir := t.TempDir()
+	if err := a.Archive(context.Background(), got, rawDir, p); err != nil {
+		t.Fatalf("Archive on bwrap-no-match sentinel: %v", err)
+	}
+	entries, _ := os.ReadDir(rawDir)
+	if len(entries) != 0 {
+		t.Errorf("rawDir must be empty after no-op Archive; got %d entry/entries", len(entries))
+	}
+}
+
+// TestArchiveAdapter_SourcePath_CrossMode_NoContamination verifies that with
+// identical SessionName + Worktree + HarnessSessionID, the three isolation
+// modes (bwrap, host, sandbox-exec) return paths that differ along the
+// documented dimensions — no cross-contamination (AC #9).
+func TestArchiveAdapter_SourcePath_CrossMode_NoContamination(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const sessionName = "nixos-config@cross-mode"
+	const worktree = "/tmp/test-cross-mode"
+	const harnessSessionID = "ses_CROSS"
+	const instanceID = "inst-cross-1234"
+
+	a := pi.NewArchiveAdapter()
+	base := harnessarchive.SourceParams{
+		SessionName:      sessionName,
+		HarnessSessionID: harnessSessionID,
+		Worktree:         worktree,
+		InstanceID:       instanceID,
+	}
+
+	hostParams := base
+	hostParams.IsolationMode = "host"
+	hostPath, err := a.SourcePath(hostParams)
+	if err != nil {
+		t.Fatalf("SourcePath (host): %v", err)
+	}
+
+	bwrapParams := base
+	bwrapParams.IsolationMode = "bwrap"
+	bwrapPath, err := a.SourcePath(bwrapParams)
+	if err != nil {
+		t.Fatalf("SourcePath (bwrap): %v", err)
+	}
+
+	sandboxParams := base
+	sandboxParams.IsolationMode = "sandbox-exec"
+	sandboxPath, err := a.SourcePath(sandboxParams)
+	if err != nil {
+		t.Fatalf("SourcePath (sandbox-exec): %v", err)
+	}
+
+	// All three must differ.
+	if hostPath == bwrapPath {
+		t.Errorf("host and bwrap returned the same path: %q", hostPath)
+	}
+	if hostPath == sandboxPath {
+		t.Errorf("host and sandbox-exec returned the same path: %q", hostPath)
+	}
+	if bwrapPath == sandboxPath {
+		t.Errorf("bwrap and sandbox-exec returned the same path: %q", bwrapPath)
+	}
+
+	// host: under <fakeHome>/.pi/agent/sessions/
+	hostPrefix := filepath.Join(fakeHome, ".pi", "agent", "sessions")
+	if !strings.HasPrefix(hostPath, hostPrefix) {
+		t.Errorf("host path %q does not have prefix %q", hostPath, hostPrefix)
+	}
+
+	// bwrap: under <stateHome>/prism/run/<dirHash>/pi-agent/sessions/, and
+	// MUST NOT touch .pi/agent.
+	bwrapPrefix := filepath.Join(
+		stateHome, "prism", "run",
+		session.SessionDirName(sessionName),
+		"pi-agent", "sessions",
+	)
+	if !strings.HasPrefix(bwrapPath, bwrapPrefix) {
+		t.Errorf("bwrap path %q does not have prefix %q", bwrapPath, bwrapPrefix)
+	}
+	if strings.Contains(bwrapPath, filepath.Join(".pi", "agent")) {
+		t.Errorf("bwrap path %q must not contain .pi/agent", bwrapPath)
+	}
+
+	// sandbox-exec: under <fakeHome>/.local/state/prism/sessions/<instanceID>/home/.pi/agent/sessions/
+	sandboxPrefix := filepath.Join(
+		fakeHome, ".local", "state", "prism", "sessions", instanceID, "home",
+		".pi", "agent", "sessions",
+	)
+	if !strings.HasPrefix(sandboxPath, sandboxPrefix) {
+		t.Errorf("sandbox-exec path %q does not have prefix %q", sandboxPath, sandboxPrefix)
 	}
 }


### PR DESCRIPTION
Closes #1814

## Summary

`piArchiveAdapter.SourcePath` was missing a branch for `IsolationMode == "bwrap"`. Under bwrap, pi writes its JSONL to `<XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl` — *not* to `~/.pi/agent/sessions/`. The archive lookup was therefore landing on a path that has never existed, `os.IsNotExist` no-opped, and worker session conversation history was lost on cleanup with the log line `pi archive: Export: raw/session.jsonl not found — no export produced`.

This PR adds the missing branch. The host and sandbox-exec branches are byte-identical to before; only bwrap is new.

## Commits → ACs

1. **`pi archive: refactor SourcePath to per-branch sessionsRoot, add bwrap mode`**
   - Refactors `SourcePath` to compute `sessionsRoot` per IsolationMode in a small `piSessionsRoot` helper, with three cases:
     - `sandbox-exec` (+ `InstanceID != ""`) → `<stagingHome>/.pi/agent/sessions` *(unchanged)* — AC #4
     - `bwrap` (+ `SessionName != ""`) → `<XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions` — AC #1, #5
     - default (host / podman / empty / bwrap-without-SessionName / sandbox-exec-without-InstanceID) → `<home>/.pi/agent/sessions` *(unchanged)* — AC #3, #6
   - `sessionDirHash` comes from `internal/session.SessionDirName` (imported), not a duplicate — AC #5.
   - The file-scan logic that locates `*_<HarnessSessionID>.jsonl` is unchanged — AC #2, #7.

2. **`pi archive: tests for bwrap-mode SourcePath/Archive`**
   - `TestArchiveAdapter_SourcePath_Bwrap_FindsMatchingFile` — stage a fake JSONL at the bwrap layout, assert `SourcePath` returns it, and that the prefix uses `session.SessionDirName` (AC #1, #2, #5).
   - `TestArchiveAdapter_Archive_Bwrap_EndToEnd` — `SourcePath` → `Archive` produces `rawDir/session.jsonl` byte-identical to source (AC #8).
   - `TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName` — empty `SessionName` under bwrap → sentinel that `Archive` no-ops on (AC #6).
   - `TestArchiveAdapter_SourcePath_Bwrap_NoMatchingFile` — encoded-cwd dir exists but no match → sentinel inside that dir; `Archive` no-ops (AC #7).
   - `TestArchiveAdapter_SourcePath_CrossMode_NoContamination` — same `(SessionName, Worktree, HarnessSessionID)` across host/bwrap/sandbox-exec returns three distinct paths, each rooted in the expected mode-specific prefix (AC #9).
   - All existing tests that previously read the real `$HOME` are hardened with `t.Setenv("HOME", t.TempDir())` so the suite stays compatible with the Nix homeless-shelter sandbox.
   - The `bwrap` entry is removed from the `NonSandboxExec_UsesRealHome` mode list (covered by the dedicated bwrap tests above).

## Quality gates (AC #10, #11)

- `go build ./...` from `modules/programs/prism/prism/` — passes.
- `go test ./...` from `modules/programs/prism/prism/` — passes.
- `nix build .#prism` from repo root — passes.
- `nix build --impure --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'` — passes (homeless-shelter sandbox).

## Out of scope

- No design change to APPEND_SYSTEM.md delivery or pi-side `--session-dir` defaulting.
- No reordering of cleanup steps (archive already precedes per-session run-dir removal).
- No change to the `host` or `sandbox-exec` branches' behaviour.

## Coordination

Parallel branch `remove-iris` (#1815) edits only the `EncodePiCWD` doc comment in this file. This PR does not touch that comment; if `remove-iris` lands first the rebase is trivial (accept their comment edit, keep our `SourcePath` changes), and vice versa.