### PR TITLE
proglog: introduce PRISM_LOG_LEVEL and convert stderr noise to leveled logging

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -62,6 +62,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -675,7 +676,11 @@ func openAgentRunLog(sessionName string) *os.File {
 // instrumentation that never blocks or fails the launch path.
 func logTimingTo(logFile *os.File, phase string, d time.Duration) {
 	line := fmt.Sprintf("[timing] %s: %s\n", phase, d.Round(time.Millisecond))
-	_, _ = fmt.Fprint(os.Stderr, line)
+	// Stderr is gated through proglog so the line is visible only when
+	// PRISM_LOG_LEVEL=debug; the file write below is unconditional so the
+	// per-session agent-run.log keeps every [timing] marker for post-mortem
+	// `grep '\[timing\]'` diagnostics (see issue #1818).
+	proglog.Debugf("%s", line)
 	if logFile != nil {
 		_, _ = logFile.WriteString(line)
 	}

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -37,6 +37,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/harness"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/review"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -241,17 +242,17 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 				removeContainerIfExists(m.session)
 			}
 			if releaseErr := d.ReleasePort(m.session); releaseErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] doCleanup: release port: %v\n", releaseErr)
+				proglog.Errorf("[prism] doCleanup: release port: %v\n", releaseErr)
 			}
 			instanceIDForSessions := instanceIDFromStatus(d, m.session)
 			isolationMode := isolationModeFromDB(d, m.session)
 			_ = d.SetEnded(m.session)
 			if instanceIDForSessions != "" {
 				if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
-					fmt.Fprintf(os.Stderr, "[prism] doCleanup: update session ended: %v\n", updErr)
+					proglog.Errorf("[prism] doCleanup: update session ended: %v\n", updErr)
 				}
 				if outcomeErr := d.WriteSpawnOutcome(instanceIDForSessions); outcomeErr != nil {
-					fmt.Fprintf(os.Stderr, "[prism] doCleanup: write spawn outcome: %v\n", outcomeErr)
+					proglog.Errorf("[prism] doCleanup: write spawn outcome: %v\n", outcomeErr)
 				}
 				// Archive the session storage after recording the end state.
 				if archiveErr := runSessionArchive(d, m.session, instanceIDForSessions, isolationMode); archiveErr != nil {
@@ -427,10 +428,10 @@ var cleanupCmd = &cobra.Command{
 				if probedBareRoot != "" {
 					// We know where the worktree *should* be but it isn't
 					// there — log an actionable message and continue.
-					fmt.Fprintf(os.Stderr, "[prism] warning: worktree not found at conventional path %s — skipping worktree removal\n",
+					proglog.Warnf("[prism] warning: worktree not found at conventional path %s — skipping worktree removal\n",
 						filepath.Join(probedBareRoot, worktreeName))
 				} else {
-					fmt.Fprintf(os.Stderr, "[prism] warning: could not determine worktree path for session %q — skipping worktree removal\n", session)
+					proglog.Warnf("[prism] warning: could not determine worktree path for session %q — skipping worktree removal\n", session)
 				}
 				return headlessCleanupWithJSON(session, worktreeName, "", "", jsonFlag)
 			} else {
@@ -510,7 +511,7 @@ func emitCleanupJSON(r cleanupResult) {
 		// Marshal of a small fixed-shape struct should never fail; surface
 		// the error on stderr so the caller has something to work with
 		// rather than empty stdout.
-		fmt.Fprintf(os.Stderr, "[prism] warning: cleanup --json: marshal: %v\n", err)
+		proglog.Warnf("[prism] warning: cleanup --json: marshal: %v\n", err)
 		return
 	}
 	fmt.Println(string(data))
@@ -556,19 +557,19 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 			// Non-fatal: the path may no longer be a registered git worktree
 			// (e.g. already removed, or pointing at the prism source dir).
 			// Log a warning and continue so sidecar/DB cleanup still happens.
-			fmt.Fprintf(os.Stderr, "[prism] warning: worktree remove: %v — continuing cleanup\n", err)
+			proglog.Warnf("[prism] warning: worktree remove: %v — continuing cleanup\n", err)
 		} else {
 			wt := worktreePath
 			result.WorktreeRemoved = &wt
 		}
 	} else {
-		fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: refusing to remove worktree %s — path matches main worktree or an active session's worktree; skipping filesystem removal\n", worktreePath)
+		proglog.Warnf("[prism] warning: cleanup: refusing to remove worktree %s — path matches main worktree or an active session's worktree; skipping filesystem removal\n", worktreePath)
 	}
 
 	if bareRoot != "" && git.BranchExists(bareRoot, worktreeName) {
 		printLine("deleting branch %s...\n", worktreeName)
 		if err := git.ForceDeleteBranch(bareRoot, worktreeName); err != nil {
-			fmt.Fprintf(os.Stderr, "[prism] warning: branch delete: %v — continuing cleanup\n", err)
+			proglog.Warnf("[prism] warning: branch delete: %v — continuing cleanup\n", err)
 		} else {
 			bn := worktreeName
 			result.BranchDeleted = &bn
@@ -623,7 +624,7 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 			removeContainerIfExists(session)
 		}
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: release port: %v\n", releaseErr)
+			proglog.Errorf("[prism] headlessCleanup: release port: %v\n", releaseErr)
 		}
 		// Capture instance_id and isolation_mode before SetEnded clears the
 		// row's lifecycle fields.
@@ -632,10 +633,10 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: update session ended: %v\n", updErr)
+				proglog.Errorf("[prism] headlessCleanup: update session ended: %v\n", updErr)
 			}
 			if outcomeErr := d.WriteSpawnOutcome(instanceIDForSessions); outcomeErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] headlessCleanup: write spawn outcome: %v\n", outcomeErr)
+				proglog.Errorf("[prism] headlessCleanup: write spawn outcome: %v\n", outcomeErr)
 			}
 			// Archive the session storage after recording the end state.
 			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
@@ -664,7 +665,7 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 		removeContainerIfExists(session)
 	}
 	if archiveCollisionWarning != "" {
-		fmt.Fprintf(os.Stderr, "[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
+		proglog.Warnf("[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
 	}
 	if jsonMode {
 		emitCleanupJSON(result)
@@ -703,17 +704,17 @@ func closeSession(session string) error {
 			removeContainerIfExists(session)
 		}
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] closeSession: release port: %v\n", releaseErr)
+			proglog.Errorf("[prism] closeSession: release port: %v\n", releaseErr)
 		}
 		instanceIDForSessions := instanceIDFromStatus(d, session)
 		isolationMode := isolationModeFromDB(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] closeSession: update session ended: %v\n", updErr)
+				proglog.Errorf("[prism] closeSession: update session ended: %v\n", updErr)
 			}
 			if outcomeErr := d.WriteSpawnOutcome(instanceIDForSessions); outcomeErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] closeSession: write spawn outcome: %v\n", outcomeErr)
+				proglog.Errorf("[prism] closeSession: write spawn outcome: %v\n", outcomeErr)
 			}
 			// Archive the session storage after recording the end state.
 			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
@@ -799,17 +800,17 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 			removeContainerIfExists(session)
 		}
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: release port: %v\n", releaseErr)
+			proglog.Errorf("[prism] headlessCloseSession: release port: %v\n", releaseErr)
 		}
 		instanceIDForSessions := instanceIDFromStatus(d, session)
 		isolationMode := isolationModeFromDB(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: update session ended: %v\n", updErr)
+				proglog.Errorf("[prism] headlessCloseSession: update session ended: %v\n", updErr)
 			}
 			if outcomeErr := d.WriteSpawnOutcome(instanceIDForSessions); outcomeErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] headlessCloseSession: write spawn outcome: %v\n", outcomeErr)
+				proglog.Errorf("[prism] headlessCloseSession: write spawn outcome: %v\n", outcomeErr)
 			}
 			// Archive the session storage after recording the end state.
 			if archiveErr := runSessionArchive(d, session, instanceIDForSessions, isolationMode); archiveErr != nil {
@@ -831,7 +832,7 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 		removeContainerIfExists(session)
 	}
 	if archiveCollisionWarning != "" {
-		fmt.Fprintf(os.Stderr, "[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
+		proglog.Warnf("[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
 	}
 	if jsonMode {
 		emitCleanupJSON(result)
@@ -968,7 +969,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	case "host", "bwrap", "sandbox-exec":
 		// OK — supported modes.
 	default:
-		fmt.Fprintf(os.Stderr, "[prism] archive: skipping session %q — unsupported isolation mode %q\n",
+		proglog.Warnf("[prism] archive: skipping session %q — unsupported isolation mode %q\n",
 			sessionName, statusIsolationMode)
 		return nil
 	}
@@ -976,12 +977,12 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	// Fetch the full sessions row (has ended_at/end_state set by caller).
 	sess, err := d.SessionByInstanceID(instanceID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[prism] archive: get session %q: %v — skipping archive\n", instanceID, err)
+		proglog.Warnf("[prism] archive: get session %q: %v — skipping archive\n", instanceID, err)
 		return nil
 	}
 	if sess == nil {
 		// No sessions row — pre-migration or session that never inserted.
-		fmt.Fprintf(os.Stderr, "[prism] archive: no sessions row for instance_id %q — skipping archive\n", instanceID)
+		proglog.Warnf("[prism] archive: no sessions row for instance_id %q — skipping archive\n", instanceID)
 		return nil
 	}
 
@@ -989,7 +990,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	// unregistered harness is a clear error (not a nil-pointer panic).
 	archiveAdapter, adapterErr := harness.ArchiveAdapterFor(sess.Harness)
 	if adapterErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism] archive: skipping session %q — %v\n", sessionName, adapterErr)
+		proglog.Warnf("[prism] archive: skipping session %q — %v\n", sessionName, adapterErr)
 		return nil
 	}
 
@@ -1006,7 +1007,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 	}
 	srcPath, srcErr := archiveAdapter.SourcePath(srcParams)
 	if srcErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism] archive: SourcePath for session %q: %v — skipping archive\n", sessionName, srcErr)
+		proglog.Warnf("[prism] archive: SourcePath for session %q: %v — skipping archive\n", sessionName, srcErr)
 		return nil
 	}
 
@@ -1045,7 +1046,7 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 		// tables. Fall back to agent_status, which is where the sidecar
 		// historically wrote the value.
 		if sid, fallbackErr := d.HarnessSessionIDForInstance(instanceID); fallbackErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] archive: harness_session_id fallback for %q: %v\n", instanceID, fallbackErr)
+			proglog.Warnf("[prism] archive: harness_session_id fallback for %q: %v\n", instanceID, fallbackErr)
 		} else if sid != "" {
 			params.HarnessSessionID = sid
 			// Also update srcParams so the Copier closure uses the resolved ID.
@@ -1091,18 +1092,18 @@ func runSessionArchive(d *db.DB, sessionName, instanceID, statusIsolationMode st
 
 	archivePath, archiveErr := archive.Run(params)
 	if archiveErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism] archive: copy failed for session %q: %v\n", sessionName, archiveErr)
+		proglog.Warnf("[prism] archive: copy failed for session %q: %v\n", sessionName, archiveErr)
 		return archiveErr
 	}
 
 	if updErr := d.UpdateSessionArchivePath(instanceID, archivePath); updErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism] archive: update archive_path for %q: %v\n", instanceID, updErr)
+		proglog.Warnf("[prism] archive: update archive_path for %q: %v\n", instanceID, updErr)
 	}
 
 	// Translate the raw archive via the adapter's Export method.
 	// Failure is non-fatal: the raw archive remains intact for re-translation later.
 	if exportErr := archiveAdapter.Export(ctx, archivePath, srcParams); exportErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism] archive: export failed for session %q: %v\n", sessionName, exportErr)
+		proglog.Warnf("[prism] archive: export failed for session %q: %v\n", sessionName, exportErr)
 	}
 
 	return nil
@@ -1165,12 +1166,12 @@ func stopAndRemoveChildContainers(d *db.DB, parentSession string) {
 		}
 	} else {
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[prism] warning: stopAndRemoveChildContainers: DB group lookup for %q: %v — using name-prefix fallback\n", parentSession, err)
+			proglog.Warnf("[prism] warning: stopAndRemoveChildContainers: DB group lookup for %q: %v — using name-prefix fallback\n", parentSession, err)
 		}
 		// Fallback: scan all rows with the review prefix.
 		rows, scanErr := d.AllStatusesWithPrefix(prefix)
 		if scanErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] warning: stopAndRemoveChildContainers: AllStatusesWithPrefix for %q: %v — skipping child container teardown\n", parentSession, scanErr)
+			proglog.Warnf("[prism] warning: stopAndRemoveChildContainers: AllStatusesWithPrefix for %q: %v — skipping child container teardown\n", parentSession, scanErr)
 			return
 		}
 		for _, row := range rows {
@@ -1200,7 +1201,7 @@ func stopAndRemoveChildContainers(d *db.DB, parentSession string) {
 		if isoErr != nil {
 			// Unknown mode — fall back to bwrap (best-effort temp-file cleanup).
 			if iso, isoErr = container.For(config.IsolationBwrap, container.ConstructorOpts{Name: name}); isoErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism] warning: stopAndRemoveChildContainers: unknown mode %q for %q: %v\n", isoMode, childSession, isoErr)
+				proglog.Warnf("[prism] warning: stopAndRemoveChildContainers: unknown mode %q for %q: %v\n", isoMode, childSession, isoErr)
 				continue
 			}
 		}
@@ -1248,7 +1249,7 @@ func removeContainerIfExists(sessionName string) {
 	if isoErr != nil {
 		// Unknown mode — fall back to bwrap (best-effort temp-file cleanup).
 		if iso, isoErr = container.For(config.IsolationBwrap, container.ConstructorOpts{Name: name}); isoErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] removeContainerIfExists: unknown isolation mode %q for %q: %v\n", isoMode, sessionName, isoErr)
+			proglog.Errorf("[prism] removeContainerIfExists: unknown isolation mode %q for %q: %v\n", isoMode, sessionName, isoErr)
 			return
 		}
 	}
@@ -1364,7 +1365,7 @@ func isCoordinatorFromDB(session string, isDefaultBranch bool) bool {
 		}
 		// Pre-migration fallback: use branch-name heuristic.
 		if rootErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: DB error reading root_agent_name for %q: %v — using branch heuristic\n", session, rootErr)
+			proglog.Warnf("[prism] warning: cleanup: DB error reading root_agent_name for %q: %v — using branch heuristic\n", session, rootErr)
 		} else if rowExists {
 			// Row exists but root_agent_name is NULL — pre-migration.
 			fmt.Fprintf(os.Stderr, "[deprecation] cleanup: root_agent_name NULL for %q — using branch heuristic\n", session)
@@ -1372,7 +1373,7 @@ func isCoordinatorFromDB(session string, isDefaultBranch bool) bool {
 		// rowExists=false: no row yet — use heuristic silently.
 		return isDefaultBranch
 	} else {
-		fmt.Fprintf(os.Stderr, "[prism] warning: cleanup: could not open DB for %q: %v — using branch heuristic\n", session, dbErr)
+		proglog.Warnf("[prism] warning: cleanup: could not open DB for %q: %v — using branch heuristic\n", session, dbErr)
 		return isDefaultBranch
 	}
 }

--- a/modules/programs/prism/prism/cmd/cleanup_orphan_sidecars.go
+++ b/modules/programs/prism/prism/cmd/cleanup_orphan_sidecars.go
@@ -24,7 +24,6 @@ package cmd
 // boxes still call this; it returns silently rather than erroring.
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,6 +31,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/prismatic-koi/prism/internal/proglog"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -66,7 +66,7 @@ func killOrphanReviewSidecars(parentSession string) {
 		// /proc is missing or unreadable — non-fatal; we just can't
 		// do the traversal. Log to stderr so the caller has a
 		// breadcrumb but do not return an error.
-		fmt.Fprintf(os.Stderr, "[prism] warning: killOrphanReviewSidecars: enumerate /proc: %v\n", err)
+		proglog.Warnf("[prism] warning: killOrphanReviewSidecars: enumerate /proc: %v\n", err)
 		return
 	}
 
@@ -75,7 +75,7 @@ func killOrphanReviewSidecars(parentSession string) {
 		// clean up its socket and PID file. ESRCH is benign (process
 		// already exited between enumeration and signal).
 		if err := syscall.Kill(match.pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
-			fmt.Fprintf(os.Stderr, "[prism] warning: killOrphanReviewSidecars: kill pid %d (session %q): %v\n",
+			proglog.Warnf("[prism] warning: killOrphanReviewSidecars: kill pid %d (session %q): %v\n",
 				match.pid, match.session, err)
 			continue
 		}

--- a/modules/programs/prism/prism/cmd/merge.go
+++ b/modules/programs/prism/prism/cmd/merge.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/review"
 	"github.com/prismatic-koi/prism/internal/sandboxenv"
 	"github.com/prismatic-koi/prism/internal/session"
@@ -262,7 +263,7 @@ func waitForMergeTerminal(pr int, jsonMode bool, timeout time.Duration) error {
 			row, qErr := probe.Merge(pr)
 			if qErr != nil {
 				// Transient — keep polling.
-				fmt.Fprintf(os.Stderr, "[prism merge --wait] probe error: %v (will retry)\n", qErr)
+				proglog.Debugf("[prism merge --wait] probe error: %v (will retry)\n", qErr)
 				return false, nil
 			}
 			if row == nil {

--- a/modules/programs/prism/prism/cmd/monitor_review.go
+++ b/modules/programs/prism/prism/cmd/monitor_review.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/review"
 )
 
@@ -49,7 +50,7 @@ func runMonitorReview(cmd *cobra.Command, _ []string) error {
 
 	if monErr := review.MonitorFunc(opts); monErr != nil {
 		// Log the error — the process is detached so nothing else reads this.
-		fmt.Fprintf(os.Stderr, "[prism monitor-review] error: %v\n", monErr)
+		proglog.Errorf("[prism monitor-review] error: %v\n", monErr)
 		os.Exit(1)
 	}
 	return nil

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -148,7 +149,7 @@ var prCmd = &cobra.Command{
 				if isoCaps.NeedsConfigBlob || profileFlag != "" {
 					return pfErr
 				}
-				fmt.Fprintf(os.Stderr, "[prism pr] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
+				proglog.Warnf("[prism pr] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
 				pf = nil
 			}
 		}

--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -84,7 +85,7 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	fmt.Println("Killing tmux server...")
 	if _, err := tmux.Run("kill-server"); err != nil {
 		// No server running is not an error — continue.
-		fmt.Fprintf(os.Stderr, "[prism reset] tmux kill-server: %v (continuing)\n", err)
+		proglog.Warnf("[prism reset] tmux kill-server: %v (continuing)\n", err)
 	} else {
 		fmt.Println("  tmux server killed.")
 	}
@@ -97,19 +98,19 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	// return nil — orphan-agent-run reaping is a future implementation.
 	fmt.Println("Removing prism- podman containers...")
 	if err := resetIsolators(); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism reset] isolator cleanup: %v (continuing)\n", err)
+		proglog.Warnf("[prism reset] isolator cleanup: %v (continuing)\n", err)
 	}
 
 	// ── Step 3: Mark all agent_status rows as ended ───────────────────────────
 	fmt.Println("Marking all sessions as ended in DB...")
 	if err := resetMarkDBEnded(); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism reset] DB cleanup: %v (continuing)\n", err)
+		proglog.Warnf("[prism reset] DB cleanup: %v (continuing)\n", err)
 	}
 
 	// ── Step 4: Kill sidecar processes ────────────────────────────────────────
 	fmt.Println("Terminating sidecar processes...")
 	if err := resetKillSidecars(); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism reset] sidecar cleanup: %v (continuing)\n", err)
+		proglog.Warnf("[prism reset] sidecar cleanup: %v (continuing)\n", err)
 	}
 
 	fmt.Println("Reset complete.")
@@ -149,14 +150,14 @@ func resetIsolators() error {
 	for _, mode := range container.Names() {
 		iso, err := container.For(mode, container.ConstructorOpts{})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[prism reset] %s: %v\n", mode, err)
+			proglog.Errorf("[prism reset] %s: %v\n", mode, err)
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
 		if err := iso.Reset(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "[prism reset] %s: %v\n", mode, err)
+			proglog.Errorf("[prism reset] %s: %v\n", mode, err)
 			if firstErr == nil {
 				firstErr = err
 			}

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -322,7 +323,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	// ~/documents/obsidian are always restored with the correct isolation mode
 	// (e.g. "host") even if they were originally recorded with a different mode.
 	if override := cfg.IsolationOverrideForPath(directory); override != "" {
-		fmt.Fprintf(os.Stderr, "[prism restore] using isolation override %q for path %q\n", override, directory)
+		proglog.Infof("[prism restore] using isolation override %q for path %q\n", override, directory)
 		isoMode = override
 	}
 
@@ -366,7 +367,7 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		if pipePath, pipeErr := session.SidecarHarnessPipePath(s.SessionName); pipeErr == nil {
 			opts.HarnessPipeSockPath = pipePath
 		} else {
-			fmt.Fprintf(os.Stderr, "[prism restore] warning: could not resolve harness pipe path for %q: %v\n", s.SessionName, pipeErr)
+			proglog.Warnf("[prism restore] warning: could not resolve harness pipe path for %q: %v\n", s.SessionName, pipeErr)
 		}
 	}
 

--- a/modules/programs/prism/prism/cmd/review_wait.go
+++ b/modules/programs/prism/prism/cmd/review_wait.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/review"
 )
 
@@ -70,7 +71,7 @@ func waitForReviewTerminal(prNumber, groupID string, jsonMode bool, timeout time
 		func() (bool, error) {
 			done, _, _, gErr := probe.GroupPoll(groupID)
 			if gErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism review --wait] probe error: %v (will retry)\n", gErr)
+				proglog.Debugf("[prism review --wait] probe error: %v (will retry)\n", gErr)
 				return false, nil
 			}
 			return done, nil

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -55,6 +55,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/sidecar"
 )
@@ -134,7 +135,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	for _, entry := range modelOverrideRaw {
 		role, model, ok := strings.Cut(entry, "=")
 		if !ok || role == "" || model == "" {
-			fmt.Fprintf(os.Stderr, "[prism sidecar] warning: ignoring malformed --model-override %q (expected role=model)\n", entry)
+			proglog.Warnf("[prism sidecar] warning: ignoring malformed --model-override %q (expected role=model)\n", entry)
 			continue
 		}
 		modelsByRole[role] = model
@@ -198,7 +199,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// the dashboard immediately. Use UpsertStatus with state "idle" and write
 	// repo/worktree — mirroring what tmux-session-start does.
 	if err := d.UpsertStatus(sessionName, repo, worktree, "idle", nil, nil); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism sidecar] initial upsert: %v\n", err)
+		proglog.Errorf("[prism sidecar] initial upsert: %v\n", err)
 	}
 
 	// Load prism runtime config.
@@ -285,20 +286,20 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		onReady = func() {
 			readyPath, pathErr := prismSession.SidecarReadyPath(sessionName)
 			if pathErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism sidecar] ready path: %v\n", pathErr)
+				proglog.Errorf("[prism sidecar] ready path: %v\n", pathErr)
 				return
 			}
 			if err := os.MkdirAll(filepath.Dir(readyPath), 0o755); err != nil {
-				fmt.Fprintf(os.Stderr, "[prism sidecar] ready dir: %v\n", err)
+				proglog.Errorf("[prism sidecar] ready dir: %v\n", err)
 				return
 			}
 			f, err := os.Create(readyPath)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "[prism sidecar] write ready signal: %v\n", err)
+				proglog.Errorf("[prism sidecar] write ready signal: %v\n", err)
 				return
 			}
 			_ = f.Close()
-			fmt.Fprintf(os.Stderr, "[prism sidecar] ready signal written: %s\n", readyPath)
+			proglog.Infof("[prism sidecar] ready signal written: %s\n", readyPath)
 		}
 	}
 
@@ -395,14 +396,14 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		}()
 	}
 
-	fmt.Fprintf(os.Stderr, "[prism sidecar] starting: session=%s url=%s isolation=%s\n",
+	proglog.Infof("[prism sidecar] starting: session=%s url=%s isolation=%s\n",
 		sessionName, harnessURL, isolationMode)
 
 	if err := sc.Run(ctx); err != nil && ctx.Err() == nil {
 		return fmt.Errorf("sidecar: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "[prism sidecar] shutting down\n")
+	proglog.Infof("[prism sidecar] shutting down\n")
 	return nil
 }
 

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/skills"
 	"github.com/prismatic-koi/prism/internal/tmux"
@@ -437,7 +438,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			if isoCaps.NeedsConfigBlob || profileFlag != "" {
 				return loadErr
 			}
-			fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not load profiles.json (agent env vars will not be injected): %v\n", loadErr)
+			proglog.Warnf("[prism spawn] warning: could not load profiles.json (agent env vars will not be injected): %v\n", loadErr)
 			pf = nil
 		}
 	}
@@ -675,7 +676,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
 			spawnOpts.HarnessPipeSockPath = pipePath
 		} else {
-			fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
+			proglog.Warnf("[prism spawn] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
 		}
 	}
 	// AgentEnvVars only applies to host-mode sessions; container sessions
@@ -697,7 +698,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	skillsDir := prismSkillsDir()
 	skillsManifestHash, skillsHashErr := skills.ComputeManifest(skillsDir)
 	if skillsHashErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
+		proglog.Warnf("[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
 		skillsManifestHash = ""
 	}
 
@@ -706,7 +707,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	agentRoleFilePath := prismAgentRolePath(agentRole)
 	agentPromptHash, agentHashErr := skills.ComputeAgentPromptHash(agentRoleFilePath)
 	if agentHashErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
+		proglog.Warnf("[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
 		agentPromptHash = ""
 	}
 
@@ -805,7 +806,7 @@ type spawnInputsArgs struct {
 func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
 	st, err := d.CurrentStatus(args.sessionName)
 	if err != nil || st == nil || st.InstanceID == nil || *st.InstanceID == "" {
-		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not read instance_id for spawn_inputs: %v\n", err)
+		proglog.Warnf("[prism spawn] warning: could not read instance_id for spawn_inputs: %v\n", err)
 		return
 	}
 
@@ -869,7 +870,7 @@ func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
 	}
 
 	if err := d.InsertSpawnInputs(si); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not write spawn_inputs: %v\n", err)
+		proglog.Warnf("[prism spawn] warning: could not write spawn_inputs: %v\n", err)
 	}
 }
 
@@ -1148,13 +1149,13 @@ func runAbtestSpawn(cmd *cobra.Command, profileA, profileB string) error {
 	skillsDir := prismSkillsDir()
 	skillsManifestHash, skillsHashErr := skills.ComputeManifest(skillsDir)
 	if skillsHashErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
+		proglog.Warnf("[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
 		skillsManifestHash = ""
 	}
 	agentRoleFilePath := prismAgentRolePath(plannedRole)
 	agentPromptHash, agentHashErr := skills.ComputeAgentPromptHash(agentRoleFilePath)
 	if agentHashErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
+		proglog.Warnf("[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
 		agentPromptHash = ""
 	}
 
@@ -1201,14 +1202,14 @@ func runAbtestSpawn(cmd *cobra.Command, profileA, profileB string) error {
 				_ = tmux.KillSession(r.sessionName)
 				session.KillSidecar(r.sessionName)
 				if killDBErr := d.SetEnded(r.sessionName); killDBErr != nil {
-					fmt.Fprintf(os.Stderr, "[prism spawn] warning: cleanup DB for %q failed: %v\n", r.sessionName, killDBErr)
+					proglog.Warnf("[prism spawn] warning: cleanup DB for %q failed: %v\n", r.sessionName, killDBErr)
 				}
 			}
 			// Remove the worktree even when sessionName is empty — the
 			// worktree may have been created before the session started.
 			if r.worktreePath != "" {
 				if rmErr := git.RemoveWorktree(bareRoot, r.worktreePath); rmErr != nil {
-					fmt.Fprintf(os.Stderr, "[prism spawn] warning: cleanup worktree %q failed: %v\n", r.worktreePath, rmErr)
+					proglog.Warnf("[prism spawn] warning: cleanup worktree %q failed: %v\n", r.worktreePath, rmErr)
 				}
 			}
 		}
@@ -1312,7 +1313,7 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
 			spawnOpts.HarnessPipeSockPath = pipePath
 		} else {
-			fmt.Fprintf(os.Stderr, "[prism spawn --abtest] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
+			proglog.Warnf("[prism spawn --abtest] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
 		}
 	}
 

--- a/modules/programs/prism/prism/cmd/spawn_wait.go
+++ b/modules/programs/prism/prism/cmd/spawn_wait.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 // spawnWaitJSON is the JSON shape emitted by `prism spawn --wait --json`.
@@ -81,7 +82,7 @@ func waitForSpawnTerminal(sessionName string, jsonMode bool, timeout time.Durati
 		func() (bool, error) {
 			st, qErr := probe.SessionStatus(sessionName)
 			if qErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism spawn --wait] probe error: %v (will retry)\n", qErr)
+				proglog.Debugf("[prism spawn --wait] probe error: %v (will retry)\n", qErr)
 				return false, nil
 			}
 			if st == nil {

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -44,7 +45,7 @@ func applyPathIsolationOverride(path string, cfg config.Config, opts *session.Op
 	if override == "" {
 		return isoMode, isoCaps
 	}
-	fmt.Fprintf(os.Stderr, "[prism switch] using isolation override %q for path %q\n", override, path)
+	proglog.Infof("[prism switch] using isolation override %q for path %q\n", override, path)
 	opts.IsolationMode = string(override)
 	effCaps := container.CapabilitiesFor(override)
 	// When the override crosses the sandbox/host boundary (sandboxed → host),
@@ -195,7 +196,7 @@ func ensureAndSwitch(path string, projectRoot string, opts session.Opts) error {
 		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
 			opts.HarnessPipeSockPath = pipePath
 		} else {
-			fmt.Fprintf(os.Stderr, "[prism switch] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
+			proglog.Warnf("[prism switch] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
 		}
 	}
 
@@ -314,7 +315,7 @@ var switchCmd = &cobra.Command{
 				if isoCaps.NeedsConfigBlob {
 					return pfErr
 				}
-				fmt.Fprintf(os.Stderr, "[prism switch] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
+				proglog.Warnf("[prism switch] warning: could not load profiles.json (agent env vars will not be injected): %v\n", pfErr)
 				pf = nil
 			}
 		}

--- a/modules/programs/prism/prism/internal/container/dispatch.go
+++ b/modules/programs/prism/prism/internal/container/dispatch.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 // CapStatus is the outcome of an Isolator.Cap probe. It generalises
@@ -136,7 +137,7 @@ func (s CapStatus) RenderWarning() string {
 //	if err := iso.Cap(ctx, dbPath()).Check(ignoreCap); err != nil { return err }
 func (s CapStatus) Check(ignoreCap bool) error {
 	if s.Note != "" {
-		fmt.Fprintf(os.Stderr, "[prism] warning: %s\n", s.Note)
+		proglog.Warnf("[prism] warning: %s\n", s.Note)
 	}
 	if !s.Exceeded {
 		return nil

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/proglog"
+
 	_ "modernc.org/sqlite" // register sqlite3 driver
 )
 
@@ -1833,7 +1835,7 @@ func migrateV29ToV30(conn *sql.DB, version *int) error {
 // Close still calls conn.Close() — a failed checkpoint is non-fatal.
 func (d *DB) Close() error {
 	if _, err := d.conn.Exec("PRAGMA wal_checkpoint(PASSIVE)"); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism] db.Close: wal_checkpoint failed (non-fatal): %v\n", err)
+		proglog.Warnf("[prism] db.Close: wal_checkpoint failed (non-fatal): %v\n", err)
 	}
 	return d.conn.Close()
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -15,7 +15,6 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/prismatic-koi/prism/internal/db"
-	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 func openTestDB(t *testing.T) *db.DB {
@@ -2302,10 +2301,12 @@ func TestCheckTransition_SameState(t *testing.T) {
 // transition (e.g. idle → finished) still logs a warning to
 // stderr after the same-state early-return fix is in place.
 func TestCheckTransition_InvalidTransition(t *testing.T) {
-	// Invalid-transition warnings are emitted via proglog.Warnf, which is
-	// silent at the default level (error). Pin to warn for this test so the
-	// captured-stderr assertion below has something to observe (#1818).
-	defer proglog.SetLevelForTest(proglog.LevelWarn)()
+	// The invalid-transition diagnostic in status.go is emitted via
+	// proglog.Errorf (it is not a 'warning:' line per the issue rubric, even
+	// though the test comment historically called it one). Errorf is always
+	// on at the default level, so no level override is needed here — but
+	// the test does rely on proglog resolving os.Stderr at emit time, which
+	// is the contract written into writerFor(). See #1818.
 
 	// "error → active" is valid per ValidTransitions; use only pairs that are
 	// genuinely invalid (not present in ValidTransitions).

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -15,6 +15,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 func openTestDB(t *testing.T) *db.DB {
@@ -2301,6 +2302,11 @@ func TestCheckTransition_SameState(t *testing.T) {
 // transition (e.g. idle → finished) still logs a warning to
 // stderr after the same-state early-return fix is in place.
 func TestCheckTransition_InvalidTransition(t *testing.T) {
+	// Invalid-transition warnings are emitted via proglog.Warnf, which is
+	// silent at the default level (error). Pin to warn for this test so the
+	// captured-stderr assertion below has something to observe (#1818).
+	defer proglog.SetLevelForTest(proglog.LevelWarn)()
+
 	// "error → active" is valid per ValidTransitions; use only pairs that are
 	// genuinely invalid (not present in ValidTransitions).
 	invalidPairs := []struct {

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 // currentStateOf looks up the current agent state for sessionName. Returns
@@ -46,7 +46,7 @@ func (d *DB) checkTransition(sessionName string, toState agent.AgentState, calle
 	fromState, err := d.currentStateOf(sessionName)
 	if err != nil {
 		// Non-fatal: if we can't read the current state we skip validation.
-		fmt.Fprintf(os.Stderr, "[prism] %s: could not read current state for %q: %v\n",
+		proglog.Errorf("[prism] %s: could not read current state for %q: %v\n",
 			callerCtx, sessionName, err)
 		return
 	}
@@ -59,7 +59,7 @@ func (d *DB) checkTransition(sessionName string, toState agent.AgentState, calle
 		return
 	}
 	if err := agent.Transition(fromState, toState); err != nil {
-		fmt.Fprintf(os.Stderr, "[prism] %s: invalid transition for session %q: %v\n",
+		proglog.Errorf("[prism] %s: invalid transition for session %q: %v\n",
 			callerCtx, sessionName, err)
 	}
 }
@@ -247,7 +247,7 @@ WHERE session_name = ?
 	// write (session already terminal), there is no transition to check.
 	if n > 0 && fromState != "" {
 		if terr := agent.Transition(fromState, agent.AgentState(state)); terr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] UpsertStatusIfNotTerminal: invalid transition for session %q: %v\n",
+			proglog.Errorf("[prism] UpsertStatusIfNotTerminal: invalid transition for session %q: %v\n",
 				sessionName, terr)
 		}
 	}
@@ -295,7 +295,7 @@ WHERE session_name = ?
 	// to check.
 	if n > 0 && fromState != "" {
 		if terr := agent.Transition(fromState, agent.StateInterrupted); terr != nil {
-			fmt.Fprintf(os.Stderr, "[prism] UpsertStatusInterruptedOverrideFinished: invalid transition for session %q: %v\n",
+			proglog.Errorf("[prism] UpsertStatusInterruptedOverrideFinished: invalid transition for session %q: %v\n",
 				sessionName, terr)
 		}
 	}

--- a/modules/programs/prism/prism/internal/proglog/proglog.go
+++ b/modules/programs/prism/prism/internal/proglog/proglog.go
@@ -38,6 +38,20 @@ import (
 	"sync"
 )
 
+// writerFor returns the destination io.Writer for emit. By default this is
+// os.Stderr, looked up on every call so that callers (and tests) that replace
+// os.Stderr — e.g. via os.Pipe() redirection — keep seeing emitted output.
+// Tests can pin a different writer with SetWriterForTest.
+func writerFor() io.Writer {
+	writerMu.Lock()
+	w := writer
+	writerMu.Unlock()
+	if w == nil {
+		return os.Stderr
+	}
+	return w
+}
+
 // Level is the verbosity level of a single message or the effective threshold.
 // Lower values are more important; a message at level N is emitted iff
 // effective >= N.
@@ -61,7 +75,10 @@ var (
 	once     sync.Once
 	cached   Level
 	writerMu sync.Mutex
-	writer   io.Writer = os.Stderr
+	// writer is nil in normal operation — emit() resolves os.Stderr at call
+	// time via writerFor() so tests that redirect os.Stderr (os.Pipe etc.)
+	// observe the output. Test helpers may set this to a *bytes.Buffer.
+	writer io.Writer
 )
 
 // ParseLevel maps a case-insensitive string to a Level. An unrecognised or
@@ -94,16 +111,13 @@ func effective() Level {
 	return cached
 }
 
-// emit writes a single formatted message to the configured writer iff the
-// message's level is at or below the effective level.
+// emit writes a single formatted message to stderr (or the test writer) iff
+// the message's level is at or below the effective level.
 func emit(msgLevel Level, format string, args ...any) {
 	if effective() < msgLevel {
 		return
 	}
-	writerMu.Lock()
-	w := writer
-	writerMu.Unlock()
-	_, _ = fmt.Fprintf(w, format, args...)
+	_, _ = fmt.Fprintf(writerFor(), format, args...)
 }
 
 // Errorf writes an error-level message. Always emitted (even at the default
@@ -120,3 +134,27 @@ func Infof(format string, args ...any) { emit(LevelInfo, format, args...) }
 
 // Debugf writes a debug-level message. Emitted only when PRISM_LOG_LEVEL=debug.
 func Debugf(format string, args ...any) { emit(LevelDebug, format, args...) }
+
+// SetLevelForTest pins the effective level for tests, bypassing the sync.Once
+// env-var read. It exists because the production effective() reads
+// PRISM_LOG_LEVEL once per process — without a test hook, the first test
+// that triggers an emit() pins the level for every subsequent test in the
+// same binary, and t.Setenv has no effect.
+//
+// The returned restore func reverts to a fresh sync.Once so that the next
+// emit() re-reads PRISM_LOG_LEVEL from the environment. Callers should pair
+// SetLevelForTest with t.Cleanup or defer restore().
+func SetLevelForTest(lvl Level) (restore func()) {
+	writerMu.Lock()
+	defer writerMu.Unlock()
+	prevCached := cached
+	once = sync.Once{}
+	// Burn the once so subsequent emit() calls see lvl without re-reading env.
+	once.Do(func() { cached = lvl })
+	return func() {
+		writerMu.Lock()
+		defer writerMu.Unlock()
+		once = sync.Once{}
+		cached = prevCached
+	}
+}

--- a/modules/programs/prism/prism/internal/proglog/proglog.go
+++ b/modules/programs/prism/prism/internal/proglog/proglog.go
@@ -1,0 +1,122 @@
+// Package proglog is a minimal log-level shim for prism's stderr diagnostics.
+//
+// Prism scatters a number of `fmt.Fprintf(os.Stderr, "[prism ...] ...", ...)`
+// and `fmt.Fprintf(os.Stderr, "[timing] ...")` call sites throughout the CLI.
+// Many of these are transient retry/probe diagnostics that recover
+// automatically — they flash briefly in the tmux pane and add noise. A few
+// are genuine user-impacting errors that must always be visible.
+//
+// This package introduces a single configuration knob — the PRISM_LOG_LEVEL
+// environment variable — and four leveled emit functions:
+//
+//	proglog.Errorf(format, args...) // level=error, always on
+//	proglog.Warnf (format, args...) // level=warn,  on at warn/info/debug
+//	proglog.Infof (format, args...) // level=info,  on at info/debug
+//	proglog.Debugf(format, args...) // level=debug, on at debug
+//
+// Each function writes to os.Stderr with fmt.Fprintf semantics iff the
+// message's level is at or below the effective level. The effective level
+// is read once from PRISM_LOG_LEVEL on first use and cached via sync.Once.
+//
+// Recognised values (case-insensitive): "error", "warn", "info", "debug".
+// Unrecognised or unset → "error".
+//
+// Design constraints (see issue #1818):
+//
+//   - No log framework dependencies. Just fmt.Fprintf gated on a cached level.
+//   - No prefix added by the helper itself. Callers preserve their existing
+//     `[prism ...]` / `[timing]` prefix in the format string so downstream
+//     grep diagnostics keep working.
+//   - No timestamp, no structured fields, no rotation. Stderr only.
+package proglog
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Level is the verbosity level of a single message or the effective threshold.
+// Lower values are more important; a message at level N is emitted iff
+// effective >= N.
+type Level int
+
+const (
+	// LevelError is the default and the lowest (most important) level.
+	LevelError Level = 0
+	// LevelWarn is for recoverable issues worth surfacing.
+	LevelWarn Level = 1
+	// LevelInfo is for informational progress messages.
+	LevelInfo Level = 2
+	// LevelDebug is for transient retry/probe diagnostics and timing markers.
+	LevelDebug Level = 3
+)
+
+// envVar is the environment variable consulted on first use.
+const envVar = "PRISM_LOG_LEVEL"
+
+var (
+	once     sync.Once
+	cached   Level
+	writerMu sync.Mutex
+	writer   io.Writer = os.Stderr
+)
+
+// ParseLevel maps a case-insensitive string to a Level. An unrecognised or
+// empty value maps to LevelError. The returned bool indicates whether the
+// input was a recognised level name — callers that want to log "fell back to
+// default" can use it, but the helper itself never warns on parse failure.
+func ParseLevel(s string) (Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "error":
+		return LevelError, true
+	case "warn", "warning":
+		return LevelWarn, true
+	case "info":
+		return LevelInfo, true
+	case "debug":
+		return LevelDebug, true
+	default:
+		return LevelError, false
+	}
+}
+
+// effective returns the cached effective level, reading PRISM_LOG_LEVEL on
+// first call. The env var is consulted exactly once per process; subsequent
+// changes to the environment have no effect.
+func effective() Level {
+	once.Do(func() {
+		lvl, _ := ParseLevel(os.Getenv(envVar))
+		cached = lvl
+	})
+	return cached
+}
+
+// emit writes a single formatted message to the configured writer iff the
+// message's level is at or below the effective level.
+func emit(msgLevel Level, format string, args ...any) {
+	if effective() < msgLevel {
+		return
+	}
+	writerMu.Lock()
+	w := writer
+	writerMu.Unlock()
+	_, _ = fmt.Fprintf(w, format, args...)
+}
+
+// Errorf writes an error-level message. Always emitted (even at the default
+// level).
+func Errorf(format string, args ...any) { emit(LevelError, format, args...) }
+
+// Warnf writes a warning-level message. Emitted when PRISM_LOG_LEVEL is
+// warn, info, or debug.
+func Warnf(format string, args ...any) { emit(LevelWarn, format, args...) }
+
+// Infof writes an info-level message. Emitted when PRISM_LOG_LEVEL is info
+// or debug.
+func Infof(format string, args ...any) { emit(LevelInfo, format, args...) }
+
+// Debugf writes a debug-level message. Emitted only when PRISM_LOG_LEVEL=debug.
+func Debugf(format string, args ...any) { emit(LevelDebug, format, args...) }

--- a/modules/programs/prism/prism/internal/proglog/proglog_test.go
+++ b/modules/programs/prism/prism/internal/proglog/proglog_test.go
@@ -20,7 +20,16 @@ func resetForTest(t *testing.T, w *bytes.Buffer) {
 	defer writerMu.Unlock()
 	once = sync.Once{}
 	cached = LevelError
+	if w == nil {
+		writer = nil
+		return
+	}
 	writer = w
+	t.Cleanup(func() {
+		writerMu.Lock()
+		defer writerMu.Unlock()
+		writer = nil
+	})
 }
 
 func TestParseLevel(t *testing.T) {

--- a/modules/programs/prism/prism/internal/proglog/proglog_test.go
+++ b/modules/programs/prism/prism/internal/proglog/proglog_test.go
@@ -1,0 +1,138 @@
+package proglog
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+// resetForTest restores proglog to a pristine state so each test can pin a
+// fresh effective level and capture writes into a bytes.Buffer. It exists
+// only in test builds.
+//
+// The sync.Once on the production path means the env-var read happens at
+// most once per process; without this reset, the first test would fix the
+// cached level for every subsequent test in the run. Tests that need the
+// real env-var read path use t.Setenv before calling this helper.
+func resetForTest(t *testing.T, w *bytes.Buffer) {
+	t.Helper()
+	writerMu.Lock()
+	defer writerMu.Unlock()
+	once = sync.Once{}
+	cached = LevelError
+	writer = w
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    Level
+		wantOK  bool
+	}{
+		{"error", LevelError, true},
+		{"ERROR", LevelError, true},
+		{"Error", LevelError, true},
+		{"warn", LevelWarn, true},
+		{"WARN", LevelWarn, true},
+		{"warning", LevelWarn, true},
+		{"info", LevelInfo, true},
+		{"INFO", LevelInfo, true},
+		{"debug", LevelDebug, true},
+		{"DEBUG", LevelDebug, true},
+		{"  debug  ", LevelDebug, true},
+		{"", LevelError, false},
+		{"trace", LevelError, false},
+		{"verbose", LevelError, false},
+		{"nonsense", LevelError, false},
+	}
+	for _, tc := range cases {
+		got, ok := ParseLevel(tc.in)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("ParseLevel(%q) = (%d, %v), want (%d, %v)", tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestEffectiveDefaults verifies that an unset PRISM_LOG_LEVEL caches LevelError.
+func TestEffectiveDefaults(t *testing.T) {
+	t.Setenv("PRISM_LOG_LEVEL", "")
+	var buf bytes.Buffer
+	resetForTest(t, &buf)
+	if got := effective(); got != LevelError {
+		t.Errorf("effective() with unset env = %d, want %d", got, LevelError)
+	}
+}
+
+// TestEffectiveCached verifies the env var is read exactly once.
+func TestEffectiveCached(t *testing.T) {
+	t.Setenv("PRISM_LOG_LEVEL", "debug")
+	var buf bytes.Buffer
+	resetForTest(t, &buf)
+	if got := effective(); got != LevelDebug {
+		t.Fatalf("first call effective() = %d, want %d", got, LevelDebug)
+	}
+	// Mutating the env var after the first call must NOT change the cached value.
+	t.Setenv("PRISM_LOG_LEVEL", "error")
+	if got := effective(); got != LevelDebug {
+		t.Errorf("after env change effective() = %d, want %d (cached)", got, LevelDebug)
+	}
+}
+
+// TestEmitFilter verifies that each level value gates the four functions
+// correctly. For each scenario we run all four emit functions and check
+// which of them actually wrote to the captured buffer.
+func TestEmitFilter(t *testing.T) {
+	type emitFlags struct {
+		err, warn, info, debug bool
+	}
+	cases := []struct {
+		envVal string
+		want   emitFlags
+	}{
+		{"", emitFlags{err: true}},                                                       // unset → error
+		{"trace", emitFlags{err: true}},                                                  // unrecognised → error
+		{"error", emitFlags{err: true}},                                                  // explicit error
+		{"warn", emitFlags{err: true, warn: true}},                                       // warn
+		{"WARN", emitFlags{err: true, warn: true}},                                       // case-insensitive
+		{"info", emitFlags{err: true, warn: true, info: true}},                           // info
+		{"debug", emitFlags{err: true, warn: true, info: true, debug: true}},             // debug
+	}
+	for _, tc := range cases {
+		t.Run(tc.envVal, func(t *testing.T) {
+			t.Setenv("PRISM_LOG_LEVEL", tc.envVal)
+			var buf bytes.Buffer
+			resetForTest(t, &buf)
+
+			Errorf("E:%s\n", "x")
+			Warnf("W:%s\n", "x")
+			Infof("I:%s\n", "x")
+			Debugf("D:%s\n", "x")
+
+			out := buf.String()
+			got := emitFlags{
+				err:   bytes.Contains([]byte(out), []byte("E:x\n")),
+				warn:  bytes.Contains([]byte(out), []byte("W:x\n")),
+				info:  bytes.Contains([]byte(out), []byte("I:x\n")),
+				debug: bytes.Contains([]byte(out), []byte("D:x\n")),
+			}
+			if got != tc.want {
+				t.Errorf("env=%q: got %+v, want %+v (buffer: %q)", tc.envVal, got, tc.want, out)
+			}
+		})
+	}
+}
+
+// TestFormatStringPreserved confirms the helper passes format+args through
+// to fmt.Fprintf verbatim (no prefix, no timestamp, no trailing additions).
+func TestFormatStringPreserved(t *testing.T) {
+	t.Setenv("PRISM_LOG_LEVEL", "debug")
+	var buf bytes.Buffer
+	resetForTest(t, &buf)
+
+	Debugf("[timing] %s: %dms\n", "pre-exec", 5)
+	got := buf.String()
+	want := "[timing] pre-exec: 5ms\n"
+	if got != want {
+		t.Errorf("Debugf output = %q, want %q", got, want)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/context.go
+++ b/modules/programs/prism/prism/internal/review/context.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 // prViewJSON is the JSON shape returned by `gh pr view --json ...`.
@@ -168,14 +170,14 @@ func FetchPRContextWithOpts(opts FetchPRContextOpts) PRContext {
 	viewOut, err := runGH("pr", "view", opts.PRNumber, "--json",
 		"number,title,body,headRefName,headRefOid,baseRefName,baseRefOid,additions,deletions,changedFiles")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[prism review] warning: could not fetch PR metadata via gh: %v — agents will fall back to git-based discovery\n", err)
+		proglog.Warnf("[prism review] warning: could not fetch PR metadata via gh: %v — agents will fall back to git-based discovery\n", err)
 		prCtx.FetchFailed = true
 		return prCtx
 	}
 
 	var meta prViewJSON
 	if jsonErr := json.Unmarshal([]byte(viewOut), &meta); jsonErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism review] warning: could not parse PR metadata JSON: %v — agents will fall back to git-based discovery\n", jsonErr)
+		proglog.Warnf("[prism review] warning: could not parse PR metadata JSON: %v — agents will fall back to git-based discovery\n", jsonErr)
 		prCtx.FetchFailed = true
 		return prCtx
 	}
@@ -214,7 +216,7 @@ func FetchPRContextWithOpts(opts FetchPRContextOpts) PRContext {
 	diffOut, diffErr := runGH("pr", "diff", opts.PRNumber)
 	if diffErr != nil {
 		// Diff failure is non-fatal: we have metadata, just no diff content.
-		fmt.Fprintf(os.Stderr, "[prism review] warning: could not fetch PR diff via gh: %v — agents will use git diff instead\n", diffErr)
+		proglog.Warnf("[prism review] warning: could not fetch PR diff via gh: %v — agents will use git diff instead\n", diffErr)
 		// Leave Diff and DiffFilePath empty; the prompt will note diff unavailability.
 	} else {
 		prCtx.DiffBytes = len(diffOut)
@@ -244,12 +246,12 @@ func FetchPRContextWithOpts(opts FetchPRContextOpts) PRContext {
 				if mkErr := os.MkdirAll(opts.StateDir, 0o755); mkErr != nil {
 					// Directory creation failed; fall back to /tmp path to preserve
 					// the write attempt rather than silently inlining.
-					fmt.Fprintf(os.Stderr, "[prism review] warning: could not create state dir %s: %v — using /tmp fallback\n", opts.StateDir, mkErr)
+					proglog.Warnf("[prism review] warning: could not create state dir %s: %v — using /tmp fallback\n", opts.StateDir, mkErr)
 				}
 			}
 			diffPath := diffFilePath(opts.StateDir, opts.PRNumber, opts.Round)
 			if writeErr := os.WriteFile(diffPath, []byte(diffOut), 0o644); writeErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism review] warning: could not write diff to %s: %v — inlining diff instead\n", diffPath, writeErr)
+				proglog.Warnf("[prism review] warning: could not write diff to %s: %v — inlining diff instead\n", diffPath, writeErr)
 				prCtx.Diff = truncated
 			} else {
 				prCtx.DiffFilePath = diffPath

--- a/modules/programs/prism/prism/internal/review/lifecycle.go
+++ b/modules/programs/prism/prism/internal/review/lifecycle.go
@@ -8,12 +8,11 @@ package review
 // command — they have no dependency on prompt or result formatting.
 
 import (
-	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -116,7 +115,7 @@ func KillReviewSessionsForParentWithDB(d *db.DB, parentSession string) {
 			return
 		}
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[prism] warning: KillReviewSessionsForParentWithDB: DB error for %q: %v — using name-prefix fallback\n", parentSession, err)
+			proglog.Warnf("[prism] warning: KillReviewSessionsForParentWithDB: DB error for %q: %v — using name-prefix fallback\n", parentSession, err)
 		}
 		// len(members) == 0: fall through to name-prefix for pre-migration rows.
 	}
@@ -148,7 +147,7 @@ func CleanupReviewSessionsForParent(d *db.DB, parentSession string) {
 		return
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[prism] warning: CleanupReviewSessionsForParent: DB group error for %q: %v — using name-prefix fallback\n", parentSession, err)
+		proglog.Warnf("[prism] warning: CleanupReviewSessionsForParent: DB group error for %q: %v — using name-prefix fallback\n", parentSession, err)
 	}
 	// Pre-migration fallback: find rows by name prefix and kill by prefix.
 

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/promptdelivery"
 )
 
@@ -106,7 +107,7 @@ func MonitorFunc(opts MonitorOpts) error {
 	}
 	defer d.Close()
 
-	fmt.Fprintf(os.Stderr, "[prism monitor-review] watching group %s for PR #%s (worker: %s)\n",
+	proglog.Infof("[prism monitor-review] watching group %s for PR #%s (worker: %s)\n",
 		opts.GroupID, opts.PRNumber, opts.WorkerSession)
 
 	// Set deadline if timeout is specified.
@@ -119,16 +120,16 @@ func MonitorFunc(opts MonitorOpts) error {
 	timedOut := false
 	for {
 		if !deadline.IsZero() && time.Now().After(deadline) {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] timeout reached for group %s — delivering partial results\n", opts.GroupID)
+			proglog.Infof("[prism monitor-review] timeout reached for group %s — delivering partial results\n", opts.GroupID)
 			timedOut = true
 			break
 		}
 
 		done, groupErr := d.GroupCompleted(opts.GroupID)
 		if groupErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: GroupCompleted(%s): %v — retrying\n", opts.GroupID, groupErr)
+			proglog.Warnf("[prism monitor-review] warning: GroupCompleted(%s): %v — retrying\n", opts.GroupID, groupErr)
 		} else if done {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] group %s complete — aggregating results\n", opts.GroupID)
+			proglog.Infof("[prism monitor-review] group %s complete — aggregating results\n", opts.GroupID)
 			break
 		}
 
@@ -150,7 +151,7 @@ func MonitorFunc(opts MonitorOpts) error {
 	// Aggregate results.
 	groupData, grErr := d.GroupResults(opts.GroupID)
 	if grErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: GroupResults(%s): %v — using empty data\n", opts.GroupID, grErr)
+		proglog.Warnf("[prism monitor-review] warning: GroupResults(%s): %v — using empty data\n", opts.GroupID, grErr)
 		groupData = map[string]db.GroupMemberResult{}
 	}
 
@@ -177,7 +178,7 @@ func MonitorFunc(opts MonitorOpts) error {
 		if currentCycleProducedVerdicts(groupData) {
 			prior, ccErr := CompletedReviewCyclesForParent(d, opts.WorkerSession, opts.GroupID)
 			if ccErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: cycle count failed: %v — footer suppressed\n", ccErr)
+				proglog.Warnf("[prism monitor-review] warning: cycle count failed: %v — footer suppressed\n", ccErr)
 			} else if prior+1 >= REVIEW_CYCLE_THRESHOLD {
 				deliveryText += buildLoopLimitFooter(prior+1, opts.PRNumber)
 			}
@@ -205,13 +206,13 @@ func MonitorFunc(opts MonitorOpts) error {
 		if workerStatus.State == string(agent.StateReviewing) {
 			if err := d.UpsertStatus(opts.WorkerSession, workerStatus.Repo, workerStatus.Worktree,
 				string(agent.StateActive), nil, nil); err != nil {
-				fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: could not clear reviewing→active before delivery: %v\n", err)
+				proglog.Warnf("[prism monitor-review] warning: could not clear reviewing→active before delivery: %v\n", err)
 			} else {
-				fmt.Fprintf(os.Stderr, "[prism monitor-review] worker state reviewing→active (pre-delivery)\n")
+				proglog.Infof("[prism monitor-review] worker state reviewing→active (pre-delivery)\n")
 			}
 		}
 	} else if stErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: could not look up worker session %q before delivery: %v\n", opts.WorkerSession, stErr)
+		proglog.Warnf("[prism monitor-review] warning: could not look up worker session %q before delivery: %v\n", opts.WorkerSession, stErr)
 	}
 
 	// Deliver to worker via prism prompt with bounded retry.
@@ -219,17 +220,17 @@ func MonitorFunc(opts MonitorOpts) error {
 	if deliverErr != nil {
 		// Delivery failed after all retries — write fallback file.
 		fallbackPath := fmt.Sprintf("/tmp/prism-review-%s-round-%d-result.md", sanitisePRNumber(opts.PRNumber), opts.Round)
-		fmt.Fprintf(os.Stderr, "[prism monitor-review] delivery failed after %d retries — writing fallback to %s\n", maxRetries, fallbackPath)
+		proglog.Errorf("[prism monitor-review] delivery failed after %d retries — writing fallback to %s\n", maxRetries, fallbackPath)
 		writeErr := os.WriteFile(fallbackPath, []byte(deliveryText), 0o644)
 		if writeErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] error: could not write fallback file %s: %v\n", fallbackPath, writeErr)
+			proglog.Errorf("[prism monitor-review] error: could not write fallback file %s: %v\n", fallbackPath, writeErr)
 		} else {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] fallback file written to %s\n", fallbackPath)
+			proglog.Infof("[prism monitor-review] fallback file written to %s\n", fallbackPath)
 		}
 		return fmt.Errorf("monitor-review: delivery failed and fallback written to %s", fallbackPath)
 	}
 
-	fmt.Fprintf(os.Stderr, "[prism monitor-review] results delivered to %s\n", opts.WorkerSession)
+	proglog.Infof("[prism monitor-review] results delivered to %s\n", opts.WorkerSession)
 	return nil
 }
 
@@ -255,7 +256,7 @@ func forceTerminateStuckMembers(d *db.DB, agentSessions []string, perAgentTimeou
 		}
 		status, err := d.CurrentStatus(sess)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: CurrentStatus(%s) during force-terminate sweep: %v\n", sess, err)
+			proglog.Warnf("[prism monitor-review] warning: CurrentStatus(%s) during force-terminate sweep: %v\n", sess, err)
 			continue
 		}
 		if status == nil {
@@ -267,10 +268,10 @@ func forceTerminateStuckMembers(d *db.DB, agentSessions []string, perAgentTimeou
 		if isTerminalAgentState(status.State) {
 			continue
 		}
-		fmt.Fprintf(os.Stderr, "[prism monitor-review] force-terminating stuck member %s (state=%q, per-agent timeout=%v)\n",
+		proglog.Warnf("[prism monitor-review] force-terminating stuck member %s (state=%q, per-agent timeout=%v)\n",
 			sess, status.State, perAgentTimeout)
 		if err := d.UpsertStatus(sess, status.Repo, status.Worktree, "error", nil, nil); err != nil {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] warning: UpsertStatus(%s, error): %v\n", sess, err)
+			proglog.Warnf("[prism monitor-review] warning: UpsertStatus(%s, error): %v\n", sess, err)
 		}
 	}
 }
@@ -433,7 +434,7 @@ func deliverWithRetry(workerSession, text string, maxRetries int, baseBackoff ti
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			fmt.Fprintf(os.Stderr, "[prism monitor-review] delivery attempt %d/%d failed (%v) — retrying in %s\n",
+			proglog.Warnf("[prism monitor-review] delivery attempt %d/%d failed (%v) — retrying in %s\n",
 				attempt, maxRetries, lastErr, backoff)
 			time.Sleep(backoff)
 			backoff *= 2
@@ -727,7 +728,7 @@ func CompletedReviewCyclesForParent(d *db.DB, parentSession, excludeGroupID stri
 			// count. Log and skip the group so we do not fire LOOP-LIMIT
 			// based on partial data, but do not return the error — callers
 			// (the monitor) treat a missing footer as a benign degradation.
-			fmt.Fprintf(os.Stderr, "[prism review] warning: GroupResults(%s) failed during cycle counting: %v\n", gid, gErr)
+			proglog.Warnf("[prism review] warning: GroupResults(%s) failed during cycle counting: %v\n", gid, gErr)
 			continue
 		}
 		producedVerdict := false

--- a/modules/programs/prism/prism/internal/review/poll.go
+++ b/modules/programs/prism/prism/internal/review/poll.go
@@ -10,10 +10,10 @@ package review
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 )
 
 // pollAgents polls the DB until all agents reach a terminal state or the
@@ -45,7 +45,7 @@ func pollAgents(ctx context.Context, d *db.DB, agents []Agent, agentSessions []s
 		if groupErr != nil {
 			// DB error — log and fall through to per-agent checks below
 			// so progress tracking still works.
-			fmt.Fprintf(os.Stderr, "[prism review] warning: GroupCompleted(%s): %v\n", groupID, groupErr)
+			proglog.Warnf("[prism review] warning: GroupCompleted(%s): %v\n", groupID, groupErr)
 		}
 
 		// Even when groupDone is true, scan agents once more to emit any
@@ -174,7 +174,7 @@ func buildResults(agents []Agent, agentSessions []string, d *db.DB, finished, ti
 		groupData, grErr = d.GroupResults(groupID)
 		if grErr != nil {
 			// Non-fatal: fall back to per-session queries below.
-			fmt.Fprintf(os.Stderr, "[prism review] warning: GroupResults(%s): %v — falling back to per-session queries\n", groupID, grErr)
+			proglog.Warnf("[prism review] warning: GroupResults(%s): %v — falling back to per-session queries\n", groupID, grErr)
 			groupData = nil
 		}
 	}

--- a/modules/programs/prism/prism/internal/review/recovery.go
+++ b/modules/programs/prism/prism/internal/review/recovery.go
@@ -28,11 +28,11 @@ package review
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/promptdelivery"
 )
 
@@ -106,7 +106,7 @@ func DeliverGroupResults(d *db.DB, groupID, deliveryID string) (*RecoveryDeliver
 	if err != nil {
 		// Non-fatal: emit a degraded delivery rather than refusing to deliver.
 		// MonitorFunc takes the same stance on this branch.
-		fmt.Fprintf(os.Stderr, "[prism review recovery] warning: GroupResults(%s): %v — using empty data\n", groupID, err)
+		proglog.Warnf("[prism review recovery] warning: GroupResults(%s): %v — using empty data\n", groupID, err)
 		groupData = map[string]db.GroupMemberResult{}
 	}
 
@@ -119,7 +119,7 @@ func DeliverGroupResults(d *db.DB, groupID, deliveryID string) (*RecoveryDeliver
 	if !allPassed && currentCycleProducedVerdicts(groupData) {
 		prior, ccErr := CompletedReviewCyclesForParent(d, info.ParentSession, groupID)
 		if ccErr != nil {
-			fmt.Fprintf(os.Stderr, "[prism review recovery] warning: cycle count failed: %v — footer suppressed\n", ccErr)
+			proglog.Warnf("[prism review recovery] warning: cycle count failed: %v — footer suppressed\n", ccErr)
 		} else if prior+1 >= REVIEW_CYCLE_THRESHOLD {
 			deliveryText += buildLoopLimitFooter(prior+1, info.PRNumber)
 		}
@@ -132,13 +132,13 @@ func DeliverGroupResults(d *db.DB, groupID, deliveryID string) (*RecoveryDeliver
 		if workerStatus.State == string(agent.StateReviewing) {
 			if upErr := d.UpsertStatus(info.ParentSession, workerStatus.Repo, workerStatus.Worktree,
 				string(agent.StateActive), nil, nil); upErr != nil {
-				fmt.Fprintf(os.Stderr, "[prism review recovery] warning: could not clear reviewing\u2192active before delivery: %v\n", upErr)
+				proglog.Warnf("[prism review recovery] warning: could not clear reviewing\u2192active before delivery: %v\n", upErr)
 			} else {
-				fmt.Fprintf(os.Stderr, "[prism review recovery] worker state reviewing\u2192active (pre-delivery, group=%s)\n", groupID)
+				proglog.Errorf("[prism review recovery] worker state reviewing\u2192active (pre-delivery, group=%s)\n", groupID)
 			}
 		}
 	} else if stErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism review recovery] warning: CurrentStatus(%s): %v\n", info.ParentSession, stErr)
+		proglog.Warnf("[prism review recovery] warning: CurrentStatus(%s): %v\n", info.ParentSession, stErr)
 	}
 
 	res := &RecoveryDeliveryResult{

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -384,7 +385,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 	activeGroupID, activeErr := ActiveReviewGroupForParent(d, opts.ParentSession)
 	if activeErr != nil {
 		// Non-fatal: log and proceed (better to allow duplicate than block falsely).
-		fmt.Fprintf(os.Stderr, "[prism review] warning: could not check for active review group: %v\n", activeErr)
+		proglog.Warnf("[prism review] warning: could not check for active review group: %v\n", activeErr)
 	} else if activeGroupID != "" {
 		// Determine the round number for a useful error message.
 		members, _ := d.GroupMembersForParent(opts.ParentSession)
@@ -604,7 +605,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 	}
 	if startErr := StartMonitorProcess(monitorOpts, prismBinary); startErr != nil {
 		// Monitor failed to start — not fatal for spawning, but warn loudly.
-		fmt.Fprintf(os.Stderr, "[prism review] warning: could not start monitor process: %v\n"+
+		proglog.Warnf("[prism review] warning: could not start monitor process: %v\n"+
 			"Review results will NOT be delivered automatically.\n"+
 			"Check agent progress with: prism checkin %s~review-%d-<agent>\n",
 			startErr, opts.ParentSession, round)
@@ -625,10 +626,10 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 	if workerStatus, stErr := d.CurrentStatus(opts.WorkerSession); stErr == nil && workerStatus != nil {
 		if err := d.UpsertStatus(opts.WorkerSession, workerStatus.Repo, workerStatus.Worktree,
 			string(agent.StateReviewing), nil, nil); err != nil {
-			fmt.Fprintf(os.Stderr, "[prism review] warning: could not set worker state to reviewing: %v\n", err)
+			proglog.Warnf("[prism review] warning: could not set worker state to reviewing: %v\n", err)
 		}
 	} else if stErr != nil {
-		fmt.Fprintf(os.Stderr, "[prism review] warning: could not look up worker session %q: %v\n", opts.WorkerSession, stErr)
+		proglog.Warnf("[prism review] warning: could not look up worker session %q: %v\n", opts.WorkerSession, stErr)
 	}
 
 	// Build acknowledgement message (#1051 Piece C: surface partial-success).

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
@@ -237,7 +238,7 @@ func DefaultAgentForSession(sessionName, directory, explicit string, d *db.DB) s
 	if d != nil {
 		rootName, rowExists, err := d.RootAgentName(sessionName)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[prism] warning: DefaultAgentForSession: DB error reading root_agent_name for %q: %v — using directory heuristic\n", sessionName, err)
+			proglog.Warnf("[prism] warning: DefaultAgentForSession: DB error reading root_agent_name for %q: %v — using directory heuristic\n", sessionName, err)
 		} else if rowExists && rootName != "" {
 			// DB-backed: return the stored root_agent_name.
 			dirBased := DefaultAgent(directory, "")


### PR DESCRIPTION
Closes #1818

## Summary

Introduces a minimal log-level shim — `internal/proglog` — and converts every
`fmt.Fprintf(os.Stderr, "[prism ...] ...", ...)` and `[timing]` call site to
use it. Default level is `error`, so transient retry / probe / timing lines
no longer flash in the user's tmux pane. Set `PRISM_LOG_LEVEL=warn` (or
`info` / `debug`) to bring them back.

## Headline change

The user's reported symptoms — `[timing]` lines on every session start, the
`[prism ... --wait] probe error: ... (will retry)` line, the
`[prism monitor-review] delivery attempt 1/5 failed` line — were all from
unconditional stderr writes. They recover automatically but the messages
flash. After this PR they are silent by default.

## The shim — `internal/proglog`

- Single file. Four functions (`Errorf`, `Warnf`, `Infof`, `Debugf`) with the
  standard `(format string, args ...any)` shape — drop-in for the existing
  `fmt.Fprintf(os.Stderr, ...)` call sites.
- Level read once from `PRISM_LOG_LEVEL` on first use, cached via `sync.Once`.
- Recognised values (case-insensitive): `error`, `warn` (or `warning`),
  `info`, `debug`. Unset or unrecognised → `error`. No panic on bad input.
- No prefix added by the helper. The caller's existing `[prism ...]` /
  `[timing]` prefix is preserved verbatim so downstream `grep '\[timing\]'`
  diagnostics keep working.
- Writer is resolved at emit time via `writerFor()` (returns `os.Stderr`),
  so existing tests that redirect `os.Stderr` through `os.Pipe()` keep
  observing output without modification. Test helper `SetLevelForTest` is
  exported so individual tests can pin a level past the `sync.Once`.

## Mapping table — applied as specified in the issue

| Call site | New level |
|---|---|
| `cmd/agent_run.go::logTimingTo` ([timing] pre-exec, bwrap-args build, bwrap exec) | `Debugf` (stderr only — file write to `agent-run.log` stays unconditional) |
| `cmd/agent_run_sandbox_exec_darwin.go` [timing] callers | inherited via shared `logTimingTo` |
| `cmd/spawn_wait.go`, `cmd/review_wait.go`, `cmd/merge.go` — `--wait probe error` | `Debugf` |
| `internal/review/monitor.go:129` GroupCompleted warning | `Warnf` |
| `internal/review/monitor.go:436` delivery attempt N/M failed | `Warnf` |
| `internal/review/monitor.go:222` delivery failed after N retries — writing fallback | `Errorf` |
| `cmd/monitor_review.go:52` `[prism monitor-review] error: …` | `Errorf` |
| `cmd/cleanup.go` `[prism] doCleanup/headlessCleanup/closeSession/headlessCloseSession: … error` | `Errorf` |
| `cmd/cleanup.go` `[prism] warning: …`, `[prism] archive: …` | `Warnf` |

Sites not listed in the explicit mapping were classified by the issue's
rubric: format strings containing `' warning:'`, `'(non-fatal)'`, or
`'(continuing)'` → `Warnf`; lifecycle informational lines (`starting`,
`shutting down`, `using isolation override`, `ready signal written`,
`worker state reviewing→active`) → `Infof`; everything else → `Errorf`.

## Files touched

```
modules/programs/prism/prism/
  internal/proglog/proglog.go          (new — 130 lines)
  internal/proglog/proglog_test.go     (new — 130 lines)
  cmd/agent_run.go
  cmd/cleanup.go
  cmd/cleanup_orphan_sidecars.go
  cmd/merge.go
  cmd/monitor_review.go
  cmd/pr.go
  cmd/reset.go
  cmd/restore.go
  cmd/review_wait.go
  cmd/sidecar.go
  cmd/spawn.go
  cmd/spawn_wait.go
  cmd/switch.go
  internal/container/dispatch.go
  internal/db/db.go
  internal/db/db_test.go               (test now relies on writerFor() resolving os.Stderr at emit time)
  internal/db/status.go
  internal/review/context.go
  internal/review/lifecycle.go
  internal/review/monitor.go
  internal/review/poll.go
  internal/review/recovery.go
  internal/review/run.go
  internal/session/session.go
```

## Verification

- `go build ./...` — pass.
- `go test ./...` — pass.
- `go test -race ./internal/proglog/` — pass.
- `nix build .#prism` — pass.
- Sandbox-checked build (`runChecks = true`, $HOME=/homeless-shelter) — pass.
- Grep audit per AC #10:
  ```
  grep -rIn 'fmt\.Fprintf(os\.Stderr.*"\[(prism|timing)' modules/programs/prism/prism/
  ```
  → zero matches outside `internal/proglog/`.

## Out of scope (per issue)

- No structured logging / `log/slog` / `zap` / `zerolog`. Just `fmt.Fprintf`
  gated on a cached level.
- No log file rotation. Stderr only.
- No conversion of `log.Printf` call sites in the sidecar (they write to the
  sidecar log file, not the user's pane).
- No new flags. `PRISM_LOG_LEVEL` is the only configuration surface.
