### PR TITLE
pi-coding-agent: bump 0.72.1 → 0.75.3

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts
@@ -36,7 +36,7 @@ export interface OAuthCredentials {
   expires: number
 }
 
-// pi-specific: OAuthLoginCallbacks mirrors @mariozechner/pi-ai's interface
+// pi-specific: OAuthLoginCallbacks mirrors @earendil-works/pi-ai's interface
 export interface OAuthLoginCallbacks {
   onAuth: (opts: { url: string; instructions: string }) => void
   onManualCodeInput?: () => Promise<string>

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -16,8 +16,8 @@ import {
   ModelRegistry,
   type ExtensionAPI,
   type ProviderConfig,
-} from "@mariozechner/pi-coding-agent"
-import type { OAuthCredentials } from "@mariozechner/pi-ai"
+} from "@earendil-works/pi-coding-agent"
+import type { OAuthCredentials } from "@earendil-works/pi-ai"
 import { initLogger, log } from "./logger.ts"
 import {
   loginAnthropic,
@@ -26,7 +26,7 @@ import {
 } from "./auth.ts"
 import { getCachedCredentials, repairCredentials } from "./credentials.ts"
 import { transformBody, transformResponseStream } from "./transforms.ts"
-import { streamSimpleAnthropic } from "@mariozechner/pi-ai"
+import { streamSimpleAnthropic } from "@earendil-works/pi-ai"
 import { getModelBetas, getExcludedBetas } from "./betas.ts"
 import { config } from "./model-config.ts"
 import {
@@ -124,7 +124,7 @@ export default function (pi: ExtensionAPI) {
       }
 
       const { createAssistantMessageEventStream, calculateCost } =
-        require("@mariozechner/pi-ai") as typeof import("@mariozechner/pi-ai")
+        require("@earendil-works/pi-ai") as typeof import("@earendil-works/pi-ai")
 
       const stream = createAssistantMessageEventStream()
 

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/stream.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/stream.test.ts
@@ -27,7 +27,7 @@ import { sanitizeSystemText, buildAnthropicSystemPrompt } from "./stream.ts"
 function legacySanitize(text: string): string {
   const PI_REMOVAL_ANCHORS = [
     "pi-coding-agent",
-    "@mariozechner/pi-coding-agent",
+    "@earendil-works/pi-coding-agent",
     "badlogic/pi-mono",
   ]
   const paragraphs = text.split(/\n\n+/)
@@ -139,17 +139,17 @@ describe("sanitizeSystemText — prose pi → Claude Code substitution", () => {
 // [functional] PI_REMOVAL_ANCHORS paragraph filtering preserved
 // ---------------------------------------------------------------------------
 describe("sanitizeSystemText — PI_REMOVAL_ANCHORS paragraph filtering", () => {
-  it("removes a paragraph anchored by '@mariozechner/pi-coding-agent'", () => {
+  it("removes a paragraph anchored by '@earendil-works/pi-coding-agent'", () => {
     const input = [
       "Normal intro paragraph.",
-      "This extension is @mariozechner/pi-coding-agent and does things.",
+      "This extension is @earendil-works/pi-coding-agent and does things.",
       "Normal trailing paragraph.",
     ].join("\n\n")
 
     const output = sanitizeSystemText(input)
 
     assert.ok(
-      !output.includes("@mariozechner/pi-coding-agent"),
+      !output.includes("@earendil-works/pi-coding-agent"),
       "anchor paragraph should be stripped",
     )
     assert.ok(
@@ -324,7 +324,7 @@ describe("sanitizeSystemText — prose-only no regression", () => {
   })
 
   it("PI_REMOVAL_ANCHORS still work in prose-only prompts", () => {
-    const input = "Intro.\n\n@mariozechner/pi-coding-agent extension.\n\nEnd."
+    const input = "Intro.\n\n@earendil-works/pi-coding-agent extension.\n\nEnd."
     const newOutput = sanitizeSystemText(input)
     const oldOutput = legacySanitize(input)
     assert.equal(newOutput, oldOutput)

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts
@@ -21,7 +21,7 @@ import type {
   ToolResultMessage,
   Message,
   Tool,
-} from "@mariozechner/pi-ai"
+} from "@earendil-works/pi-ai"
 
 // ──────────────────────────────────────────────
 // Type helpers
@@ -74,7 +74,7 @@ const CLAUDE_CODE_IDENTITY =
   "You are Claude Code, Anthropic's official CLI for Claude."
 const PI_REMOVAL_ANCHORS = [
   "pi-coding-agent",
-  "@mariozechner/pi-coding-agent",
+  "@earendil-works/pi-coding-agent",
   "badlogic/pi-mono",
 ] as const
 

--- a/modules/programs/prism/pi/extensions/atlassian/index.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/index.ts
@@ -13,7 +13,7 @@
 //
 // See UPSTREAM.md for auth method rationale and token storage location.
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { Type } from "typebox"
 import { createMcpSession, type McpSession, type McpTool, getDefaultCloudId } from "./mcp-client.ts"
 import { loadTokens, getValidAccessToken, loginAtlassian, type AtlassianTokens } from "./auth.ts"

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -3348,13 +3348,13 @@ describe("iris constants", () => {
 //
 // Source of the pinned shapes (pi 0.72.1):
 //   - AssistantMessageEvent union:
-//     node_modules/@mariozechner/pi-ai/dist/types.d.ts:185-225
+//     node_modules/@earendil-works/pi-ai/dist/types.d.ts:185-225
 //   - AssistantMessage / TextContent / ThinkingContent / ToolCall:
-//     node_modules/@mariozechner/pi-ai/dist/types.d.ts:75-160
+//     node_modules/@earendil-works/pi-ai/dist/types.d.ts:75-160
 //   - MessageEndEvent (assistantMessage is delivered to extensions verbatim):
 //     dist/core/extensions/types.d.ts:513
 //   - agent-loop's `text_delta` emission path:
-//     node_modules/@mariozechner/pi-agent-core/dist/agent-loop.js:181-196
+//     node_modules/@earendil-works/pi-agent-core/dist/agent-loop.js:181-196
 // ---------------------------------------------------------------------------
 
 describe("#1764: pi 0.72.1 AssistantMessageEvent — isAssistantTextDeltaEvent", () => {

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -63,7 +63,7 @@ import type {
   ExtensionAPI,
   ExtensionContext,
   ProviderConfig,
-} from "@mariozechner/pi-coding-agent"
+} from "@earendil-works/pi-coding-agent"
 
 // ---------------------------------------------------------------------------
 // Constants — kept at module scope so unit tests can import them.
@@ -995,7 +995,7 @@ export function coerceToolOutput(content: unknown): string {
  * duplicate emission from `message_end`.
  *
  * The shape comes from pi 0.72.1's pi-ai package:
- * `node_modules/@mariozechner/pi-ai/dist/types.d.ts:185-225`.
+ * `node_modules/@earendil-works/pi-ai/dist/types.d.ts:185-225`.
  * The AssistantMessageEvent union includes:
  *   start, text_start, text_delta, text_end,
  *   thinking_start, thinking_delta, thinking_end,
@@ -1023,7 +1023,7 @@ export function isAssistantTextDeltaEvent(
  * with no text blocks, or malformed input.
  *
  * Source-of-truth for the shape:
- * `node_modules/@mariozechner/pi-ai/dist/types.d.ts:143` (`AssistantMessage`)
+ * `node_modules/@earendil-works/pi-ai/dist/types.d.ts:143` (`AssistantMessage`)
  * and the `TextContent`/`ThinkingContent`/`ToolCall` interfaces above it.
  */
 export function extractAssistantText(message: unknown): string[] {

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -6,7 +6,7 @@ package pi
 // Unlike some harnesses, PI has no SQLite database — it is a pure flat-file store.
 //
 // Source path layout (authoritative reference: docs/pi-rpc-interface.md Q5,
-// confirmed against pi 0.72.1 dist/core/session-manager.js line 213):
+// confirmed against pi 0.75.3 dist/core/session-manager.js line 213):
 //
 //	~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl
 //
@@ -252,7 +252,7 @@ func (a *piArchiveAdapter) Version(_ context.Context) (string, error) {
 }
 
 // EncodePiCWD encodes an absolute directory path to the directory name pi uses
-// for its session storage. The formula mirrors pi 0.72.1
+// for its session storage. The formula mirrors pi 0.75.3
 // dist/core/session-manager.js line 213:
 //
 //	--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -20,7 +20,7 @@ func encodePiCWDForTest(cwd string) string {
 	return "--" + r.Replace(stripped) + "--"
 }
 
-// TestEncodePiCWD verifies the encoding formula matches pi 0.72.1
+// TestEncodePiCWD verifies the encoding formula matches pi 0.75.3
 // dist/core/session-manager.js line 213.
 func TestEncodePiCWD(t *testing.T) {
 	cases := []struct {

--- a/modules/programs/prism/prism/internal/payload/payload.go
+++ b/modules/programs/prism/prism/internal/payload/payload.go
@@ -76,7 +76,7 @@ type MsgAssistant struct {
 //
 // Pre-#1783 the struct declared `tool`, `args` (Go `string`), and
 // `messageId` — a wire format that no live producer has emitted since
-// at least pi 0.72.1. Renderers using the old fields saw
+// at least pi 0.75.3. Renderers using the old fields saw
 // `json.Unmarshal` fail on `args` (object vs string mismatch) and
 // emitted `(parse error)` for every tool call. The rename here
 // realigns the consumer side with the upstream wire shape; the older

--- a/modules/programs/prism/prism/internal/payload/payload_test.go
+++ b/modules/programs/prism/prism/internal/payload/payload_test.go
@@ -89,7 +89,7 @@ func TestMsgAssistant_Roundtrip(t *testing.T) {
 // TestToolCall_Roundtrip covers the post-#1783 wire shape: `name`,
 // `args` (json.RawMessage / JSON object), `id`. The previous test
 // used the old `tool`/`messageId`/string-args trio which had drifted
-// silently from pi 0.72.1's emitted payload — see issue #1783 for
+// silently from pi 0.75.3's emitted payload — see issue #1783 for
 // the full root cause analysis.
 func TestToolCall_Roundtrip(t *testing.T) {
 	in := payload.ToolCall{
@@ -132,7 +132,7 @@ func TestToolResult_Roundtrip(t *testing.T) {
 }
 
 // TestToolCall_PiExtensionWireShape is the regression test required
-// by issue #1783's acceptance criteria: pins the pi 0.72.1
+// by issue #1783's acceptance criteria: pins the pi 0.75.3
 // prism-extension wire format so an upstream rename surfaces here as
 // a deliberate test failure rather than a silent (parse error)
 // regression in the iris TUI.

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -41,18 +41,36 @@ rec {
           newSrc = prev.fetchFromGitHub {
             owner = "badlogic";
             repo = "pi-mono";
-            tag = "v0.72.1";
-            hash = "sha256-SqUxghc60P3HfmaFJGB/m23mvzw0cD7cDEUrNFOqo0Y=";
+            tag = "v0.75.3";
+            hash = "sha256-c/+cxkp/EZ2PLERxTENN5edXHEs7M2oqzNepjRA4TIE=";
           };
         in
         prev.pi-coding-agent.overrideAttrs (old: {
-          version = "0.72.1";
+          version = "0.75.3";
           src = newSrc;
           npmDeps = prev.fetchNpmDeps {
             inherit (old) npmWorkspace;
             src = newSrc;
-            hash = "sha256-KUC1xQK6oJXtg962YeLOnO76uTdR10/VNa9iiCdT3VM=";
+            hash = "sha256-/mWjrZFzRmtkbWYMJOXKnLPxFITFndq5hgdY0DnPfAg=";
           };
+          # Upstream nixpkgs' postInstall hard-codes the old
+          # @mariozechner/* workspace names; in v0.75.0 the monorepo
+          # renamed to @earendil-works/*. Re-derive postInstall with the
+          # new names.
+          postInstall = ''
+            local nm="$out/lib/node_modules/pi-monorepo/node_modules"
+
+            for ws in @earendil-works/pi-ai:packages/ai \
+                      @earendil-works/pi-agent-core:packages/agent \
+                      @earendil-works/pi-tui:packages/tui; do
+              IFS=: read -r pkg src <<< "$ws"
+              rm "$nm/$pkg"
+              cp -r "$src" "$nm/$pkg"
+            done
+
+            find "$nm" -type l -lname '*/packages/*' -delete
+            find "$nm/.bin" -xtype l -delete
+          '';
         });
 
       # direnv: disable the test phase on Darwin to work around a hang in


### PR DESCRIPTION
Bumps the pinned `pi-coding-agent` override from 0.72.1 → 0.75.3.

## Changes

- **`overlays/default.nix`** — bump `tag`/`version`/`hash` for the pi-mono source, recompute `npmDeps.hash`, and override `postInstall`. Nixpkgs' `postInstall` hard-codes the old `@mariozechner/*` workspace names; v0.75.0 renamed the monorepo to `@earendil-works/*`, so we re-derive the install step with the new package names.
- **`modules/programs/prism/pi/extensions/`** — replace all `@mariozechner/*` imports and string references with `@earendil-works/*`. Affects `prism.ts`, `prism.test.ts`, `anthropic-oauth/{auth,index,stream,stream.test}.ts`, and `atlassian/index.ts`. The spawn prompt explicitly mentioned only `prism.ts`/`prism.test.ts`, but the AC says no `@mariozechner/*` imports remain *anywhere* in `extensions/`, so the other modules are included too.
- **prism Go source** — update version-string comments referencing `pi 0.72.1` → `pi 0.75.3` in `internal/harness/pi/archive{,_test}.go` and `internal/payload/payload{,_test}.go`. The CWD-encoding formula (`session-manager.js:213`) and the recorded payload fixture are both unchanged in 0.75.3 — verified by re-running the tests against the bumped pi without any fixture edits.

## Verification

- `pi --version` from the built `pi-coding-agent` reports `0.75.3`.
- `go build ./...` and `go test ./...` pass from `modules/programs/prism/prism/`.
- `nix build .#prism` from the repo root succeeds.
- `tsx --test` exits 0 for `anthropic-oauth/{stream,auth,credentials}.test.ts` and `atlassian/slim.test.ts`. `prism.test.ts` reports all 74 suites pass (the node test runner does not exit cleanly afterwards — this is a pre-existing condition on `main`, separate informational escalation filed).

Closes #1817