### PR TITLE
pi/extensions: add --test-force-exit to documented test invocations

### DIFF
--- a/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
+++ b/modules/programs/prism/pi/extensions/atlassian/slim.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for slim.ts — field-drop logic for Atlassian MCP responses.
-// Run with: tsx --test slim.test.ts (from this directory)
-// Or: cd modules/programs/prism/pi/extensions/atlassian && tsx --test slim.test.ts
+// Run with: tsx --test --test-force-exit slim.test.ts (from this directory)
+// Or: cd modules/programs/prism/pi/extensions/atlassian && tsx --test --test-force-exit slim.test.ts
 
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -1,5 +1,5 @@
 // Unit tests for the prism PI extension's pure helpers.
-// Run with: node --test --import tsx prism.test.ts
+// Run with: node --test --test-force-exit --import tsx prism.test.ts
 //
 // We test the helper functions in isolation: truncation, endpoint parsing,
 // the JSONL line reader, and the inbound dispatcher with a mock API. The


### PR DESCRIPTION
Node's `--test-force-exit` flag exits the test runner cleanly when `prism.test.ts` (and `atlassian/slim.test.ts`) finish but the event loop is held open by leaked net/timer handles.

## Changes

- `prism.test.ts` line 2: updated "Run with:" comment to include `--test-force-exit`
- `atlassian/slim.test.ts` lines 2–3: both documented invocations updated to include `--test-force-exit`
- No test logic changed; `git diff --stat` shows only comment-line changes

## Verification

All tests pass and exit cleanly:

```
time tsx --test --test-force-exit prism.test.ts
# 274 tests, 70 suites, 0 fail — exits in ~2.6s

time tsx --test --test-force-exit atlassian/slim.test.ts
# 32 tests, 10 suites, 0 fail — exits in ~0.5s

for f in anthropic-oauth/{auth,credentials,stream}.test.ts; do node --test --test-force-exit "$f"; done
# all pass, no changes needed
```

Closes #1822