### PR TITLE
dashboard: remove growSession inflation, compute titleW directly

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/session_column_width_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/session_column_width_test.go
@@ -284,11 +284,10 @@ func TestSessionColumnWidth_DashViewIntegration(t *testing.T) {
 	if headerLine == "" {
 		t.Fatal("could not find header line in DashView output for long sessions")
 	}
-	// The session column spans treePrefixW(10) + sessionW(after growSession).
-	// What matters: DashView started from 22, not the old hardcoded 20-char floor,
-	// so the total session area fits the actual content without using the old floor.
-	// We can't easily check the exact final width (growSession may add more),
-	// but we verify the header renders without panic and contains expected labels.
+	// The session column spans treePrefixW(10) + sessionW, where sessionW is
+	// the content-derived width from SessionColumnWidth (clamped to [7, 40]).
+	// titleW absorbs all remaining horizontal space with no inflation of sessionW.
+	// Verify the header renders without panic and contains the expected labels.
 	for _, label := range []string{"session", "state", "title"} {
 		if !strings.Contains(headerLine, label) {
 			t.Errorf("header line missing %q: %q", label, headerLine)

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -455,10 +455,10 @@ func SortDisplayed(ss []AgentSession) {
 //     Using the maximum of both formulas ensures correctness in all modes.
 //
 // Constants are defined here as unexported values to avoid import cycles;
-// the view's own sessionWCap and treePrefixW constants must stay in sync.
+// treePrefixW must stay in sync with the constant of the same name in view.go.
 func SessionColumnWidth(sessions []AgentSession) int {
 	const sessionWMin = 7  // len("session") — never truncate the column header
-	const sessionWCap = 40 // must match sessionWCap in view.go
+	const sessionWCap = 40 // maximum session column width
 	const treePrefixW = 10 // must match treePrefixW in view.go
 	const d1PrefixLen = 6  // "  ├── " or "  └── "
 	const d2PrefixLen = 10 // "  │   ├── " or "  │   └── "

--- a/modules/programs/prism/prism/internal/dashboard/view.go
+++ b/modules/programs/prism/prism/internal/dashboard/view.go
@@ -180,7 +180,6 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	const treePrefixW = 10
 	const stateW = 10
 	const dotW = 2
-	const sessionWCap = 40 // maximum session width before the rest goes to title
 
 	// fixedCore is the non-negotiable fixed overhead: leading space + dot +
 	// treePrefixW + gap-before-state + stateW.
@@ -190,21 +189,10 @@ func DashView(d Shared, currentSession string, cursorActive bool) string {
 	// across all displayed entries, clamped to [7, 40].
 	sessionW := SessionColumnWidth(d.Displayed)
 
-	// growSession offers surplus space to sessionW (up to sessionWCap) before
-	// allocating the rest to titleW.
-	growSession := func(tw int) int {
-		if tw > 2 && sessionW < sessionWCap {
-			gain := min(tw-2, sessionWCap-sessionW)
-			sessionW += gain
-			tw -= gain
-		}
-		return tw
-	}
-
 	// Layout: " " + dot(2) + treePrefixW + sessionW + 2 + stateW + 2 + titleW.
 	// titleW absorbs all leftover width; below the minimum it clamps to 0,
 	// suppressing the title column.
-	titleW := growSession(d.Width - fixedCore - sessionW - 2)
+	titleW := d.Width - fixedCore - sessionW - 2
 	if titleW < 0 {
 		titleW = 0
 	}


### PR DESCRIPTION
## Summary

Removes the `growSession` closure and `sessionWCap` constant from `internal/dashboard/view.go` that were greedily inflating the session column width up to 40 cells even when session names were much shorter. This created dead space between the session name and state columns proportional to terminal width.

## Root cause

`growSession` repurposed `sessionWCap` as an expansion target instead of a clamp — the opposite of its intent. `SessionColumnWidth` in `sessions.go` already enforces the [7, 40] clamp correctly; `view.go` was inflating past the content-derived width before allocating remaining space to `titleW`.

## Fix

```go
// Before
growSession := func(tw int) int { ... }
titleW := growSession(d.Width - fixedCore - sessionW - 2)

// After  
titleW := d.Width - fixedCore - sessionW - 2
if titleW < 0 { titleW = 0 }
```

- Session column now renders at exactly `SessionColumnWidth(d.Displayed)` — content-derived, clamped to [7, 40]
- Title column absorbs all remaining horizontal space
- Negative-titleW clamp preserved (suppresses title column on very narrow terminals)
- The `sessionWCap = 40` constant in `sessions.go` stays (still enforces the clamp for long names)
- Updated stale `must match sessionWCap in view.go` comment in `sessions.go` and removed `growSession may add more` hedging in test

## Testing

- `go build ./...` ✅
- `go test ./internal/dashboard/...` ✅  
- `nix build .#prism` ✅

Closes #1824