### PR TITLE
skills/atlassian: replace CLI-negation paragraph with positive MCP-path description

### DIFF
--- a/modules/programs/prism/skills/atlassian/SKILL.md
+++ b/modules/programs/prism/skills/atlassian/SKILL.md
@@ -24,9 +24,7 @@ Load this skill when:
 
 ## Integration: pi atlassian-mcp extension
 
-Atlassian operations are performed exclusively via the **pi atlassian-mcp extension** — a TypeScript extension bundled with pi that connects to `mcp.atlassian.com` using OAuth PKCE.
-
-**There is no standalone `atlassian` CLI binary.** The old CLI has been removed. Do not attempt to call `atlassian` from a Bash tool.
+Atlassian operations are performed via the **pi atlassian-mcp extension** — a TypeScript extension bundled with pi that connects to `mcp.atlassian.com` using OAuth PKCE. Use the MCP tools listed below; there is no separate command-line surface.
 
 ### Authentication
 


### PR DESCRIPTION
Remove the three sentences that named the removed atlassian CLI binary and replace the paragraph with positive wording that describes only the MCP path. The negation was priming agents to attempt the CLI despite being told not to.

Changes:
- Dropped the 'There is no standalone `atlassian` CLI binary.' sentence
- Dropped 'The old CLI has been removed.' sentence
- Dropped 'Do not attempt to call `atlassian` from a Bash tool.' sentence
- Replaced the two-sentence block with a single positive sentence: 'Use the MCP tools listed below; there is no separate command-line surface.'
- Also removed 'exclusively' from the lead sentence (which implied an alternative path exists)

Only `modules/programs/prism/skills/atlassian/SKILL.md` is modified.

Closes #1833