### PR TITLE
skills/atlassian + agents: add Jira ticket lifecycle policy

### DIFF
--- a/modules/programs/prism/agents/coordinator.md
+++ b/modules/programs/prism/agents/coordinator.md
@@ -18,6 +18,7 @@ Before acting, pause and think through the full scope of the request. Identify w
 
 When given a ticket, issue, or feature request:
 - Read it in full. Use the Atlassian MCP for Jira tickets, `gh issue view` for GitHub issues.
+- For Jira tickets you spawn a worker against: the worker is responsible for transitioning to `In Progress` when work starts. After the PR merges, verify the ticket is in a terminal state (`Done` / `Closed` / `Resolved`); if not, transition it yourself before cleaning up the worker session.
 - Break it into concrete, independently-deliverable subtasks.
 - Decide: one agent with a broad prompt, or multiple agents with tightly scoped prompts? Prefer one agent unless tasks are genuinely parallel and non-conflicting (touching different files/systems).
 

--- a/modules/programs/prism/agents/worker.md
+++ b/modules/programs/prism/agents/worker.md
@@ -70,6 +70,18 @@ commit history is disposable — commit early, commit often.
 
 Push your branch when work is complete. Work is not done until pushed.
 
+## Jira ticket lifecycle
+
+If your spawn prompt references a Jira ticket (e.g. `PLAT-123`), keep its state in sync with your actual progress:
+
+1. **Before your first commit**, transition the ticket to `In Progress`:
+   ```
+   transitionJiraIssueByName(issueIdOrKey: "PLAT-123", transitionName: "In Progress")
+   ```
+2. **After your PR is merged** (or, for non-PR work, after the change is live), transition the ticket to its terminal state. Use `Done` if it is available; otherwise call `getTransitionsForJiraIssue` to find the correct closed state for this project (`Closed`, `Resolved`, `Complete`, etc.).
+
+Load the `atlassian` skill for full tool usage. Reading a ticket to gather context or decide whether to action it does not change the ticket state — transition only when you actually start or finish work.
+
 ## Quality gates
 
 After each meaningful code change, run the quality gates described in the repo's

--- a/modules/programs/prism/skills/atlassian/SKILL.md
+++ b/modules/programs/prism/skills/atlassian/SKILL.md
@@ -160,6 +160,47 @@ If the name matches no available transition, it returns an error listing the
 available names. `getJiraIssue` also returns a `transitions` array so you
 can see available transitions alongside the issue data.
 
+## Lifecycle: when to transition a ticket
+
+A Jira board reflects reality only when agents keep ticket state in sync with actual work. Transition tickets at the right moments so humans can trust the board at a glance.
+
+### Mandatory transitions
+
+**1. When work starts → transition to `In Progress`**
+
+As soon as you begin acting on a ticket — first commit, first PR draft, first substantive investigation that produces output — transition it to `In Progress`:
+
+```
+# You have been asked to action PLAT-123. Before your first commit:
+transitionJiraIssueByName(issueIdOrKey: "PLAT-123", transitionName: "In Progress")
+# Now begin the work.
+```
+
+**2. When work completes → transition to the terminal state**
+
+Once the work is done — PR merged, doc published, change deployed — transition the ticket to its closed state:
+
+```
+# PR has been merged. Transition the ticket:
+transitionJiraIssueByName(issueIdOrKey: "PLAT-123", transitionName: "Done")
+```
+
+The terminal state name varies by project workflow. `Done` is the default; if it is not available, call `getTransitionsForJiraIssue` (or read the `transitions` array returned by `getJiraIssue`) to find the correct closed state for this project — `Closed`, `Resolved`, `Complete`, or similar.
+
+### Read-only interactions — keep the state as-is
+
+When you are reading a ticket purely for context — gathering background, summarising the issue, or evaluating whether to action it — the ticket state stays exactly as it is. Transition only when you actually begin or finish work.
+
+### Coordinator / worker boundary
+
+The coordinator that files a ticket and spawns a worker leaves the ticket in its initial state — the worker owns the `In Progress` transition at the moment it starts. After the PR merges, the coordinator verifies the ticket reached a terminal state and transitions it if the worker has not already done so.
+
+### Blocked or handed-off tickets (judgement call)
+
+If you escalate, hand off to a human, or otherwise pause on a ticket before completion, add a comment explaining the situation and optionally transition to a suitable intermediate state (`Blocked`, `In Review`, etc.) based on what is available in the project workflow.
+
+---
+
 ### Confluence: fetch-edit-push
 
 ```


### PR DESCRIPTION
Add explicit guidance on when agents should transition Jira tickets, so tickets stop piling up in the wrong state.

## Changes

- **** — new `## Lifecycle: when to transition a ticket` section after the existing comment/transition pattern block. States two mandatory transitions (In Progress on start, terminal state on done), gives concrete `transitionJiraIssueByName` examples for each, covers the terminal-state-name-varies caveat (consult `getTransitionsForJiraIssue`), clarifies the read-only carve-out (keep state as-is when only gathering context), and notes the coordinator/worker boundary.

- **`modules/programs/prism/agents/coordinator.md`** — new bullet in the Intake section making the coordinator the post-merge safety net: after a merge, verify the ticket reached a terminal state and transition it if the worker has not already done so.

- **`modules/programs/prism/agents/worker.md`** — new `## Jira ticket lifecycle` section stating the worker's responsibility: transition to In Progress before first commit, transition to terminal state after PR merge.

All phrasing is positive (says what to do, not what to avoid) — consistent with the anti-pattern fix in #1833.

Closes #1835