### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778958912,
-        "narHash": "sha256-6pvS9rIF9mZRj1ENwu9fDLHeG1JFDTCpRyy6vJhXkTA=",
+        "lastModified": 1779226674,
+        "narHash": "sha256-wuOkjI6pRiN4sEn/EPBRnNW5cmcpvd7xtIM8y5LooAs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "6e8dc7aa0e65fce67c76e18227a13a7d529f2cdf",
+        "rev": "65fb947964bd44fc0008faf77d1fcb7a9f40bb32",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778954430,
-        "narHash": "sha256-oaNyOr05lblaQdtbkbN1wO0b2KLIL2O1LkmwDgdQp4I=",
+        "lastModified": 1779336838,
+        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26aaab785b0bab4af60a2c42b22760fa906ef22a",
+        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1778994018,
-        "narHash": "sha256-1hLwYcVtihqndx7hd/g0wslX4SAKsKiA4oQSec4RuxI=",
+        "lastModified": 1779341285,
+        "narHash": "sha256-cSDp+SHQSdAScHeN4Oyg2851ZtPjhYU/GsTLWCN92HM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bd78d54f18fc660d6316f580be636c4f277d9f53",
+        "rev": "838e49ca74f6d8a3ca4d233b321b801fd18fe40e",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/26207951983

## Closure diff: navi

```
abseil-cpp: 3.3 MiB
acl: 125.2 KiB
alsa-lib: 1.8 MiB
alsa-topology-conf: 336.1 KiB
alsa-ucm-conf: 841.8 KiB
at-spi2-core: ∅ → 2.60.1, 2.3 MiB
attr: 90.5 KiB
audit: 420.4 KiB
avahi: 1.6 MiB
bash: 1.8 MiB
bluez: 10.1 MiB
brotli: 961.9 KiB
bubblewrap: ∅ → 0.11.2, 102.6 KiB
bzip2: 86.9 KiB
cairo: 2.1 MiB
cdparanoia-iii: 366.9 KiB
cjson: 72.3 KiB
claude-code: 2.1.141 → 2.1.145, 1.4 MiB
coreutils: ∅ → 9.11, 1.7 MiB
cracklib: 803.0 KiB
cryptsetup: 2.7 MiB
cups: ∅ → 2.4.19, 4.7 MiB
curl: ∅ → 8.20.0, 1.2 MiB
dav1d: 2.5 MiB
db: 3.5 MiB
dbus: 461.6 KiB
dconf: 324.5 KiB
dejavu-fonts-minimal: 742.6 KiB
elfutils: 4.0 MiB
ell: 658.7 KiB
expat: ∅ → 2.8.0, 306.2 KiB
fdk-aac: 1.6 MiB
ffado: 3.1 MiB
ffmpeg-headless: ∅ → 8.1, 33.7 MiB
fftw-double: 3.9 MiB
fftw-single: 4.1 MiB
file: ∅ → 5.47, 10.4 MiB
flac: 778.8 KiB
fontconfig: 1.6 MiB
freetype: 2.2 MiB
fribidi: 162.5 KiB
gcc: 10.0 MiB
gdbm: 448.6 KiB
gdk-pixbuf: ∅ → 2.44.6, 2.8 MiB
giflib: 407.5 KiB
glib: ∅ → 2.88.1, 15.3 MiB
glibc: 33.5 MiB
glibmm: 4.2 MiB
gmp-with-cxx: 1.5 MiB
gnum4: 1.1 MiB
gnutls: ∅ → 3.8.13, 3.6 MiB
gobject-introspection: 1.2 MiB
graphene: 182.5 KiB
graphite2: 228.0 KiB
gsettings-desktop-schemas: ∅ → 50.1, 6.2 MiB
gst-plugins-base: 8.8 MiB
gstreamer: 5.9 MiB
gtest: 842.0 KiB
gtk+3: 41.6 MiB
harfbuzz: ∅ → 13.2.1, 3.7 MiB
hwdata: 9.9 MiB
icu4c: 38.2 MiB
iso-codes: 22.6 MiB
json-c: 244.8 KiB
json-glib: 662.9 KiB
kbd: 2.7 MiB
kexec-tools: 262.5 KiB
keyutils: 41.8 KiB
kmod: 325.6 KiB
krb5: 2.7 MiB
lame: 348.7 KiB
lcms2: 484.3 KiB
ldacBT: 88.7 KiB
lerc: 842.4 KiB
libao: 123.7 KiB
libaom: 8.4 MiB
libapparmor: 590.5 KiB
libappindicator-gtk3: 89.7 KiB
libarchive: ∅ → 3.8.7, 949.8 KiB
libass: 253.1 KiB
libavc1394: 145.7 KiB
libbluray: 1.1 MiB
libbpf: ∅ → 1.7.0, 2.1 MiB
libcamera: 6.1 MiB
libcanberra: 251.2 KiB
libcap: 73.4 KiB
libcap-ng: ∅ → 0.9.3, 166.7 KiB
libcbor: 83.6 KiB
libconfig: 398.1 KiB
libdaemon: 41.0 KiB
libdatrie: 42.2 KiB
libdbusmenu-gtk3: 632.5 KiB
libdeflate: 458.6 KiB
libdrm: ∅ → 2.4.133, 1.8 MiB
libebur128: 54.2 KiB
libepoxy: 1.7 MiB
libevent: 861.7 KiB
libffi: 72.1 KiB
libfido2: ∅ → 1.17.0, 1.1 MiB
libfreeaptx: 55.5 KiB
libgcrypt: 1.8 MiB
libglvnd: 2.5 MiB
libgpg-error: 885.0 KiB
libical: 3.9 MiB
libidn2: 359.5 KiB
libiec61883: 154.8 KiB
libjack2: 420.7 KiB
libjpeg-turbo: 2.0 MiB
liblc3: 175.1 KiB
libmad: 142.5 KiB
libmicrohttpd: 260.4 KiB
libmpg123: 1.1 MiB
libmysofa: 1.3 MiB
libnotify: 111.2 KiB
libogg: 47.0 KiB
libopenmpt: 2.9 MiB
libopus: 501.2 KiB
libpciaccess: 172.0 KiB
libpng-apng: 273.3 KiB
libpsl: 114.9 KiB
libpulseaudio: 4.7 MiB
libpwquality: 382.5 KiB
libraw1394: 196.5 KiB
librist: 422.9 KiB
libsamplerate: 1.5 MiB
libseccomp: 193.8 KiB
libselinux: 690.2 KiB
libsigc++: 42.0 KiB
libsndfile: 644.6 KiB
libsoup: 1.2 MiB
libssh: 682.3 KiB
libssh2: 326.6 KiB
libtasn1: 95.8 KiB
libthai: 637.0 KiB
libtheora: 675.4 KiB
libtiff: 739.2 KiB
libtool: 57.0 KiB
libtpms: 1.1 MiB
libunistring: 2.0 MiB
libunwind: 267.6 KiB
libusb: 158.0 KiB
libuv: 271.9 KiB
libva: 353.6 KiB
libva-minimal: 254.3 KiB
libvmaf: 2.7 MiB
libvorbis: 1.1 MiB
libvpx: 8.9 MiB
libwebp: 3.4 MiB
libx11: 2.6 MiB
libxau: 27.1 KiB
libxcb: 1.4 MiB
libxcomposite: 25.1 KiB
libxcrypt: 141.0 KiB
libxcursor: 78.0 KiB
libxdamage: 17.9 KiB
libxdmcp: 31.2 KiB
libxext: 93.7 KiB
libxfixes: 33.9 KiB
libxft: 151.0 KiB
libxi: 87.7 KiB
libxinerama: 21.7 KiB
libxkbcommon: 1.0 MiB
libxml++: 299.8 KiB
libxml2: ∅ → 2.15.2, 1.4 MiB
libxrandr: 62.6 KiB
libxrender: 53.2 KiB
libxscrnsaver: 32.9 KiB
libxtst: 117.6 KiB
libxv: 31.4 KiB
libyaml: 143.9 KiB
lilv: 380.8 KiB
linux-pam: 1.8 MiB
lttng-ust: 1.8 MiB
lvm2: ∅ → 2.03.39, 443.7 KiB
lz4: 256.0 KiB
lzo: 159.7 KiB
mailcap: 116.6 KiB
mbedtls: ∅ → 3.6.6, 12.7 MiB
mesa-libgbm: 58.2 KiB
mpdecimal: 220.9 KiB
mpg123: 1.1 MiB
ncurses: 3.7 MiB
nettle: 723.5 KiB
nghttp2: ∅ → 1.69.0, 225.3 KiB
nghttp3: 227.7 KiB
ngtcp2: 484.3 KiB
nspr: ∅ → 4.39, 349.8 KiB
nss: ∅ → 3.112.5, 4.0 MiB
numactl: 269.9 KiB
ocl-icd: 609.3 KiB
openapv: 719.7 KiB
openfec: 204.4 KiB
openjpeg: 1.6 MiB
openssl: 8.9 MiB
opusfile: 124.6 KiB
orc: 844.3 KiB
p11-kit: 5.7 MiB
pango: ∅ → 1.57.1, 917.4 KiB
pcre2: 2.0 MiB
pcsclite: 107.3 KiB
pipewire: ∅ → 1.6.5, 16.7 MiB
pixman: 858.3 KiB
procps: 3.0 MiB
publicsuffix-list: 328.2 KiB
python3: ∅ → 3.13.13, 126.9 MiB
qrencode: 62.6 KiB
readline: 494.5 KiB
ripgrep: 6.2 MiB
roc-toolkit: 7.9 MiB
sbc: 276.9 KiB
serd: 137.3 KiB
socat: 860.2 KiB
sord: 99.5 KiB
sox-unstable: 701.6 KiB
soxr: 298.4 KiB
spandsp: 983.9 KiB
speech-dispatcher: 488.3 KiB
speex: 133.7 KiB
speexdsp: 78.5 KiB
sqlite: 5.6 MiB
sratom: 47.2 KiB
srt: 6.8 MiB
svt-av1: 8.1 MiB
systemd: 59.9 MiB
systemd-minimal: 20.1 MiB
systemd-minimal-libs: 4.0 MiB
tinysparql: ∅ → 3.11.1, 4.7 MiB
tpm2-tss: 3.2 MiB
tremor-unstable: 132.7 KiB
tzdata: ∅ → 2026b, 2.0 MiB
unbound: ∅ → 1.25.0, 1.1 MiB
util-linux-minimal: 2.4 MiB
v4l-utils: 782.0 KiB
vid.stab: 552.5 KiB
vulkan-loader: 683.8 KiB
wavpack: 547.0 KiB
wayland: ∅ → 1.25.0, 264.1 KiB
webrtc-audio-processing: 1.2 MiB
x264: 2.4 MiB
x265: 23.7 MiB
xgcc: 193.0 KiB
xkeyboard-config: 10.3 MiB
xorgproto: 1.6 MiB
xvidcore: 786.7 KiB
xz: 837.8 KiB
zimg: 758.8 KiB
zix: 142.0 KiB
zlib: 278.8 KiB
zstd: 1.1 MiB
zvbi: 1.0 MiB
```

## Closure diff: tui

```
abseil-cpp: 3.3 MiB
acl: 125.2 KiB
alsa-lib: 1.8 MiB
alsa-topology-conf: 336.1 KiB
alsa-ucm-conf: 841.8 KiB
at-spi2-core: ∅ → 2.60.1, 2.3 MiB
attr: 90.5 KiB
audit: 420.4 KiB
avahi: 1.6 MiB
bash: 1.8 MiB
bluez: 10.1 MiB
brotli: 961.9 KiB
bubblewrap: ∅ → 0.11.2, 102.6 KiB
bzip2: 86.9 KiB
cairo: 2.1 MiB
cdparanoia-iii: 366.9 KiB
cjson: 72.3 KiB
claude-code: 2.1.141 → 2.1.145, 1.4 MiB
coreutils: ∅ → 9.11, 1.7 MiB
cracklib: 803.0 KiB
cryptsetup: 2.7 MiB
cups: ∅ → 2.4.19, 4.7 MiB
curl: ∅ → 8.20.0, 1.2 MiB
dav1d: 2.5 MiB
db: 3.5 MiB
dbus: 461.6 KiB
dconf: 324.5 KiB
dejavu-fonts-minimal: 742.6 KiB
elfutils: 4.0 MiB
ell: 658.7 KiB
expat: ∅ → 2.8.0, 306.2 KiB
fdk-aac: 1.6 MiB
ffado: 3.1 MiB
ffmpeg-headless: ∅ → 8.1, 33.7 MiB
fftw-double: 3.9 MiB
fftw-single: 4.1 MiB
file: ∅ → 5.47, 10.4 MiB
flac: 778.8 KiB
fontconfig: 1.6 MiB
freetype: 2.2 MiB
fribidi: 162.5 KiB
gcc: 10.0 MiB
gdbm: 448.6 KiB
gdk-pixbuf: ∅ → 2.44.6, 2.8 MiB
giflib: 407.5 KiB
glib: ∅ → 2.88.1, 15.3 MiB
glibc: 33.5 MiB
glibmm: 4.2 MiB
gmp-with-cxx: 1.5 MiB
gnum4: 1.1 MiB
gnutls: ∅ → 3.8.13, 3.6 MiB
gobject-introspection: 1.2 MiB
graphene: 182.5 KiB
graphite2: 228.0 KiB
gsettings-desktop-schemas: ∅ → 50.1, 6.2 MiB
gst-plugins-base: 8.8 MiB
gstreamer: 5.9 MiB
gtest: 842.0 KiB
gtk+3: 41.6 MiB
harfbuzz: ∅ → 13.2.1, 3.7 MiB
hwdata: 9.9 MiB
icu4c: 38.2 MiB
iso-codes: 22.6 MiB
json-c: 244.8 KiB
json-glib: 662.9 KiB
kbd: 2.7 MiB
kexec-tools: 262.5 KiB
keyutils: 41.8 KiB
kmod: 325.6 KiB
krb5: 2.7 MiB
lame: 348.7 KiB
lcms2: 484.3 KiB
ldacBT: 88.7 KiB
lerc: 842.4 KiB
libao: 123.7 KiB
libaom: 8.4 MiB
libapparmor: 590.5 KiB
libappindicator-gtk3: 89.7 KiB
libarchive: ∅ → 3.8.7, 949.8 KiB
libass: 253.1 KiB
libavc1394: 145.7 KiB
libbluray: 1.1 MiB
libbpf: ∅ → 1.7.0, 2.1 MiB
libcamera: 6.1 MiB
libcanberra: 251.2 KiB
libcap: 73.4 KiB
libcap-ng: ∅ → 0.9.3, 166.7 KiB
libcbor: 83.6 KiB
libconfig: 398.1 KiB
libdaemon: 41.0 KiB
libdatrie: 42.2 KiB
libdbusmenu-gtk3: 632.5 KiB
libdeflate: 458.6 KiB
libdrm: ∅ → 2.4.133, 1.8 MiB
libebur128: 54.2 KiB
libepoxy: 1.7 MiB
libevent: 861.7 KiB
libffi: 72.1 KiB
libfido2: ∅ → 1.17.0, 1.1 MiB
libfreeaptx: 55.5 KiB
libgcrypt: 1.8 MiB
libglvnd: 2.5 MiB
libgpg-error: 885.0 KiB
libical: 3.9 MiB
libidn2: 359.5 KiB
libiec61883: 154.8 KiB
libjack2: 420.7 KiB
libjpeg-turbo: 2.0 MiB
liblc3: 175.1 KiB
libmad: 142.5 KiB
libmicrohttpd: 260.4 KiB
libmpg123: 1.1 MiB
libmysofa: 1.3 MiB
libnotify: 111.2 KiB
libogg: 47.0 KiB
libopenmpt: 2.9 MiB
libopus: 501.2 KiB
libpciaccess: 172.0 KiB
libpng-apng: 273.3 KiB
libpsl: 114.9 KiB
libpulseaudio: 4.7 MiB
libpwquality: 382.5 KiB
libraw1394: 196.5 KiB
librist: 422.9 KiB
libsamplerate: 1.5 MiB
libseccomp: 193.8 KiB
libselinux: 690.2 KiB
libsigc++: 42.0 KiB
libsndfile: 644.6 KiB
libsoup: 1.2 MiB
libssh: 682.3 KiB
libssh2: 326.6 KiB
libtasn1: 95.8 KiB
libthai: 637.0 KiB
libtheora: 675.4 KiB
libtiff: 739.2 KiB
libtool: 57.0 KiB
libtpms: 1.1 MiB
libunistring: 2.0 MiB
libunwind: 267.6 KiB
libusb: 158.0 KiB
libuv: 271.9 KiB
libva: 353.6 KiB
libva-minimal: 254.3 KiB
libvmaf: 2.7 MiB
libvorbis: 1.1 MiB
libvpx: 8.9 MiB
libwebp: 3.4 MiB
libx11: 2.6 MiB
libxau: 27.1 KiB
libxcb: 1.4 MiB
libxcomposite: 25.1 KiB
libxcrypt: 141.0 KiB
libxcursor: 78.0 KiB
libxdamage: 17.9 KiB
libxdmcp: 31.2 KiB
libxext: 93.7 KiB
libxfixes: 33.9 KiB
libxft: 151.0 KiB
libxi: 87.7 KiB
libxinerama: 21.7 KiB
libxkbcommon: 1.0 MiB
libxml++: 299.8 KiB
libxml2: ∅ → 2.15.2, 1.4 MiB
libxrandr: 62.6 KiB
libxrender: 53.2 KiB
libxscrnsaver: 32.9 KiB
libxtst: 117.6 KiB
libxv: 31.4 KiB
libyaml: 143.9 KiB
lilv: 380.8 KiB
linux-pam: 1.8 MiB
lttng-ust: 1.8 MiB
lvm2: ∅ → 2.03.39, 443.7 KiB
lz4: 256.0 KiB
lzo: 159.7 KiB
mailcap: 116.6 KiB
mbedtls: ∅ → 3.6.6, 12.7 MiB
mesa-libgbm: 58.2 KiB
mpdecimal: 220.9 KiB
mpg123: 1.1 MiB
ncurses: 3.7 MiB
nettle: 723.5 KiB
nghttp2: ∅ → 1.69.0, 225.3 KiB
nghttp3: 227.7 KiB
ngtcp2: 484.3 KiB
nspr: ∅ → 4.39, 349.8 KiB
nss: ∅ → 3.112.5, 4.0 MiB
numactl: 269.9 KiB
ocl-icd: 609.3 KiB
openapv: 719.7 KiB
openfec: 204.4 KiB
openjpeg: 1.6 MiB
openssl: 8.9 MiB
opusfile: 124.6 KiB
orc: 844.3 KiB
p11-kit: 5.7 MiB
pango: ∅ → 1.57.1, 917.4 KiB
pcre2: 2.0 MiB
pcsclite: 107.3 KiB
pipewire: ∅ → 1.6.5, 16.7 MiB
pixman: 858.3 KiB
procps: 3.0 MiB
publicsuffix-list: 328.2 KiB
python3: ∅ → 3.13.13, 126.9 MiB
qrencode: 62.6 KiB
readline: 494.5 KiB
ripgrep: 6.2 MiB
roc-toolkit: 7.9 MiB
sbc: 276.9 KiB
serd: 137.3 KiB
socat: 860.2 KiB
sord: 99.5 KiB
sox-unstable: 701.6 KiB
soxr: 298.4 KiB
spandsp: 983.9 KiB
speech-dispatcher: 488.3 KiB
speex: 133.7 KiB
speexdsp: 78.5 KiB
sqlite: 5.6 MiB
sratom: 47.2 KiB
srt: 6.8 MiB
svt-av1: 8.1 MiB
systemd: 59.9 MiB
systemd-minimal: 20.1 MiB
systemd-minimal-libs: 4.0 MiB
tinysparql: ∅ → 3.11.1, 4.7 MiB
tpm2-tss: 3.2 MiB
tremor-unstable: 132.7 KiB
tzdata: ∅ → 2026b, 2.0 MiB
unbound: ∅ → 1.25.0, 1.1 MiB
util-linux-minimal: 2.4 MiB
v4l-utils: 782.0 KiB
vid.stab: 552.5 KiB
vulkan-loader: 683.8 KiB
wavpack: 547.0 KiB
wayland: ∅ → 1.25.0, 264.1 KiB
webrtc-audio-processing: 1.2 MiB
x264: 2.4 MiB
x265: 23.7 MiB
xgcc: 193.0 KiB
xkeyboard-config: 10.3 MiB
xorgproto: 1.6 MiB
xvidcore: 786.7 KiB
xz: 837.8 KiB
zimg: 758.8 KiB
zix: 142.0 KiB
zlib: 278.8 KiB
zstd: 1.1 MiB
zvbi: 1.0 MiB
```