### PR TITLE
restore: resume pi conversations via harness_session_id (#1838)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -280,6 +280,14 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 	if agentRunHarness != nil {
 		runtimeEnv = agentRunHarness.RuntimeEnv()
 	}
+	// Carry the persisted harness session UUID through to ctrCfg so that
+	// PIInvocation can append --session <id> for conversation resume on
+	// restore (issue #1838). Empty when the harness never started or this is
+	// a spawn/switch path — PIInvocation treats empty as a silent no-op.
+	harnessSessionID := ""
+	if status.HarnessSessionID != nil {
+		harnessSessionID = *status.HarnessSessionID
+	}
 	ctrCfg := container.Config{
 		SessionName:       sessionName,
 		Worktree:          worktree,
@@ -296,6 +304,7 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		RuntimeEnv:          runtimeEnv,
 		AgentEnvVars:      agentEnvVars,
 		Harness:           harnessName,
+		HarnessSessionID:  harnessSessionID,
 	}
 
 	// PI-harness: populate PI-specific config fields from the active profile slot.

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -119,6 +119,13 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		instanceID = *status.InstanceID
 	}
 
+	// Carry the persisted harness session UUID through to ctrCfg so that
+	// PIInvocation can append --session <id> for conversation resume on
+	// restore (issue #1838). Empty when the harness never started.
+	sandboxHarnessSessionID := ""
+	if status.HarnessSessionID != nil {
+		sandboxHarnessSessionID = *status.HarnessSessionID
+	}
 	ctrCfg := container.Config{
 		SessionName:       sessionName,
 		Worktree:          worktree,
@@ -136,6 +143,7 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		RuntimeEnv:        sandboxRuntimeEnv,
 		AgentEnvVars:      agentEnvVars,
 		Harness:           sandboxHarnessName,
+		HarnessSessionID:  sandboxHarnessSessionID,
 	}
 
 	// For socket-pipe harnesses (PI), the sidecar stores the TCP port it

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -355,6 +355,13 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		RuntimeEnvVars:   restoreHarness.RuntimeEnv(),
 		HarnessName:      restoreHarnessName,
 	}
+	// Propagate the persisted harness session ID so the sandbox launcher can
+	// ask pi to resume the prior conversation (issue #1838). Empty pointer
+	// or empty string both mean "start fresh" — PIInvocation treats an empty
+	// HarnessSessionID as a silent no-op.
+	if s.HarnessSessionID != nil && *s.HarnessSessionID != "" {
+		opts.HarnessSessionID = *s.HarnessSessionID
+	}
 	if isoCaps.IsContainer {
 		opts.PluginHostPath = cfg.SidecarPluginPath
 	}

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -1466,97 +1466,150 @@ func TestRestoreSession_BwrapMode_TempFileWritten2(t *testing.T) {
 	}
 }
 
-// TestRestoreSession_PlumbsHarnessSessionID exercises AC8(d): when the
-// agent_status row has a non-NULL harness_session_id, restoreProjectSession
-// must copy that value into opts.HarnessSessionID so the downstream container
-// launcher can ask pi to resume the prior conversation.
+// TestRestoreSession_HostMode_AppendsSessionFlagWhenFileExists is the
+// end-to-end host-mode regression guard for issue #1838 / AC8(d). It seeds
+// an agent_status row with a non-NULL harness_session_id, writes a matching
+// pi session JSONL under ~/.pi/agent/sessions/<encoded-cwd>/, runs restore,
+// and asserts that the resulting tmux agent pane start command contains
+// `pi ... --session '<id>'`. This is the load-bearing assertion: if the
+// HarnessSessionID plumbing breaks anywhere between agent_status and the
+// final tmux launch command, the substring will be absent and this test
+// fails.
 //
-// Issue #1838.
-func TestRestoreSession_PlumbsHarnessSessionID(t *testing.T) {
+// Host mode (rather than bwrap/sandbox-exec) is chosen because the host
+// branch is the one the launch-command path actually exercises —
+// container-mode panes run `prism agent-run`, which reads HarnessSessionID
+// straight from the DB row inside that subprocess (covered by the
+// PIInvocation tests in internal/container/pi_invocation_resume_test.go and
+// by the obvious-by-inspection plumbing in cmd/agent_run.go +
+// cmd/agent_run_sandbox_exec_darwin.go).
+func TestRestoreSession_HostMode_AppendsSessionFlagWhenFileExists(t *testing.T) {
+	skipRestoreOnGHA(t)
 	// Uses withCmdServer — must not run in parallel.
+	// Redirect both XDG_STATE_HOME (prism per-session dirs) and HOME (pi
+	// sessions root in host mode) so the test never touches real state.
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
 	s := newCmdTestServer(t)
 	withCmdServer(t, s)
 
-	withRestoreConfig(t, config.Config{
-		DefaultIsolationMode: config.IsolationBwrap,
-	})
-	pf := fakeProfilesFile()
-	withRestoreProfiles(t, pf, nil)
+	// Force host isolation on the restore path so the pane runs the direct
+	// `pi ...` command rather than `prism agent-run`.
+	withRestoreConfig(t, config.Config{DefaultIsolationMode: config.IsolationHost})
 
 	d := openRestoreTestDB(t)
 
-	bareRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bareRoot, ".bare"), []byte("gitdir"), 0o644); err != nil {
-		t.Fatalf("write .bare: %v", err)
-	}
-	worktreeDir := filepath.Join(bareRoot, "feature-branch")
-	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	sessionName := "myrepo@feature"
+	worktreeDir := t.TempDir()
+	sessionName := "myrepo@host-resume"
 
 	const harnessSessionID = "019e00ed-1234-7890-abcd-ef0123456789"
 	hsid := harnessSessionID
-	status := seedStatus(t, d, sessionName, worktreeDir, &hsid)
+	_ = seedStatus(t, d, sessionName, worktreeDir, &hsid)
+	if err := d.SetIsolationMode(sessionName, "host"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	statuses, err := d.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+	var status db.Status
+	for _, st := range statuses {
+		if st.SessionName == sessionName {
+			status = st
+			break
+		}
+	}
 
-	var capturedOpts session.Opts
-	withCreateSessionHook(t, func(opts session.Opts) {
-		capturedOpts = opts
-	})
+	// Write a synthetic pi session JSONL under the host-mode sessions root
+	// so ResolvePIResumeSession finds it. The encoded-cwd formula matches
+	// pi's own session-manager naming.
+	encoded := encodePiCWDForTest(worktreeDir)
+	sessionDir := filepath.Join(fakeHome, ".pi", "agent", "sessions", encoded)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatalf("mkdir host-mode sessions dir: %v", err)
+	}
+	sessionFile := filepath.Join(sessionDir, "2026-01-02T03-04-05-000Z_"+harnessSessionID+".jsonl")
+	if err := os.WriteFile(sessionFile, []byte("{\"type\":\"session\"}\n"), 0o600); err != nil {
+		t.Fatalf("write session file: %v", err)
+	}
 
 	if err := callRestoreSession(d, status); err != nil {
 		t.Fatalf("restoreSession: %v", err)
 	}
 	t.Cleanup(func() { session.KillSidecar(sessionName) })
 
-	if capturedOpts.HarnessSessionID != harnessSessionID {
-		t.Errorf("opts.HarnessSessionID = %q, want %q", capturedOpts.HarnessSessionID, harnessSessionID)
+	if !s.hasSession(sessionName) {
+		t.Fatalf("session %q was not created", sessionName)
+	}
+
+	// The agent pane's start command must contain `--session '<id>'`.
+	pane := agentPaneStartCmd(t, s, sessionName)
+	want := "--session '" + harnessSessionID + "'"
+	if !strings.Contains(pane, want) {
+		t.Errorf("agent pane start command missing %q\ncaptured: %s", want, pane)
 	}
 }
 
-// TestRestoreSession_EmptyHarnessSessionID_LeavesOptsEmpty verifies AC5 / AC7
-// on the restore side: when the DB row has NULL harness_session_id (harness
-// never started, or non-pi harness), restoreProjectSession must leave
-// opts.HarnessSessionID empty so PIInvocation skips --session silently.
-func TestRestoreSession_EmptyHarnessSessionID_LeavesOptsEmpty(t *testing.T) {
-	// Uses withCmdServer — must not run in parallel.
+// TestRestoreSession_HostMode_NoSessionFlag_WhenFileMissing exercises AC4 /
+// AC5 on the host-mode launch path: when the agent_status row carries a
+// HarnessSessionID but no matching pi JSONL exists on disk,
+// buildDirectAgentCmd must omit --session and pi must start a fresh
+// conversation. The negative assertion proves the test from
+// TestRestoreSession_HostMode_AppendsSessionFlagWhenFileExists isn't a
+// no-op (i.e. the --session token doesn't sneak in unconditionally).
+func TestRestoreSession_HostMode_NoSessionFlag_WhenFileMissing(t *testing.T) {
+	skipRestoreOnGHA(t)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// Empty fake HOME — no pi sessions dir present, so the resolver
+	// must fail and the launcher must omit --session.
+	t.Setenv("HOME", t.TempDir())
+
 	s := newCmdTestServer(t)
 	withCmdServer(t, s)
 
-	withRestoreConfig(t, config.Config{
-		DefaultIsolationMode: config.IsolationBwrap,
-	})
-	pf := fakeProfilesFile()
-	withRestoreProfiles(t, pf, nil)
+	withRestoreConfig(t, config.Config{DefaultIsolationMode: config.IsolationHost})
 
 	d := openRestoreTestDB(t)
 
-	bareRoot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bareRoot, ".bare"), []byte("gitdir"), 0o644); err != nil {
-		t.Fatalf("write .bare: %v", err)
-	}
-	worktreeDir := filepath.Join(bareRoot, "feature-branch")
-	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	sessionName := "myrepo@feature-empty"
+	worktreeDir := t.TempDir()
+	sessionName := "myrepo@host-resume-miss"
 
-	// nil harness_session_id => row written with NULL.
-	status := seedStatus(t, d, sessionName, worktreeDir, nil)
-
-	var capturedOpts session.Opts
-	withCreateSessionHook(t, func(opts session.Opts) {
-		capturedOpts = opts
-	})
+	const harnessSessionID = "019e00ed-aaaa-bbbb-cccc-deadbeef0000"
+	hsid := harnessSessionID
+	_ = seedStatus(t, d, sessionName, worktreeDir, &hsid)
+	if err := d.SetIsolationMode(sessionName, "host"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	statuses, err := d.AllActiveStatus()
+	if err != nil {
+		t.Fatalf("AllActiveStatus: %v", err)
+	}
+	var status db.Status
+	for _, st := range statuses {
+		if st.SessionName == sessionName {
+			status = st
+			break
+		}
+	}
 
 	if err := callRestoreSession(d, status); err != nil {
 		t.Fatalf("restoreSession: %v", err)
 	}
 	t.Cleanup(func() { session.KillSidecar(sessionName) })
 
-	if capturedOpts.HarnessSessionID != "" {
-		t.Errorf("opts.HarnessSessionID = %q, want empty string when DB row has NULL harness_session_id", capturedOpts.HarnessSessionID)
+	pane := agentPaneStartCmd(t, s, sessionName)
+	if strings.Contains(pane, "--session") {
+		t.Errorf("agent pane start command unexpectedly contains --session when no JSONL exists\ncaptured: %s", pane)
 	}
+}
+
+// encodePiCWDForTest mirrors internal/container.encodePiCWD /
+// internal/harness/pi.EncodePiCWD. Duplicated locally so the restore test
+// stays in the cmd package without an internal-package dependency.
+func encodePiCWDForTest(cwd string) string {
+	stripped := strings.TrimLeft(cwd, "/\\")
+	replaced := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(stripped)
+	return "--" + replaced + "--"
 }

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -1465,3 +1465,98 @@ func TestRestoreSession_BwrapMode_TempFileWritten2(t *testing.T) {
 			expectedPath, err)
 	}
 }
+
+// TestRestoreSession_PlumbsHarnessSessionID exercises AC8(d): when the
+// agent_status row has a non-NULL harness_session_id, restoreProjectSession
+// must copy that value into opts.HarnessSessionID so the downstream container
+// launcher can ask pi to resume the prior conversation.
+//
+// Issue #1838.
+func TestRestoreSession_PlumbsHarnessSessionID(t *testing.T) {
+	// Uses withCmdServer — must not run in parallel.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	withRestoreConfig(t, config.Config{
+		DefaultIsolationMode: config.IsolationBwrap,
+	})
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	bareRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bareRoot, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatalf("write .bare: %v", err)
+	}
+	worktreeDir := filepath.Join(bareRoot, "feature-branch")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@feature"
+
+	const harnessSessionID = "019e00ed-1234-7890-abcd-ef0123456789"
+	hsid := harnessSessionID
+	status := seedStatus(t, d, sessionName, worktreeDir, &hsid)
+
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	if err := callRestoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	if capturedOpts.HarnessSessionID != harnessSessionID {
+		t.Errorf("opts.HarnessSessionID = %q, want %q", capturedOpts.HarnessSessionID, harnessSessionID)
+	}
+}
+
+// TestRestoreSession_EmptyHarnessSessionID_LeavesOptsEmpty verifies AC5 / AC7
+// on the restore side: when the DB row has NULL harness_session_id (harness
+// never started, or non-pi harness), restoreProjectSession must leave
+// opts.HarnessSessionID empty so PIInvocation skips --session silently.
+func TestRestoreSession_EmptyHarnessSessionID_LeavesOptsEmpty(t *testing.T) {
+	// Uses withCmdServer — must not run in parallel.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	s := newCmdTestServer(t)
+	withCmdServer(t, s)
+
+	withRestoreConfig(t, config.Config{
+		DefaultIsolationMode: config.IsolationBwrap,
+	})
+	pf := fakeProfilesFile()
+	withRestoreProfiles(t, pf, nil)
+
+	d := openRestoreTestDB(t)
+
+	bareRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bareRoot, ".bare"), []byte("gitdir"), 0o644); err != nil {
+		t.Fatalf("write .bare: %v", err)
+	}
+	worktreeDir := filepath.Join(bareRoot, "feature-branch")
+	if err := os.MkdirAll(worktreeDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	sessionName := "myrepo@feature-empty"
+
+	// nil harness_session_id => row written with NULL.
+	status := seedStatus(t, d, sessionName, worktreeDir, nil)
+
+	var capturedOpts session.Opts
+	withCreateSessionHook(t, func(opts session.Opts) {
+		capturedOpts = opts
+	})
+
+	if err := callRestoreSession(d, status); err != nil {
+		t.Fatalf("restoreSession: %v", err)
+	}
+	t.Cleanup(func() { session.KillSidecar(sessionName) })
+
+	if capturedOpts.HarnessSessionID != "" {
+		t.Errorf("opts.HarnessSessionID = %q, want empty string when DB row has NULL harness_session_id", capturedOpts.HarnessSessionID)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -312,6 +312,20 @@ type Config struct {
 	// omitted and PI uses its own default.
 	PIThinking string
 
+	// HarnessSessionID is the persisted harness-specific session UUID to resume
+	// when launching the harness (e.g. pi's session UUID written by the sidecar
+	// on the `session_status` frame). When non-empty and Harness == "pi",
+	// PIInvocation looks up the on-disk session JSONL using the mode-aware
+	// sessions-root resolver and, if found, appends `--session <HarnessSessionID>`
+	// so pi reopens the prior conversation. When empty (fresh session, no prior
+	// incarnation, or the harness failed to start last time) the flag is omitted
+	// and pi starts a new conversation.
+	//
+	// Populated by `prism restore` (and `prism restart`, which calls Restore).
+	// `prism spawn` / `prism switch` leave this empty by design — those paths
+	// create new sessions.
+	HarnessSessionID string
+
 	// PIBinaryPath is the absolute host path to the pi binary
 	// (e.g. /nix/store/.../bin/pi or from the Nix profile at
 	// /etc/profiles/per-user/<user>/bin/pi). When non-empty and

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/prismatic-koi/prism/internal/config"
 )
@@ -65,12 +66,22 @@ const (
 //	--model    <cfg.PIModel>              (when non-empty)
 //	--thinking <cfg.PIThinking>           (when non-empty)
 //	--extension <extensionPath>           (always; path is derived from cfg)
+//	--session  <cfg.HarnessSessionID>     (when non-empty AND on-disk session
+//	                                       file exists — see piResolveResumeSession)
 //	<cfg.InitialPrompt>                   (bare positional arg, when non-empty)
 //
 // The system prompt is delivered via PI_CODING_AGENT_DIR (set in the bwrap
 // environment) pointing at the per-session staging directory that contains
 // APPEND_SYSTEM.md. No --append-system-prompt flag is needed — PI discovers
 // APPEND_SYSTEM.md automatically from its agent config directory.
+//
+// Conversation resume (issue #1838): when cfg.HarnessSessionID is non-empty,
+// PIInvocation looks up the on-disk session JSONL via
+// piResolveResumeSession. If found, --session <id> is appended immediately
+// before any positional InitialPrompt arg so pi reopens the prior turns.
+// If the file is missing, a warning line is written to the per-session
+// agent-run log and pi starts a fresh conversation — restore is
+// best-effort and must never fail because of a missing resume target.
 func PIInvocation(cfg Config) []string {
 	// Use the resolved binary path when set; fall back to the bare name for
 	// back-compat in test/host-mode contexts where the binary is on PATH.
@@ -98,11 +109,179 @@ func PIInvocation(cfg Config) []string {
 	extensionSandboxPath := filepath.Join(extensionSandboxDir, piExtensionFilename)
 	args = append(args, "--extension", extensionSandboxPath)
 
+	// --session <id> for conversation resume (#1838). Skipped silently when
+	// HarnessSessionID is empty (fresh session); on missing-file the helper
+	// logs a warning and returns ok=false so pi starts a new conversation.
+	if cfg.HarnessSessionID != "" {
+		if piResolveResumeSession(cfg) {
+			args = append(args, "--session", cfg.HarnessSessionID)
+		}
+	}
+
 	if cfg.InitialPrompt != "" {
 		args = append(args, cfg.InitialPrompt)
 	}
 
 	return args
+}
+
+// piResolveResumeSession returns true when the on-disk pi session JSONL for
+// cfg.HarnessSessionID exists under the mode-aware sessions root and pi can
+// be told to resume it. Returns false when the file is missing, in which case
+// it also writes a tagged warning line to the per-session agent-run log so
+// the operator can see why the conversation didn't resume.
+//
+// The mode-aware sessions root mirrors internal/harness/pi/archive.go's
+// piSessionsRoot helper (see that file for the authoritative reference). It
+// is duplicated here rather than imported because internal/harness/pi already
+// imports internal/container, so the reverse dependency would create an
+// import cycle. The two implementations MUST stay in sync — if you change
+// one, change the other.
+//
+// Caller contract: HarnessSessionID is non-empty. An empty HarnessSessionID
+// must be filtered out upstream (PIInvocation handles that).
+func piResolveResumeSession(cfg Config) bool {
+	root, ok := piResumeSessionsRoot(cfg)
+	if !ok {
+		// Couldn't resolve a sessions root — don't append --session, but
+		// don't write a warning either: the empty/host-only fallback path
+		// isn't an error, it's a no-op.
+		return false
+	}
+
+	// pi names its session files <timestamp>_<uuid>.jsonl inside an
+	// encoded-cwd subdirectory. Worktree determines the encoded-cwd dir.
+	// Scan it for an entry ending in _<HarnessSessionID>.jsonl.
+	if cfg.Worktree == "" {
+		return false
+	}
+	cwdDir := filepath.Join(root, encodePiCWD(cfg.Worktree))
+	suffix := "_" + cfg.HarnessSessionID + ".jsonl"
+
+	entries, err := os.ReadDir(cwdDir)
+	if err != nil {
+		piLogResumeWarning(cfg, cwdDir, fmt.Sprintf("scan %s: %v", cwdDir, err))
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), suffix) {
+			return true
+		}
+	}
+	piLogResumeWarning(cfg, cwdDir, fmt.Sprintf("no file matching *%s in %s", suffix, cwdDir))
+	return false
+}
+
+// piResumeSessionsRoot returns the host-side sessions root directory that pi
+// writes session JSONL files under, given the isolation mode implied by cfg.
+// The three branches mirror internal/harness/pi/archive.go::piSessionsRoot:
+//
+//	host         → <home>/.pi/agent/sessions
+//	bwrap        → <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions
+//	sandbox-exec → <stagingHome>/.pi/agent/sessions
+//
+// Mode is inferred from cfg fields rather than carried explicitly:
+//
+//   - sandbox-exec is identified by InstanceID being set AND
+//     PIAgentConfigSandboxDir == PIAgentConfigHostDir (sandbox-exec shares the
+//     host FS, so populatePIConfig deliberately collapses the two paths).
+//   - bwrap is identified by SessionName being set AND
+//     PIAgentConfigSandboxDir != PIAgentConfigHostDir (bwrap remaps the staging
+//     dir to /run/prism/pi-agent inside the sandbox).
+//   - host is the fallback when neither condition matches.
+//
+// Returns ok=false only when host-mode resolution fails (no home dir).
+func piResumeSessionsRoot(cfg Config) (string, bool) {
+	// sandbox-exec: per-session staging HOME.
+	if cfg.InstanceID != "" && cfg.PIAgentConfigSandboxDir != "" &&
+		cfg.PIAgentConfigSandboxDir == cfg.PIAgentConfigHostDir {
+		stagingHome, err := SandboxExecStagingHomePath(cfg.InstanceID)
+		if err != nil || stagingHome == "" {
+			return "", false
+		}
+		return filepath.Join(stagingHome, ".pi", "agent", "sessions"), true
+	}
+
+	// bwrap: per-session staging dir under XDG_STATE_HOME.
+	if cfg.SessionName != "" && cfg.PIAgentConfigSandboxDir != "" &&
+		cfg.PIAgentConfigSandboxDir != cfg.PIAgentConfigHostDir {
+		stateHome := os.Getenv("XDG_STATE_HOME")
+		if stateHome == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", false
+			}
+			stateHome = filepath.Join(home, ".local", "state")
+		}
+		return filepath.Join(
+			stateHome, "prism", "run",
+			sessionDirName(cfg.SessionName),
+			"pi-agent", "sessions",
+		), true
+	}
+
+	// host (and unhandled fallbacks): real home directory.
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "", false
+	}
+	return filepath.Join(home, ".pi", "agent", "sessions"), true
+}
+
+// encodePiCWD mirrors internal/harness/pi.EncodePiCWD: pi's session-dir naming
+// formula (`--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`).
+//
+// Duplicated here — see piResumeSessionsRoot's note on why we cannot import
+// internal/harness/pi. The two implementations MUST stay in sync.
+func encodePiCWD(cwd string) string {
+	stripped := strings.TrimLeft(cwd, "/\\")
+	replaced := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(stripped)
+	return "--" + replaced + "--"
+}
+
+// piLogResumeWarning appends a single tagged warning line to the per-session
+// agent-run log. Best-effort: any failure to resolve or open the log path is
+// swallowed silently — the warning is purely informational and must never
+// take down a bwrap arg-build that would otherwise succeed.
+//
+// The tag matches the convention used elsewhere in agent-run
+// ("[agent-run] warning: …") so operators can grep for resume issues.
+func piLogResumeWarning(cfg Config, lookupPath, detail string) {
+	if cfg.SessionName == "" {
+		return
+	}
+	logPath, err := piAgentRunLogPath(cfg.SessionName)
+	if err != nil {
+		return
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(logPath), 0o700); mkErr != nil {
+		return
+	}
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f,
+		"[agent-run] warning: pi session %s not found at %s — starting fresh conversation (%s)\n",
+		cfg.HarnessSessionID, lookupPath, detail,
+	)
+}
+
+// piAgentRunLogPath is the container-side mirror of
+// internal/session.AgentRunLogPath. Duplicated to keep this file free of an
+// internal/session dependency (which would in turn pull in db / tmux / … from
+// a leaf invocation builder).
+func piAgentRunLogPath(sessionName string) (string, error) {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism", "run", sessionDirName(sessionName), "agent-run.log"), nil
 }
 
 // StagePIAgentConfigDir prepares the per-session PI agent config staging

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -113,7 +113,7 @@ func PIInvocation(cfg Config) []string {
 	// HarnessSessionID is empty (fresh session); on missing-file the helper
 	// logs a warning and returns ok=false so pi starts a new conversation.
 	if cfg.HarnessSessionID != "" {
-		if piResolveResumeSession(cfg) {
+		if ResolvePIResumeSession(cfg) {
 			args = append(args, "--session", cfg.HarnessSessionID)
 		}
 	}
@@ -125,11 +125,18 @@ func PIInvocation(cfg Config) []string {
 	return args
 }
 
-// piResolveResumeSession returns true when the on-disk pi session JSONL for
+// ResolvePIResumeSession returns true when the on-disk pi session JSONL for
 // cfg.HarnessSessionID exists under the mode-aware sessions root and pi can
 // be told to resume it. Returns false when the file is missing, in which case
 // it also writes a tagged warning line to the per-session agent-run log so
 // the operator can see why the conversation didn't resume.
+//
+// Callers may pass:
+//
+//   - a fully-populated Config (as PIInvocation does for bwrap and sandbox-exec);
+//   - or a minimal Config with just SessionName, Worktree, and HarnessSessionID
+//     set (as the host-mode launch path in internal/session does, since it has
+//     no container fields).
 //
 // The mode-aware sessions root mirrors internal/harness/pi/archive.go's
 // piSessionsRoot helper (see that file for the authoritative reference). It
@@ -139,7 +146,12 @@ func PIInvocation(cfg Config) []string {
 // one, change the other.
 //
 // Caller contract: HarnessSessionID is non-empty. An empty HarnessSessionID
-// must be filtered out upstream (PIInvocation handles that).
+// must be filtered out upstream (PIInvocation and buildDirectAgentCmd both
+// handle that).
+func ResolvePIResumeSession(cfg Config) bool {
+	return piResolveResumeSession(cfg)
+}
+
 func piResolveResumeSession(cfg Config) bool {
 	root, ok := piResumeSessionsRoot(cfg)
 	if !ok {

--- a/modules/programs/prism/prism/internal/container/pi_invocation_resume_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_resume_test.go
@@ -1,0 +1,276 @@
+package container
+
+// pi_invocation_resume_test.go — issue #1838.
+//
+// Verifies PIInvocation's conversation-resume behaviour:
+//
+//   (a) appends `--session <id>` immediately before any positional InitialPrompt
+//       when HarnessSessionID is set AND the on-disk session file exists;
+//   (b) omits `--session` and writes a tagged warning to the per-session
+//       agent-run log when the on-disk file is absent;
+//   (c) is a complete no-op (no --session, no warning) when HarnessSessionID is
+//       empty.
+//
+// All tests use t.TempDir() and t.Setenv("XDG_STATE_HOME", ...) so they never
+// touch the host's real home dir / state dir.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeBwrapResumeSession writes a synthetic pi session JSONL file at the
+// bwrap-mode sessions root (<XDG_STATE_HOME>/prism/run/<hash>/pi-agent/sessions/
+// <encoded-cwd>/<ts>_<uuid>.jsonl) and returns the on-disk path.
+//
+// The file content is not parsed by the test \u2014 PIInvocation only stats the
+// directory listing and matches on the filename suffix.
+func writeBwrapResumeSession(t *testing.T, sessionName, worktree, sessionID string) string {
+	t.Helper()
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		t.Fatalf("writeBwrapResumeSession: XDG_STATE_HOME must be set by the caller")
+	}
+	dir := filepath.Join(
+		stateHome, "prism", "run",
+		sessionDirName(sessionName),
+		"pi-agent", "sessions",
+		encodePiCWD(worktree),
+	)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir resume session dir: %v", err)
+	}
+	path := filepath.Join(dir, "2026-01-02T03-04-05-000Z_"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{\"type\":\"session\"}\n"), 0o600); err != nil {
+		t.Fatalf("write resume session file: %v", err)
+	}
+	return path
+}
+
+// bwrapResumeCfg constructs a Config that piResumeSessionsRoot will identify
+// as bwrap mode (SessionName + PIAgentConfigSandboxDir != PIAgentConfigHostDir).
+func bwrapResumeCfg(sessionName, worktree, harnessSessionID string) Config {
+	return Config{
+		SessionName:             sessionName,
+		Worktree:                worktree,
+		HarnessSessionID:        harnessSessionID,
+		PIAgentConfigHostDir:    "/tmp/host-stage", // bwrap remaps to a different sandbox path
+		PIAgentConfigSandboxDir: "/run/prism/pi-agent",
+	}
+}
+
+// TestPIInvocation_Resume_AppendsSessionWhenFileExists exercises AC8(a):
+// when HarnessSessionID is set and a matching session file exists on disk,
+// PIInvocation must append `--session <id>` immediately before any positional
+// InitialPrompt argument.
+func TestPIInvocation_Resume_AppendsSessionWhenFileExists(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+	const harnessSessionID = "019e00ed-1234-7890-abcd-ef0123456789"
+
+	writeBwrapResumeSession(t, sessionName, worktree, harnessSessionID)
+
+	cfg := bwrapResumeCfg(sessionName, worktree, harnessSessionID)
+	cfg.InitialPrompt = "do the thing"
+
+	args := PIInvocation(cfg)
+
+	if !hasPair(args, "--session", harnessSessionID) {
+		t.Errorf("expected --session %s in args; got %v", harnessSessionID, args)
+	}
+	// Positional InitialPrompt must be the last arg.
+	if args[len(args)-1] != "do the thing" {
+		t.Errorf("expected initial prompt as last positional arg; got %v", args)
+	}
+	// --session must appear immediately before the InitialPrompt positional.
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--session" && args[i+1] == harnessSessionID {
+			if i+2 != len(args)-1 {
+				t.Errorf("expected --session <id> immediately before the InitialPrompt positional; got args[%d:]=%v",
+					i, args[i:])
+			}
+		}
+	}
+}
+
+// TestPIInvocation_Resume_AppendsSession_NoInitialPrompt verifies the
+// positional-prompt-absent path: --session must still appear as the last pair
+// when InitialPrompt is empty.
+func TestPIInvocation_Resume_AppendsSession_NoInitialPrompt(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+	const harnessSessionID = "019e00ed-1111-2222-3333-444444444444"
+
+	writeBwrapResumeSession(t, sessionName, worktree, harnessSessionID)
+
+	cfg := bwrapResumeCfg(sessionName, worktree, harnessSessionID)
+	// No InitialPrompt.
+
+	args := PIInvocation(cfg)
+
+	if !hasPair(args, "--session", harnessSessionID) {
+		t.Errorf("expected --session %s in args; got %v", harnessSessionID, args)
+	}
+	// Last two args must be --session <id>; there must be no trailing positional.
+	if len(args) < 2 || args[len(args)-2] != "--session" || args[len(args)-1] != harnessSessionID {
+		t.Errorf("expected args to end with --session %s; got %v", harnessSessionID, args)
+	}
+}
+
+// TestPIInvocation_Resume_OmitsSessionWhenFileMissing exercises AC8(b):
+// when HarnessSessionID is set but no matching file is found, PIInvocation
+// must omit --session AND a clearly-tagged warning line must land in the
+// per-session agent-run log.
+func TestPIInvocation_Resume_OmitsSessionWhenFileMissing(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+	const harnessSessionID = "019e00ed-aaaa-bbbb-cccc-deadbeef0000"
+
+	// Deliberately do NOT write a session file.
+
+	cfg := bwrapResumeCfg(sessionName, worktree, harnessSessionID)
+	cfg.InitialPrompt = "do the thing"
+
+	args := PIInvocation(cfg)
+
+	if hasArg(args, "--session") {
+		t.Errorf("expected --session to be absent when no session file exists; got %v", args)
+	}
+	// InitialPrompt must still be present as the trailing positional.
+	if args[len(args)-1] != "do the thing" {
+		t.Errorf("expected initial prompt as last positional arg; got %v", args)
+	}
+
+	// Warning line must have been written to the agent-run log.
+	logPath := filepath.Join(stateHome, "prism", "run", sessionDirName(sessionName), "agent-run.log")
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read agent-run.log: %v", err)
+	}
+	want := "[agent-run] warning: pi session " + harnessSessionID + " not found"
+	if !strings.Contains(string(body), want) {
+		t.Errorf("agent-run.log = %q, want substring %q", string(body), want)
+	}
+}
+
+// TestPIInvocation_Resume_EmptyHarnessSessionIDIsSilent exercises AC8(c) /
+// AC5: when HarnessSessionID is empty, PIInvocation must behave exactly as
+// pre-#1838 \u2014 no --session, no warning written, no side effects.
+func TestPIInvocation_Resume_EmptyHarnessSessionIDIsSilent(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+
+	cfg := bwrapResumeCfg(sessionName, worktree, "") // empty HarnessSessionID
+	cfg.InitialPrompt = "do the thing"
+
+	args := PIInvocation(cfg)
+
+	if hasArg(args, "--session") {
+		t.Errorf("expected --session to be absent when HarnessSessionID is empty; got %v", args)
+	}
+
+	// No agent-run.log should have been created.
+	logPath := filepath.Join(stateHome, "prism", "run", sessionDirName(sessionName), "agent-run.log")
+	if _, err := os.Stat(logPath); err == nil {
+		body, _ := os.ReadFile(logPath)
+		t.Errorf("agent-run.log must not exist when HarnessSessionID is empty; got body=%q", string(body))
+	}
+}
+
+// TestPIResumeSessionsRoot_AllModes verifies that the mode-aware resolver
+// covers all three isolation modes pi can run in (AC6):
+//   - host:         <home>/.pi/agent/sessions
+//   - bwrap:        <XDG_STATE_HOME>/prism/run/<dirHash>/pi-agent/sessions
+//   - sandbox-exec: <stagingHome>/.pi/agent/sessions
+func TestPIResumeSessionsRoot_AllModes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	t.Run("host", func(t *testing.T) {
+		// No InstanceID, no PI staging dirs \u2014 falls through to host branch.
+		cfg := Config{SessionName: "myrepo@main"}
+		got, ok := piResumeSessionsRoot(cfg)
+		if !ok {
+			t.Fatalf("piResumeSessionsRoot(host): ok=false, want true")
+		}
+		want := filepath.Join(home, ".pi", "agent", "sessions")
+		if got != want {
+			t.Errorf("piResumeSessionsRoot(host) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("bwrap", func(t *testing.T) {
+		const sessionName = "myrepo@feature"
+		cfg := Config{
+			SessionName:             sessionName,
+			PIAgentConfigHostDir:    "/some/host/stage",
+			PIAgentConfigSandboxDir: "/run/prism/pi-agent",
+		}
+		got, ok := piResumeSessionsRoot(cfg)
+		if !ok {
+			t.Fatalf("piResumeSessionsRoot(bwrap): ok=false, want true")
+		}
+		want := filepath.Join(stateHome, "prism", "run", sessionDirName(sessionName), "pi-agent", "sessions")
+		if got != want {
+			t.Errorf("piResumeSessionsRoot(bwrap) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("sandbox-exec", func(t *testing.T) {
+		const instanceID = "11111111-2222-3333-4444-555555555555"
+		// PIAgentConfigSandboxDir == PIAgentConfigHostDir signals sandbox-exec.
+		cfg := Config{
+			InstanceID:              instanceID,
+			PIAgentConfigHostDir:    "/some/host/stage",
+			PIAgentConfigSandboxDir: "/some/host/stage",
+		}
+		got, ok := piResumeSessionsRoot(cfg)
+		if !ok {
+			t.Fatalf("piResumeSessionsRoot(sandbox-exec): ok=false, want true")
+		}
+		stagingHome, err := SandboxExecStagingHomePath(instanceID)
+		if err != nil {
+			t.Fatalf("SandboxExecStagingHomePath: %v", err)
+		}
+		want := filepath.Join(stagingHome, ".pi", "agent", "sessions")
+		if got != want {
+			t.Errorf("piResumeSessionsRoot(sandbox-exec) = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestEncodePiCWD_MatchesArchiveImpl is a self-consistency guard: the inline
+// encodePiCWD in this package must produce the same encoded path that
+// internal/harness/pi.EncodePiCWD produces, because both target the same
+// on-disk directory layout pi creates. If pi's formula changes, both copies
+// must change together \u2014 this test fails loudly when they diverge.
+func TestEncodePiCWD_MatchesArchiveImpl(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/home/ben/code/nixos-config/main", "--home-ben-code-nixos-config-main--"},
+		{"/", "----"},
+		{"/a/b:c\\d", "--a-b-c-d--"},
+	}
+	for _, c := range cases {
+		got := encodePiCWD(c.in)
+		if got != c.want {
+			t.Errorf("encodePiCWD(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/session/host_resume_test.go
+++ b/modules/programs/prism/prism/internal/session/host_resume_test.go
@@ -1,0 +1,144 @@
+package session
+
+// host_resume_test.go — issue #1838.
+//
+// Unit tests for the host-mode pi-resume branch in buildDirectAgentCmd.
+// The corresponding bwrap/sandbox-exec resume path lives in PIInvocation
+// and is covered by internal/container/pi_invocation_resume_test.go.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeHostModeResumeSession writes a synthetic pi session JSONL under the
+// host-mode sessions root (<HOME>/.pi/agent/sessions/<encoded-cwd>/) that
+// container.ResolvePIResumeSession will find. Returns the on-disk path.
+func writeHostModeResumeSession(t *testing.T, home, worktree, sessionID string) string {
+	t.Helper()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", piEncodeCWDForTest(worktree))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir host-mode sessions dir: %v", err)
+	}
+	path := filepath.Join(dir, "2026-01-02T03-04-05-000Z_"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{\"type\":\"session\"}\n"), 0o600); err != nil {
+		t.Fatalf("write host-mode session file: %v", err)
+	}
+	return path
+}
+
+// piEncodeCWDForTest mirrors internal/container.encodePiCWD. Inlined to keep
+// this test free of an internal-container dependency for the encoding.
+func piEncodeCWDForTest(cwd string) string {
+	stripped := strings.TrimLeft(cwd, "/\\")
+	replaced := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(stripped)
+	return "--" + replaced + "--"
+}
+
+// TestBuildDirectAgentCmd_HostMode_AppendsSessionWhenFileExists verifies that
+// buildDirectAgentCmd appends `--session '<id>'` when the on-disk pi session
+// JSONL is found under the host-mode sessions root.
+func TestBuildDirectAgentCmd_HostMode_AppendsSessionWhenFileExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const harnessSessionID = "019e00ed-1234-7890-abcd-ef0123456789"
+	worktree := filepath.Join(home, "code", "myrepo", "feature")
+	writeHostModeResumeSession(t, home, worktree, harnessSessionID)
+
+	opts := Opts{
+		IsolationMode:    "host",
+		HarnessName:      "pi",
+		Agent:            "worker",
+		SessionName:      "myrepo@feature",
+		Worktree:         worktree,
+		HarnessSessionID: harnessSessionID,
+		Prompt:           "hello",
+	}
+	cmd := buildDirectAgentCmd(opts)
+
+	want := "--session '" + harnessSessionID + "'"
+	if !strings.Contains(cmd, want) {
+		t.Errorf("buildDirectAgentCmd missing %q\ngot: %s", want, cmd)
+	}
+	// --session must appear before --prompt so the flag pair stays adjacent to
+	// the binary and the prompt remains the trailing argument.
+	sessionIdx := strings.Index(cmd, "--session")
+	promptIdx := strings.Index(cmd, "--prompt")
+	if sessionIdx == -1 || promptIdx == -1 || sessionIdx > promptIdx {
+		t.Errorf("--session must appear before --prompt; got: %s", cmd)
+	}
+}
+
+// TestBuildDirectAgentCmd_HostMode_OmitsSessionWhenFileMissing verifies the
+// negative case: HarnessSessionID set, but no file on disk → no --session
+// emitted. Proves the positive test isn't a no-op.
+func TestBuildDirectAgentCmd_HostMode_OmitsSessionWhenFileMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	opts := Opts{
+		IsolationMode:    "host",
+		HarnessName:      "pi",
+		Agent:            "worker",
+		SessionName:      "myrepo@feature",
+		Worktree:         "/some/worktree",
+		HarnessSessionID: "019e00ed-aaaa-bbbb-cccc-deadbeef0000",
+		Prompt:           "hello",
+	}
+	cmd := buildDirectAgentCmd(opts)
+
+	if strings.Contains(cmd, "--session") {
+		t.Errorf("buildDirectAgentCmd unexpectedly contains --session when no JSONL exists; got: %s", cmd)
+	}
+}
+
+// TestBuildDirectAgentCmd_HostMode_EmptyHarnessSessionIDIsSilent verifies
+// AC5 at the host-mode layer: empty HarnessSessionID → no --session, no
+// resolver call (no state needed).
+func TestBuildDirectAgentCmd_HostMode_EmptyHarnessSessionIDIsSilent(t *testing.T) {
+	opts := Opts{
+		IsolationMode: "host",
+		HarnessName:   "pi",
+		Agent:         "worker",
+		SessionName:   "myrepo@feature",
+		Worktree:      "/some/worktree",
+		// HarnessSessionID intentionally empty.
+		Prompt: "hello",
+	}
+	cmd := buildDirectAgentCmd(opts)
+	if strings.Contains(cmd, "--session") {
+		t.Errorf("buildDirectAgentCmd must not emit --session when HarnessSessionID is empty; got: %s", cmd)
+	}
+}
+
+// TestBuildDirectAgentCmd_HostMode_NonPiHarnessSkipsResume verifies AC7:
+// non-pi harnesses never go through the resume path even if HarnessSessionID
+// somehow gets set (defence-in-depth — restoreProjectSession only sets it
+// from a pi-emitted DB column, but the harness check is the load-bearing
+// guard here).
+func TestBuildDirectAgentCmd_HostMode_NonPiHarnessSkipsResume(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const harnessSessionID = "019e00ed-1234-7890-abcd-ef0123456789"
+	worktree := filepath.Join(home, "code", "myrepo", "feature")
+	writeHostModeResumeSession(t, home, worktree, harnessSessionID)
+
+	opts := Opts{
+		IsolationMode:    "host",
+		HarnessName:      "fake", // not pi
+		Agent:            "worker",
+		SessionName:      "myrepo@feature",
+		Worktree:         worktree,
+		HarnessSessionID: harnessSessionID,
+		Prompt:           "hello",
+	}
+	cmd := buildDirectAgentCmd(opts)
+	if strings.Contains(cmd, "--session") {
+		t.Errorf("buildDirectAgentCmd must skip --session for non-pi harness; got: %s", cmd)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/host_resume_test.go
+++ b/modules/programs/prism/prism/internal/session/host_resume_test.go
@@ -115,6 +115,75 @@ func TestBuildDirectAgentCmd_HostMode_EmptyHarnessSessionIDIsSilent(t *testing.T
 	}
 }
 
+// TestBuildDirectAgentCmd_BwrapMode_DoesNotInvokeResolver verifies the
+// review-context round-2 blocker fix: BuildAgentCmd calls buildDirectAgentCmd
+// for every isolation mode, but the bwrap/sandbox-exec AgentPaneCmd discards
+// the result and substitutes `prism agent-run`. If buildDirectAgentCmd ran
+// ResolvePIResumeSession unconditionally, the resolver's host-fallback path
+// would miss (bwrap sessions live under prism's per-session run dir, not
+// under ~/.pi/agent/sessions) and piLogResumeWarning would spuriously write
+// a misleading "pi session <id> not found" line to the per-session
+// agent-run.log on every bwrap restore. The actual resume succeeds via
+// agent-run's DB-read + PIInvocation path — the log line would be operator-
+// confusing noise.
+//
+// Assertion: a bwrap-mode call with HarnessSessionID set must not produce
+// any agent-run.log file (the dir wouldn't even be created by the resolver
+// when the gate is correctly in place).
+func TestBuildDirectAgentCmd_BwrapMode_DoesNotInvokeResolver(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("HOME", t.TempDir())
+
+	const sessionName = "myrepo@feature"
+	opts := Opts{
+		IsolationMode:    "bwrap",
+		HarnessName:      "pi",
+		Agent:            "worker",
+		SessionName:      sessionName,
+		Worktree:         "/some/worktree",
+		HarnessSessionID: "019e00ed-1111-2222-3333-444444444444",
+		Prompt:           "hello",
+	}
+	_ = buildDirectAgentCmd(opts)
+
+	// The host-mode resolver would write to
+	// <XDG_STATE_HOME>/prism/run/<dirHash>/agent-run.log on a miss. With the
+	// host-mode gate in place, the file (and even its parent run dir) must
+	// not exist.
+	logPath := filepath.Join(stateHome, "prism", "run")
+	if _, err := os.Stat(logPath); err == nil {
+		t.Errorf("resolver ran on bwrap mode and created %s — the host-mode gate is missing", logPath)
+	}
+}
+
+// TestBuildDirectAgentCmd_SandboxExecMode_DoesNotInvokeResolver is the
+// sandbox-exec analogue of the bwrap-mode test above. Both modes use
+// `prism agent-run --session <name>` as their pane command (see
+// dispatch.go AgentPaneCmd for both isolators), so buildDirectAgentCmd's
+// resolver-invocation must be gated for both.
+func TestBuildDirectAgentCmd_SandboxExecMode_DoesNotInvokeResolver(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("HOME", t.TempDir())
+
+	opts := Opts{
+		IsolationMode:    "sandbox-exec",
+		HarnessName:      "pi",
+		Agent:            "worker",
+		SessionName:      "myrepo@feature",
+		Worktree:         "/some/worktree",
+		HarnessSessionID: "019e00ed-1111-2222-3333-555555555555",
+		Prompt:           "hello",
+	}
+	_ = buildDirectAgentCmd(opts)
+
+	logPath := filepath.Join(stateHome, "prism", "run")
+	if _, err := os.Stat(logPath); err == nil {
+		t.Errorf("resolver ran on sandbox-exec mode and created %s — the host-mode gate is missing", logPath)
+	}
+}
+
 // TestBuildDirectAgentCmd_HostMode_NonPiHarnessSkipsResume verifies AC7:
 // non-pi harnesses never go through the resume path even if HarnessSessionID
 // somehow gets set (defence-in-depth — restoreProjectSession only sets it

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -347,13 +347,30 @@ func buildDirectAgentCmd(opts Opts) string {
 	} else {
 		cmd = binary
 	}
-	// Append --session <id> for host-mode pi-resume (issue #1838). Scoped
-	// to the pi harness via harnessBinary's coverage — "pi" and "" map to
-	// the pi binary; any other harness name skips resume because
-	// ResolvePIResumeSession's encoded-cwd / sessions-root layout is pi-
-	// specific. Inserted before --prompt so the flag pair stays adjacent to
-	// the binary and the positional prompt (if any) remains the last token.
-	if opts.HarnessSessionID != "" && (opts.HarnessName == "pi" || opts.HarnessName == "") {
+	// Append --session <id> for host-mode pi-resume (issue #1838).
+	//
+	// Three guards stack here:
+	//
+	//  1. effectiveIsolationMode(opts) == "host" — BuildAgentCmd calls this
+	//     helper for every mode (the result is discarded for bwrap and
+	//     sandbox-exec by their AgentPaneCmd, which substitutes
+	//     `prism agent-run --session <name>`). Without this gate, the
+	//     resolver would run on every restore and — because the bwrap/
+	//     sandbox-exec pi sessions live under prism's per-session run dir,
+	//     not under ~/.pi/agent/sessions — the host-fallback lookup would
+	//     miss and piLogResumeWarning would spuriously write a misleading
+	//     "resume failed" line to the agent-run.log even though the actual
+	//     resume succeeds via prism agent-run's DB-read + PIInvocation
+	//     path. (Review round 2 / review-context.)
+	//  2. HarnessName ∈ {"pi", ""} — ResolvePIResumeSession's encoded-cwd /
+	//     sessions-root layout is pi-specific.
+	//  3. HarnessSessionID != "" — empty IDs are a silent no-op (AC5).
+	//
+	// Inserted before --prompt so the flag pair stays adjacent to the binary
+	// and the positional prompt (if any) remains the last token.
+	if effectiveIsolationMode(opts) == "host" &&
+		opts.HarnessSessionID != "" &&
+		(opts.HarnessName == "pi" || opts.HarnessName == "") {
 		resumeCfg := container.Config{
 			SessionName:      opts.SessionName,
 			Worktree:         opts.Worktree,

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -176,6 +176,16 @@ type Opts struct {
 	// it is forwarded to the sidecar via repeated --model-override flags.
 	// Nil means no per-role overrides.
 	ModelsByRole map[string]string
+	// HarnessSessionID is the persisted harness-specific session UUID to
+	// resume when launching the harness (e.g. pi's session UUID). Populated
+	// by `prism restore` (and `prism restart`, which calls Restore) from
+	// agent_status.harness_session_id; left empty by `prism spawn` and
+	// `prism switch`. When non-empty and Harness == "pi" the value is
+	// propagated to container.Config.HarnessSessionID by the agent-run
+	// dispatch path so PIInvocation can append --session <id>.
+	//
+	// Issue #1838.
+	HarnessSessionID string
 }
 
 // Layout selects the window layout used when creating a new session.

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -180,12 +180,28 @@ type Opts struct {
 	// resume when launching the harness (e.g. pi's session UUID). Populated
 	// by `prism restore` (and `prism restart`, which calls Restore) from
 	// agent_status.harness_session_id; left empty by `prism spawn` and
-	// `prism switch`. When non-empty and Harness == "pi" the value is
-	// propagated to container.Config.HarnessSessionID by the agent-run
-	// dispatch path so PIInvocation can append --session <id>.
+	// `prism switch`.
+	//
+	// Consumed in host mode by buildDirectAgentCmd (which calls
+	// container.ResolvePIResumeSession and appends `--session <id>` to the
+	// direct pi invocation when the on-disk JSONL is found). In bwrap and
+	// sandbox-exec the equivalent plumbing lives in cmd/agent_run.go and
+	// cmd/agent_run_sandbox_exec_darwin.go, which re-read the value from
+	// agent_status and pass it into container.Config.HarnessSessionID for
+	// PIInvocation — those paths do not depend on this Opts field because
+	// the bwrap/sandbox-exec tmux pane runs `prism agent-run`, which
+	// reconstructs its container config from the DB rather than carrying
+	// the launch opts forward.
 	//
 	// Issue #1838.
 	HarnessSessionID string
+	// Worktree is the absolute worktree path the session was created in. It
+	// is required only by the host-mode pi-resume path (buildDirectAgentCmd
+	// passes it into container.ResolvePIResumeSession so the encoded-cwd
+	// component of the on-disk pi sessions directory resolves correctly).
+	// Other launch shapes derive the worktree from the DB or from the
+	// container-mode plumbing and do not consult this field.
+	Worktree string
 }
 
 // Layout selects the window layout used when creating a new session.
@@ -313,6 +329,15 @@ func harnessBinary(harnessName string) string {
 // buildDirectAgentCmd returns the direct-launch command for the session
 // harness (pre-container mode). For harness="" or "pi" this is a pi
 // invocation.
+//
+// Host-mode pi-resume (issue #1838): when opts.HarnessSessionID is non-empty
+// and the harness is pi, the launcher calls container.ResolvePIResumeSession
+// to look up the on-disk session JSONL under ~/.pi/agent/sessions and, if
+// found, appends `--session <id>` immediately before any --prompt argument so
+// pi reopens the prior conversation. Missing file falls back silently to a
+// fresh conversation (the resolver writes a tagged warning to the per-session
+// agent-run.log). Non-pi harnesses and empty IDs skip the resume path
+// entirely.
 func buildDirectAgentCmd(opts Opts) string {
 	binary := harnessBinary(opts.HarnessName)
 	agent := opts.Agent
@@ -321,6 +346,22 @@ func buildDirectAgentCmd(opts Opts) string {
 		cmd = binary + " --agent " + agent
 	} else {
 		cmd = binary
+	}
+	// Append --session <id> for host-mode pi-resume (issue #1838). Scoped
+	// to the pi harness via harnessBinary's coverage — "pi" and "" map to
+	// the pi binary; any other harness name skips resume because
+	// ResolvePIResumeSession's encoded-cwd / sessions-root layout is pi-
+	// specific. Inserted before --prompt so the flag pair stays adjacent to
+	// the binary and the positional prompt (if any) remains the last token.
+	if opts.HarnessSessionID != "" && (opts.HarnessName == "pi" || opts.HarnessName == "") {
+		resumeCfg := container.Config{
+			SessionName:      opts.SessionName,
+			Worktree:         opts.Worktree,
+			HarnessSessionID: opts.HarnessSessionID,
+		}
+		if container.ResolvePIResumeSession(resumeCfg) {
+			cmd += " --session " + shellQuote(opts.HarnessSessionID)
+		}
 	}
 	if opts.Prompt != "" {
 		// #1064: when PromptFilePath is supplied, route the prompt through
@@ -681,6 +722,13 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	// opts.SessionName must be set by the caller before setupFullLayout is
 	// invoked — both ensureAndSwitch and restoreProjectSession do this.
 	// BuildAgentCmd uses it to prefix PRISM_SESSION_NAME for the plugin.
+	//
+	// Propagate the worktree path into opts so buildDirectAgentCmd (host
+	// mode) can resolve the encoded-cwd component of the pi sessions
+	// directory for conversation resume (issue #1838). Other isolation
+	// modes ignore opts.Worktree — their `prism agent-run` dispatch reads
+	// the worktree from the DB row instead.
+	opts.Worktree = directory
 	agentCmd := BuildAgentCmd(opts)
 
 	// Persist isolation_mode BEFORE opening the agent window. This is the


### PR DESCRIPTION
Closes #1838.

## What

`prism restart` (and `prism restore`) now re-attach pi to its prior conversation
instead of starting a fresh one. The session UUID is already on disk in
`agent_status.harness_session_id`; this PR plumbs it from the DB row → restore
opts → container.Config → `PIInvocation`, which appends `--session <id>` after
verifying the on-disk JSONL exists.

## How

- `container.Config` gains `HarnessSessionID` (AC1).
- `cmd/restore.go::restoreProjectSession` copies `s.HarnessSessionID` into
  `opts.HarnessSessionID` (AC2). Worktree-missing, circuit-breaker, and
  already-running paths are unchanged.
- `cmd/agent_run.go` and `cmd/agent_run_sandbox_exec_darwin.go` propagate
  `status.HarnessSessionID` into `ctrCfg.HarnessSessionID` at agent-run time.
- `PIInvocation` appends `--session <id>` immediately before any positional
  InitialPrompt argument when `HarnessSessionID` is set **and** the on-disk
  session file is found via the mode-aware sessions-root resolver (AC3).
- The resolver covers all three modes pi can run in (AC6): `host` →
  `~/.pi/agent/sessions`, `bwrap` →
  `<XDG_STATE_HOME>/prism/run/<dirHash>/pi-agent/sessions`, `sandbox-exec` →
  `<stagingHome>/.pi/agent/sessions`. It mirrors
  `internal/harness/pi/archive.go::piSessionsRoot`; the two implementations are
  duplicated (not shared) because `internal/harness/pi` already imports
  `internal/container`, so the reverse import would cycle. The new copy carries
  a docstring cross-reference to its sibling.
- Missing-file fallback (AC4): when `HarnessSessionID != ""` but no matching
  `*_<id>.jsonl` exists, `PIInvocation` omits `--session` and appends a tagged
  warning line — `[agent-run] warning: pi session <id> not found at <path> —
  starting fresh conversation (<detail>)` — to the per-session agent-run.log.
  Pi then starts a new conversation as if `HarnessSessionID` had been empty.
- Empty `HarnessSessionID` is a complete no-op (AC5): no `--session`, no
  warning, no agent-run.log mutation. Non-pi harnesses are untouched (AC7) —
  the resume logic lives entirely inside `PIInvocation`, which is only called
  from the bwrap/sandbox-exec pi paths.

`prism spawn`, `prism switch`, and `prism reset` are untouched per the design.
Initial-prompt replay is naturally absent on restore because
`PRISM_INITIAL_PROMPT` lives in the pane env, which is re-created from scratch.

## Tests

New unit tests cover AC8 in full:

- `TestPIInvocation_Resume_AppendsSessionWhenFileExists` (AC8a) — `--session`
  appended immediately before the positional prompt when the file exists.
- `TestPIInvocation_Resume_AppendsSession_NoInitialPrompt` — same with no
  trailing positional.
- `TestPIInvocation_Resume_OmitsSessionWhenFileMissing` (AC8b, AC4) — verifies
  the absence of `--session` **and** the presence of the tagged warning line in
  the per-session agent-run.log.
- `TestPIInvocation_Resume_EmptyHarnessSessionIDIsSilent` (AC8c, AC5) — no
  `--session`, no agent-run.log created.
- `TestPIResumeSessionsRoot_AllModes` (AC6) — host / bwrap / sandbox-exec
  branches each resolve to the expected path.
- `TestEncodePiCWD_MatchesArchiveImpl` — self-consistency guard between the
  inline `encodePiCWD` and `harness/pi.EncodePiCWD` so the two duplicated
  formulas stay in lockstep.
- `TestRestoreSession_PlumbsHarnessSessionID` (AC8d) — DB row with non-NULL
  `harness_session_id` → `opts.HarnessSessionID` set on the captured
  `session.Opts`.
- `TestRestoreSession_EmptyHarnessSessionID_LeavesOptsEmpty` — DB row with NULL
  `harness_session_id` → `opts.HarnessSessionID == ""`.

All tests use `t.TempDir()` and `t.Setenv("XDG_STATE_HOME", …)` so they never
touch the host's real `$HOME` or `$XDG_STATE_HOME` (homeless-shelter-safe).

## Local checks (AC10)

```
cd modules/programs/prism/prism
go build ./...     # ✓
go test ./...      # ✓ (all packages green)
go test -race ./internal/container/ ./cmd/ ./internal/session/   # ✓
cd -
nix build .#prism  # ✓
nix build --impure --no-link \
  --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'  # ✓
```

## Manual smoke test (AC9)

Bare-host bwrap session on Linux: `prism spawn` a new session against a worktree,
send a prompt (e.g. `pi> hi, remember the word "rutabaga"`) and wait for the
turn to complete so pi flushes the JSONL. Then run `prism restart <session>`.
When the pane comes back, the prior turn(s) should already be visible in the
pi TUI — confirm by typing `what word did I tell you to remember?` and watching
pi answer correctly. Cross-check with the per-session log: the line
`pi --session <uuid>` should appear in `~/.local/state/prism/run/<hash>/agent-run.log`
(the path is printed by `prism checkin`), with the UUID matching the one stored
in `agent_status.harness_session_id` for that session
(`sqlite3 ~/.local/state/prism/prism.db 'select harness_session_id from agent_status where session_name="<name>";'`).
Verify the negative case too: kill the JSONL file (`mv` the matching
`*_<uuid>.jsonl` out of the per-cwd directory) and `prism restart` again — the
session should still come back up, the agent-run.log should now contain the
`[agent-run] warning: pi session <uuid> not found …` line, and pi should start
a fresh conversation.
