### PR TITLE
nav: remove agent-state filter from vertical spine (#1839)

### DIFF
--- a/modules/programs/prism/prism/internal/nav/nav.go
+++ b/modules/programs/prism/prism/internal/nav/nav.go
@@ -59,25 +59,18 @@ func IsSpineRow(s dashboard.AgentSession) bool {
 	return true
 }
 
-// terminalStates is the set of agent states that exclude a session from the
-// navigable vertical spine, per the issue spec. Sessions in any of these
-// states are skipped even if `ended_at IS NULL` has not yet been written by
-// the lifecycle layer.
-var terminalStates = map[string]bool{
-	"finished":    true,
-	"deleted":     true,
-	"interrupted": true,
-}
-
 // IsNavigableSpine reports whether s should be included in the up/down
-// navigable spine. The session must be a spine row (per IsSpineRow), not in
-// a terminal state, and must have a live tmux session (the latter checked
-// by the caller via the liveCheck callback because tmux IO is impure).
+// navigable spine. The session must be a spine row (per IsSpineRow) and
+// must have a live tmux session (the latter checked by the caller via the
+// liveCheck callback because tmux IO is impure).
+//
+// Agent state is intentionally NOT consulted here. `agent_status.state ==
+// "finished"` means the current turn is finished and the agent is idle
+// waiting for input — it does not mean the session has ended. True session
+// termination is gated by `ended_at IS NOT NULL` at the DB layer
+// (`db.AllActiveStatus`) and by tmux liveness at runtime; see issue #1839.
 func IsNavigableSpine(s dashboard.AgentSession, liveCheck func(string) bool) bool {
 	if !IsSpineRow(s) {
-		return false
-	}
-	if terminalStates[s.AgentState] {
 		return false
 	}
 	if liveCheck != nil && !liveCheck(s.Name) {

--- a/modules/programs/prism/prism/internal/nav/nav_test.go
+++ b/modules/programs/prism/prism/internal/nav/nav_test.go
@@ -76,20 +76,25 @@ func TestIsSpineRow(t *testing.T) {
 	}
 }
 
-func TestVerticalTargets_FiltersTerminalAndNonLive(t *testing.T) {
+// TestVerticalTargets_FiltersNonLive verifies that liveness is the only
+// runtime filter applied to the spine — sessions in any agent state
+// (including "finished", which means the turn is over but the session is
+// alive) are included as long as their tmux session is live. Depth-2 and
+// review-group rows are still excluded by IsSpineRow. See issue #1839.
+func TestVerticalTargets_FiltersNonLive(t *testing.T) {
 	sessions := makeSessions(t,
 		[2]string{"alpha@main", "active"},
-		[2]string{"alpha@feature", "active"}, // depth-1: included (issue #1800)
-		[2]string{"beta@main", "finished"},   // terminal state: excluded
+		[2]string{"alpha@feature", "active"},                       // depth-1: included (issue #1800)
+		[2]string{"beta@main", "finished"},                         // finished but live: included (issue #1839)
 		[2]string{"gamma@main", "idle"},
-		[2]string{"gamma@feature~review-1-review-goal", "active"}, // depth-2: excluded
+		[2]string{"gamma@feature~review-1-review-goal", "active"},  // depth-2: excluded
 		[2]string{"delta@main", "active"},                          // not live: excluded
 		[2]string{"scratchpad", "idle"},
 	)
-	live := liveSet("alpha@main", "alpha@feature", "gamma@main", "gamma@feature~review-1-review-goal", "scratchpad")
+	live := liveSet("alpha@main", "alpha@feature", "beta@main", "gamma@main", "gamma@feature~review-1-review-goal", "scratchpad")
 
 	got := nav.VerticalTargets(sessions, live)
-	want := []string{"alpha@main", "alpha@feature", "gamma@main", "scratchpad"}
+	want := []string{"alpha@main", "alpha@feature", "beta@main", "gamma@main", "scratchpad"}
 	if !equalSlice(got, want) {
 		t.Errorf("VerticalTargets = %v, want %v", got, want)
 	}
@@ -198,32 +203,71 @@ func TestVerticalTargets_MainOnlyRepo(t *testing.T) {
 	}
 }
 
-// TestVerticalTargets_TerminalStateExcludesDepth1 verifies that depth-1
-// children in terminal states are excluded from the spine, just like
-// top-level rows.
-func TestVerticalTargets_TerminalStateExcludesDepth1(t *testing.T) {
-	for _, state := range []string{"finished", "deleted", "interrupted"} {
+// TestVerticalTargets_DepthOneStateAgnostic verifies that depth-1 children
+// are included in the spine regardless of their AgentState, as long as
+// their tmux session is live. Previously these were excluded for terminal
+// states; per issue #1839 that filter was wrong ("finished" means turn
+// complete, not session ended).
+func TestVerticalTargets_DepthOneStateAgnostic(t *testing.T) {
+	for _, state := range []string{"finished", "deleted", "interrupted", "idle", "active"} {
 		sessions := makeSessions(t,
 			[2]string{"repo@main", "active"},
 			[2]string{"repo@feature", state},
 		)
 		got := nav.VerticalTargets(sessions, alwaysLive)
-		if len(got) != 1 || got[0] != "repo@main" {
-			t.Errorf("depth-1 state=%q: got %v, want [repo@main]", state, got)
+		want := []string{"repo@main", "repo@feature"}
+		if !equalSlice(got, want) {
+			t.Errorf("depth-1 state=%q: got %v, want %v", state, got, want)
 		}
 	}
 }
 
-func TestVerticalTargets_TerminalStatesExcluded(t *testing.T) {
-	for _, state := range []string{"finished", "deleted", "interrupted"} {
+// TestVerticalTargets_TopLevelStateAgnostic mirrors the depth-1 variant:
+// top-level rows in any agent state are included as long as they are live.
+// Issue #1839.
+func TestVerticalTargets_TopLevelStateAgnostic(t *testing.T) {
+	for _, state := range []string{"finished", "deleted", "interrupted", "idle", "active"} {
 		sessions := makeSessions(t,
 			[2]string{"alpha@main", "active"},
 			[2]string{"beta@main", state},
 		)
 		got := nav.VerticalTargets(sessions, alwaysLive)
-		if len(got) != 1 || got[0] != "alpha@main" {
-			t.Errorf("state=%q: got %v, want [alpha@main]", state, got)
+		want := []string{"alpha@main", "beta@main"}
+		if !equalSlice(got, want) {
+			t.Errorf("top-level state=%q: got %v, want %v", state, got, want)
 		}
+	}
+}
+
+// TestVerticalTargets_FinishedAndActive_BothNavigable is the positive
+// regression for issue #1839. Two sessions, one `active`, one `finished`,
+// both live: both must be in the spine and C-j-style ResolveVertical must
+// switch between them in both directions (and wrap).
+func TestVerticalTargets_FinishedAndActive_BothNavigable(t *testing.T) {
+	sessions := makeSessions(t,
+		[2]string{"alpha@main", "active"},
+		[2]string{"beta@main", "finished"},
+	)
+	targets := nav.VerticalTargets(sessions, alwaysLive)
+	want := []string{"alpha@main", "beta@main"}
+	if !equalSlice(targets, want) {
+		t.Fatalf("VerticalTargets = %v, want %v", targets, want)
+	}
+	// Down from alpha lands on beta.
+	if next, ok := nav.ResolveVertical("alpha@main", nav.DirDown, targets); !ok || next != "beta@main" {
+		t.Errorf("down from alpha: got (%q,%v), want (beta@main,true)", next, ok)
+	}
+	// Down from beta wraps to alpha.
+	if next, ok := nav.ResolveVertical("beta@main", nav.DirDown, targets); !ok || next != "alpha@main" {
+		t.Errorf("down from beta (wrap): got (%q,%v), want (alpha@main,true)", next, ok)
+	}
+	// Up from alpha wraps to beta.
+	if next, ok := nav.ResolveVertical("alpha@main", nav.DirUp, targets); !ok || next != "beta@main" {
+		t.Errorf("up from alpha (wrap): got (%q,%v), want (beta@main,true)", next, ok)
+	}
+	// Up from beta lands on alpha.
+	if next, ok := nav.ResolveVertical("beta@main", nav.DirUp, targets); !ok || next != "alpha@main" {
+		t.Errorf("up from beta: got (%q,%v), want (alpha@main,true)", next, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary

`prism nav up`/`down` (C-j / C-k on the agent window) was intermittently a silent no-op. With two sessions open, C-j sometimes switched and sometimes did nothing — and the instant the "stuck" agent started working again, the binding started working. The cause was a state filter in `internal/nav/nav.go::IsNavigableSpine` that excluded any session whose `agent_status.state` was one of `finished`, `deleted`, or `interrupted`.

But `agent_status.state == "finished"` does **not** mean the session is dead — it means the current turn is complete and the agent is idle waiting for input. That's the single most common state to want to nav *to* (a coordinator sitting at the dashboard prompt is always in state `finished`). True session termination is already gated by `db.AllActiveStatus` (`ended_at IS NOT NULL`) at the DB layer and by `tmux.HasSession` at runtime. Liveness alone is the right filter; agent state is not.

## Change

- Delete the `terminalStates` map and its use in `IsNavigableSpine`.
- The two filters that remain in `IsNavigableSpine` are `IsSpineRow` (predicate-only, no IO) and `liveCheck` (tmux liveness).
- Update tests that asserted exclusion-by-state to assert inclusion-by-state, and add a new positive regression: two sessions, one `active`, one `finished`, both live → both navigable, `ResolveVertical` switches between them in both directions and wraps.
- `ResolveLateral` / `ResolveReviewContext` are untouched — they were already correct (no state filter, only liveness).

## Manual smoke test

1. Spawn two sessions in the same repo: `prism spawn --branch test-a --prompt 'say hi'` and `prism spawn --branch test-b --prompt 'say hi'`.
2. Wait until both agents finish their first turn (state goes `finished`).
3. Attach to one, hit C-j on the agent window — verify it switches to the other.
4. Hit C-j again — verify it wraps back.
5. Send a follow-up prompt to one of them, leave the other idle, repeat: C-j should switch in both directions regardless of state.

## Pre-PR checks

- `go build ./...` ✅
- `go test ./...` ✅ (all packages, including `internal/nav`)
- `nix build .#prism` ✅

CI `pr-gate` will re-run the nix-sandboxed test on top of these.

Closes #1839
