### PR TITLE
sidecar: keep reviewingInFlight true until review-complete prompt is on the wire (#1843)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/delivery_dedup.go
+++ b/modules/programs/prism/prism/internal/sidecar/delivery_dedup.go
@@ -112,8 +112,15 @@ const pendingReplayCapacity = 16
 // reconnect loop drains the slice in arrival order and enqueues each entry
 // with `replay: true` set on the prompt frame so the receiver can identify
 // it as a replayed (not fresh) delivery. Issue #1685 AC #7.
+//
+// Source carries the originating /prompt request's `source` field through
+// the buffer so the flush path can run source-specific bookkeeping after a
+// successful re-enqueue. In particular, source=="review-complete" is the
+// signal for flushPendingReplay to clear reviewingInFlight (the same flag
+// the synchronous-delivery branch clears post-DeliverPrompt). Issue #1843.
 type pendingReplayDelivery struct {
 	DeliveryID string
 	Text       string
 	DeliverAs  string
+	Source     string
 }

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -727,12 +727,16 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Session string `json:"session"`
 			Prompt  string `json:"prompt"`
 			// Source identifies the logical origin of the delivery. When
-			// "review-complete" the sidecar clears reviewingInFlight before
-			// enqueuing the prompt frame, allowing the subsequent turn_start
-			// to transition normally to active. All other deliveries (coordinator
-			// follow-ups, merge-queue notifications, etc.) leave the flag
-			// unchanged — clearing on non-review prompts would prematurely end
-			// the reviewing window and reintroduce the race (#1372, AC #7).
+			// "review-complete" the sidecar clears reviewingInFlight AFTER the
+			// prompt frame is enqueued on the outbound writer (synchronous-
+			// success path) or after flushPendingReplay re-enqueues the frame
+			// post-reconnect (buffered path) — see #1843. Clearing only after
+			// the frame is on the wire keeps the events.go suppression guards
+			// armed through the delivery window, preventing the spurious
+			// "finished" notification class (#1372 / #1652). All other
+			// deliveries (coordinator follow-ups, merge-queue notifications,
+			// etc.) leave the flag unchanged — clearing on non-review prompts
+			// would prematurely end the reviewing window (#1372, AC #7).
 			Source string `json:"source,omitempty"`
 			// DeliverAs controls the delivery mode for same-session PI targets.
 			// Accepted values: "steer", "followUp", "nextTurn". When omitted the
@@ -807,20 +811,26 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					}
 				}
 
-				// Clear reviewingInFlight only when this is the monitor's
-				// review-complete delivery (source == "review-complete"). This
-				// ensures the turn_start that immediately follows the delivered
-				// prompt sees reviewingInFlight=false and correctly transitions
-				// to active. Non-review deliveries (coordinator follow-ups,
-				// merge-queue notifications) must NOT clear the flag — doing so
-				// would prematurely end the reviewing window and allow idle
-				// debounce to fire a spurious "finished" transition before the
-				// real review-complete prompt arrives (#1372, AC #7).
-				if req.Source == "review-complete" {
-					s.mu.Lock()
-					s.reviewingInFlight = false
-					s.mu.Unlock()
-				}
+				// reviewingInFlight handling for source=="review-complete":
+				// see issue #1843. The flag MUST remain true until the prompt
+				// is actually on the wire (or, on the buffered path, has been
+				// re-enqueued from flushPendingReplay) — otherwise an
+				// incidental state_change{finished} / session.idle arriving
+				// between this point and the actual delivery evades the
+				// suppression guards in events.go and fires a spurious
+				// "finished" notification (the #1372 / #1652 race class).
+				//
+				// Strategy (#1843):
+				//   - Synchronous-success path: call DeliverPrompt first;
+				//     clear reviewingInFlight only after it returns true.
+				//   - Buffered (PI-disconnected) path: tag the pending entry
+				//     with Source=="review-complete" and leave the flag set.
+				//     flushPendingReplay clears it after the replayed frame is
+				//     successfully enqueued post-reconnect.
+				//
+				// Non-review-complete deliveries (coordinator follow-ups,
+				// merge-queue notifications) must NEVER clear the flag — doing
+				// so would prematurely end the reviewing window (#1372, AC #7).
 				s.logger().Printf("sidecar: host-API /prompt: delivering via socket-pipe to self (%s) deliver_as=%s", req.Session, deliverAs)
 				if !s.DeliverPrompt(req.Prompt, deliverAs) {
 					// PI extension is disconnected. Buffer the delivery so it
@@ -829,15 +839,28 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					// Pre-#1685 behaviour returned 503; the new contract is that
 					// a single /prompt call delivers exactly once (after
 					// reconnect, marked replay) rather than failing the call.
-					// Issue #1685 AC #7.
+					// Issue #1685 AC #7. Source is propagated so flushPendingReplay
+					// can clear reviewingInFlight after the replayed frame is
+					// enqueued on the new connection (#1843).
 					s.bufferPendingReplay(pendingReplayDelivery{
 						DeliveryID: req.DeliveryID,
 						Text:       req.Prompt,
 						DeliverAs:  deliverAs,
+						Source:     req.Source,
 					})
-					s.logger().Printf("sidecar: host-API /prompt: PI disconnected, buffered for replay (session=%s deliver_as=%s delivery_id=%s)", req.Session, deliverAs, req.DeliveryID)
+					s.logger().Printf("sidecar: host-API /prompt: PI disconnected, buffered for replay (session=%s deliver_as=%s delivery_id=%s source=%s)", req.Session, deliverAs, req.DeliveryID, req.Source)
 					writeJSON(w, http.StatusOK, map[string]bool{"buffered": true})
 					return
+				}
+				// Synchronous success: the prompt frame is enqueued on the
+				// outbound writer. Now it is safe to clear reviewingInFlight
+				// for the review-complete case — the suppression guards have
+				// served their purpose, and the immediately-following turn_start
+				// must observe the cleared flag to transition normally to active.
+				if req.Source == "review-complete" {
+					s.mu.Lock()
+					s.reviewingInFlight = false
+					s.mu.Unlock()
 				}
 				writeJSON(w, http.StatusOK, map[string]string{})
 				return

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -450,6 +450,17 @@ type Sidecar struct {
 	// delivers the review-complete prompt via /prompt (same-session,
 	// TransportSocketPipe path only — HTTP-harness sessions bypass /prompt).
 	//
+	// Clearing semantics for the same-session /prompt path (#1843):
+	//   - Synchronous-success branch: cleared AFTER DeliverPrompt returns true.
+	//     Clearing earlier would let an incidental state_change{finished} /
+	//     session.idle frame slip past the suppression guards in events.go and
+	//     fire a spurious "finished" notification — the #1372 / #1652 race class.
+	//   - Buffered-for-replay branch (PI disconnected at delivery time):
+	//     remains true until flushPendingReplay re-enqueues the replayed frame
+	//     on the next handshake. The pendingReplayDelivery's Source field
+	//     carries the "review-complete" tag through the buffer so the flush
+	//     path knows which entry's enqueue triggers the clear.
+	//
 	// The suppress guards in events.go additionally check currentDBState() ==
 	// StateReviewing so they lift naturally when the monitor's pre-delivery DB
 	// write ("active") lands, even on HTTP-harness sessions where
@@ -2426,6 +2437,21 @@ func (s *Sidecar) flushPendingReplay() {
 			// Outbound channel not yet live or another disconnect raced us.
 			// Re-buffer so the next handshake picks it up.
 			requeue = append(requeue, d)
+			continue
+		}
+		// Successful re-enqueue: if this entry was the monitor's
+		// review-complete delivery, clear reviewingInFlight now — the
+		// synchronous-delivery branch in host_api.go was unable to clear
+		// it because DeliverPrompt failed (PI disconnected at the time),
+		// so the flag has remained true to keep the events.go suppression
+		// guards active through the disconnect window. With the replayed
+		// frame now on the wire, the suppression has done its job and the
+		// post-replay turn_start must observe the cleared flag. Issue #1843.
+		if d.Source == "review-complete" {
+			s.mu.Lock()
+			s.reviewingInFlight = false
+			s.mu.Unlock()
+			s.logger().Printf("sidecar: flushPendingReplay: cleared reviewingInFlight after replayed review-complete enqueue (delivery_id=%s)", d.DeliveryID)
 		}
 	}
 	if len(requeue) > 0 {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_reviewing_inflight_replay_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_reviewing_inflight_replay_test.go
@@ -1,0 +1,280 @@
+package sidecar
+
+// Tests for issue #1843: reviewingInFlight must not be cleared on the
+// same-session /prompt review-complete branch until the prompt frame is
+// actually on the wire — either synchronously (DeliverPrompt success) or
+// after flushPendingReplay re-enqueues a buffered entry.
+//
+// Two scenarios are covered:
+//
+//   1. Happy path (synchronous success): PI extension connected,
+//      /prompt review-complete returns 200 with no buffered marker, and
+//      reviewingInFlight is false after the handler returns.
+//
+//   2. Buffered-for-replay path: PI extension disconnected, /prompt
+//      review-complete returns 200 with buffered:true, the entry carries
+//      Source="review-complete", reviewingInFlight remains true through
+//      the disconnect window (so a state_change{finished} arriving during
+//      that window is suppressed by handleSessionFinished), and
+//      flushPendingReplay clears the flag after the replayed enqueue
+//      succeeds.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// TestHostAPI_Prompt_ReviewComplete_SyncSuccess_ClearsAfterDeliver is the
+// AC #1 / AC #5 happy-path test. It verifies that when DeliverPrompt
+// succeeds synchronously, reviewingInFlight ends up false after the handler
+// returns. This mirrors the existing
+// TestHostAPI_Prompt_ReviewComplete_ClearsReviewingInFlight test but is kept
+// here too so the #1843 fix has its own focused regression target — both the
+// invert-order branch and the existing semantics are exercised in one place.
+func TestHostAPI_Prompt_ReviewComplete_SyncSuccess_ClearsAfterDeliver(t *testing.T) {
+	d := openTestDB(t)
+	sessionName := "myrepo@piworker"
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "reviewing", nil, nil); err != nil {
+		t.Fatalf("seed DB reviewing state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+
+	// Connected pipe — DeliverPrompt will succeed synchronously.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"review results here","source":"review-complete"}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `"buffered":true`) {
+		t.Errorf("synchronous-success response should not carry buffered:true; body=%s", rr.Body.String())
+	}
+
+	// AC #1: flag is false on return.
+	sc.mu.Lock()
+	inFlight := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if inFlight {
+		t.Error("reviewingInFlight = true after synchronous review-complete delivery, want false")
+	}
+
+	// Sanity: frame really was enqueued.
+	select {
+	case <-fakePipeCh:
+	default:
+		t.Error("expected a frame in the pipe channel after synchronous review-complete delivery")
+	}
+}
+
+// TestHostAPI_Prompt_ReviewComplete_Buffered_KeepsFlagAndSuppressesFinish is
+// the AC #2 / AC #3 / AC #4 regression test for the buffered-for-replay
+// branch. The full timeline:
+//
+//  1. Worker sidecar is mid-review (reviewingInFlight=true, DB=reviewing).
+//  2. PI extension is disconnected (harnessPipeOutCh is nil).
+//  3. Monitor POSTs /prompt with source=review-complete.
+//     - Response is 200 buffered:true.
+//     - The buffered entry's Source is "review-complete".
+//     - reviewingInFlight is STILL true (#1843 invariant) — the original
+//     bug cleared it before DeliverPrompt was even tried.
+//  4. During the disconnect window, the worker's runtime emits a
+//     state_change{finished} (simulated by calling handleSessionFinished
+//     directly — equivalent to the path a real frame takes through
+//     handlePipeFrame). The finished-debounce timer is created.
+//  5. Fire the debounce: handleSessionFinished must observe
+//     reviewingInFlight=true and SUPPRESS the transition. The DB state must
+//     not become StateFinished — which also implies notifyCoordinator (the
+//     branch that calls it inside the suppression-gated block) is NOT
+//     invoked. This is the same suppression invariant guarded by #1372 /
+//     #1652; this test re-asserts it for the buffered review-complete path.
+//  6. Reconnect: install a fresh pipe channel and call flushPendingReplay
+//     directly. The replayed frame is enqueued, and flushPendingReplay
+//     clears reviewingInFlight (Source="review-complete" branch).
+//  7. After flush, reviewingInFlight is false — the post-replay turn_start
+//     will transition normally to active.
+//
+// The test uses a synthetic clock (newSocketPipeSidecarWithClock would also
+// work; we use the simpler in-memory hostAPI pattern instead because the
+// debounce timer and flushPendingReplay can both be driven directly).
+func TestHostAPI_Prompt_ReviewComplete_Buffered_KeepsFlagAndSuppressesFinish(t *testing.T) {
+	d := openTestDB(t)
+	sessionName := "myrepo@piworker"
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "reviewing", nil, nil); err != nil {
+		t.Fatalf("seed DB reviewing state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+	clk := sc.cfg.Clock.(*testClock)
+
+	// Step 1 + 2: reviewingInFlight=true, PI disconnected.
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	// harnessPipeOutCh remains nil — DeliverPrompt will return false.
+	sc.mu.Unlock()
+
+	// Step 3: POST /prompt with source=review-complete.
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"myrepo@piworker","prompt":"review results here","source":"review-complete","delivery_id":"d-1843"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"buffered":true`) {
+		t.Fatalf("body = %q, want it to contain \"buffered\":true (PI disconnected so entry must be buffered)", rr.Body.String())
+	}
+
+	// Buffered entry must carry Source="review-complete" so the flush path
+	// knows which entry's enqueue clears the flag.
+	sc.mu.Lock()
+	if got := len(sc.pendingReplayDeliveries); got != 1 {
+		sc.mu.Unlock()
+		t.Fatalf("pendingReplayDeliveries length = %d, want 1", got)
+	}
+	bufferedSource := sc.pendingReplayDeliveries[0].Source
+	bufferedID := sc.pendingReplayDeliveries[0].DeliveryID
+	sc.mu.Unlock()
+	if bufferedSource != "review-complete" {
+		t.Errorf("buffered entry Source = %q, want %q (tag must propagate so flush path can clear reviewingInFlight)", bufferedSource, "review-complete")
+	}
+	if bufferedID != "d-1843" {
+		t.Errorf("buffered entry DeliveryID = %q, want %q (sanity)", bufferedID, "d-1843")
+	}
+
+	// AC #2: reviewingInFlight must still be true after the buffered-path
+	// /prompt returns. The pre-#1843 code cleared it before DeliverPrompt
+	// was even called, exposing the suppression-evasion race.
+	sc.mu.Lock()
+	inFlightAfterBuffer := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if !inFlightAfterBuffer {
+		t.Fatal("reviewingInFlight cleared after buffered review-complete /prompt — #1843 regression (this is exactly the bug the issue describes)")
+	}
+
+	// Step 4: simulate state_change{finished} arriving during the
+	// disconnect window. handleSessionFinished installs a finished-debounce
+	// timer; we wait for it (the test clock's WaitForTimerCount captures the
+	// AfterFunc registration) and then fire it manually.
+	sc.handleSessionFinished()
+
+	timer := clk.WaitForTimerCount(1, 2*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer created after handleSessionFinished")
+	}
+
+	// Step 5: fire the debounce. With #1843 fixed, the closure in
+	// handleSessionFinished sees reviewingInFlight=true and suppresses the
+	// transition. Without the fix, the pre-cleared flag would let the
+	// closure overwrite DB state to StateFinished and call
+	// goNotify(notifyCoordinator).
+	timer.Fire()
+	// Give the closure a brief window to run (it acquires s.mu, which is
+	// not held here, so this is just a scheduling yield).
+	time.Sleep(100 * time.Millisecond)
+
+	st := getState(t, sc.cfg.DB, sc.cfg.SessionName)
+	if st == string(agent.StateFinished) {
+		t.Errorf("session transitioned to StateFinished during the buffered-replay window — #1843 regression (state=%q, want anything but %q)", st, agent.StateFinished)
+	}
+
+	// Sanity: reviewingInFlight must still be true (the suppression path
+	// does not clear it).
+	sc.mu.Lock()
+	inFlightAfterDebounce := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if !inFlightAfterDebounce {
+		t.Error("reviewingInFlight cleared by finished-debounce suppression path (should be unchanged)")
+	}
+
+	// Step 6: reconnect — install a fresh pipe channel and flush the buffer.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	sc.flushPendingReplay()
+
+	// The replayed frame should be on the pipe channel.
+	select {
+	case <-fakePipeCh:
+	default:
+		t.Error("expected a replayed frame on the pipe channel after flushPendingReplay")
+	}
+
+	// Step 7: AC #2 closing condition — reviewingInFlight is now false
+	// (the Source="review-complete" branch in flushPendingReplay cleared it
+	// after the successful re-enqueue).
+	sc.mu.Lock()
+	inFlightAfterFlush := sc.reviewingInFlight
+	bufferLen := len(sc.pendingReplayDeliveries)
+	sc.mu.Unlock()
+	if inFlightAfterFlush {
+		t.Error("reviewingInFlight still true after flushPendingReplay re-enqueued the review-complete entry — flush path must clear it (AC #2)")
+	}
+	if bufferLen != 0 {
+		t.Errorf("pendingReplayDeliveries length after flush = %d, want 0", bufferLen)
+	}
+}
+
+// TestFlushPendingReplay_NonReviewSourceDoesNotClearFlag is a defensive
+// regression test: flushPendingReplay must clear reviewingInFlight ONLY for
+// entries whose Source is "review-complete". A buffered coordinator
+// follow-up (Source=="") that happens to flush while a review is in flight
+// must leave the flag alone — otherwise we'd reintroduce the #1372 class of
+// "non-review prompt prematurely ends the reviewing window".
+func TestFlushPendingReplay_NonReviewSourceDoesNotClearFlag(t *testing.T) {
+	d := openTestDB(t)
+	sessionName := "myrepo@piworker"
+	if err := d.UpsertStatus(sessionName, "myrepo", "/wt", "reviewing", nil, nil); err != nil {
+		t.Fatalf("seed DB reviewing state: %v", err)
+	}
+
+	sc := newPiSidecarForHostAPITest(t, sessionName, "myrepo", "worker", d)
+
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.pendingReplayDeliveries = []pendingReplayDelivery{
+		{
+			DeliveryID: "follow-up-1",
+			Text:       "coordinator follow-up while review still in flight",
+			DeliverAs:  "nextTurn",
+			Source:     "", // non-review-complete
+		},
+	}
+	sc.mu.Unlock()
+
+	// Install a pipe channel so deliverPromptFrame succeeds.
+	fakePipeCh := make(chan []byte, 10)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = fakePipeCh
+	sc.mu.Unlock()
+
+	sc.flushPendingReplay()
+
+	// Drain the channel (sanity).
+	select {
+	case <-fakePipeCh:
+	default:
+		t.Fatal("expected the follow-up frame to be enqueued")
+	}
+
+	// The flag must still be true — only Source=="review-complete" clears it.
+	sc.mu.Lock()
+	inFlight := sc.reviewingInFlight
+	sc.mu.Unlock()
+	if !inFlight {
+		t.Error("flushPendingReplay cleared reviewingInFlight for a non-review-complete entry — must only clear for Source==\"review-complete\" (#1843 / #1372 invariant)")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes issue #1843: the same-session `/prompt` branch for `source=="review-complete"` cleared `reviewingInFlight` **before** `DeliverPrompt` was even attempted. Between that clear and the actual delivery — especially the buffered-for-replay path after a PI extension disconnect — the reviewing-suppression guards in `events.go` (`handleSessionFinished`, `handleSessionIdle`, `handleSessionStatus`, and `handleServerConnected`'s recovery timer) all key on `reviewingInFlight && DB state==reviewing`. With the flag prematurely false, an incidental `state_change{finished}` / `session.idle` arriving in that window slipped past the guards and fired a spurious 'finished' notification to the coordinator — re-introducing the closed #1372 / #1652 race class.

## Implementation shape

As discussed in [issue #1843 comment](https://github.com/prismatic-koi/nixos-config/issues/1843#issuecomment-4506236903), the fix combines the two shapes the issue listed:

1. **Invert order on the synchronous-success path.** Call `DeliverPrompt` first; clear `reviewingInFlight` only after it returns true (frame on the outbound writer). This closes the happy-path window with no extra plumbing.

2. **Tag the replay entry on the disconnected path.** Add a `Source` field to `pendingReplayDelivery` and propagate the `/prompt` request's `source` through the buffer. The flag stays true through buffering + reconnect. `flushPendingReplay` clears it after a `Source=="review-complete"` entry's frame is successfully re-enqueued post-reconnect.

Why both rather than just one: invert-only handles the common synchronous case but leaves no mechanism to clear the flag after a buffered delivery is eventually flushed; tag-only correctly handles both cases but is heavier than necessary for the synchronous-success path. Combined, both paths preserve the same invariant — `reviewingInFlight` stays true until the review-complete prompt is actually enqueued for the wire.

The 'flush ack' point in AC #2 is necessarily `deliverPromptFrame == true` (frame enqueued on the outbound writer channel) — there is no explicit PI-side ack frame and the existing protocol's contract is "enqueue == delivered".

## Test scenarios (paraphrased from AC's "test" lines)

Three new tests live in `internal/sidecar/sidecar_reviewing_inflight_replay_test.go`:

- **`TestHostAPI_Prompt_ReviewComplete_SyncSuccess_ClearsAfterDeliver`** (AC #1, AC #5): PI extension connected; POST `/prompt` with `source=review-complete`; assert 200, frame enqueued, and `reviewingInFlight == false` on return.

- **`TestHostAPI_Prompt_ReviewComplete_Buffered_KeepsFlagAndSuppressesFinish`** (AC #2, AC #3, AC #4): PI extension disconnected; POST `/prompt review-complete` → 200 `buffered:true`, buffered entry carries `Source="review-complete"`, `reviewingInFlight` is still true. Inject a `state_change{finished}` during the disconnect window via `handleSessionFinished`; fire the debounce — DB state must NOT become `StateFinished` (which also implies `notifyCoordinator` from the gated branch is not invoked). Then install a fresh pipe channel and call `flushPendingReplay`: replayed frame is enqueued and `reviewingInFlight` is cleared.

- **`TestFlushPendingReplay_NonReviewSourceDoesNotClearFlag`** (defensive): buffered entry with `Source==""` (e.g. coordinator follow-up) flushing while a review is in flight must NOT clear the flag — preserves the #1372 "non-review prompt must not end the reviewing window" invariant.

Negative-control verified: temporarily reverting only `host_api.go` re-fails the buffered test on both expected invariants (Source field missing on the buffered entry; flag cleared prematurely between buffer and flush).

## Quality gates

All from a clean run on this branch:

- `go build ./...` — pass
- `go test ./...` — pass (full prism suite)
- `go test -race ./internal/sidecar/...` — pass (the bug class is concurrency-shaped, so the sidecar package is race-tested explicitly per the issue's instructions)
- `nix build .#prism` — pass

## Out of scope

Per the issue: no refactor of `reviewingInFlight` into a richer state machine, and the cross-session `/prompt` branch (which already orders correctly) is untouched.

Closes #1843