### PR TITLE
mergequeue: handle BLOCKED + CHANGES_REQUESTED, log unknown decisions

### DIFF
--- a/modules/programs/prism/agents/coordinator.md
+++ b/modules/programs/prism/agents/coordinator.md
@@ -249,6 +249,7 @@ Once the sense-check passes, enqueue the PR in the merge queue and continue with
    - **`PR #N has merge conflicts...`** — `prism prompt <worker-session>` to rebase and push, then `prism merge <number>` again.
    - **`PR #N CI failed...`** — `prism prompt <worker-session>` to investigate and fix, then `prism merge <number>` again.
    - **`PR #N is blocked — human reviewer approval required...`** — request a human review on the PR (e.g. `gh pr review --request <user>`); once approved, `prism merge <number>` again.
+   - **`PR #N is blocked — reviewer requested changes...`** — `prism prompt <worker-session>` to address the reviewer's requested changes and re-request review on the PR; once the reviewer re-approves, `prism merge <number>` again.
    - **`PR #N was closed without merging...`** — typically nothing; the PR was closed deliberately.
 3. Use `prism merges` to inspect the current queue at any time.
 

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -383,6 +383,8 @@ func (w *Watcher) failAndNotify(head *db.PendingMerge, errMsg string) {
 		notifyText = fmt.Sprintf("PR #%d was closed without merging — removed from queue", head.PR)
 	case "human reviewer approval required before merge":
 		notifyText = fmt.Sprintf("PR #%d is blocked — human reviewer approval required before merge", head.PR)
+	case "reviewer requested changes — fix and re-request review":
+		notifyText = fmt.Sprintf("PR #%d is blocked — reviewer requested changes — fix and re-request review", head.PR)
 	default:
 		notifyText = fmt.Sprintf("PR #%d merge failed: %s", head.PR, errMsg)
 	}

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -233,13 +233,18 @@ func (w *Watcher) tick(ctx context.Context) {
 		w.failAndNotify(head, "merge conflicts")
 
 	case "BLOCKED":
-		// Disambiguate: CI failure, review required, or still running.
+		// Disambiguate: CI failure, review required, changes requested, or still running.
 		if hasCIFailure(prInfo.StatusCheckRollup) {
 			w.failAndNotify(head, "CI failed")
 		} else if prInfo.ReviewDecision == "REVIEW_REQUIRED" {
 			w.failAndNotify(head, "human reviewer approval required before merge")
+		} else if prInfo.ReviewDecision == "CHANGES_REQUESTED" {
+			w.failAndNotify(head, "reviewer requested changes — fix and re-request review")
 		} else {
-			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure or review requirement — staying watching", head.PR)
+			// Include the actual ReviewDecision string so any future unhandled
+			// value (new GitHub enum addition, unexpected empty/"" state) surfaces
+			// in the operator log rather than vanishing into a generic message.
+			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure or known review requirement (reviewDecision=%q) — staying watching", head.PR, prInfo.ReviewDecision)
 		}
 
 	case "UNSTABLE":

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1,9 +1,11 @@
 package mergequeue
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -527,6 +529,10 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 			fw.watcher.failAndNotify(head, "CI failed")
 		} else if prInfoVal.ReviewDecision == "REVIEW_REQUIRED" {
 			fw.watcher.failAndNotify(head, "human reviewer approval required before merge")
+		} else if prInfoVal.ReviewDecision == "CHANGES_REQUESTED" {
+			fw.watcher.failAndNotify(head, "reviewer requested changes — fix and re-request review")
+		} else {
+			log.Printf("[mergequeue] PR #%d BLOCKED but no CI failure or known review requirement (reviewDecision=%q) — staying watching", head.PR, prInfoVal.ReviewDecision)
 		}
 
 	case "UNSTABLE":
@@ -992,6 +998,133 @@ func TestWatcher_BLOCKEDNoReviewDecisionNoCIStaysWatching(t *testing.T) {
 	}
 	if row.Status != "watching" {
 		t.Errorf("status: got %q, want watching", row.Status)
+	}
+}
+
+// TestWatcher_BLOCKEDWithChangesRequested transitions to failed with the
+// changes-requested notification message when reviewDecision is
+// "CHANGES_REQUESTED" and CI is passing. Regression test for issue #1884:
+// previously this case fell through to the "staying watching" log branch
+// and the PR sat in the queue forever.
+func TestWatcher_BLOCKEDWithChangesRequested(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-changes"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-changes")
+
+	if _, err := d.EnqueueMerge(1884, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "SUCCESS"}},
+				ReviewDecision:    "CHANGES_REQUESTED",
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	// Row must have transitioned to failed with the expected reason.
+	const wantMsg = "reviewer requested changes — fix and re-request review"
+	row, err := d.PendingMergeByPR(1884)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "failed" {
+		t.Errorf("status: got %q, want failed", row.Status)
+	}
+	if row.Error == nil || *row.Error != wantMsg {
+		t.Errorf("error: got %v, want %q", row.Error, wantMsg)
+	}
+
+	// Notification must have been sent and contain the expected text.
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator")
+	}
+	var body map[string]any
+	if err := json.Unmarshal(srv.lastBody, &body); err != nil {
+		t.Fatalf("unmarshal notification body: %v", err)
+	}
+	parts, _ := body["parts"].([]interface{})
+	if len(parts) == 0 {
+		t.Fatal("notification body has no parts")
+	}
+	part, _ := parts[0].(map[string]interface{})
+	text, _ := part["text"].(string)
+	if !strings.Contains(text, "PR #1884") {
+		t.Errorf("notification text %q does not contain 'PR #1884'", text)
+	}
+	if !strings.Contains(text, wantMsg) {
+		t.Errorf("notification text %q does not contain changes-requested message", text)
+	}
+}
+
+// TestWatcher_BLOCKEDUnrecognisedReviewDecisionLogsValue verifies the
+// defensive log branch: an unrecognised ReviewDecision value (e.g. a future
+// GitHub enum addition) keeps the row in watching state AND emits a log line
+// containing the literal decision string for forensic visibility.
+func TestWatcher_BLOCKEDUnrecognisedReviewDecisionLogsValue(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-blocked-foobar"
+	session := "myrepo@main"
+
+	if _, err := d.EnqueueMerge(1885, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, http.DefaultClient,
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:             "OPEN",
+				MergeStateStatus:  "BLOCKED",
+				StatusCheckRollup: []checkEntry{{Conclusion: "SUCCESS"}},
+				ReviewDecision:    "FOOBAR",
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	// Capture log output only around processHead so we don't pick up the
+	// unrelated repo-resolution log lines emitted by New().
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+
+	fw.processHead(context.Background())
+
+	// Row stays in watching state (stay-watching path).
+	row, err := d.PendingMergeByPR(1885)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "watching" {
+		t.Errorf("status: got %q, want watching (unrecognised decision must not terminate)", row.Status)
+	}
+
+	// Log line must include the literal value "FOOBAR" for forensic visibility.
+	logged := buf.String()
+	if !strings.Contains(logged, "FOOBAR") {
+		t.Errorf("log output %q does not contain literal \"FOOBAR\"", logged)
+	}
+	if !strings.Contains(logged, "PR #1885") {
+		t.Errorf("log output %q does not reference PR #1885", logged)
 	}
 }
 

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -437,6 +437,7 @@ When a queued PR reaches a terminal outcome, the watcher delivers a bus notifica
 | CI failure | `PR #N CI failed — needs worker fix` |
 | Closed without merging | `PR #N was closed without merging — removed from queue` |
 | Review required | `PR #N is blocked — human reviewer approval required before merge` |
+| Changes requested | `PR #N is blocked — reviewer requested changes — fix and re-request review` |
 | Other merge failure | `PR #N merge failed: <error>` |
 | Coordinator session ended while watching | Row transitions to `abandoned` — surfaces via `prism merges list --abandoned` only; no live notification. |
 
@@ -451,6 +452,7 @@ When a merge-queue notification arrives, treat it as high-priority (same as a wo
 | `CI failed` | `prism prompt <worker-session>` asking it to investigate the failed check, fix, and push; re-enqueue with `prism merge <pr>` |
 | `closed without merging` | Usually nothing — the PR was closed deliberately. Investigate if unexpected. |
 | `blocked — human reviewer approval required` | Request a human review on the PR (e.g. via `gh pr review --request <user>`). Once approved, re-enqueue with `prism merge <pr>`. |
+| `blocked — reviewer requested changes` | `prism prompt <worker-session>` asking it to address the reviewer's requested changes and re-request review on the PR. Once the reviewer re-approves, re-enqueue with `prism merge <pr>`. |
 | `merge failed: <error>` | Read the error, decide whether to retry (`prism merge <pr>`) or escalate to the user. |
 | `abandoned` (via `--abandoned` listing) | A new coordinator decides whether to re-enqueue with `prism merge <pr>`. |
 


### PR DESCRIPTION
## Failure mode

When a PR sat in the prism merge queue with `mergeStateStatus=BLOCKED` and `reviewDecision=CHANGES_REQUESTED` (the value GitHub returns after a reviewer leaves a 'Request changes' review with no CI failure and no required-review setting), the BLOCKED handler in `internal/mergequeue/watcher.go` fell through to the catch-all `log.Printf` 'staying watching' branch. The row never transitioned to a terminal state, the coordinator that enqueued the PR was never notified, and the only escape was `prism merges cancel` or sidecar shutdown.

## Fix

- Add an explicit BLOCKED sub-branch for `ReviewDecision == "CHANGES_REQUESTED"` that calls `failAndNotify` with the reason **"reviewer requested changes — fix and re-request review"**. This writes a terminal `failed` row to `pending_merges` and notifies the coordinator.
- Harden the catch-all log branch: it now includes the actual `ReviewDecision` string (`reviewDecision=%q`) so any future unhandled enum value (or unexpected empty state) surfaces in the operator log rather than vanishing into a generic message.

## Tests

- **`TestWatcher_BLOCKEDWithChangesRequested`** — stubs `runGHFunc` to return `BLOCKED` + `CHANGES_REQUESTED` with passing CI, drives `processHead`, and asserts: (a) the `pending_merges` row is `failed` with the expected reason string; (b) a coordinator notification was sent containing both `PR #1884` and the reason text.
- **`TestWatcher_BLOCKEDUnrecognisedReviewDecisionLogsValue`** — stubs `BLOCKED` + `FOOBAR` (a synthetic unknown enum value), drives `processHead`, and asserts: (a) the row stays in `watching` state (no terminal transition for unknown decisions); (b) the captured log output contains the literal string `FOOBAR` and the PR number, proving the forensic-visibility log line fires.

The test helper `processHead` (which duplicates the BLOCKED switch logic) was updated to mirror the new branches so the tests exercise the same disambiguation flow.

Existing `TestWatcher_BLOCKED*` tests continue to pass; full `go test ./...` and `go test -race ./internal/mergequeue/...` are green, and `nix build .#prism` succeeds.

Closes #1884