### PR TITLE
dashboard: distinguish empty success from DB error (fix ghost sessions)

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/model.go
+++ b/modules/programs/prism/prism/internal/dashboard/model.go
@@ -120,6 +120,19 @@ type Shared struct {
 // snapSession is the session name to snap the cursor to on first load
 // (pass the currentSession value from the mode-specific model).
 // Returns the updated Shared and whether a snap was performed.
+//
+// The nil-vs-empty distinction on msg.Sessions is the wire contract between
+// FetchSessionsFromDB and this method:
+//
+//   - nil          → DB error (openDB or AllActiveStatus failed). Preserve
+//     the last-known session list so the dashboard does not flash empty on
+//     a transient failure.
+//   - empty slice  → successful fetch returned zero non-meta sessions. Clear
+//     the displayed list so the dashboard reflects reality (no ghost rows).
+//   - non-empty    → normal update; replace the list.
+//
+// FilterAgentSessions is responsible for upholding the empty-slice half of
+// the contract: it always returns a non-nil slice. See issue #1859.
 func (d Shared) ApplySessionsMsg(msg SessionsMsg, snapSession string) (Shared, bool) {
 	d.Loading = false
 	if msg.Sessions != nil {

--- a/modules/programs/prism/prism/internal/dashboard/persistent_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/persistent_test.go
@@ -1,12 +1,29 @@
 package dashboard_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/prismatic-koi/prism/internal/dashboard"
 )
+
+// unopenableDBPath returns a filesystem path that cannot be opened as a
+// sqlite DB: it sits beneath a regular file (not a directory), so the
+// os.MkdirAll() inside db.Open() fails with ENOTDIR. Using a path under a
+// regular file is portable and does not depend on /nonexistent staying
+// absent across test runs (#1859).
+func unopenableDBPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to create blocker file: %v", err)
+	}
+	return filepath.Join(blocker, "prism.db")
+}
 
 // TestPersistentInit_SchedulesSessionSyncTick verifies that PersistentModel.Init
 // returns a non-nil command batch that includes at least 4 commands:
@@ -48,7 +65,7 @@ func TestPersistentInit_SchedulesSessionSyncTick(t *testing.T) {
 func TestPersistentUpdate_SessionSyncTickMsg_HandledGracefully(t *testing.T) {
 	// Use a fake DB path so openDB fails cleanly — FetchSessionsFromDB will
 	// return an empty SessionsMsg rather than querying a real DB.
-	dashboard.SetTestDBPath("/nonexistent/path/prism.db")
+	dashboard.SetTestDBPath(unopenableDBPath(t))
 	t.Cleanup(func() { dashboard.SetTestDBPath("") })
 
 	m := dashboard.NewPersistentModel("", "")
@@ -118,8 +135,8 @@ func TestPersistentUpdate_SessionSyncTickMsg_HandledGracefully(t *testing.T) {
 // SessionsMsg{} with nil Sessions on error; ApplySessionsMsg guards nil so the
 // existing session list is preserved.
 func TestPersistentUpdate_SessionSyncTickMsg_RetainsSessionsOnDBError(t *testing.T) {
-	// Point the DB at a nonexistent path so FetchSessionsFromDB always errors.
-	dashboard.SetTestDBPath("/nonexistent/path/prism.db")
+	// Point the DB at an unopenable path so FetchSessionsFromDB always errors.
+	dashboard.SetTestDBPath(unopenableDBPath(t))
 	t.Cleanup(func() { dashboard.SetTestDBPath("") })
 
 	m := dashboard.NewPersistentModel("", "")
@@ -182,4 +199,78 @@ func TestPersistentUpdate_SessionSyncTickMsg_RetainsSessionsOnDBError(t *testing
 			i = len(batch) // break loop
 		}
 	}
+}
+
+// TestPersistentUpdate_SessionsMsg_AllThreeSignals drives the PersistentModel
+// through every signal the FetchSessionsFromDB → ApplySessionsMsg wire
+// carries, asserting the resulting PersistentModel.Sessions state. This is the
+// PersistentModel-level companion to TestApplySessionsMsg_ThreeStates in
+// poll_test.go and the central regression test for #1859.
+//
+//   - (a) non-empty success: Sessions is a non-empty slice → list updates.
+//   - (b) empty success:     Sessions is an empty non-nil slice → list clears
+//     (the regression: ghost rows after every prism session was cleaned up).
+//   - (c) DB error:          Sessions is nil                  → list preserved.
+func TestPersistentUpdate_SessionsMsg_AllThreeSignals(t *testing.T) {
+	// Seed the model with two pre-existing sessions, then drive each signal.
+	seed := func(t *testing.T) dashboard.PersistentModel {
+		t.Helper()
+		m := dashboard.NewPersistentModel("", "")
+		m2, _ := m.Update(dashboard.SessionsMsg{Sessions: []dashboard.AgentSession{
+			{Name: "nixos-config@main"},
+			{Name: "nixos-config@feature"},
+		}})
+		pm, ok := m2.(dashboard.PersistentModel)
+		if !ok {
+			t.Fatalf("seed: Update returned %T, want PersistentModel", m2)
+		}
+		if len(pm.Sessions) != 2 {
+			t.Fatalf("seed: want 2 sessions, got %d", len(pm.Sessions))
+		}
+		return pm
+	}
+
+	t.Run("a: non-empty success updates list", func(t *testing.T) {
+		pm := seed(t)
+		fresh := []dashboard.AgentSession{
+			{Name: "nixos-config@main"},
+			{Name: "nixos-config@feature"},
+			{Name: "nixos-config@bugfix"},
+		}
+		m2, _ := pm.Update(dashboard.SessionsMsg{Sessions: fresh})
+		pm2, ok := m2.(dashboard.PersistentModel)
+		if !ok {
+			t.Fatalf("Update returned %T, want PersistentModel", m2)
+		}
+		if len(pm2.Sessions) != 3 {
+			t.Errorf("want 3 sessions after non-empty success, got %d", len(pm2.Sessions))
+		}
+	})
+
+	t.Run("b: empty success clears list (no ghost rows)", func(t *testing.T) {
+		pm := seed(t)
+		// An empty-but-non-nil slice models a successful fetch that returned
+		// zero non-meta sessions — the #1859 scenario.
+		m2, _ := pm.Update(dashboard.SessionsMsg{Sessions: []dashboard.AgentSession{}})
+		pm2, ok := m2.(dashboard.PersistentModel)
+		if !ok {
+			t.Fatalf("Update returned %T, want PersistentModel", m2)
+		}
+		if len(pm2.Sessions) != 0 {
+			t.Errorf("want 0 sessions after empty success (no ghost rows), got %d: %+v", len(pm2.Sessions), pm2.Sessions)
+		}
+	})
+
+	t.Run("c: DB error preserves list", func(t *testing.T) {
+		pm := seed(t)
+		// SessionsMsg with nil Sessions models a DB error.
+		m2, _ := pm.Update(dashboard.SessionsMsg{Sessions: nil})
+		pm2, ok := m2.(dashboard.PersistentModel)
+		if !ok {
+			t.Fatalf("Update returned %T, want PersistentModel", m2)
+		}
+		if len(pm2.Sessions) != 2 {
+			t.Errorf("want 2 sessions preserved after DB error, got %d", len(pm2.Sessions))
+		}
+	})
 }

--- a/modules/programs/prism/prism/internal/dashboard/poll_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/poll_test.go
@@ -1,0 +1,139 @@
+package dashboard_test
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/dashboard"
+)
+
+// TestFilterAgentSessions_AlwaysNonNil locks down the nil-vs-empty wire
+// contract documented on Shared.ApplySessionsMsg: FilterAgentSessions must
+// return a non-nil slice on every successful call, including the case where
+// every input session is a meta session and the result is empty. See #1859.
+func TestFilterAgentSessions_AlwaysNonNil(t *testing.T) {
+	t.Run("nil input returns empty non-nil", func(t *testing.T) {
+		out := dashboard.FilterAgentSessions(nil)
+		if out == nil {
+			t.Fatal("FilterAgentSessions(nil) returned nil; want empty non-nil slice")
+		}
+		if len(out) != 0 {
+			t.Errorf("len = %d, want 0", len(out))
+		}
+	})
+
+	t.Run("empty input returns empty non-nil", func(t *testing.T) {
+		out := dashboard.FilterAgentSessions([]dashboard.AgentSession{})
+		if out == nil {
+			t.Fatal("FilterAgentSessions([]) returned nil; want empty non-nil slice")
+		}
+		if len(out) != 0 {
+			t.Errorf("len = %d, want 0", len(out))
+		}
+	})
+
+	t.Run("only meta sessions returns empty non-nil", func(t *testing.T) {
+		// This is the regression case from #1859: every prism session was
+		// cleaned up, only scratchpad and prism-dashboard remain. Before the
+		// fix, FilterAgentSessions returned a nil slice here, which
+		// ApplySessionsMsg then conflated with the DB-error signal and
+		// preserved stale rows.
+		in := []dashboard.AgentSession{
+			{Name: "scratchpad"},
+			{Name: "prism-dashboard"},
+		}
+		out := dashboard.FilterAgentSessions(in)
+		if out == nil {
+			t.Fatal("FilterAgentSessions(meta-only) returned nil; want empty non-nil slice (would cause ghost rows in dashboard)")
+		}
+		if len(out) != 0 {
+			t.Errorf("len = %d, want 0 (meta sessions must be filtered out)", len(out))
+		}
+	})
+
+	t.Run("mixed input filters meta and returns rest", func(t *testing.T) {
+		in := []dashboard.AgentSession{
+			{Name: "scratchpad"},
+			{Name: "nixos-config@main"},
+			{Name: "prism-dashboard"},
+			{Name: "nixos-config@feature"},
+		}
+		out := dashboard.FilterAgentSessions(in)
+		if out == nil {
+			t.Fatal("returned nil")
+		}
+		if len(out) != 2 {
+			t.Fatalf("len = %d, want 2", len(out))
+		}
+		if out[0].Name != "nixos-config@main" || out[1].Name != "nixos-config@feature" {
+			t.Errorf("unexpected order/contents: %+v", out)
+		}
+	})
+}
+
+// TestApplySessionsMsg_ThreeStates exercises every signal the
+// FetchSessionsFromDB → ApplySessionsMsg wire carries:
+//
+//   - (a) non-empty success: Sessions is a non-empty slice → list updates.
+//   - (b) empty success:     Sessions is an empty non-nil slice → list clears.
+//   - (c) DB error:          Sessions is nil                  → list preserved.
+//
+// This is the central regression test for #1859. Before the fix, state (b)
+// and state (c) were indistinguishable because FilterAgentSessions returned a
+// nil slice when zero non-meta sessions survived filtering — meaning empty
+// success was treated as a DB error and the dashboard never updated to "no
+// active sessions" after the last prism session was cleaned up.
+func TestApplySessionsMsg_ThreeStates(t *testing.T) {
+	seed := func() dashboard.Shared {
+		// Build a Shared with two pre-existing sessions, as if a prior
+		// successful fetch had populated the list.
+		d := dashboard.Shared{
+			Sessions: []dashboard.AgentSession{
+				{Name: "nixos-config@main"},
+				{Name: "nixos-config@feature"},
+			},
+		}
+		return d
+	}
+
+	t.Run("a: non-empty success updates list", func(t *testing.T) {
+		d := seed()
+		fresh := []dashboard.AgentSession{
+			{Name: "nixos-config@main"},
+			{Name: "nixos-config@feature"},
+			{Name: "nixos-config@bugfix"},
+		}
+		d2, _ := d.ApplySessionsMsg(dashboard.SessionsMsg{Sessions: fresh}, "")
+		if len(d2.Sessions) != 3 {
+			t.Fatalf("want 3 sessions after non-empty success, got %d", len(d2.Sessions))
+		}
+		if d2.Sessions[2].Name != "nixos-config@bugfix" {
+			t.Errorf("new session not present: %+v", d2.Sessions)
+		}
+	})
+
+	t.Run("b: empty success clears list", func(t *testing.T) {
+		d := seed()
+		// An empty-but-non-nil slice models a successful fetch that returned
+		// zero non-meta sessions (e.g. every prism session was cleaned up,
+		// only scratchpad and prism-dashboard remain).
+		empty := []dashboard.AgentSession{}
+		d2, _ := d.ApplySessionsMsg(dashboard.SessionsMsg{Sessions: empty}, "")
+		if len(d2.Sessions) != 0 {
+			t.Errorf("want 0 sessions after empty success (no ghost rows), got %d: %+v", len(d2.Sessions), d2.Sessions)
+		}
+		// Displayed must also reflect the empty list.
+		if len(d2.Displayed) != 0 {
+			t.Errorf("want Displayed empty after empty success, got %d: %+v", len(d2.Displayed), d2.Displayed)
+		}
+	})
+
+	t.Run("c: DB error preserves list", func(t *testing.T) {
+		d := seed()
+		// A SessionsMsg with nil Sessions models a DB error in
+		// FetchSessionsFromDB (openDB or AllActiveStatus failed).
+		d2, _ := d.ApplySessionsMsg(dashboard.SessionsMsg{Sessions: nil}, "")
+		if len(d2.Sessions) != 2 {
+			t.Errorf("want 2 sessions preserved after DB error, got %d: %+v", len(d2.Sessions), d2.Sessions)
+		}
+	})
+}

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -534,8 +534,16 @@ func SessionColumnWidth(sessions []AgentSession) int {
 
 // FilterAgentSessions removes internal sessions (scratchpad, prism-dashboard)
 // from the slice.
+//
+// The returned slice is always non-nil — even when every input session is a
+// meta session and the result is empty, this returns an empty-but-non-nil
+// slice. This is load-bearing: the dashboard relies on nil-vs-empty to
+// distinguish "DB error, preserve last-known sessions" (nil, set by
+// FetchSessionsFromDB on error) from "successful fetch returned zero
+// non-meta sessions" (empty non-nil, which must clear the displayed list).
+// See issue #1859 and the nil-guard in Shared.ApplySessionsMsg.
 func FilterAgentSessions(all []AgentSession) []AgentSession {
-	var out []AgentSession
+	out := make([]AgentSession, 0, len(all))
 	for _, s := range all {
 		if session.IsMetaSession(s.Name) {
 			continue


### PR DESCRIPTION
Closes #1859.

## Fix shape chosen

Option (1) from the issue — tighten the slice contract on `FilterAgentSessions` so it always returns a non-nil slice (`make([]AgentSession, 0, len(all))` instead of `var out []AgentSession`). This is the smallest change that fixes the bug: the nil-vs-empty distinction on `SessionsMsg.Sessions` now correctly encodes "DB error" (nil) vs "successful fetch returned zero non-meta sessions" (empty non-nil), and the existing nil-guard in `Shared.ApplySessionsMsg` does the right thing for both. Option (2) (explicit `Err` field) would also work but is more invasive for no behavioural gain — the contract is now documented in detail on both `FilterAgentSessions` and `ApplySessionsMsg`.

## Three-state test scenarios (paraphrased from ACs)

The fix is locked down by two parallel test groups that drive every signal the `FetchSessionsFromDB → ApplySessionsMsg` wire carries:

- **(a) non-empty success** — `SessionsMsg{Sessions: [...]}` with rows → displayed list updates to the new list.
- **(b) empty success** — `SessionsMsg{Sessions: []AgentSession{}}` (the regression case from #1859, where every prism session has been cleaned up and only meta sessions remain) → displayed list updates to empty, no ghost rows.
- **(c) DB error** — `SessionsMsg{Sessions: nil}` (what `FetchSessionsFromDB` returns when `openDB` or `AllActiveStatus` fails) → previously displayed list is preserved.

The new `TestApplySessionsMsg_ThreeStates` exercises `Shared.ApplySessionsMsg` directly; the new `TestPersistentUpdate_SessionsMsg_AllThreeSignals` exercises the same three signals through the `PersistentModel.Update` path. A third test, `TestFilterAgentSessions_AlwaysNonNil`, locks the non-nil contract at the `FilterAgentSessions` level on nil, empty, meta-only, and mixed inputs.

The pre-existing `TestPersistentUpdate_SessionSyncTickMsg_RetainsSessionsOnDBError` is preserved but tightened: it now uses a DB path beneath a regular file (so `os.MkdirAll` inside `db.Open` fails with `ENOTDIR`) instead of `/nonexistent/path/...`, which had been working coincidentally because the empty-DB path was being treated as a "preserve" signal by the very bug this PR fixes.

## Manual smoke test

Open the persistent dashboard with at least one user-spawned session present (e.g. \`nixos-config@feature\`). Confirm the row is visible. Then clean up every user session (\`prism cleanup <session>\` for each, or just the one). The dashboard's 10-second session-sync tick (or any push event from a sidecar) will trigger a re-fetch; the displayed list should drop to empty within one tick interval rather than continuing to show the cleaned-up rows as "ghost" entries. Killing the DB (\`mv ~/.local/state/prism/prism.db ~/.local/state/prism/prism.db.bak\`) while a session is displayed should leave the displayed rows in place — the dashboard does not flash empty on a transient DB error.

## Out of scope

Renderer changes (the existing `len(Sessions) == 0` render path already handles the empty state correctly); loading/error banners (existing behaviour of silently preserving on error is preserved by design).