### PR TITLE
db: add missing indexes for hot query paths (#1864)

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -53,8 +53,8 @@ CREATE TABLE IF NOT EXISTS agent_events (
   created_at         INTEGER NOT NULL,
   instance_id        TEXT REFERENCES sessions(instance_id)
 );
-CREATE INDEX IF NOT EXISTS idx_events_session ON agent_events(session_name, created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_events_repo    ON agent_events(repo, type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_session    ON agent_events(session_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_repo       ON agent_events(repo, type, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS sessions (
   instance_id         TEXT PRIMARY KEY,
@@ -381,6 +381,11 @@ CREATE INDEX IF NOT EXISTS idx_harness_frames_session_dir ON harness_frames(sess
 // added a now-abandoned column to the sessions table (#1640). The migration
 // is preserved as a version-counter bump only so schema_version progresses
 // linearly through deployed databases.
+// v31→v32 adds six missing indexes for hot DB query paths (#1864):
+//   - idx_events_instance, idx_events_created_at on agent_events
+//   - idx_agent_status_{active,group_id,instance_id,repo_active} on agent_status
+// Each CREATE INDEX uses IF NOT EXISTS so the migration is idempotent on a
+// fresh DB (which already has the indexes via the declarative schema block).
 //
 func Open(path string) (*DB, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -419,7 +424,8 @@ func Open(path string) (*DB, error) {
 // so they apply to every connection in the pool. It closes conn on any error
 // and returns the same conn on success.
 func openAndConfigure(conn *sql.DB) (*sql.DB, error) {
-	// Create all tables.
+	// Create all tables and the indexes that reference columns guaranteed
+	// to be present in every historical table shape.
 	if _, err := conn.Exec(schema); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("db: apply schema: %w", err)
@@ -435,8 +441,57 @@ func openAndConfigure(conn *sql.DB) (*sql.DB, error) {
 		return nil, err
 	}
 
+	// Apply the post-migration declarative index block. These indexes
+	// reference columns (agent_events.instance_id, agent_status.group_id,
+	// agent_status.instance_id) that may not exist on a database opened
+	// at a pre-v6 / pre-v9 / pre-v16 schema version. Running them after
+	// migrations guarantees the columns exist; running them from the
+	// declarative block (rather than only the migration) keeps fresh and
+	// migrated DBs from drifting if the v31→v32 migration is ever pruned
+	// (the DB-F16 drift class). CREATE INDEX IF NOT EXISTS makes the
+	// double-execution (declarative + migration) idempotent. (#1864)
+	if _, err := conn.Exec(postMigrationIndexes); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("db: apply post-migration indexes: %w", err)
+	}
+
 	return conn, nil
 }
+
+// postMigrationIndexes contains CREATE INDEX statements that reference
+// columns added by migrations (agent_events.instance_id added in v15→v16,
+// agent_status.instance_id added in v5→v6, agent_status.group_id added in
+// v8→v9). They cannot live in the declarative `schema` block because that
+// block executes before migrations, while tests open databases at older
+// schema versions where the referenced columns do not yet exist. The block
+// is applied after migrations so the columns are guaranteed to be present.
+//
+// Mirrors the v31→v32 migration body. The migration itself is the source
+// of truth for deployed databases; this block is the declarative mirror
+// that protects against drift if the migration is ever pruned (#1864 /
+// DB-F16). CREATE INDEX IF NOT EXISTS makes both paths idempotent.
+const postMigrationIndexes = `
+-- F1 (#1864): cover WHERE instance_id = ? on agent_events for
+-- WriteSpawnOutcome's aggregation and SessionTurnTokens. Includes type
+-- and created_at so the CASE-on-type sums and MIN(created_at) are
+-- covered without heap reads.
+CREATE INDEX IF NOT EXISTS idx_events_instance   ON agent_events(instance_id, type, created_at);
+-- F3 (#1864): standalone created_at index for EventsSince, which has no
+-- session_name / repo filter and so cannot use the leading column of
+-- idx_events_session or idx_events_repo.
+CREATE INDEX IF NOT EXISTS idx_events_created_at ON agent_events(created_at);
+-- F2 (#1864): partial indexes covering hot agent_status query paths.
+-- agent_status is never pruned, so these scale with lifetime spawn
+-- count; partial WHERE clauses keep the indexes small.
+CREATE INDEX IF NOT EXISTS idx_agent_status_active        ON agent_status(ended_at)
+  WHERE ended_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_status_group_id      ON agent_status(group_id)
+  WHERE group_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_status_instance_id   ON agent_status(instance_id)
+  WHERE instance_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_status_repo_active   ON agent_status(repo)
+  WHERE ended_at IS NULL;
+`
 
 // seedSchemaVersionIfEmpty inserts schema_version=11 when the table is empty.
 // Fresh databases have all current columns so starting at 11 is safe — the
@@ -455,7 +510,7 @@ func seedSchemaVersionIfEmpty(conn *sql.DB) error {
 }
 
 // runMigrations reads the current schema_version and applies all pending
-// migrations in order from v1 to v27.
+// migrations in order from v1 to v32.
 func runMigrations(conn *sql.DB) error {
 	var version int
 	if err := conn.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
@@ -551,6 +606,65 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV30ToV31(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV31ToV32(conn, &version); err != nil {
+		return err
+	}
+	return nil
+}
+
+// migrateV31ToV32 adds six missing indexes for hot DB query paths (#1864):
+// two on agent_events (idx_events_instance, idx_events_created_at) and four
+// partial indexes on agent_status (active, group_id, instance_id, repo_active).
+//
+// Background — the three audit findings rolled into this migration:
+//
+//   F1: agent_events.instance_id had no index. WriteSpawnOutcome's
+//       aggregation query (sessions.go) filters WHERE instance_id = ? and
+//       runs 14 CASE expressions over the matching rows once per session
+//       end; SessionTurnTokens has the same WHERE shape. Both were full
+//       table scans growing linearly with retained event volume.
+//   F2: agent_status had only the narrow partial coordinator-per-repo
+//       index, leaving GroupCompleted, ActiveSessionCountForMode,
+//       HarnessSessionIDForInstance, CoordinatorForRepo and every other
+//       active-row filter on full-table scans. agent_status is never
+//       pruned, so this scales with lifetime spawn count.
+//   F3: agent_events.created_at had no standalone index. EventsSince
+//       (prism stats --days) filters by created_at >= ? with no session/
+//       repo leading column, so neither existing index could be used.
+//
+// Each CREATE INDEX uses IF NOT EXISTS, making the migration idempotent —
+// fresh databases already have the indexes from the declarative schema
+// block above, so the migration is a no-op there. The declarative block
+// and this migration must produce identical sqlite_master output (avoiding
+// the declarative-vs-migrated drift class that DB-F16 calls out).
+func migrateV31ToV32(conn *sql.DB, version *int) error {
+	if *version >= 32 {
+		return nil
+	}
+	steps := []string{
+		// F1: cover WriteSpawnOutcome's WHERE instance_id = ? plus the CASE-on-type
+		// aggregation and MIN(created_at) selection in a single index.
+		`CREATE INDEX IF NOT EXISTS idx_events_instance   ON agent_events(instance_id, type, created_at)`,
+		// F3: cover EventsSince's WHERE created_at >= ? ORDER BY created_at ASC.
+		`CREATE INDEX IF NOT EXISTS idx_events_created_at ON agent_events(created_at)`,
+		// F2: partial indexes — agent_status is never pruned, so partials keep the
+		// indexes small (active rows only / non-NULL keys only).
+		`CREATE INDEX IF NOT EXISTS idx_agent_status_active        ON agent_status(ended_at)
+		   WHERE ended_at IS NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_agent_status_group_id      ON agent_status(group_id)
+		   WHERE group_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_agent_status_instance_id   ON agent_status(instance_id)
+		   WHERE instance_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS idx_agent_status_repo_active   ON agent_status(repo)
+		   WHERE ended_at IS NULL`,
+		`UPDATE schema_version SET version = 32`,
+	}
+	for _, s := range steps {
+		if _, err := conn.Exec(s); err != nil {
+			return fmt.Errorf("db: migration v31\u2192v32: %w", err)
+		}
+	}
+	*version = 32
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=31 (all migrations applied on Open).
+	// Verify schema_version=32 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version: got %d, want 32", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1645,8 +1645,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1711,8 +1711,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1781,8 +1781,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1876,8 +1876,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1969,8 +1969,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2513,8 +2513,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2602,8 +2602,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4452,8 +4452,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// Check each row.
@@ -4880,8 +4880,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5155,8 +5155,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5376,8 +5376,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// sessions table must exist.
@@ -5530,8 +5530,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 }
 
@@ -6084,8 +6084,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6142,8 +6142,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6444,8 +6444,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6506,8 +6506,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6665,8 +6665,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6719,8 +6719,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 
 	var startedAt int64
@@ -6873,8 +6873,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -6946,8 +6946,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7082,8 +7082,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after migration: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after migration: got %d, want 32", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7136,8 +7136,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 
 	// spawn_outcome must still exist.

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 31 {
-		t.Errorf("schema_version after fresh open = %d, want 31", ver)
+	if ver != 32 {
+		t.Errorf("schema_version after fresh open = %d, want 32", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 31 {
-		t.Errorf("schema_version after second open = %d, want 31", ver)
+	if ver != 32 {
+		t.Errorf("schema_version after second open = %d, want 32", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/db/hot_path_indexes_test.go
+++ b/modules/programs/prism/prism/internal/db/hot_path_indexes_test.go
@@ -1,0 +1,264 @@
+package db_test
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// hotPathIndexNames lists every index added by the v31→v32 migration (#1864).
+// Maps each index name to its table; the test asserts pragma_index_list
+// reports the index against the right table.
+var hotPathIndexNames = map[string]string{
+	"idx_events_instance":          "agent_events",
+	"idx_events_created_at":        "agent_events",
+	"idx_agent_status_active":      "agent_status",
+	"idx_agent_status_group_id":    "agent_status",
+	"idx_agent_status_instance_id": "agent_status",
+	"idx_agent_status_repo_active": "agent_status",
+}
+
+// TestHotPathIndexes_ExistAfterOpen verifies that every index added by the
+// v31→v32 migration (#1864) is present on a freshly opened DB. The check
+// uses pragma_index_list(<table>) rather than scanning sqlite_master so
+// that index visibility is asserted from the same metadata the planner
+// consults — if the index is reported here, EXPLAIN QUERY PLAN can use it.
+func TestHotPathIndexes_ExistAfterOpen(t *testing.T) {
+	d := openTestDB(t)
+	raw := openRawSQLite(t, d.Path())
+
+	// Build the set of indexes present per table.
+	type indexKey struct{ table, name string }
+	seen := map[indexKey]bool{}
+	for _, table := range []string{"agent_events", "agent_status"} {
+		rows, err := raw.Query(fmt.Sprintf("PRAGMA index_list(%s)", table))
+		if err != nil {
+			t.Fatalf("pragma index_list(%s): %v", table, err)
+		}
+		for rows.Next() {
+			// PRAGMA index_list columns: seq, name, unique, origin, partial.
+			var seq, isUnique, partial int
+			var name, origin string
+			if err := rows.Scan(&seq, &name, &isUnique, &origin, &partial); err != nil {
+				rows.Close()
+				t.Fatalf("scan pragma index_list(%s): %v", table, err)
+			}
+			seen[indexKey{table, name}] = true
+		}
+		rows.Close()
+	}
+
+	for idx, table := range hotPathIndexNames {
+		if !seen[indexKey{table, idx}] {
+			t.Errorf("index %q not found on table %q (pragma index_list)", idx, table)
+		}
+	}
+}
+
+// openRawSQLite opens a second connection to the same DB file using the
+// modernc.org/sqlite driver directly, so that the test can run
+// metadata-only queries (PRAGMA / EXPLAIN QUERY PLAN) without paying for
+// the db package's connection setup. WAL journal mode (set by db.Open via
+// DSN) makes the parallel read safe.
+func openRawSQLite(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("raw sql.Open: %v", err)
+	}
+	t.Cleanup(func() { raw.Close() })
+	return raw
+}
+
+// TestHotPathIndexes_QueryPlanUsesIndex captures EXPLAIN QUERY PLAN for the
+// three hot-path queries called out in #1864 and asserts each plan reports
+// `SEARCH … USING INDEX <name>` rather than `SCAN`. This proves the new
+// indexes are not just present, they are actually selected by the SQLite
+// query planner for the relevant access pattern.
+//
+// To make the planner's cost model prefer the index, the test populates the
+// DB with enough rows that a full scan would obviously lose: ~10k events
+// across 50 instances and ~500 agent_status rows across multiple groups
+// and isolation modes. The numbers mirror the AC's "populated DB" sizing.
+func TestHotPathIndexes_QueryPlanUsesIndex(t *testing.T) {
+	d := openTestDB(t)
+	raw := openRawSQLite(t, d.Path())
+
+	// Populate sessions + agent_events. 50 instances, 200 events each.
+	const nInstances = 50
+	const nEventsPerInstance = 200
+
+	now := time.Now()
+	for i := 0; i < nInstances; i++ {
+		iid := fmt.Sprintf("inst-%03d", i)
+		sessionName := fmt.Sprintf("repo@s%03d", i)
+		if err := d.InsertSession(db.Session{
+			InstanceID:  iid,
+			SessionName: sessionName,
+			Repo:        "repo",
+			Worktree:    "/tmp/worktree",
+			Harness:     "pi",
+			StartedAt:   now.Add(-time.Hour),
+		}); err != nil {
+			t.Fatalf("InsertSession[%d]: %v", i, err)
+		}
+		for j := 0; j < nEventsPerInstance; j++ {
+			eventType := "tool_call"
+			if j%17 == 0 {
+				eventType = "msg_assistant"
+			}
+			iidCopy := iid
+			if err := d.WriteEvent(db.Event{
+				ID:          uuid.New().String(),
+				SessionName: sessionName,
+				Repo:        "repo",
+				Worktree:    "/tmp/worktree",
+				InstanceID:  &iidCopy,
+				Type:        eventType,
+				Payload:     `{"inputTokens":1,"outputTokens":1}`,
+				CreatedAt:   now.Add(-time.Hour).Add(time.Duration(j) * time.Second),
+			}); err != nil {
+				t.Fatalf("WriteEvent[%d,%d]: %v", i, j, err)
+			}
+		}
+	}
+
+	// Populate agent_status. ~500 rows: half ended, half active; spread
+	// across 5 isolation modes and 20 group_ids; some carry instance_id.
+	const nStatuses = 500
+	for i := 0; i < nStatuses; i++ {
+		sessionName := fmt.Sprintf("repo@status-%04d", i)
+		// Seed with state="active". The row is created with last_seen via
+		// UpsertStatus; below we patch the columns we need for the planner.
+		if err := d.UpsertStatus(sessionName, "repo", "/tmp/worktree", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus[%d]: %v", i, err)
+		}
+		// Half the rows get ended_at set; half stay active.
+		if i%2 == 0 {
+			if err := d.SetEnded(sessionName); err != nil {
+				t.Fatalf("SetEnded[%d]: %v", i, err)
+			}
+		}
+		// Set isolation_mode round-robin across 5 modes.
+		modes := []string{"podman", "bwrap", "host", "sandbox-exec", "none"}
+		if err := d.SetIsolationMode(sessionName, modes[i%len(modes)]); err != nil {
+			t.Fatalf("SetIsolationMode[%d]: %v", i, err)
+		}
+		// 80% of rows get an instance_id; round-robin across a 20-group set.
+		if i%5 != 0 {
+			iid := fmt.Sprintf("inst-status-%04d", i)
+			if err := d.SetInstanceID(sessionName, iid); err != nil {
+				t.Fatalf("SetInstanceID[%d]: %v", i, err)
+			}
+		}
+		if i%4 == 0 {
+			gid := fmt.Sprintf("group-%03d", i%20)
+			// Register the group first so the FK is satisfied.
+			if _, err := raw.Exec(
+				`INSERT OR IGNORE INTO session_groups (group_id, parent_session) VALUES (?, ?)`,
+				gid, "parent@main",
+			); err != nil {
+				t.Fatalf("insert group_id[%d]: %v", i, err)
+			}
+			if err := d.SetGroupID(sessionName, gid); err != nil {
+				t.Fatalf("SetGroupID[%d]: %v", i, err)
+			}
+		}
+	}
+
+	// Refresh planner stats so the cost model picks the new indexes.
+	if _, err := raw.Exec("ANALYZE"); err != nil {
+		t.Fatalf("ANALYZE: %v", err)
+	}
+
+	// Each case: a representative hot-path query, the expected index name,
+	// and bind arguments. The plan text is normalised to ignore the noisy
+	// id/parent/notused columns of EXPLAIN QUERY PLAN and to ignore
+	// whitespace.
+	cases := []struct {
+		name      string
+		query     string
+		args      []any
+		wantIndex string
+	}{
+		{
+			name: "WriteSpawnOutcome_aggregation",
+			// The WriteSpawnOutcome aggregation query from sessions.go,
+			// trimmed to the access pattern (we only care about the plan).
+			query: `SELECT
+				    COUNT(*),
+				    MIN(created_at)
+				FROM agent_events
+				WHERE instance_id = ?`,
+			args:      []any{"inst-017"},
+			wantIndex: "idx_events_instance",
+		},
+		{
+			name:      "GroupCompleted_by_group_id",
+			query:     `SELECT COUNT(*) FROM agent_status WHERE group_id = ? AND state NOT IN ('finished','error','deleted') AND ended_at IS NULL`,
+			args:      []any{"group-007"},
+			wantIndex: "idx_agent_status_group_id",
+		},
+		{
+			name:      "ActiveSessionCountForMode",
+			query:     `SELECT COUNT(*) FROM agent_status WHERE ended_at IS NULL AND isolation_mode = ?`,
+			args:      []any{"podman"},
+			wantIndex: "idx_agent_status_active",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainQueryPlan(t, raw, tc.query, tc.args...)
+			if !strings.Contains(plan, "SEARCH") {
+				t.Errorf("plan does not contain SEARCH (expected index %q to be used):\n%s",
+					tc.wantIndex, plan)
+			}
+			if strings.Contains(plan, "SCAN agent_events") || strings.Contains(plan, "SCAN agent_status") {
+				t.Errorf("plan still reports a full SCAN (expected index %q to be used):\n%s",
+					tc.wantIndex, plan)
+			}
+			if !strings.Contains(plan, tc.wantIndex) {
+				// Not strictly fatal — SQLite may pick an equally good
+				// alternate index — but the AC asks us to assert on the
+				// specific index, so surface it loudly.
+				t.Errorf("plan does not reference expected index %q:\n%s",
+					tc.wantIndex, plan)
+			}
+		})
+	}
+}
+
+// explainQueryPlan runs EXPLAIN QUERY PLAN and returns the concatenated
+// detail column for each row, one per line. The detail column carries the
+// human-readable "SEARCH … USING INDEX …" / "SCAN …" text we assert on.
+func explainQueryPlan(t *testing.T, raw *sql.DB, query string, args ...any) string {
+	t.Helper()
+	rows, err := raw.Query("EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
+	}
+	defer rows.Close()
+	var b strings.Builder
+	for rows.Next() {
+		// EXPLAIN QUERY PLAN columns: id, parent, notused, detail.
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan EXPLAIN QUERY PLAN: %v", err)
+		}
+		b.WriteString(detail)
+		b.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate EXPLAIN QUERY PLAN: %v", err)
+	}
+	return b.String()
+}

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1424,8 +1424,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 31 {
-		t.Errorf("schema_version after second open: got %d, want 31", version)
+	if version != 32 {
+		t.Errorf("schema_version after second open: got %d, want 32", version)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds six missing indexes for hot DB query paths via a new `v31→v32`
migration. Bundles three audit findings (F1 / F2 / F3) into one PR because
they share a single fix shape (one new migration).

### Migration version

`v31→v32` is the next free slot — checked `runMigrations` in
`internal/db/db.go`, current max is `migrateV30ToV31`. Each `CREATE INDEX`
uses `IF NOT EXISTS` so the migration is fully idempotent.

### Indexes added

- `idx_events_instance(instance_id, type, created_at)` — covers F1
  (WriteSpawnOutcome's aggregation, SessionTurnTokens). `type` +
  `created_at` are included so SQLite can answer the 14 CASE-on-type sums
  and `MIN(created_at)` from the index alone (covering index).
- `idx_events_created_at(created_at)` — covers F3 (`EventsSince` /
  `prism stats --days`, which has no `session_name` / `repo` filter).
- `idx_agent_status_active(ended_at) WHERE ended_at IS NULL` — partial;
  covers the ubiquitous active-row filter (F2).
- `idx_agent_status_group_id(group_id) WHERE group_id IS NOT NULL` —
  partial; covers `GroupCompleted` / `GroupResults` /
  `GroupMembersForParent` / `GroupMembersForGroup` (F2).
- `idx_agent_status_instance_id(instance_id) WHERE instance_id IS NOT NULL`
  — partial; covers `HarnessSessionIDForInstance` and per-instance
  lookups (F2).
- `idx_agent_status_repo_active(repo) WHERE ended_at IS NULL` — partial;
  covers per-repo active queries including
  `AllActiveStatusForRepoAndOtherCoordinators` and `CoordinatorForRepo`
  (F2).

### Declarative-schema mirror (DB-F16 drift prevention)

Per the AC, the declarative schema block must include the same indexes
so a fresh DB and a v1→v32-migrated DB end up identical. The new indexes
reference columns added by v5→v6 / v8→v9 / v15→v16 (`agent_status.instance_id`,
`agent_status.group_id`, `agent_events.instance_id`), which are not
present on databases that tests open at older schema versions. Putting
the new `CREATE INDEX` statements inside the existing `schema` constant
(which runs *before* migrations) broke pre-v6 migration tests.

The mirror therefore lives in a separate `postMigrationIndexes` block in
`internal/db/db.go`, applied by `openAndConfigure` after `runMigrations`.
Both paths use `CREATE INDEX IF NOT EXISTS`, so a fresh DB executes the
declarative block (idempotent no-op against the v31→v32 migration that
also runs) and a migrated DB executes the migration body (idempotent
no-op against the declarative block that follows).

### EXPLAIN QUERY PLAN — before / after

Captured against a populated DB (~10k events across 50 instances, ~500
`agent_status` rows across 20 groups / 5 isolation modes) after
`ANALYZE`. The `BEFORE` column is the same DB with the six new indexes
dropped.

**Before (full SCAN):**

```
-- WriteSpawnOutcome's aggregation: WHERE instance_id = ? --
SCAN agent_events

-- GroupCompleted's count: WHERE group_id = ? AND state NOT IN (...) AND ended_at IS NULL --
SCAN agent_status

-- ActiveSessionCountForMode: WHERE ended_at IS NULL AND isolation_mode = ? --
SCAN agent_status
```

**After (SEARCH via new index):**

```
-- WriteSpawnOutcome's aggregation: WHERE instance_id = ? --
SEARCH agent_events USING COVERING INDEX idx_events_instance (instance_id=?)

-- GroupCompleted's count: WHERE group_id = ? AND state NOT IN (...) AND ended_at IS NULL --
SEARCH agent_status USING INDEX idx_agent_status_group_id (group_id=?)

-- ActiveSessionCountForMode: WHERE ended_at IS NULL AND isolation_mode = ? --
SEARCH agent_status USING INDEX idx_agent_status_active (ended_at=?)
```

Note: `idx_events_instance` is reported as a `COVERING INDEX` — the
included `type` and `created_at` columns let SQLite answer the
aggregation without any heap reads.

### Tests

- `TestHotPathIndexes_ExistAfterOpen` — `pragma index_list` on
  `agent_events` and `agent_status` must report every new index against
  the right table.
- `TestHotPathIndexes_QueryPlanUsesIndex` — three sub-tests covering
  `WriteSpawnOutcome`, `GroupCompleted`, `ActiveSessionCountForMode`,
  each asserts the plan contains `SEARCH`, does not contain `SCAN
  agent_events` / `SCAN agent_status`, and references the expected
  index name.
- Existing migration tests bumped from `want 31` → `want 32` (no
  behavioural change).

All quality gates green locally:

```
go build ./...                       # ok
go test ./...                        # all packages ok
go test -race ./internal/db/...      # ok (~42s)
nix build .#prism                    # ok
```

Closes #1864
