### PR TITLE
container: hard-fail sandbox-exec Prepare when staging HOME fails

### DIFF
--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -211,13 +211,22 @@ func (s *sandboxExecIsolator) Reset(ctx context.Context) error {
 // and returns the complete sandbox-exec argument list. Mirrors the
 // pre-refactor body of Manager.PrepareSandboxExec
 // (internal/container/container.go:637).
+//
+// If PrepareSandboxExecHome fails, Prepare returns an error immediately
+// and does not write the profile or launch the session. A staging-HOME
+// failure causes generateProfile to silently omit every (subpath …) rule
+// for the worktree, bare repo, host-API socket, and pi data dirs, producing
+// a profile that denies all worktree access — the session would crash with
+// opaque EPERM on first file open. There is no usable degraded-profile
+// fallback, so we hard-fail here (issue #1879).
 func (s *sandboxExecIsolator) Prepare(ctx context.Context, m *Manager) ([]string, error) {
-	// Populate the staging HOME with symlinks. Non-fatal if the staging HOME
-	// cannot be created (e.g. read-only home, as in the nix sandbox build
-	// environment): log and continue with a degraded profile.
+	// Populate the staging HOME with symlinks. Fail hard if the staging HOME
+	// cannot be created: without it, generateProfile omits every session-specific
+	// (subpath …) rule and the resulting profile denies worktree access entirely.
 	stagingHome, err := m.PrepareSandboxExecHome()
 	if err != nil {
-		log.Printf("container: sandbox-exec: prepare staging home: %v — launching with degraded profile", err)
+		return nil, fmt.Errorf("container: sandbox-exec: cannot prepare staging HOME %s: %w",
+			stagingHome, err)
 	}
 	_ = stagingHome // consumed by generateProfile via m.sandboxExecHomePath()
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -514,6 +514,101 @@ func TestPrepareSandboxExec_ProfilePathIsSessionScoped(t *testing.T) {
 			mA.sandboxExecProfilePath(), mA.name)
 	}
 }
+// TestSandboxExecPrepare_StagingHomeFailurePropagated verifies that when
+// PrepareSandboxExecHome fails (e.g. because the staging-home path is
+// blocked by a pre-existing regular file), sandboxExecIsolator.Prepare
+// returns a non-nil error whose message mentions the staging HOME failure.
+// The session must NOT launch: no profile file is written and no
+// sandbox-exec subprocess is started (issue #1879).
+func TestSandboxExecPrepare_StagingHomeFailurePropagated(t *testing.T) {
+	// Build the manager and derive the staging home path before injecting the
+	// failure, so we know which path to block.
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "staging-home-fail-test",
+		Worktree:    t.TempDir(),
+	})
+
+	// sandboxExecHomePath relies on os.UserHomeDir() (or $HOME fallback).
+	// Call it directly so the test knows the exact path that will be blocked.
+	stagingHome, err := m.sandboxExecHomePath()
+	if err != nil {
+		t.Fatalf("sandboxExecHomePath: %v", err)
+	}
+
+	// Ensure the staging home's parent exists so we can create the blocker file.
+	if err := os.MkdirAll(filepath.Dir(stagingHome), 0o755); err != nil {
+		t.Fatalf("MkdirAll parent of staging home: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(stagingHome)) })
+
+	// Plant a regular file at the staging home path. When PrepareSandboxExecHome
+	// calls os.MkdirAll(stagingHome, ...) it will fail with ENOTDIR because the
+	// path already exists as a file, not a directory.
+	if err := os.WriteFile(stagingHome, []byte("blocker"), 0o644); err != nil {
+		t.Fatalf("WriteFile blocker at staging home path %s: %v", stagingHome, err)
+	}
+
+	// Prepare must return a non-nil error.
+	iso := &sandboxExecIsolator{name: m.name}
+	args, prepErr := iso.Prepare(context.Background(), m)
+	if prepErr == nil {
+		t.Fatalf("Prepare: expected non-nil error when staging home cannot be created, got nil (args=%v)", args)
+	}
+
+	// The error message must name the staging HOME failure so the operator
+	// knows what went wrong (AC: "clear error message naming the staging HOME
+	// path and the underlying cause").
+	errMsg := prepErr.Error()
+	if !strings.Contains(errMsg, "staging HOME") && !strings.Contains(errMsg, "staging home") {
+		t.Errorf("error message must mention staging HOME; got: %q", errMsg)
+	}
+	if !strings.Contains(errMsg, stagingHome) {
+		t.Errorf("error message must include the staging HOME path %q; got: %q", stagingHome, errMsg)
+	}
+
+	// No profile file must be written — the session did not advance to the
+	// write-profile step.
+	profilePath := m.sandboxExecProfilePath()
+	if _, statErr := os.Stat(profilePath); statErr == nil {
+		t.Errorf("profile file %q was written despite Prepare returning an error: launch was not aborted", profilePath)
+		_ = os.Remove(profilePath)
+	}
+}
+
+// TestSandboxExecPrepare_StagingHomeFailurePropagated_NilArgs verifies that
+// the Prepare error is a hard fail and the returned args slice is nil,
+// confirming no sandbox-exec argument list was produced for the caller to
+// use (regression guard for issue #1879).
+func TestSandboxExecPrepare_StagingHomeFailurePropagated_NilArgs(t *testing.T) {
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "staging-home-fail-nil-args-test",
+		Worktree:    t.TempDir(),
+	})
+
+	stagingHome, err := m.sandboxExecHomePath()
+	if err != nil {
+		t.Fatalf("sandboxExecHomePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(stagingHome), 0o755); err != nil {
+		t.Fatalf("MkdirAll parent: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(stagingHome)) })
+	if err := os.WriteFile(stagingHome, []byte("blocker"), 0o644); err != nil {
+		t.Fatalf("WriteFile blocker: %v", err)
+	}
+
+	iso := &sandboxExecIsolator{name: m.name}
+	args, prepErr := iso.Prepare(context.Background(), m)
+	if prepErr == nil {
+		t.Fatalf("expected error, got nil (args=%v)", args)
+	}
+	if args != nil {
+		t.Errorf("args must be nil on error; got %v", args)
+	}
+}
+
 // TestSandboxExecBuildArgs_HarnessImmediatelyAfterProfile verifies that the
 // harness binary appears at args[3] — directly after "sandbox-exec -f
 // <profile>". This is the shape the AC requires.


### PR DESCRIPTION
## Summary

`sandboxExecIsolator.Prepare` previously swallowed `PrepareSandboxExecHome` errors via `log.Printf` and continued into `writeProfile`. `generateProfile` then saw `stagingErr != nil` and silently omitted every `(subpath …)` rule for the staging HOME / worktree / bare repo / host-API socket / pi data dirs — producing a profile that denied all worktree access. The session launched but crashed with opaque EPERM on first file open.

## Fix

Option 1 — hard fail (as recommended in the issue):

- Return an error immediately from `Prepare` when `PrepareSandboxExecHome` fails, with a clear message naming the staging HOME path and the underlying cause. The session does not launch.
- Remove the misleading "launching with degraded profile" log line.

The rationale: there is no usable degraded-profile fallback. Without the staging-HOME-derived rules, `generateProfile` omits all session-specific `(subpath …)` allows, producing a profile that denies worktree access entirely. A session that cannot read its worktree is not "degraded", it's broken.

## Acceptance Criteria

- [x] [functional] When `PrepareSandboxExecHome` fails, the failure is propagated to the caller of `sandboxExecIsolator.Prepare` with a clear error message naming the staging HOME path and the underlying cause. The session does not launch.
- [x] [functional] The misleading "launching with degraded profile" log line is removed.
- [x] [test] `TestSandboxExecPrepare_StagingHomeFailurePropagated`: injects a `PrepareSandboxExecHome` failure by pre-creating a regular file at the staging home path (causing `os.MkdirAll` to return ENOTDIR), asserts `Prepare` returns a non-nil error whose message mentions the staging HOME failure and path, and verifies no profile is written.
- [x] [test] `TestSandboxExecPrepare_StagingHomeFailurePropagated_NilArgs`: regression guard — returned args slice is nil on error (no sandbox-exec argument list produced).
- [x] [regression] Existing happy-path tests for sandbox-exec Prepare (`TestPrepareSandboxExec_WritesProfileAndReturnsArgs`, etc.) continue to pass.
- [x] [test] `go test ./internal/container/ -race` passes (pre-existing failures in bwrap/integration tests reproduce on main unchanged).
- [x] `nix build .#prism` passes.

Closes #1879