### PR TITLE
bitwarden: disable unlock-via-sdk flag to fix bogus session (#1894)

### DIFF
--- a/modules/programs/bitwarden.nix
+++ b/modules/programs/bitwarden.nix
@@ -1,3 +1,10 @@
+# Workaround for bitwarden/clients#20703 / issue #1894:
+# The `unlock-via-sdk` feature flag is server-pushed and triggers a broken code
+# path in bitwarden-cli that causes `bw unlock --raw` to return a bogus session.
+# Pinning to nixpkgs-stable (overlays/default.nix) is insufficient because the
+# bug surfaces regardless of client version when the server sends the flag.
+# This module patches data.json after every activation to keep the flag false.
+# See also: modules/programs/qutebrowser/userscripts/bitwarden-prefetch
 {
   config,
   pkgs,
@@ -11,25 +18,48 @@
     };
   };
   config = lib.mkIf config.nx.programs.bitwarden.enable {
-    home-manager.users.${config.nx.username} = {
-      home.packages = with pkgs; [
-        bitwarden-desktop
-        bitwarden-cli
-      ];
-      home.persistence."/persist" = {
-        directories = [
-          ".config/Bitwarden"
-          ".config/Bitwarden CLI"
+    home-manager.users.${config.nx.username} =
+      {
+        lib,
+        ...
+      }:
+      {
+        home.packages = with pkgs; [
+          bitwarden-desktop
+          bitwarden-cli
         ];
+        home.persistence."/persist" = {
+          directories = [
+            ".config/Bitwarden"
+            ".config/Bitwarden CLI"
+          ];
+        };
+        xdg.desktopEntries.bitwarden = lib.mkIf pkgs.stdenv.isLinux {
+          name = "Bitwarden";
+          comment = "Secure and free password manager for all of your devices";
+          icon = "bitwarden";
+          # force wayland
+          exec = "bitwarden --enable-features=UseOzonePlatform --ozone-platform=wayland";
+          mimeType = [ "x-scheme-handler/bitwarden" ];
+        };
+        # Disable the server-pushed `unlock-via-sdk` feature flag after every
+        # activation. When the flag is true, `bw unlock --raw` returns a session
+        # that does not actually unlock the vault (bitwarden/clients#20703, #1894).
+        # The hook is a no-op when data.json does not yet exist (pre-login), and
+        # idempotent when the flag is already false.
+        home.activation.bitwardenDisableUnlockViaSdk = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          _bw_data="$HOME/.config/Bitwarden CLI/data.json"
+          if [ -f "$_bw_data" ]; then
+            if ! ${pkgs.jq}/bin/jq -e \
+                 '.global_config_byServer."https://api.bitwarden.com".featureStates."unlock-via-sdk" == false' \
+                 "$_bw_data" >/dev/null 2>&1; then
+              ${pkgs.jq}/bin/jq \
+                '.global_config_byServer."https://api.bitwarden.com".featureStates."unlock-via-sdk" = false' \
+                "$_bw_data" > "$_bw_data.tmp" \
+                && mv "$_bw_data.tmp" "$_bw_data"
+            fi
+          fi
+        '';
       };
-      xdg.desktopEntries.bitwarden = lib.mkIf pkgs.stdenv.isLinux {
-        name = "Bitwarden";
-        comment = "Secure and free password manager for all of your devices";
-        icon = "bitwarden";
-        # force wayland
-        exec = "bitwarden --enable-features=UseOzonePlatform --ozone-platform=wayland";
-        mimeType = [ "x-scheme-handler/bitwarden" ];
-      };
-    };
   };
 }

--- a/modules/programs/qutebrowser/userscripts/bitwarden-prefetch
+++ b/modules/programs/qutebrowser/userscripts/bitwarden-prefetch
@@ -12,10 +12,14 @@ import subprocess
 import time
 
 # Upstream regression reference: https://github.com/bitwarden/clients/issues/20703
-# When the buggy bitwarden-cli versions (2026.3.0+) are in use, `bw unlock --raw`
-# returns an 88-char session token that `bw status` / `bw list` silently reject.
-# We defend against re-introduction by validating any freshly minted session via
-# `bw status` before persisting it.
+# issue #1894 — server-pushed `unlock-via-sdk` flag causes `bw unlock --raw` to
+# return a bogus session regardless of client version. Two layers of defence:
+#   1. home.activation hook in modules/programs/bitwarden.nix patches data.json
+#      after every `nh switch` to keep the flag false.
+#   2. patch_unlock_via_sdk() below patches data.json immediately before every
+#      `bw unlock` call so that a fresh login or a server-pushed flag flip cannot
+#      re-introduce the broken path between activations.
+# See also: overlays/default.nix (bitwarden-cli pin comment)
 UPSTREAM_ISSUE = "bitwarden/clients#20703"
 
 
@@ -59,8 +63,46 @@ def session_unlocks_vault(session_key):
     except Exception:
         return False
 
+def patch_unlock_via_sdk():
+    """Patch data.json to set unlock-via-sdk = false before calling bw unlock.
+
+    This is a defensive measure against a server-pushed feature flag that causes
+    `bw unlock --raw` to return a bogus session (bitwarden/clients#20703, #1894).
+    The home.activation hook in modules/programs/bitwarden.nix provides the same
+    patch after every `nh switch`; this call handles the window between a fresh
+    `bw login` and the next activation, and guards against mid-session flag flips.
+    No-op when data.json does not exist or when the flag is already false.
+    """
+    config_dir = os.path.join(
+        os.environ.get("XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")),
+        "Bitwarden CLI",
+    )
+    data_path = os.path.join(config_dir, "data.json")
+    if not os.path.exists(data_path):
+        return
+    try:
+        with open(data_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        server_cfg = data.setdefault("global_config_byServer", {})
+        bw_cfg = server_cfg.setdefault("https://api.bitwarden.com", {})
+        feature_states = bw_cfg.setdefault("featureStates", {})
+        if feature_states.get("unlock-via-sdk") is False:
+            return  # already correct, no write needed
+        feature_states["unlock-via-sdk"] = False
+        tmp_path = data_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, data_path)
+    except Exception as e:
+        print(f"Warning: could not patch unlock-via-sdk in data.json: {e}", file=sys.stderr)
+
+
 def unlock_bitwarden():
     """Unlock Bitwarden using the password from environment variable.
+
+    Patches the unlock-via-sdk feature flag to false before invoking `bw unlock`
+    to prevent the server-pushed flag from triggering the bogus-session path
+    (bitwarden/clients#20703, #1894).
 
     Returns a session key only if it is validated as actually unlocking the
     vault. If validation fails, prints an error referencing the upstream issue
@@ -69,6 +111,10 @@ def unlock_bitwarden():
     master_pass = os.getenv("BITWARDEN_PASSWORD")
     if not master_pass:
         return None
+
+    # Patch the feature flag before unlocking so the server cannot force the
+    # broken code path via a freshly written data.json or a mid-session flip.
+    patch_unlock_via_sdk()
 
     try:
         process = subprocess.run(

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,13 +28,18 @@ rec {
       claude-code = masterPkgs.claude-code;
       discord = masterPkgs.discord;
 
-      # bitwarden-cli: upstream 2026.3.0+ regressed `bw unlock --raw` — the
-      # returned session token is silently rejected by `bw status` / `bw list`,
-      # breaking all non-interactive automation (qutebrowser userscript,
-      # bitwarden-prefetch). Pin to nixpkgs-stable (currently 2025.9.0) which
-      # predates the regression.
-      # See: https://github.com/bitwarden/clients/issues/20703
-      # Remove this override once upstream lands a fix.
+      # bitwarden-cli: pinned to nixpkgs-stable as the most-vetted source.
+      # NOTE: pinning alone is no longer sufficient to prevent the `bw unlock
+      # --raw` bogus-session regression (bitwarden/clients#20703, issue #1894).
+      # nixpkgs-stable rolled forward to bitwarden-cli-2025.11.0 which still
+      # carries the bug. The root cause is a server-pushed feature flag
+      # (`unlock-via-sdk`) that triggers the broken code path regardless of
+      # client version. The durable fix is the `unlock-via-sdk = false` patch
+      # in modules/programs/bitwarden.nix (home.activation hook) and the
+      # defensive patch in modules/programs/qutebrowser/userscripts/bitwarden-prefetch.
+      # The pin is kept for institutional memory and because nixpkgs-stable
+      # remains our most-vetted package source.
+      # See: https://github.com/prismatic-koi/nixos-config/issues/1894
       bitwarden-cli = stablePkgs.bitwarden-cli;
       pi-coding-agent =
         let


### PR DESCRIPTION
## Summary

Fixes the `bw unlock --raw` bogus-session regression described in #1894. The
root cause is a server-pushed feature flag (`unlock-via-sdk = true`) that
triggers a broken code path in bitwarden-cli regardless of which client version
is installed — so the nixpkgs-stable pin from #1809 is no longer sufficient.

## Changes

### 1. `modules/programs/bitwarden.nix` — home.activation hook

Adds `home.activation.bitwardenDisableUnlockViaSdk` which patches
`~/.config/Bitwarden CLI/data.json` after every `nh switch` to set
`.global_config_byServer."https://api.bitwarden.com".featureStates."unlock-via-sdk" = false`.

- No-op when `data.json` does not exist (fresh install / pre-login).
- Idempotent: the jq check runs first; the file is only rewritten when
  the value differs.
- Pattern matches existing activation hooks in this repo
  (`prism/tmux.nix::reloadTmuxConfig`, `wallpaper/default.nix::renderWallpaper`).

### 2. `modules/programs/qutebrowser/userscripts/bitwarden-prefetch` — defensive patch

Adds `patch_unlock_via_sdk()` which is called inside `unlock_bitwarden()`
immediately before the `bw unlock` subprocess. This guards against:
- the window between a fresh `bw login` and the next activation, and
- a mid-session server-pushed flag flip back to `true`.

No-op when `data.json` does not exist or the flag is already false.
Atomic: writes to a `.tmp` file then `os.replace()`.

### 3. `overlays/default.nix` — pin comment update

Updates the bitwarden-cli pin comment to explain that pinning alone is
insufficient, notes that nixpkgs-stable rolled forward to 2025.11.0
(which still carries the bug), and links to issue #1894.

## Manual smoke test

Run on the local machine after `nh switch` on this branch:

```
# 1. Verify activation hook ran:
jq '.global_config_byServer."https://api.bitwarden.com".featureStates."unlock-via-sdk"'    "$HOME/.config/Bitwarden CLI/data.json"
# Expected: false
```

> Could not run the full interactive smoke test (steps 2–4 require the vault
> password and a live Bitwarden session) in this automated environment. The
> activation-hook logic and the Python `patch_unlock_via_sdk()` function were
> verified with unit-level shell and Python tests in the worker session:
>
> **Shell tests (activation hook logic):**
> - flag = true → patched to false: **PASS**
> - flag = false → no-op (mtime unchanged): **PASS**
> - file missing → no error: **PASS**
>
> **Python tests (patch_unlock_via_sdk):**
> - flag = True → False: **PASS**
> - flag = False → no-op: **PASS**
> - file missing → no-op: **PASS**
> - no server key at all → creates structure + sets false: **PASS**
>
> `nix flake check` passes.

Closes #1894