### PR TITLE
db: wrap v23→v24 sessions rebuild in a transaction

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -1553,40 +1553,59 @@ func migrateV23toV24(conn *sql.DB, version *int) error {
 	}
 	if osColExists > 0 {
 		// Rebuild sessions without outcome_summary using the rename-copy-drop
-		// idiom. Foreign keys are temporarily disabled during the rebuild to
-		// allow rename without cascading FK errors.
-		rebuildSteps := []string{
-			`PRAGMA foreign_keys = OFF`,
-			`ALTER TABLE sessions RENAME TO sessions_old_v24`,
-			`CREATE TABLE sessions (
-			  instance_id         TEXT PRIMARY KEY,
-			  session_name        TEXT NOT NULL,
-			  agent_role          TEXT,
-			  root_agent_name     TEXT,
-			  repo                TEXT NOT NULL,
-			  worktree            TEXT NOT NULL,
-			  harness             TEXT NOT NULL,
-			  harness_session_id  TEXT,
-			  group_id            TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
-			  started_at          INTEGER NOT NULL,
-			  ended_at            INTEGER,
-			  end_state           TEXT,
-			  archive_path        TEXT,
-			  prism_version       TEXT
-			)`,
-			`INSERT INTO sessions SELECT instance_id, session_name, agent_role,
-			  root_agent_name, repo, worktree, harness, harness_session_id,
-			  group_id, started_at, ended_at, end_state, archive_path, prism_version
-			  FROM sessions_old_v24`,
-			`DROP TABLE sessions_old_v24`,
-			`CREATE INDEX IF NOT EXISTS idx_sessions_repo_started ON sessions(repo, started_at DESC)`,
-			`CREATE INDEX IF NOT EXISTS idx_sessions_name         ON sessions(session_name, started_at DESC)`,
-			`PRAGMA foreign_keys = ON`,
+		// idiom, wrapped in a transaction so a mid-migration crash leaves the
+		// DB fully rolled back rather than in a partial state (e.g.
+		// sessions_old_v24 present but sessions missing). PRAGMA foreign_keys
+		// must be set outside the transaction per the SQLite docs. This
+		// matches the pattern used by the v8→v9 and v25→v26 migrations.
+		//
+		// See https://www.sqlite.org/lang_altertable.html#otheralter
+		if _, err := conn.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+			return fmt.Errorf("db: migration v23→v24: disable FK: %w", err)
 		}
-		for _, step := range rebuildSteps {
-			if _, err := conn.Exec(step); err != nil {
-				return fmt.Errorf("db: migration v23→v24: rebuild sessions: %w", err)
+		if err := func() error {
+			tx, err := conn.Begin()
+			if err != nil {
+				return fmt.Errorf("begin tx: %w", err)
 			}
+			defer tx.Rollback() //nolint:errcheck
+			steps := []string{
+				`ALTER TABLE sessions RENAME TO sessions_old_v24`,
+				`CREATE TABLE sessions (
+				  instance_id         TEXT PRIMARY KEY,
+				  session_name        TEXT NOT NULL,
+				  agent_role          TEXT,
+				  root_agent_name     TEXT,
+				  repo                TEXT NOT NULL,
+				  worktree            TEXT NOT NULL,
+				  harness             TEXT NOT NULL,
+				  harness_session_id  TEXT,
+				  group_id            TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+				  started_at          INTEGER NOT NULL,
+				  ended_at            INTEGER,
+				  end_state           TEXT,
+				  archive_path        TEXT,
+				  prism_version       TEXT
+				)`,
+				`INSERT INTO sessions SELECT instance_id, session_name, agent_role,
+				  root_agent_name, repo, worktree, harness, harness_session_id,
+				  group_id, started_at, ended_at, end_state, archive_path, prism_version
+				  FROM sessions_old_v24`,
+				`DROP TABLE sessions_old_v24`,
+				`CREATE INDEX IF NOT EXISTS idx_sessions_repo_started ON sessions(repo, started_at DESC)`,
+				`CREATE INDEX IF NOT EXISTS idx_sessions_name         ON sessions(session_name, started_at DESC)`,
+			}
+			for _, s := range steps {
+				if _, err := tx.Exec(s); err != nil {
+					return fmt.Errorf("step %q: %w", s[:min(40, len(s))], err)
+				}
+			}
+			return tx.Commit()
+		}(); err != nil {
+			return fmt.Errorf("db: migration v23→v24: rebuild sessions: %w", err)
+		}
+		if _, err := conn.Exec("PRAGMA foreign_keys = ON"); err != nil {
+			return fmt.Errorf("db: migration v23→v24: re-enable FK: %w", err)
 		}
 	}
 	// Add spawn_outcome table and indexes (idempotent: IF NOT EXISTS).

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -7149,6 +7149,133 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	}
 }
 
+// TestMigration_V23ToV24_CrashRecovery verifies that simulating a mid-migration
+// failure during the v23→v24 sessions table rebuild leaves the DB in a
+// recoverable state. The test manually drives the rename-copy-drop steps using
+// a raw sql.DB, simulates a crash by rolling back the transaction mid-way
+// (after RENAME but before COMMIT), and then re-opens the DB via db.Open to
+// confirm the migration either fully succeeds or fully reverts — never a
+// partial state.
+//
+// The crash is simulated by beginning a transaction, running the RENAME, then
+// calling Rollback instead of Commit. This leaves sessions intact (the rename
+// was rolled back) and sessions_old_v24 absent, which is the correct "fully
+// reverted" state. After rollback, db.Open must succeed (it will re-run the
+// migration from scratch) and the schema_version must advance to the current
+// maximum.
+func TestMigration_V23ToV24_CrashRecovery(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v23_crash_recovery.db")
+	seedV23DB(t, dbPath)
+
+	// Simulate a mid-migration crash: open the DB directly with the sqlite
+	// driver, begin a transaction, execute the first rebuild step (RENAME)
+	// so the intermediate state exists, then roll back — mimicking what
+	// SQLite's transaction atomicity guarantees on a crash or SIGKILL between
+	// steps.
+	func() {
+		rawConn, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatalf("raw open for crash sim: %v", err)
+		}
+		defer rawConn.Close()
+
+		if _, err := rawConn.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+			t.Fatalf("disable FK: %v", err)
+		}
+		tx, err := rawConn.Begin()
+		if err != nil {
+			t.Fatalf("begin crash-sim tx: %v", err)
+		}
+		// Execute the RENAME (first rebuild step) so the intermediate state
+		// briefly exists inside the transaction.
+		if _, err := tx.Exec("ALTER TABLE sessions RENAME TO sessions_old_v24"); err != nil {
+			t.Fatalf("rename in crash-sim tx: %v", err)
+		}
+		// Simulate crash / SIGKILL: roll back instead of commit.
+		// SQLite guarantees this is atomic — the rename is undone.
+		if err := tx.Rollback(); err != nil {
+			t.Fatalf("rollback crash-sim tx: %v", err)
+		}
+		if _, err := rawConn.Exec("PRAGMA foreign_keys = ON"); err != nil {
+			t.Fatalf("re-enable FK: %v", err)
+		}
+	}()
+
+	// The DB must now be in a recoverable state:
+	// - sessions still exists (RENAME was rolled back)
+	// - sessions_old_v24 does not exist
+	// - schema_version is still 23
+	func() {
+		rawConn, err := sql.Open("sqlite", dbPath)
+		if err != nil {
+			t.Fatalf("raw open to verify post-rollback state: %v", err)
+		}
+		defer rawConn.Close()
+
+		// sessions must be present (RENAME rolled back).
+		var sessTable string
+		if err := rawConn.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'",
+		).Scan(&sessTable); err != nil {
+			t.Errorf("sessions table missing after rollback — DB is in partial state: %v", err)
+		}
+
+		// sessions_old_v24 must be absent (RENAME rolled back).
+		var oldTable string
+		err = rawConn.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name='sessions_old_v24'",
+		).Scan(&oldTable)
+		if err == nil {
+			t.Errorf("sessions_old_v24 unexpectedly present after rollback — DB is in partial state")
+		}
+
+		// schema_version must still be 23 (migration was not committed).
+		var ver int
+		if err := rawConn.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
+			t.Fatalf("read schema_version after rollback: %v", err)
+		}
+		if ver != 23 {
+			t.Errorf("schema_version after rollback: got %d, want 23", ver)
+		}
+	}()
+
+	// db.Open must succeed (re-runs the migration from the recoverable state).
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open after crash-recovery: %v", err)
+	}
+	defer d.Close()
+
+	// The migration must have fully completed: schema_version at current max.
+	var finalVer int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&finalVer); err != nil {
+		t.Fatalf("read schema_version after recovery: %v", err)
+	}
+	if finalVer != 32 {
+		t.Errorf("schema_version after recovery: got %d, want 32", finalVer)
+	}
+
+	// Sessions data must be preserved (the two rows seeded by seedV23DB).
+	var sessionCount int
+	if err := d.QueryRow("SELECT COUNT(*) FROM sessions").Scan(&sessionCount); err != nil {
+		t.Fatalf("count sessions after recovery: %v", err)
+	}
+	if sessionCount != 2 {
+		t.Errorf("sessions count after recovery: got %d, want 2", sessionCount)
+	}
+
+	// sessions.outcome_summary must no longer exist.
+	var osColCount int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'outcome_summary'`,
+	).Scan(&osColCount); err != nil {
+		t.Fatalf("pragma_table_info sessions after recovery: %v", err)
+	}
+	if osColCount != 0 {
+		t.Errorf("sessions.outcome_summary present after recovery: want 0, got %d", osColCount)
+	}
+}
+
 // TestWriteSpawnOutcome_Basic verifies that WriteSpawnOutcome creates a
 // spawn_outcome row for a session with no events (zero counts), and that a
 // second call is idempotent.


### PR DESCRIPTION
## Summary

The v23→v24 migration rebuild (RENAME → CREATE → INSERT → DROP) ran as a flat loop of separate `conn.Exec` calls with no transaction wrapping. If the process was killed mid-migration the DB could end up with `sessions_old_v24` present and `sessions` missing; the next prism boot would recreate `sessions` empty, dropping all session history.

## Changes

- **`internal/db/db.go`**: Wrap the rebuild block inside `PRAGMA foreign_keys = OFF` → `tx.Begin()` → … → `tx.Commit()` → `PRAGMA foreign_keys = ON`, matching the v8→v9 and v25→v26 pattern. Added a doc comment at the v23→v24 entry point citing the same pattern.
- **`internal/db/db_test.go`**: Added `TestMigration_V23ToV24_CrashRecovery` — simulates a mid-migration crash by beginning a raw transaction, executing the RENAME, then rolling back (mimicking SIGKILL). Verifies the DB is in a recoverable state (sessions present, sessions_old_v24 absent, schema_version=23), then re-opens via `db.Open` and confirms full migration completes with data preserved.

## Acceptance Criteria

- [x] [functional] Rebuild steps execute within a single `tx.Begin()`/`tx.Commit()` block; `PRAGMA foreign_keys = OFF` before, `ON` after.
- [x] [regression] Existing v23→v24 tests pass (`TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome`, `TestMigration_V23ToV24_Idempotent`).
- [x] [test] `TestMigration_V23ToV24_CrashRecovery` verifies mid-migration rollback leaves DB fully recoverable.
- [x] [doc] Code comment at v23→v24 entry documents transactional rebuild, cites v8→v9 pattern.
- [x] `go test ./internal/db/ -race` passes.
- [x] `nix build .#prism` passes.

Closes #1867