### PR TITLE
mergequeue: scope lookupWorkerArchivePath by instance_id/repo to avoid cross-repo collision

### DIFF
--- a/modules/programs/prism/prism/internal/db/sessions.go
+++ b/modules/programs/prism/prism/internal/db/sessions.go
@@ -226,6 +226,16 @@ func (d *DB) SessionsByNamePattern(suffix string) ([]Session, error) {
 	return d.querySessions(sessionsSelectCols+` WHERE session_name LIKE ? ESCAPE '\' ORDER BY started_at DESC`, "%"+escaped)
 }
 
+// SessionsByNamePatternAndRepo returns all sessions rows whose session_name ends
+// with the given suffix AND whose repo equals the given repo, ordered by
+// started_at DESC. Used by lookupWorkerArchivePath to scope the PR-number suffix
+// match to a single repository, avoiding false matches when two repos share the
+// same PR number.
+func (d *DB) SessionsByNamePatternAndRepo(suffix, repo string) ([]Session, error) {
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(suffix)
+	return d.querySessions(sessionsSelectCols+` WHERE session_name LIKE ? ESCAPE '\' AND repo = ? ORDER BY started_at DESC`, "%"+escaped, repo)
+}
+
 // SessionTurnTokens returns per-turn token data for the given instance_id.
 func (d *DB) SessionTurnTokens(instanceID string) ([]TokenTurn, error) {
 	const q = `

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -351,7 +351,7 @@ func (w *Watcher) succeedAndNotify(ctx context.Context, head *db.PendingMerge) {
 		log.Printf("[mergequeue] TerminateMerge(merged) PR #%d: %v", head.PR, err)
 	}
 	// Look up the worker session's archive_path from the sessions table.
-	archivePath := w.lookupWorkerArchivePath(head.PR)
+	archivePath := w.lookupWorkerArchivePath(head)
 	var notifyText string
 	if archivePath != "" {
 		notifyText = fmt.Sprintf(
@@ -467,9 +467,50 @@ func (w *Watcher) notify(ctx context.Context, targetSession, targetInstanceID, t
 // lookupWorkerArchivePath finds the most recent sessions row for the PR's
 // worker branch (heuristic: session_name ends with "@<prNumber>").
 // Returns the archive_path if found, or "".
-func (w *Watcher) lookupWorkerArchivePath(pr int) string {
-	branchSuffix := fmt.Sprintf("@%d", pr)
-	sessions, err := w.db.SessionsByNamePattern(branchSuffix)
+//
+// Scoping strategy (to avoid returning an archive from a different repo that
+// happens to share the same PR number):
+//
+//  1. Primary path — when head.InstanceID is non-empty, look up the
+//     coordinator session via its instance_id to obtain the authoritative
+//     repo slug, then scope the session-name suffix query to that repo.
+//
+//  2. Legacy fallback — when head.InstanceID is empty (rows written before
+//     instance_id was added to pending_merges), scope by w.repo directly.
+//     A log line is emitted so the legacy path is visible in production logs.
+func (w *Watcher) lookupWorkerArchivePath(head *db.PendingMerge) string {
+	branchSuffix := fmt.Sprintf("@%d", head.PR)
+
+	var repo string
+	if head.InstanceID != "" {
+		// Primary path: resolve the repo from the coordinator session that owns
+		// this pending_merges row. This is the most precise scope — it ties the
+		// worker-archive lookup to the exact coordinator instance that enqueued
+		// the PR, preventing cross-repo collisions when two repos share a PR
+		// number (e.g. nixos-config@782 vs myrepo@782).
+		coordinator, err := w.db.SessionByInstanceID(head.InstanceID)
+		if err == nil && coordinator != nil && coordinator.Repo != "" {
+			repo = coordinator.Repo
+		}
+	}
+	if repo == "" {
+		// Legacy fallback: instance_id was not set on this pending_merges row
+		// (pre-dates the instance_id column), or the coordinator session row is
+		// missing. Scope by w.repo, which is resolved once at watcher startup.
+		if head.InstanceID == "" {
+			log.Printf("[mergequeue] lookupWorkerArchivePath PR #%d: PendingMerge has empty instance_id — using legacy repo fallback (repo=%q)", head.PR, w.repo)
+		}
+		repo = w.repo
+	}
+
+	var sessions []db.Session
+	var err error
+	if repo != "" {
+		sessions, err = w.db.SessionsByNamePatternAndRepo(branchSuffix, repo)
+	} else {
+		// Last resort: no repo info available; fall back to unscoped lookup.
+		sessions, err = w.db.SessionsByNamePattern(branchSuffix)
+	}
 	if err != nil || len(sessions) == 0 {
 		return ""
 	}

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -2339,6 +2339,126 @@ func TestWatcher_GenuineFailure_NoRegression(t *testing.T) {
 	}
 }
 
+// ── lookupWorkerArchivePath scoping tests ─────────────────────────────────────
+
+// seedWorkerSession inserts a sessions row simulating a worker session for the
+// given PR branch (session_name = "<repoShort>@<pr>", repo = repoFull). The
+// optional archivePath is set on the row if non-empty.
+func seedWorkerSession(t *testing.T, d *db.DB, instanceID, sessionName, repo, archivePath string) {
+	t.Helper()
+	sess := db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/tmp/wt-" + instanceID,
+		Harness:     "pi",
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("seedWorkerSession InsertSession(%s): %v", sessionName, err)
+	}
+	if archivePath != "" {
+		if err := d.UpdateSessionArchivePath(instanceID, archivePath); err != nil {
+			t.Fatalf("seedWorkerSession UpdateSessionArchivePath(%s): %v", instanceID, err)
+		}
+	}
+}
+
+// seedCoordinatorSession inserts both an agent_status row and a sessions row for
+// a coordinator, so that SessionByInstanceID can resolve it.
+func seedCoordinatorSession(t *testing.T, d *db.DB, sessionName, instanceID, repo string) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, repo, "/tmp/coord-wt", "active", nil, nil); err != nil {
+		t.Fatalf("seedCoordinatorSession UpsertStatus(%s): %v", sessionName, err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("seedCoordinatorSession SetInstanceID(%s): %v", sessionName, err)
+	}
+	sess := db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/tmp/coord-wt",
+		Harness:     "pi",
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("seedCoordinatorSession InsertSession(%s): %v", sessionName, err)
+	}
+}
+
+// TestLookupWorkerArchivePath_InstanceIDScoping verifies that when two repos
+// share a PR number (e.g. nixos-config@782 and myrepo@782), the primary lookup
+// path (head.InstanceID non-empty) returns the correct archive for the repo
+// whose coordinator enqueued the merge.
+func TestLookupWorkerArchivePath_InstanceIDScoping(t *testing.T) {
+	d := openTestDB(t)
+
+	// Coordinator for nixos-config.
+	coordInstanceID := "coord-inst-nixos-782"
+	coordSession := "nixos-config@main"
+	coordRepo := "owner/nixos-config"
+	seedCoordinatorSession(t, d, coordSession, coordInstanceID, coordRepo)
+
+	// Worker sessions: one per repo, both ending in @782.
+	seedWorkerSession(t, d, "worker-inst-nixos-782", "nixos-config@782", "owner/nixos-config",
+		"/archives/nixos-config-782.tar.gz")
+	seedWorkerSession(t, d, "worker-inst-myrepo-782", "myrepo@782", "owner/myrepo",
+		"/archives/myrepo-782.tar.gz")
+
+	w := &Watcher{
+		db:          d,
+		instanceID:  coordInstanceID,
+		sessionName: coordSession,
+		httpClient:  http.DefaultClient,
+		repo:        coordRepo,
+	}
+
+	head := &db.PendingMerge{
+		PR:          782,
+		SessionName: coordSession,
+		InstanceID:  coordInstanceID,
+	}
+
+	got := w.lookupWorkerArchivePath(head)
+	want := "/archives/nixos-config-782.tar.gz"
+	if got != want {
+		t.Errorf("lookupWorkerArchivePath: got %q, want %q", got, want)
+	}
+}
+
+// TestLookupWorkerArchivePath_LegacyRepoFallback verifies that when
+// head.InstanceID is empty (a legacy pending_merges row), lookupWorkerArchivePath
+// falls back to scoping by w.repo and still returns the correct archive.
+func TestLookupWorkerArchivePath_LegacyRepoFallback(t *testing.T) {
+	d := openTestDB(t)
+
+	// Worker sessions: one per repo, both ending in @782.
+	seedWorkerSession(t, d, "worker-leg-nixos-782", "nixos-config@782", "owner/nixos-config",
+		"/archives/nixos-config-legacy-782.tar.gz")
+	seedWorkerSession(t, d, "worker-leg-myrepo-782", "myrepo@782", "owner/myrepo",
+		"/archives/myrepo-legacy-782.tar.gz")
+
+	w := &Watcher{
+		db:          d,
+		instanceID:  "",
+		sessionName: "nixos-config@main",
+		httpClient:  http.DefaultClient,
+		repo:        "owner/nixos-config",
+	}
+
+	// Legacy row: InstanceID is empty.
+	head := &db.PendingMerge{
+		PR:          782,
+		SessionName: "nixos-config@main",
+		InstanceID:  "",
+	}
+
+	got := w.lookupWorkerArchivePath(head)
+	want := "/archives/nixos-config-legacy-782.tar.gz"
+	if got != want {
+		t.Errorf("lookupWorkerArchivePath legacy fallback: got %q, want %q", got, want)
+	}
+}
+
 // TestFetchRequiredChecks_ErrorStaysWatching verifies the Watcher.tick()
 // integration: when fetchRequiredChecks returns an error on an UNSTABLE PR,
 // the row stays in watching and no merge is attempted. This exercises the


### PR DESCRIPTION
## Summary

Fixes a bug where `lookupWorkerArchivePath` could return an archive path from
the wrong repo when two repos share a PR number (e.g. `nixos-config@782` and
`myrepo@782`). The previous `LIKE '%@782'` query used a StartedAt tiebreak
which was arbitrary when sessions from different repos matched.

## Changes

**`internal/db/sessions.go`**
- Add `SessionsByNamePatternAndRepo(suffix, repo string)`: same suffix LIKE
  query as `SessionsByNamePattern` but additionally scopes to `repo = ?`.

**`internal/mergequeue/watcher.go`**
- Change `lookupWorkerArchivePath(pr int)` → `lookupWorkerArchivePath(head *db.PendingMerge)` so the caller's `PendingMerge` context is available.
- Primary path: when `head.InstanceID` is non-empty, look up the coordinator
  session via `SessionByInstanceID` to obtain its authoritative repo slug,
  then scope the suffix query to that repo with `SessionsByNamePatternAndRepo`.
- Legacy fallback: when `head.InstanceID` is empty (rows written before the
  `instance_id` column), scope by `w.repo` directly and emit a clear log line.
- Last resort: if no repo is resolvable, fall back to the original unscoped
  query (preserves existing behaviour for any edge-case where `w.repo` is
  also empty).

**`internal/mergequeue/watcher_test.go`**
- `TestLookupWorkerArchivePath_InstanceIDScoping`: seeds two sessions from
  different repos ending in `@782`; asserts the correct archive is returned
  when `head.InstanceID` is set (primary path).
- `TestLookupWorkerArchivePath_LegacyRepoFallback`: same setup but
  `head.InstanceID` is empty; asserts the repo-scoped fallback picks the
  right archive (legacy path).

## Testing

- `go test ./internal/mergequeue/ -race` ✅
- `nix build .#prism` ✅
- All existing `lookupWorkerArchivePath` callers updated.

Closes #1886