### PR TITLE
git: fix Stat() to split numstat lines on tab, not whitespace

### DIFF
--- a/modules/programs/prism/prism/internal/git/git.go
+++ b/modules/programs/prism/prism/internal/git/git.go
@@ -62,7 +62,7 @@ func Stat(dir string) (DiffStat, error) {
 			if line == "" {
 				continue
 			}
-			parts := strings.Fields(line)
+			parts := strings.SplitN(line, "\t", 3)
 			if len(parts) < 3 {
 				continue
 			}

--- a/modules/programs/prism/prism/internal/git/git_test.go
+++ b/modules/programs/prism/prism/internal/git/git_test.go
@@ -505,6 +505,92 @@ func TestStat_DeduplicatesStagedAndUnstaged(t *testing.T) {
 	}
 }
 
+// TestStat_FilenameWithSpace verifies that Stat correctly parses a filename
+// containing spaces from git diff --numstat output (tab-delimited, not
+// space-delimited).
+func TestStat_FilenameWithSpace(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	initRepo(t, dir, "main")
+
+	// Create a tracked file whose name contains a space.
+	spaceFile := filepath.Join(dir, "my notes.md")
+	if err := os.WriteFile(spaceFile, []byte("initial\n"), 0o644); err != nil {
+		t.Fatalf("write 'my notes.md': %v", err)
+	}
+	c := exec.Command("git", "add", "my notes.md")
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git add 'my notes.md': %v\n%s", err, out)
+	}
+	c = exec.Command("git", "commit", "-m", "add notes")
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	// Modify the file so it appears in the diff.
+	if err := os.WriteFile(spaceFile, []byte("initial\nmore content\n"), 0o644); err != nil {
+		t.Fatalf("modify 'my notes.md': %v", err)
+	}
+
+	stat, err := Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+	// Exactly one file changed — the file with a space in its name.
+	if stat.Files != 1 {
+		t.Errorf("Stat.Files = %d, want 1", stat.Files)
+	}
+}
+
+// TestStat_TwoFilesWithSharedSpacePrefix verifies that two paths sharing the
+// same space-delimited prefix (e.g. "docs/my notes.md" and
+// "docs/my other.md") are counted as two distinct files, not collapsed into
+// one entry by a split-on-spaces parser.
+func TestStat_TwoFilesWithSharedSpacePrefix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	initRepo(t, dir, "main")
+
+	// Create two files whose paths share the same first space-delimited token.
+	files := []string{"docs/my notes.md", "docs/my other.md"}
+	if err := os.Mkdir(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("initial\n"), 0o644); err != nil {
+			t.Fatalf("write %q: %v", name, err)
+		}
+	}
+	c := exec.Command("git", "add", "docs/my notes.md", "docs/my other.md")
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	c = exec.Command("git", "commit", "-m", "add docs")
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	// Modify both files so they appear in the diff.
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("initial\nmore\n"), 0o644); err != nil {
+			t.Fatalf("modify %q: %v", name, err)
+		}
+	}
+
+	stat, err := Stat(dir)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+	// Both files must be counted independently — not collapsed into one.
+	if stat.Files != 2 {
+		t.Errorf("Stat.Files = %d, want 2 (both space-named files counted separately)", stat.Files)
+	}
+}
+
 // initEmptyBareRepo creates an empty bare git repo at dir with HEAD pointing
 // at defaultBranch. No commits are made.
 func initEmptyBareRepo(t *testing.T, dir, defaultBranch string) {


### PR DESCRIPTION
## Problem

`Stat()` in `internal/git/git.go` used `strings.Fields(line)` to parse `git diff --numstat HEAD` output and took `parts[2]` as the filename. Since `git diff --numstat` is tab-delimited (`added\tdeleted\tfilename`), any filename containing spaces was truncated at the first space — `docs/my notes.md` became `docs/my`. Two paths sharing the same space-delimited prefix also collided in the `seen` map.

## Fix

Replace `strings.Fields(line)` with `strings.SplitN(line, "\t", 3)` so the filename column (third tab-separated segment) is captured intact regardless of spaces.

## Tests added

- `TestStat_FilenameWithSpace` — stages a file named `my notes.md`, modifies it, and asserts `Stat()` returns `Files == 1`.
- `TestStat_TwoFilesWithSharedSpacePrefix` — stages `docs/my notes.md` and `docs/my other.md`, modifies both, and asserts `Stat()` returns `Files == 2`.

All existing `Stat()` tests continue to pass. `go test ./internal/git/ -race` and `nix build .#prism` both pass.

Closes #1861