### PR TITLE
session: treat malformed state_change payload as bare-active in strict mode

### DIFF
--- a/modules/programs/prism/prism/internal/session/readiness.go
+++ b/modules/programs/prism/prism/internal/session/readiness.go
@@ -277,17 +277,22 @@ func promptReadinessSatisfied(d *db.DB, sessionName string, requirePromptDeliver
 }
 
 // payloadIsBareActive reports whether a state_change payload is the bare
-// "agent transitioned to active" event. Returns true only when the payload
-// parses as {"state":"active"} — anything else (idle, finished, error,
-// interrupted, parse failure) is treated as "not bare active" and counts as
-// progress evidence. Conservative on parse failure: an unparseable payload
-// is assumed to be progress (rather than risk the gate hanging).
+// "agent transitioned to active" event. Returns true when the payload parses
+// as {"state":"active"}, and also returns true when the payload cannot be
+// parsed at all. Treating a malformed payload as "bare active" means the
+// strict-mode gate does not count it as progress evidence — the gate falls
+// through to the deadline-based timeout rather than declaring premature
+// success. The deadline at WaitForReadyWithOpts already prevents indefinite
+// hangs, so returning true here is the correct conservative choice for the
+// failure class strict mode was added to catch (lost/corrupted prompts).
 func payloadIsBareActive(payload string) bool {
 	var p struct {
 		State string `json:"state"`
 	}
 	if err := json.Unmarshal([]byte(payload), &p); err != nil {
-		return false
+		// Malformed payload — treat as bare active so the strict-mode gate
+		// falls through to the deadline rather than declaring ready.
+		return true
 	}
 	return p.State == "active"
 }

--- a/modules/programs/prism/prism/internal/session/readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/readiness_test.go
@@ -218,6 +218,110 @@ func errorWrap(prefix string, inner error) error {
 	return &wrappedErr{prefix: prefix, inner: inner}
 }
 
+// ── WaitForReadyWithOpts — strict mode (RequirePromptDelivered) ──────────────
+
+// TestWaitForReadyWithOpts_StrictMode_MalformedPayloadTimesOut verifies that a
+// state_change event with an unparseable payload does NOT satisfy the
+// strict-mode gate. The gate must fall through to the deadline and return a
+// *ReadinessTimeoutError rather than treating the malformed payload as
+// progress evidence.
+func TestWaitForReadyWithOpts_StrictMode_MalformedPayloadTimesOut(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@strict-malformed"
+	seedSession(t, d, sess)
+
+	// Inject a state_change with a truncated / unparseable payload.
+	evt := db.Event{
+		ID:          "evt-malformed",
+		SessionName: sess,
+		Repo:        "test",
+		Worktree:    "/tmp",
+		Type:        "state_change",
+		Payload:     `{"state":truncated`,
+	}
+	if err := d.WriteEvent(evt); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	const timeout = 500 * time.Millisecond
+	err := session.WaitForReadyWithOpts(d, sess, session.ReadinessOpts{
+		Timeout:                timeout,
+		RequirePromptDelivered: true,
+	})
+
+	if err == nil {
+		t.Fatal("WaitForReadyWithOpts: got nil, want *ReadinessTimeoutError — malformed payload must not satisfy strict gate")
+	}
+	if !session.IsReadinessTimeout(err) {
+		t.Errorf("WaitForReadyWithOpts error = %v (type %T), want *ReadinessTimeoutError", err, err)
+	}
+}
+
+// TestWaitForReadyWithOpts_StrictMode_BareActivePayloadTimesOut verifies the
+// boundary case: a well-formed bare {"state":"active"} payload also does not
+// satisfy the strict gate — the agent acknowledged idle/active but has not
+// yet shown evidence of processing the prompt.
+func TestWaitForReadyWithOpts_StrictMode_BareActivePayloadTimesOut(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@strict-bare-active"
+	seedSession(t, d, sess)
+
+	evt := db.Event{
+		ID:          "evt-bare-active",
+		SessionName: sess,
+		Repo:        "test",
+		Worktree:    "/tmp",
+		Type:        "state_change",
+		Payload:     `{"state":"active"}`,
+	}
+	if err := d.WriteEvent(evt); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	const timeout = 500 * time.Millisecond
+	err := session.WaitForReadyWithOpts(d, sess, session.ReadinessOpts{
+		Timeout:                timeout,
+		RequirePromptDelivered: true,
+	})
+
+	if err == nil {
+		t.Fatal("WaitForReadyWithOpts: got nil, want *ReadinessTimeoutError — bare-active must not satisfy strict gate")
+	}
+	if !session.IsReadinessTimeout(err) {
+		t.Errorf("WaitForReadyWithOpts error = %v (type %T), want *ReadinessTimeoutError", err, err)
+	}
+}
+
+// TestWaitForReadyWithOpts_StrictMode_NonBareActivePayloadReturnsReady verifies
+// the regression path: a well-formed state_change carrying a non-bare-active
+// state (e.g. "finished") satisfies the strict gate and returns nil.
+func TestWaitForReadyWithOpts_StrictMode_NonBareActivePayloadReturnsReady(t *testing.T) {
+	d := openReadinessTestDB(t)
+	const sess = "myrepo@strict-non-bare"
+	seedSession(t, d, sess)
+
+	evt := db.Event{
+		ID:          "evt-non-bare",
+		SessionName: sess,
+		Repo:        "test",
+		Worktree:    "/tmp",
+		Type:        "state_change",
+		Payload:     `{"state":"finished"}`,
+	}
+	if err := d.WriteEvent(evt); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	err := session.WaitForReadyWithOpts(d, sess, session.ReadinessOpts{
+		Timeout:                2 * time.Second,
+		RequirePromptDelivered: true,
+	})
+
+	if err != nil {
+		t.Errorf("WaitForReadyWithOpts: got %v, want nil — non-bare-active state_change must satisfy strict gate", err)
+	}
+}
+
 // ── WaitForReady — argument validation ────────────────────────────────────────
 
 // TestWaitForReady_RequiresDB verifies the nil-DB guard.


### PR DESCRIPTION
## Summary

In strict mode (`RequirePromptDelivered=true`), `payloadIsBareActive` was returning `false` on `json.Unmarshal` failure with a comment claiming this was "conservative". The effect was the opposite: a malformed payload caused the strict gate to declare ready prematurely — exactly the failure class strict mode was added to catch.

**Fix:** return `true` on parse failure so the gate treats malformed payloads the same as bare `{"state":"active"}` and falls through to the deadline. The deadline at `WaitForReadyWithOpts` already prevents indefinite hangs.

## Changes

- `readiness.go`: change `payloadIsBareActive` parse-failure return from `false` → `true`; rewrite comment to describe the actual semantic
- `readiness_test.go`: add three new strict-mode tests:
  - `MalformedPayloadTimesOut`: strict gate ignores truncated JSON and times out with `*ReadinessTimeoutError`
  - `BareActivePayloadTimesOut`: boundary — bare active also falls through to timeout
  - `NonBareActivePayloadReturnsReady`: regression — `{"state":"finished"}` still returns ready

## Non-strict mode

Unaffected — `payloadIsBareActive` is only consulted in the strict path of `promptReadinessSatisfied`.

Closes #1882