### PR TITLE
container: add 5s timeout and per-BareRoot cache to githubAccountFromBareRoot

### DIFF
--- a/modules/programs/prism/prism/internal/container/credentials.go
+++ b/modules/programs/prism/prism/internal/container/credentials.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -48,10 +49,26 @@ func (m *Manager) writeClaudeCredentials() {
 	m.claudeCredentialsReady = true
 }
 
+// gitBareRootTimeout is the per-call timeout for git subprocess invocations
+// inside githubAccountFromBareRoot. Matches the convention introduced for
+// internal/review/context.go (#1888). A bare git dir on a network FS or a
+// credential helper waiting on a missing TTY should not block indefinitely.
+const gitBareRootTimeout = 5 * time.Second
+
+// githubAccountCache caches the result of githubAccountFromBareRoot keyed on
+// bareRoot. The remote URL is stable for the lifetime of the worktree, so the
+// cache never needs to be invalidated.
+var githubAccountCache sync.Map // map[string]string
+
 // githubAccountFromBareRoot returns the GitHub account (organisation or user)
 // for the repo by reading the origin remote URL from the bare git dir.
 // Returns "" when the bare root is empty, git is unavailable, or the remote
 // URL does not match a github.com URL pattern.
+//
+// Results are cached per bareRoot so repeated calls (e.g. once per spawn)
+// do not re-fork git. The git subprocess is bounded by gitBareRootTimeout
+// to prevent an indefinite hang on network-FS repos or misbehaving credential
+// helpers.
 //
 // Supported URL formats:
 //
@@ -61,16 +78,37 @@ func githubAccountFromBareRoot(bareRoot string) string {
 	if bareRoot == "" {
 		return ""
 	}
+	// Return cached result if available — the remote URL is stable.
+	if cached, ok := githubAccountCache.Load(bareRoot); ok {
+		return cached.(string)
+	}
+	account := githubAccountFromBareRootUncached(bareRoot)
+	githubAccountCache.Store(bareRoot, account)
+	return account
+}
+
+// githubAccountFromBareRootUncached performs the actual git subprocess calls
+// without consulting the cache. Exported for testing via export_test.go.
+func githubAccountFromBareRootUncached(bareRoot string) string {
 	// The bare git dir lives at <bareRoot>/.bare — use --git-dir to run git
 	// against it directly without needing to be inside a worktree.
 	bareDir := filepath.Join(bareRoot, ".bare")
-	cmd := exec.Command("git", "--git-dir", bareDir, "remote", "get-url", "origin")
-	out, err := cmd.Output()
+	ctx, cancel := context.WithTimeout(context.Background(), gitBareRootTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "--git-dir", bareDir, "remote", "get-url", "origin").Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			log.Printf("container: git --git-dir %s remote get-url origin timed out after %s", bareDir, gitBareRootTimeout)
+			return ""
+		}
 		// Also try the bareRoot itself in case it IS the raw bare git dir.
-		cmd2 := exec.Command("git", "--git-dir", bareRoot, "remote", "get-url", "origin")
-		out, err = cmd2.Output()
+		ctx2, cancel2 := context.WithTimeout(context.Background(), gitBareRootTimeout)
+		defer cancel2()
+		out, err = exec.CommandContext(ctx2, "git", "--git-dir", bareRoot, "remote", "get-url", "origin").Output()
 		if err != nil {
+			if ctx2.Err() != nil {
+				log.Printf("container: git --git-dir %s remote get-url origin timed out after %s", bareRoot, gitBareRootTimeout)
+			}
 			return ""
 		}
 	}

--- a/modules/programs/prism/prism/internal/container/credentials_timeout_test.go
+++ b/modules/programs/prism/prism/internal/container/credentials_timeout_test.go
@@ -1,0 +1,243 @@
+package container_test
+
+// credentials_timeout_test.go — timeout and cache tests for
+// githubAccountFromBareRoot.
+//
+// These tests PATH-inject a stub "git" script that sleeps longer than
+// gitBareRootTimeout and assert that the function returns within ~5s with an
+// empty string, not blocking indefinitely.
+//
+// The stub scripts use "exec sleep" (exec-replaces the shell with the sleep
+// binary) so that when exec.CommandContext sends SIGKILL to the process, there
+// is no orphaned child subprocess keeping inherited file descriptors (e.g.
+// stdout pipes) open on macOS. Without "exec", the shell spawns sleep as a
+// child; killing the shell leaves sleep alive with inherited pipes, causing
+// cmd.Run() to block until sleep exits naturally — defeating the context
+// timeout in the test.
+//
+// Reference: internal/review/subprocess_timeout_test.go (same pattern).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// writeSleepScript writes an executable shell script that sleeps for the given
+// duration to dir/<name> and returns its path.
+func writeSleepScript(t *testing.T, dir, name string, sleep time.Duration) string {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\nexec sleep %.3f\n", sleep.Seconds())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("writeSleepScript: %v", err)
+	}
+	return path
+}
+
+// writeCountScript writes an executable shell script that increments a counter
+// file and then outputs the given remoteURL. Returns the counter file path.
+func writeCountScript(t *testing.T, dir, name, remoteURL string) string {
+	t.Helper()
+	counterPath := filepath.Join(dir, "call-count")
+	// Atomically increment the counter then print the remote URL.
+	script := fmt.Sprintf("#!/bin/sh\n"+
+		"n=$(cat %q 2>/dev/null || echo 0)\n"+
+		"n=$((n+1))\n"+
+		"echo $n > %q\n"+
+		"echo %q\n",
+		counterPath, counterPath, remoteURL)
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("writeCountScript: %v", err)
+	}
+	return counterPath
+}
+
+// prependToPATH returns a PATH value with dir prepended.
+func prependToPATH(dir string) string {
+	return dir + string(os.PathListSeparator) + os.Getenv("PATH")
+}
+
+// TestGithubAccountFromBareRoot_Timeout verifies that a hanging git subprocess
+// does not block githubAccountFromBareRoot for more than ~5 s.
+//
+// Implementation note: the stub sleeps 60 s (>> gitBareRootTimeout = 5 s) so
+// the context deadline fires first. We do not reduce gitBareRootTimeout itself
+// to avoid modifying production code; the test validates the mechanism
+// (context cancellation), not the exact wall-clock value.
+func TestGithubAccountFromBareRoot_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-injection stub scripts require a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	// The stub sleeps longer than gitBareRootTimeout (5 s) so the context fires.
+	writeSleepScript(t, dir, "git", 60*time.Second)
+	t.Setenv("PATH", prependToPATH(dir))
+
+	// Sanity check: the stub git is actually found.
+	stubPath := filepath.Join(dir, "git")
+	if _, err := os.Stat(stubPath); err != nil {
+		t.Fatalf("stub git not found at %s: %v", stubPath, err)
+	}
+
+	// Clear the cache so no prior test result leaks in.
+	container.ClearGithubAccountCacheForTest()
+
+	bareRoot := t.TempDir()
+	start := time.Now()
+	result := container.GithubAccountFromBareRootUncachedForTest(bareRoot)
+	elapsed := time.Since(start)
+
+	if result != "" {
+		t.Errorf("expected empty string on timeout, got %q", result)
+	}
+
+	// The function must return within a generous bound. gitBareRootTimeout is 5 s;
+	// each call makes up to two git attempts, so the theoretical ceiling is 10 s.
+	// We allow 25 s (2.5×) for slow CI — the important assertion is that we
+	// did NOT wait the full 60 s of the stub.
+	if elapsed > 25*time.Second {
+		t.Errorf("GithubAccountFromBareRootUncachedForTest took %s, expected to time out around %s (2× %s)",
+			elapsed, 2*container.GitBareRootTimeoutForTest, container.GitBareRootTimeoutForTest)
+	}
+}
+
+// TestGithubAccountFromBareRoot_CacheHit verifies that two calls for the same
+// bareRoot result in only one underlying git invocation.
+func TestGithubAccountFromBareRoot_CacheHit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-injection stub scripts require a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	// The counting script records how many times git is called and prints the
+	// remote URL so the account can be derived.
+	counterPath := writeCountScript(t, dir, "git", "git@github.com:prismatic-koi/nixos-config.git")
+	t.Setenv("PATH", prependToPATH(dir))
+
+	// Clear the cache so this test is independent of earlier runs.
+	container.ClearGithubAccountCacheForTest()
+
+	bareRoot := t.TempDir()
+
+	// First call — must hit git.
+	result1 := container.GithubAccountFromBareRootForTest(bareRoot)
+	// Second call — must return cached value without re-forking git.
+	result2 := container.GithubAccountFromBareRootForTest(bareRoot)
+
+	if result1 != result2 {
+		t.Errorf("cache returned different value: first=%q second=%q", result1, result2)
+	}
+
+	// Read the counter. The script increments by 1 on each git invocation.
+	// Because "git --git-dir <bareRoot>/.bare" fails (the dir exists but has
+	// no .bare subdir), the uncached path also tries "git --git-dir <bareRoot>"
+	// — so one cache miss may invoke git twice. The cache hit must not invoke it
+	// again, so the total count must be ≤ 2.
+	countBytes, err := os.ReadFile(counterPath)
+	if err != nil {
+		t.Fatalf("could not read counter file %s: %v", counterPath, err)
+	}
+	var callCount int
+	if _, err := fmt.Sscanf(string(countBytes), "%d", &callCount); err != nil {
+		t.Fatalf("could not parse counter %q: %v", string(countBytes), err)
+	}
+	if callCount > 2 {
+		t.Errorf("git was invoked %d times across 2 calls; expected ≤ 2 (cache must prevent re-fork on second call)", callCount)
+	}
+}
+
+// TestGithubAccountFromBareRoot_ConcurrentCacheSafety runs many goroutines
+// calling githubAccountFromBareRoot for the same bareRoot and verifies they
+// all return the same value. This is primarily a -race detector exercise.
+func TestGithubAccountFromBareRoot_ConcurrentCacheSafety(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-injection stub scripts require a POSIX shell")
+	}
+
+	dir := t.TempDir()
+	writeCountScript(t, dir, "git", "git@github.com:prismatic-koi/nixos-config.git")
+	t.Setenv("PATH", prependToPATH(dir))
+
+	container.ClearGithubAccountCacheForTest()
+
+	bareRoot := t.TempDir()
+
+	const goroutines = 20
+	results := make([]string, goroutines)
+	var wg atomic.Int32
+	wg.Store(int32(goroutines))
+
+	ch := make(chan int, goroutines)
+	for i := 0; i < goroutines; i++ {
+		ch <- i
+	}
+	close(ch)
+
+	done := make(chan struct{})
+	go func() {
+		for i := range ch {
+			go func(idx int) {
+				results[idx] = container.GithubAccountFromBareRootForTest(bareRoot)
+				if wg.Add(-1) == 0 {
+					close(done)
+				}
+			}(i)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent calls did not complete within 30 s")
+	}
+
+	first := results[0]
+	for i, r := range results {
+		if r != first {
+			t.Errorf("goroutine %d returned %q, want %q", i, r, first)
+		}
+	}
+}
+
+// TestGithubAccountFromBareRoot_ExistingHappyPath exercises the cached path
+// against a real bare git repo (created with git init --bare) to confirm the
+// cache correctly stores and returns a valid account name.
+func TestGithubAccountFromBareRoot_ExistingHappyPath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	const remoteURL = "git@github.com:prismatic-koi/nixos-config.git"
+	bareRoot := t.TempDir()
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if out, err := exec.Command("git", "init", "--bare", bareDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "--git-dir", bareDir, "remote", "add", "origin", remoteURL).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add origin: %v\n%s", err, out)
+	}
+
+	container.ClearGithubAccountCacheForTest()
+
+	// First call (cache miss).
+	got1 := container.GithubAccountFromBareRootForTest(bareRoot)
+	if got1 != "prismatic-koi" {
+		t.Errorf("first call: got %q, want %q", got1, "prismatic-koi")
+	}
+
+	// Second call (cache hit) — must return same value.
+	got2 := container.GithubAccountFromBareRootForTest(bareRoot)
+	if got2 != "prismatic-koi" {
+		t.Errorf("second call (cache hit): got %q, want %q", got2, "prismatic-koi")
+	}
+}

--- a/modules/programs/prism/prism/internal/container/export_test.go
+++ b/modules/programs/prism/prism/internal/container/export_test.go
@@ -1,0 +1,34 @@
+package container
+
+// export_test.go — test-only export shims for unexported functions.
+//
+// These wrappers make unexported symbols accessible to external test packages
+// (package container_test) without expanding the production API surface. This
+// is the standard Go pattern for white-box testing via black-box test files.
+//
+// All declarations here are compiled only when running tests (the _test.go
+// suffix ensures they are excluded from production builds).
+
+// GithubAccountFromBareRootUncachedForTest is an exported wrapper around
+// githubAccountFromBareRootUncached for use in timeout tests.
+func GithubAccountFromBareRootUncachedForTest(bareRoot string) string {
+	return githubAccountFromBareRootUncached(bareRoot)
+}
+
+// GithubAccountFromBareRootForTest is an exported wrapper around
+// githubAccountFromBareRoot (cache-aware) for use in cache tests.
+func GithubAccountFromBareRootForTest(bareRoot string) string {
+	return githubAccountFromBareRoot(bareRoot)
+}
+
+// ClearGithubAccountCacheForTest deletes all entries from githubAccountCache.
+// Call at the start of cache tests to ensure a clean slate.
+func ClearGithubAccountCacheForTest() {
+	githubAccountCache.Range(func(k, _ any) bool {
+		githubAccountCache.Delete(k)
+		return true
+	})
+}
+
+// GitBareRootTimeoutForTest exposes gitBareRootTimeout for assertions.
+const GitBareRootTimeoutForTest = gitBareRootTimeout


### PR DESCRIPTION
## Summary

Fixes two issues with the git subprocess calls in `credentials.go:githubAccountFromBareRoot`:

1. **Timeout**: Both `exec.Command("git", ...)` calls are now `exec.CommandContext` with a 5-second deadline (`gitBareRootTimeout`), matching the convention introduced in `internal/review/context.go` (#1888). A hung git subprocess (network-FS hang, credential helper waiting on a missing TTY) no longer blocks `BuildArgs` indefinitely.

2. **Cache**: Results are stored in a package-level `sync.Map` keyed on `bareRoot`. Repeated calls for the same repo (once per spawn/agent-run) return immediately without re-forking git. The remote URL is stable for the lifetime of the worktree so no cache invalidation is needed.

## New tests

`credentials_timeout_test.go` (package `container_test`):
- `TestGithubAccountFromBareRoot_Timeout`: PATH-injects a stub `git` that sleeps 60s; asserts the function returns within 25s with an empty string (context fires around 5–10s).
- `TestGithubAccountFromBareRoot_CacheHit`: verifies two calls for the same `bareRoot` result in ≤2 underlying git invocations.
- `TestGithubAccountFromBareRoot_ConcurrentCacheSafety`: 20 goroutines calling the function concurrently, exercising the race detector.
- `TestGithubAccountFromBareRoot_ExistingHappyPath`: full integration against a real bare git repo confirming the cache returns the correct account name on both first (miss) and second (hit) calls.

`export_test.go` provides the shims needed by the external test package.

## Testing

```
go test ./internal/container/ -race -run 'TestGithubAccountFromBareRoot|TestCredentialEnvVars|TestGithubAccountFromURL'
# ok  github.com/prismatic-koi/prism/internal/container 13.130s

nix build .#prism
# builds successfully
```

Closes #1877