### PR TITLE
dashboard: add reviewing and escalated to EscalatedState priority ladder

### DIFF
--- a/modules/programs/prism/prism/internal/dashboard/review_collapse_test.go
+++ b/modules/programs/prism/prism/internal/dashboard/review_collapse_test.go
@@ -107,6 +107,53 @@ func TestEscalatedState(t *testing.T) {
 		{"precedence: interrupted beats finished",
 			[]string{"finished", "interrupted"},
 			"interrupted"},
+		// ── reviewing: background work, ranks above compacting, below active ──
+		// (a) all children reviewing — must not show "idle"
+		{"all reviewing",
+			[]string{"reviewing", "reviewing", "reviewing", "reviewing", "reviewing"},
+			"reviewing"},
+		// (b) one child reviewing, others idle
+		{"one reviewing others idle",
+			[]string{"", "", "", "", "reviewing"},
+			"reviewing"},
+		// reviewing ranks above compacting
+		{"reviewing beats compacting",
+			[]string{"compacting", "reviewing"},
+			"reviewing"},
+		// active beats reviewing (active work trumps background work)
+		{"active beats reviewing",
+			[]string{"reviewing", "active"},
+			"active"},
+		// error beats reviewing
+		{"error beats reviewing",
+			[]string{"reviewing", "error"},
+			"error"},
+		// waiting beats reviewing
+		{"waiting beats reviewing",
+			[]string{"reviewing", "waiting"},
+			"waiting"},
+		// ── escalated: awaiting coordinator, ranks above waiting ──
+		// (c) all children escalated — must not show "idle"
+		{"all escalated",
+			[]string{"escalated", "escalated", "escalated", "escalated", "escalated"},
+			"escalated"},
+		// (d) one child escalated, one active — escalated wins (most urgent)
+		{"escalated beats active",
+			[]string{"active", "escalated"},
+			"escalated"},
+		// escalated beats waiting
+		{"escalated beats waiting",
+			[]string{"waiting", "escalated"},
+			"escalated"},
+		// escalated beats error
+		{"escalated beats error",
+			[]string{"error", "escalated"},
+			"escalated"},
+		// Full precedence table including new states:
+		// escalated > waiting > error > active > reviewing > compacting > interrupted > finished > idle
+		{"full precedence with escalated and reviewing",
+			[]string{"finished", "interrupted", "compacting", "reviewing", "active", "error", "waiting", "escalated"},
+			"escalated"},
 	}
 	for _, tt := range tests {
 		got := dashboard.EscalatedState(tt.states)
@@ -700,6 +747,41 @@ func TestRenderReviewGroupRow_TreeConnectorStyleSplit(t *testing.T) {
 	}
 	if dimIdx2 := strings.Index(rowExpanded, dimSeq); dimIdx2 < 0 {
 		t.Errorf("expanded: styleDim colour sequence not found; row=%q", rowExpanded)
+	}
+}
+
+// ── Visual test: all-reviewing group row must not show "idle" ─────────────────
+
+// TestRenderReviewGroupRow_ReviewingStateNotIdle verifies that when a review-
+// group row's AgentState is "reviewing" (set by EscalatedState when all children
+// are reviewing), the rendered state column shows "reviewing", not "idle".
+// This is the visual counterpart to the EscalatedState unit test cases above.
+func TestRenderReviewGroupRow_ReviewingStateNotIdle(t *testing.T) {
+	// Use ASCII colour profile so the output is plain text and easy to search.
+	lipgloss.SetColorProfile(termenv.Ascii)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	})
+
+	styleFg := lipgloss.NewStyle()
+	styleDim := lipgloss.NewStyle()
+	d := dashboard.Shared{
+		Width:  80,
+		Cursor: 99, // cursor far away so isSelected is false
+	}
+	s := dashboard.AgentSession{
+		Name:          "repo@feature~review-1",
+		AgentState:    "reviewing", // EscalatedState result when all children are reviewing
+		IsReviewGroup: true,
+	}
+
+	row := dashboard.RenderReviewGroupRow(d, s, 0, "  ├── ", false /*collapsed*/, false /*cursorActive*/, styleDim, styleFg, 10, 12)
+
+	if strings.Contains(row, "idle") {
+		t.Errorf("group row with AgentState=\"reviewing\" must not contain \"idle\"; got row=%q", row)
+	}
+	if !strings.Contains(row, "reviewing") {
+		t.Errorf("group row with AgentState=\"reviewing\" must contain \"reviewing\"; got row=%q", row)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/dashboard/sessions.go
+++ b/modules/programs/prism/prism/internal/dashboard/sessions.go
@@ -231,30 +231,45 @@ func ReviewRoundKey(name string) string {
 }
 
 // EscalatedState returns the highest-priority state across a slice of states.
-// Priority order (highest first): waiting > error > active > compacting >
-// interrupted > finished > idle/empty.
+// Priority order (highest first):
 //
-// compacting is a first-class AgentState (see internal/agent) and ranks
-// alongside active — it means the agent is doing background work and is not
-// idle. It sits just below active so that a round with one active agent and
-// one compacting agent shows "active".
+//	escalated > waiting > error > active > reviewing > compacting >
+//	interrupted > finished > idle/empty
+//
+// Rationale for new entries (see internal/agent/machine.go for state graph):
+//
+//   - reviewing: an agent has called `prism review` and is awaiting results.
+//     Comparable to compacting — it is background work, not awaiting user input.
+//     Ranked just above compacting so that a round with one active agent and one
+//     reviewing agent shows "active" (active work trumps background work), but a
+//     round with only reviewing agents shows "reviewing" rather than the
+//     misleading "idle".
+//
+//   - escalated: an agent has called `prism escalate` and is awaiting coordinator
+//     guidance. Comparable to waiting — both states require external input before
+//     the agent can proceed. Ranked above waiting because an escalation is more
+//     urgent: it signals a blocking decision, not merely a normal turn prompt.
 func EscalatedState(states []string) string {
 	priority := func(s string) int {
 		switch s {
+		case "escalated":
+			return 8
 		case "waiting":
 			return 7
 		case "error":
 			return 6
 		case "active":
 			return 5
+		case "reviewing":
+			return 4 // background work (awaiting review results), not idle
 		case "compacting":
-			return 4
-		case "interrupted":
 			return 3
-		case "finished":
+		case "interrupted":
 			return 2
+		case "finished":
+			return 1
 		default:
-			return 1 // idle or ""
+			return 0 // idle or ""
 		}
 	}
 	best := ""


### PR DESCRIPTION
## Summary

`EscalatedState` in `internal/dashboard/sessions.go` had no cases for `reviewing` or `escalated` in its priority switch, so review groups whose children were all in those states fell through to the default branch and displayed **idle** — even though every child was actively working or awaiting coordinator input.

## Changes

**`sessions.go`** — extended the priority ladder with two new cases:
- `escalated` → priority 8 (above `waiting`): awaiting coordinator guidance is more urgent than an ordinary turn prompt
- `reviewing` → priority 4 (above `compacting`, below `active`): background work awaiting review results; ranks below active so a mixed round shows `active`

The existing priority values were shifted down by one to accommodate the new `escalated` slot at the top, and the `default` case moved from 1 to 0. All existing relative orderings are preserved.

Full order: `escalated > waiting > error > active > reviewing > compacting > interrupted > finished > idle/empty`

**`review_collapse_test.go`** — added:
- 4 required `TestEscalatedState` cases: all-reviewing, one-reviewing-others-idle, all-escalated, escalated+active
- Additional precedence coverage for reviewing and escalated vs other states
- `TestRenderReviewGroupRow_ReviewingStateNotIdle`: visual assertion that the state column shows `reviewing` (not `idle`) when `AgentState="reviewing"`

## Quality gates

- `go test ./internal/dashboard/ -race` ✅
- `nix build .#prism` ✅

Closes #1860