### PR TITLE
db: fix AllocatePort check-then-write race; add concurrency tests

### DIFF
--- a/modules/programs/prism/prism/internal/db/concurrency_test.go
+++ b/modules/programs/prism/prism/internal/db/concurrency_test.go
@@ -1,0 +1,182 @@
+package db_test
+
+// concurrency_test.go — concurrent-access tests for the db package (#1865).
+//
+// These tests fire N goroutines against a shared in-memory (temp file) DB and
+// assert correctness properties that should hold under concurrent access.  All
+// tests are run under the race detector (`go test -race`).
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestAllocatePort_Concurrent fires N goroutines each calling AllocatePort for
+// a distinct session_name and asserts that all returned ports are distinct
+// (F4, #1865).
+func TestAllocatePort_Concurrent(t *testing.T) {
+	const N = 50
+	d := openTestDB(t)
+
+	// Pre-create all N sessions sequentially so that concurrent AllocatePort
+	// calls can proceed without racing on the INSERT path.
+	for i := range N {
+		name := fmt.Sprintf("concurrent@s%d", i)
+		if err := d.UpsertStatus(name, "repo", "/code/repo/"+name, "idle", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", name, err)
+		}
+	}
+
+	type result struct {
+		port int
+		err  error
+	}
+
+	results := make([]result, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func(idx int) {
+			defer wg.Done()
+			name := fmt.Sprintf("concurrent@s%d", idx)
+			port, err := d.AllocatePort(name)
+			results[idx] = result{port: port, err: err}
+		}(i)
+	}
+	wg.Wait()
+
+	// All calls must succeed.
+	for i, r := range results {
+		if r.err != nil {
+			t.Errorf("goroutine %d: AllocatePort error: %v", i, r.err)
+		}
+	}
+
+	// All returned ports must be distinct — the core correctness guarantee.
+	seen := make(map[int]int) // port → first goroutine index
+	for i, r := range results {
+		if r.err != nil {
+			continue // already reported above
+		}
+		if prev, dup := seen[r.port]; dup {
+			t.Errorf("port collision: goroutines %d and %d both got port %d", prev, i, r.port)
+		}
+		seen[r.port] = i
+	}
+}
+
+// TestUpsertStatusWithRootAgent_Concurrent fires N goroutines all upserting
+// the same session_name with overlapping (but distinct) field sets, then
+// asserts row count = 1 and all expected fields are present per COALESCE
+// semantics (F19, #1865).
+//
+// Because COALESCE prefers the first non-NULL value, the test sets fields that
+// are written on INSERT (the first writer) and fields that are present on every
+// write (state, last_seen). The critical assertion is that exactly one row
+// exists and its non-NULL fields are consistent.
+func TestUpsertStatusWithRootAgent_Concurrent(t *testing.T) {
+	const N = 50
+	const session = "concurrent-upsert-root@main"
+	d := openTestDB(t)
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func(idx int) {
+			defer wg.Done()
+			// Each goroutine writes a distinct agentName so we can verify
+			// that at least one value survived (COALESCE keeps the first
+			// non-NULL). We always write state="active" so the final row
+			// is deterministic on the state field.
+			agentName := fmt.Sprintf("agent-%d", idx)
+			modelID := fmt.Sprintf("model-%d", idx)
+			err := d.UpsertStatusWithRootAgent(
+				session, "repo", "/code/repo/main", "active",
+				strPtr("concurrent title"),
+				nil,           // harnessSessionID
+				strPtr(agentName),
+				strPtr(modelID),
+			)
+			if err != nil {
+				t.Errorf("goroutine %d: UpsertStatusWithRootAgent: %v", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Row count must be exactly 1 — no phantom duplicates.
+	var count int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM agent_status WHERE session_name = ?", session,
+	).Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("row count: got %d, want 1", count)
+	}
+
+	// The surviving row must have non-NULL agent_name, model_id, and state.
+	s, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s.AgentName == nil {
+		t.Error("agent_name is NULL after concurrent upserts; expected non-NULL (COALESCE semantics)")
+	}
+	if s.ModelID == nil {
+		t.Error("model_id is NULL after concurrent upserts; expected non-NULL (COALESCE semantics)")
+	}
+	if s.State != "active" {
+		t.Errorf("state: got %q, want %q", s.State, "active")
+	}
+}
+
+// TestUpsertStatus_Concurrent does the same as TestUpsertStatusWithRootAgent_Concurrent
+// for the lower-level UpsertStatus method (F19, #1865).
+func TestUpsertStatus_Concurrent(t *testing.T) {
+	const N = 50
+	const session = "concurrent-upsert@main"
+	d := openTestDB(t)
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := range N {
+		go func(idx int) {
+			defer wg.Done()
+			title := fmt.Sprintf("title-%d", idx)
+			err := d.UpsertStatus(
+				session, "repo", "/code/repo/main", "active",
+				strPtr(title),
+				nil, // harnessSessionID
+			)
+			if err != nil {
+				t.Errorf("goroutine %d: UpsertStatus: %v", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Row count must be exactly 1.
+	var count int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM agent_status WHERE session_name = ?", session,
+	).Scan(&count); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("row count: got %d, want 1", count)
+	}
+
+	// The surviving row must have a non-NULL title (COALESCE keeps first writer's value).
+	s, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if s.Title == nil {
+		t.Error("title is NULL after concurrent upserts; expected non-NULL (COALESCE semantics)")
+	}
+	if s.State != "active" {
+		t.Errorf("state: got %q, want %q", s.State, "active")
+	}
+}

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -29,7 +29,7 @@ const (
 	// It must be bumped whenever a new migrateVNtoVN+1 function is added.
 	// A meta-test in db_test.go asserts that this constant equals the count of
 	// migration functions, so forgetting to bump it will fail CI.
-	currentSchemaVersion = 32
+	currentSchemaVersion = 33
 )
 
 // DB wraps a SQLite connection.
@@ -472,10 +472,13 @@ func openAndConfigure(conn *sql.DB) (*sql.DB, error) {
 // schema versions where the referenced columns do not yet exist. The block
 // is applied after migrations so the columns are guaranteed to be present.
 //
-// Mirrors the v31→v32 migration body. The migration itself is the source
-// of truth for deployed databases; this block is the declarative mirror
-// that protects against drift if the migration is ever pruned (#1864 /
+// Mirrors the v31→v32 and v32→v33 migration bodies. The migrations themselves
+// are the source of truth for deployed databases; this block is the declarative
+// mirror that protects against drift if a migration is ever pruned (#1864 /
 // DB-F16). CREATE INDEX IF NOT EXISTS makes both paths idempotent.
+// harness_port is also included here (added in v32→v33, #1865 / DB-F4) because
+// harness_port was itself added by a migration (v7→v8) so it cannot live in
+// the declarative schema block.
 const postMigrationIndexes = `
 -- F1 (#1864): cover WHERE instance_id = ? on agent_events for
 -- WriteSpawnOutcome's aggregation and SessionTurnTokens. Includes type
@@ -497,6 +500,14 @@ CREATE INDEX IF NOT EXISTS idx_agent_status_instance_id   ON agent_status(instan
   WHERE instance_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_agent_status_repo_active   ON agent_status(repo)
   WHERE ended_at IS NULL;
+-- F4 (#1865): unique partial index on harness_port so that concurrent
+-- AllocatePort calls cannot assign the same port to two sessions. The
+-- partial WHERE excludes NULL (released / never-allocated ports) so the
+-- uniqueness constraint only fires when a real port value is present.
+-- ended_at IS NULL additionally excludes ended sessions so that their
+-- reclaimed ports can be reused by new sessions.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_status_harness_port ON agent_status(harness_port)
+  WHERE harness_port IS NOT NULL AND ended_at IS NULL;
 `
 
 // seedSchemaVersionIfEmpty inserts schema_version=11 when the table is empty.
@@ -516,7 +527,7 @@ func seedSchemaVersionIfEmpty(conn *sql.DB) error {
 }
 
 // runMigrations reads the current schema_version and applies all pending
-// migrations in order from v1 to v32.
+// migrations in order from v1 to v33.
 func runMigrations(conn *sql.DB) error {
 	var version int
 	if err := conn.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
@@ -615,6 +626,9 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV31ToV32(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV32ToV33(conn, &version); err != nil {
+		return err
+	}
 	if version > currentSchemaVersion {
 		return fmt.Errorf(
 			"db schema version %d is newer than this prism binary (max %d); "+
@@ -650,6 +664,36 @@ func runMigrations(conn *sql.DB) error {
 // block above, so the migration is a no-op there. The declarative block
 // and this migration must produce identical sqlite_master output (avoiding
 // the declarative-vs-migrated drift class that DB-F16 calls out).
+// migrateV32ToV33 adds a partial unique index on agent_status.harness_port
+// (WHERE harness_port IS NOT NULL) to make concurrent AllocatePort calls
+// serialisable at the DB layer (#1865 / DB-F4). Without this index, two
+// writers racing in the check-then-write loop could both read the same
+// usedPorts snapshot, both pick the same port, and both succeed — assigning
+// the same port to two different sessions. With the unique index, the second
+// writer's UPDATE fails with a constraint violation, which AllocatePort's
+// retry loop uses as the signal to restart port selection.
+//
+// The partial WHERE (harness_port IS NOT NULL AND ended_at IS NULL) excludes
+// both NULL/released ports and ended sessions, so that ended sessions' ports
+// can be reclaimed by new sessions without triggering a constraint error.
+func migrateV32ToV33(conn *sql.DB, version *int) error {
+	if *version >= 33 {
+		return nil
+	}
+	steps := []string{
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_status_harness_port ON agent_status(harness_port)
+		   WHERE harness_port IS NOT NULL AND ended_at IS NULL`,
+		`UPDATE schema_version SET version = 33`,
+	}
+	for _, s := range steps {
+		if _, err := conn.Exec(s); err != nil {
+			return fmt.Errorf("db: migration v32\u2192v33: %w", err)
+		}
+	}
+	*version = 33
+	return nil
+}
+
 func migrateV31ToV32(conn *sql.DB, version *int) error {
 	if *version >= 32 {
 		return nil

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -44,13 +44,13 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=32 (all migrations applied on Open).
+	// Verify schema_version=33 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version: got %d, want 33", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1018,8 +1018,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1093,8 +1093,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1645,8 +1645,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1711,8 +1711,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1781,8 +1781,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1876,8 +1876,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -1969,8 +1969,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2513,8 +2513,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2602,8 +2602,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4452,8 +4452,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// Check each row.
@@ -4880,8 +4880,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5155,8 +5155,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5376,8 +5376,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// sessions table must exist.
@@ -5530,8 +5530,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 }
 
@@ -6084,8 +6084,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6142,8 +6142,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6444,8 +6444,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6506,8 +6506,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6665,8 +6665,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6719,8 +6719,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 
 	var startedAt int64
@@ -6873,8 +6873,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -6946,8 +6946,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7082,8 +7082,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after migration: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after migration: got %d, want 33", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7136,8 +7136,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 
 	// spawn_outcome must still exist.
@@ -7251,8 +7251,8 @@ func TestMigration_V23ToV24_CrashRecovery(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&finalVer); err != nil {
 		t.Fatalf("read schema_version after recovery: %v", err)
 	}
-	if finalVer != 32 {
-		t.Errorf("schema_version after recovery: got %d, want 32", finalVer)
+	if finalVer != 33 {
+		t.Errorf("schema_version after recovery: got %d, want 33", finalVer)
 	}
 
 	// Sessions data must be preserved (the two rows seeded by seedV23DB).

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 32 {
-		t.Errorf("schema_version after fresh open = %d, want 32", ver)
+	if ver != 33 {
+		t.Errorf("schema_version after fresh open = %d, want 33", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 32 {
-		t.Errorf("schema_version after second open = %d, want 32", ver)
+	if ver != 33 {
+		t.Errorf("schema_version after second open = %d, want 33", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/proglog"
+
+	sqlitelib "modernc.org/sqlite"
 )
 
 // currentStateOf looks up the current agent state for sessionName. Returns
@@ -392,9 +395,70 @@ func (d *DB) ClearEnded(sessionName string) error {
 //
 // Returns an error if all ports in the range are exhausted or if the session does
 // not exist in agent_status.
+//
+// Concurrency mechanism — transaction + retry with unique-constraint guard (#1865 / DB-F4):
+//
+// The original check-then-write design was a race: two concurrent callers could
+// both read the same usedPorts snapshot, both pick the same free port, both call
+// portAvailable() (which may transiently succeed for both because the OS listen
+// window is brief), and both write the same port to different rows — with neither
+// UPDATE failing. The fix wraps each attempt in a BEGIN IMMEDIATE transaction so
+// that SQLite serialises the read+write pair: once the first writer commits, the
+// second writer's read sees the updated row and picks a different port. A
+// partial unique index on harness_port (WHERE harness_port IS NOT NULL AND ended_at IS NULL,
+// added in migration v32→v33) provides a second line of defence: even if two transactions
+// race to write the same port, only one can commit; the other receives a
+// SQLITE_CONSTRAINT_UNIQUE error and retries from scratch. The retry budget is
+// bounded (maxRetries) to prevent an infinite loop when the range is exhausted.
 func (d *DB) AllocatePort(sessionName string) (int, error) {
+	const maxRetries = 10
+	for attempt := range maxRetries {
+		port, err := d.allocatePortOnce(sessionName)
+		if err == nil {
+			return port, nil
+		}
+		// Retry on unique-constraint violations (another concurrent caller
+		// committed the same port between our read and our write) and on
+		// SQLITE_BUSY / SQLITE_BUSY_SNAPSHOT (WAL lock contention when many
+		// goroutines issue write transactions simultaneously).
+		if (isUniqueConstraintError(err) || isBusyError(err)) && attempt < maxRetries-1 {
+			continue
+		}
+		return 0, err
+	}
+	return 0, fmt.Errorf("db: allocate port: failed after %d attempts due to concurrent allocation", maxRetries)
+}
+
+// allocatePortOnce performs a single attempt of the port-allocation logic
+// inside a BEGIN IMMEDIATE transaction. Returns an error (possibly wrapping a
+// unique-constraint violation or SQLITE_BUSY) if the chosen port was claimed
+// by a concurrent writer or if the write lock could not be acquired.
+func (d *DB) allocatePortOnce(sessionName string) (int, error) {
+	ctx := context.Background()
+	// Obtain a dedicated connection from the pool so that we can issue
+	// BEGIN IMMEDIATE directly. database/sql's BeginTx does not expose
+	// SQLite-specific locking modes; using a raw connection and executing
+	// "BEGIN IMMEDIATE" is the canonical way to avoid SQLITE_BUSY_SNAPSHOT
+	// (which the busy_timeout does not suppress).
+	conn, err := d.conn.Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("db: allocate port: acquire conn: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		// SQLITE_BUSY: another writer holds the write lock; caller retries.
+		return 0, fmt.Errorf("db: allocate port: begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			conn.ExecContext(ctx, "ROLLBACK") //nolint:errcheck
+		}
+	}()
+
 	// Collect ports currently assigned to active (non-ended) sessions.
-	rows, err := d.conn.Query(
+	rows, err := conn.QueryContext(ctx,
 		"SELECT harness_port FROM agent_status WHERE ended_at IS NULL AND harness_port IS NOT NULL",
 	)
 	if err != nil {
@@ -422,12 +486,16 @@ func (d *DB) AllocatePort(sessionName string) (int, error) {
 		if !portAvailable(port) {
 			continue
 		}
-		// Write the allocated port to agent_status.
-		res, err := d.conn.Exec(
+		// Write the allocated port inside the transaction. The unique partial
+		// index on harness_port (WHERE harness_port IS NOT NULL AND ended_at IS NULL) means this
+		// UPDATE fails with a constraint error if another transaction committed
+		// the same port concurrently.
+		res, err := conn.ExecContext(ctx,
 			"UPDATE agent_status SET harness_port = ? WHERE session_name = ?",
 			port, sessionName,
 		)
 		if err != nil {
+			// Propagate as-is; the caller checks isUniqueConstraintError.
 			return 0, fmt.Errorf("db: allocate port: update: %w", err)
 		}
 		n, err := res.RowsAffected()
@@ -437,10 +505,44 @@ func (d *DB) AllocatePort(sessionName string) (int, error) {
 		if n == 0 {
 			return 0, fmt.Errorf("db: allocate port: session %q not found in agent_status", sessionName)
 		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return 0, fmt.Errorf("db: allocate port: commit: %w", err)
+		}
+		committed = true
 		return port, nil
 	}
 
 	return 0, fmt.Errorf("db: allocate port: all ports in range %d–%d are exhausted", PortRangeStart, PortRangeEnd)
+}
+
+// isUniqueConstraintError reports whether err is a SQLite unique-constraint
+// violation (SQLITE_CONSTRAINT_UNIQUE or SQLITE_CONSTRAINT_PRIMARYKEY).
+func isUniqueConstraintError(err error) bool {
+	var sqliteErr *sqlitelib.Error
+	if errors.As(err, &sqliteErr) {
+		// SQLite extended result codes: 2067 = SQLITE_CONSTRAINT_UNIQUE,
+		// 1555 = SQLITE_CONSTRAINT_PRIMARYKEY.
+		code := sqliteErr.Code()
+		return code == 2067 || code == 1555
+	}
+	return false
+}
+
+// isBusyError reports whether err is a SQLite lock-contention error
+// (SQLITE_BUSY=5, SQLITE_BUSY_RECOVERY=261, SQLITE_BUSY_SNAPSHOT=517,
+// SQLITE_BUSY_TIMEOUT=773, or plain SQLITE_LOCKED=6).
+// These arise under WAL mode when many goroutines issue write transactions
+// simultaneously — the busy timeout does not apply to SQLITE_BUSY_SNAPSHOT.
+func isBusyError(err error) bool {
+	var sqliteErr *sqlitelib.Error
+	if errors.As(err, &sqliteErr) {
+		// All SQLITE_BUSY variants share the low 8 bits == 5;
+		// SQLITE_LOCKED shares the low 8 bits == 6.
+		code := sqliteErr.Code()
+		primary := code & 0xFF
+		return primary == 5 || primary == 6
+	}
+	return false
 }
 
 // ReleasePort sets harness_port = NULL for the given session.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1424,8 +1424,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 32 {
-		t.Errorf("schema_version after second open: got %d, want 32", version)
+	if version != 33 {
+		t.Errorf("schema_version after second open: got %d, want 33", version)
 	}
 }
 


### PR DESCRIPTION
Closes #1865

## Summary

Fixes the check-then-write race in `AllocatePort` (F4) and adds the missing concurrency tests for both `AllocatePort` and the `agent_status` upsert path (F19).

## Changes

### F4 — AllocatePort race fix (`internal/db/status.go`)

**Mechanism: transaction + retry with unique-constraint guard**

The original code queried used ports, picked the lowest free port, then wrote it via a bare `UPDATE` — no transaction, no uniqueness enforcement. Two concurrent callers could read the same snapshot and write the same port to two different sessions.

The fix:
1. **BEGIN IMMEDIATE transaction** (raw SQL on a dedicated `sql.Conn`) serialises the read+write pair. `BEGIN IMMEDIATE` acquires the write lock upfront, preventing `SQLITE_BUSY_SNAPSHOT` (which arises on deferred-BEGIN lock upgrades in WAL mode and is not suppressed by `busy_timeout`).
2. **Partial unique index** on `agent_status.harness_port WHERE harness_port IS NOT NULL AND ended_at IS NULL` added in migration **v32→v33** as a second line of defence. If two transactions still race to the same port, only one commits; the other gets `SQLITE_CONSTRAINT_UNIQUE` and `AllocatePort` retries (bounded to 10 attempts, retrying on both unique-constraint and `SQLITE_BUSY` errors). The `ended_at IS NULL` predicate excludes ended sessions, preserving port reclamation semantics.
3. **Declarative mirror** of the new index added to `postMigrationIndexes` (the index can't go in the `schema` block because `harness_port` is itself migration-added).

### F19 — Concurrency tests (`internal/db/concurrency_test.go`, new file)

- **`TestAllocatePort_Concurrent`**: N=50 goroutines each call `AllocatePort` for a distinct session; asserts all 50 returned ports are distinct. Run under `-race`.
- **`TestUpsertStatusWithRootAgent_Concurrent`**: N=50 goroutines all upsert the same session; asserts row count = 1 and non-NULL fields per COALESCE semantics.
- **`TestUpsertStatus_Concurrent`**: same for lower-level `UpsertStatus`.

### Migration (`internal/db/db.go`)

Migration **v32→v33**: `CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_status_harness_port ON agent_status(harness_port) WHERE harness_port IS NOT NULL AND ended_at IS NULL`

### Test updates

Schema-version assertions in `db_test.go`, `harness_frames_test.go`, and `mergequeue/watcher_test.go` updated from 32 → 33.

## Testing

```
go test ./internal/db/ -race   # all pass
go test ./internal/mergequeue/ -race   # all pass
nix build .#prism  # passes
```