### PR TITLE
git: extend ConvertToBare rollback to cover all post-move failure sites

### DIFF
--- a/modules/programs/prism/prism/internal/git/git.go
+++ b/modules/programs/prism/prism/internal/git/git.go
@@ -266,6 +266,12 @@ func CreateWorktree(projectPath, branchName string) (string, error) {
 	return worktreePath, nil
 }
 
+// convertToBareStepHook is called at each named step inside ConvertToBare.
+// If it returns a non-nil error that error is returned as if the step itself
+// failed, triggering rollback. The hook is nil in production and is set only
+// by tests via the package-internal convertToBareTestHook variable.
+var convertToBareStepHook func(step string) error
+
 // ConvertToBare converts a regular git repo at dir to the prism bare+worktree
 // layout in-place. progress receives human-readable step messages.
 // Returns the path to the default-branch worktree on success.
@@ -296,11 +302,72 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 		return "", fmt.Errorf("rename .git: %w", err)
 	}
 
-	rollback := func() {
+	// rollback restores the repo to its pre-conversion state. It is safe to
+	// call at any point after .git has been renamed to .git.orig. After the
+	// file-move loop completes, worktreePath and barePath may also be
+	// populated; rollback removes them and moves files back to dir.
+	//
+	// rollback is idempotent: calling it when the state is already clean is a
+	// no-op. If any individual step fails, the remaining steps are still
+	// attempted, and the caller receives a combined error describing what
+	// could not be cleaned up.
+	var rollbackErr error
+	rollback := func(worktreePath string) {
+		var errs []string
+
+		// If .git exists as a file/dir (the .bare pointer written mid-way),
+		// remove it so we can restore .git.orig unconditionally.
+		if info, e := os.Stat(gitFile); e == nil && !info.IsDir() {
+			// It's the gitfile we wrote, not the original directory — remove it.
+			if re := os.Remove(gitFile); re != nil {
+				errs = append(errs, fmt.Sprintf("remove .git file: %v", re))
+			}
+		}
+
+		// If worktreePath was populated, move entries back to dir.
+		if worktreePath != "" {
+			if entries, re := os.ReadDir(worktreePath); re == nil {
+				for _, e := range entries {
+					if e.Name() == ".git" {
+						// The worktree .git file we may have written — just remove it.
+						_ = os.Remove(filepath.Join(worktreePath, ".git"))
+						continue
+					}
+					src := filepath.Join(worktreePath, e.Name())
+					dst := filepath.Join(dir, e.Name())
+					if re2 := os.Rename(src, dst); re2 != nil {
+						errs = append(errs, fmt.Sprintf("move %s back: %v", e.Name(), re2))
+					}
+				}
+			} else if !os.IsNotExist(re) {
+				errs = append(errs, fmt.Sprintf("readdir worktree for rollback: %v", re))
+			}
+			// Remove the now-empty worktree directory (and any parent dirs for
+			// slash-branch names like "feat/foo" whose "feat" dir was created).
+			_ = os.Remove(worktreePath)
+			// If branch contains a slash, also remove the top-level segment dir.
+			_ = os.Remove(filepath.Join(dir, strings.SplitN(defaultBranch, "/", 2)[0]))
+		}
+
+		// Remove .bare.
+		if _, e := os.Stat(barePath); e == nil {
+			if re := os.RemoveAll(barePath); re != nil {
+				errs = append(errs, fmt.Sprintf("remove .bare: %v", re))
+			}
+		}
+
+		// Restore .git.orig → .git.
 		if _, e := os.Stat(origGit); e == nil {
 			if _, e2 := os.Stat(gitFile); e2 != nil {
-				_ = os.Rename(origGit, gitFile)
+				if re := os.Rename(origGit, gitFile); re != nil {
+					errs = append(errs, fmt.Sprintf("rename .git.orig → .git: %v", re))
+				}
 			}
+		}
+
+		if len(errs) > 0 {
+			rollbackErr = fmt.Errorf("rollback incomplete — manual recovery needed: %s",
+				strings.Join(errs, "; "))
 		}
 	}
 
@@ -308,7 +375,10 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	progress("  cloning bare repo (this may take a moment)...")
 	if out, err := exec.Command("git", "clone", "--bare", remoteURL, barePath).
 		CombinedOutput(); err != nil {
-		rollback()
+		rollback("")
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("bare clone failed: %w: %s", err, out)
 	}
 	progress("  bare clone done")
@@ -318,18 +388,27 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	if out, err := exec.Command("git", "--git-dir", barePath, "config",
 		"remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").
 		CombinedOutput(); err != nil {
-		rollback()
+		rollback("")
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("config fetch refspec: %w: %s", err, out)
 	}
 	if out, err := exec.Command("git", "--git-dir", barePath, "fetch", "origin").
 		CombinedOutput(); err != nil {
-		rollback()
+		rollback("")
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("fetch origin: %w: %s", err, out)
 	}
 
 	// Write .git pointer.
 	if err := os.WriteFile(gitFile, []byte("gitdir: ./.bare\n"), 0o644); err != nil {
-		rollback()
+		rollback("")
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("write .git: %w", err)
 	}
 
@@ -342,13 +421,19 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	progress("  moving working tree into " + defaultBranch + "/...")
 	worktreePath := filepath.Join(dir, defaultBranch)
 	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
-		rollback()
+		rollback("")
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("mkdir worktree: %w", err)
 	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		rollback()
+		rollback("")
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("readdir: %w", err)
 	}
 	// topLevelBranchComponent is the first path segment of the branch name.
@@ -363,7 +448,10 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 		src := filepath.Join(dir, e.Name())
 		dst := filepath.Join(worktreePath, e.Name())
 		if err := os.Rename(src, dst); err != nil {
-			rollback()
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
 			return "", fmt.Errorf("move %s: %w", e.Name(), err)
 		}
 	}
@@ -393,7 +481,20 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	// naming convention for `git worktree add` with slash-containing branch names.
 	worktreeEntryName := filepath.Base(defaultBranch)
 	worktreesDir := filepath.Join(barePath, "worktrees", worktreeEntryName)
+	if convertToBareStepHook != nil {
+		if hookErr := convertToBareStepHook("mkdir-worktrees-dir"); hookErr != nil {
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
+			return "", hookErr
+		}
+	}
 	if err := os.MkdirAll(worktreesDir, 0o755); err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("mkdir worktrees dir: %w", err)
 	}
 
@@ -404,20 +505,54 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	// repo root is moved or accessed through a different path.
 	relWorktreesDir, err := filepath.Rel(worktreePath, worktreesDir)
 	if err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("compute worktree gitdir rel path: %w", err)
+	}
+	if convertToBareStepHook != nil {
+		if hookErr := convertToBareStepHook("write-worktree-git"); hookErr != nil {
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
+			return "", hookErr
+		}
 	}
 	if err := os.WriteFile(worktreeGitFile,
 		[]byte("gitdir: "+relWorktreesDir+"\n"), 0o644); err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("write worktree .git: %w", err)
 	}
 	// Write a relative back-pointer from worktreesDir to the worktree .git file,
 	// keeping the registration relocatable.
 	relWorktreeGitFile, err := filepath.Rel(worktreesDir, worktreeGitFile)
 	if err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("compute gitdir rel path: %w", err)
+	}
+	if convertToBareStepHook != nil {
+		if hookErr := convertToBareStepHook("write-gitdir"); hookErr != nil {
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
+			return "", hookErr
+		}
 	}
 	if err := os.WriteFile(gitdirFile,
 		[]byte(relWorktreeGitFile+"\n"), 0o644); err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("write gitdir: %w", err)
 	}
 	// commondir must be a relative path from worktreesDir back to barePath.
@@ -425,20 +560,45 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	// this is always "../.." regardless of slashes in the branch name.
 	commondirRel, err := filepath.Rel(worktreesDir, barePath)
 	if err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("compute commondir rel path: %w", err)
+	}
+	if convertToBareStepHook != nil {
+		if hookErr := convertToBareStepHook("write-commondir"); hookErr != nil {
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
+			return "", hookErr
+		}
 	}
 	if err := os.WriteFile(filepath.Join(worktreesDir, "commondir"),
 		[]byte(commondirRel+"\n"), 0o644); err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("write commondir: %w", err)
+	}
+	if convertToBareStepHook != nil {
+		if hookErr := convertToBareStepHook("write-head"); hookErr != nil {
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
+			return "", hookErr
+		}
 	}
 	if err := os.WriteFile(filepath.Join(worktreesDir, "HEAD"),
 		[]byte("ref: refs/heads/"+defaultBranch+"\n"), 0o644); err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("write HEAD: %w", err)
-	}
-
-	// Remove backed-up .git.orig.
-	for _, candidate := range []string{origGit, filepath.Join(worktreePath, ".git.orig")} {
-		_ = os.RemoveAll(candidate)
 	}
 
 	// Prune stale entries.
@@ -450,12 +610,31 @@ func ConvertToBare(dir string, progress func(string)) (string, error) {
 	// Must use the worktree-specific gitdir (worktreesDir) so that read-tree
 	// writes to .bare/worktrees/<branch>/index, not the bare repo's own index.
 	progress("  populating index...")
+	if convertToBareStepHook != nil {
+		if hookErr := convertToBareStepHook("read-tree"); hookErr != nil {
+			rollback(worktreePath)
+			if rollbackErr != nil {
+				progress("  WARNING: " + rollbackErr.Error())
+			}
+			return "", hookErr
+		}
+	}
 	if out, err := exec.Command("git",
 		"--git-dir", worktreesDir,
 		"--work-tree", worktreePath,
 		"read-tree", "HEAD",
 	).CombinedOutput(); err != nil {
+		rollback(worktreePath)
+		if rollbackErr != nil {
+			progress("  WARNING: " + rollbackErr.Error())
+		}
 		return "", fmt.Errorf("read-tree: %w: %s", err, out)
+	}
+
+	// Remove backed-up .git.orig only after all steps have succeeded, so that
+	// rollback can restore it if read-tree (or a prior step) fails.
+	for _, candidate := range []string{origGit, filepath.Join(worktreePath, ".git.orig")} {
+		_ = os.RemoveAll(candidate)
 	}
 
 	progress("  done — worktree at " + worktreePath)

--- a/modules/programs/prism/prism/internal/git/git_test.go
+++ b/modules/programs/prism/prism/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -723,5 +724,138 @@ func TestCloneWorktree_NonEmptyRepo(t *testing.T) {
 		if strings.Contains(msg, "empty") || strings.Contains(msg, "orphan") {
 			t.Errorf("unexpected empty/orphan message for non-empty repo: %q", msg)
 		}
+	}
+}
+
+// assertPreConversionState verifies that dir looks exactly like a regular git
+// repo — .git is a directory, .git.orig is absent, .bare is absent, and none
+// of the original top-level entries have been moved away.
+func assertPreConversionState(t *testing.T, dir string, originalEntries []string) {
+	t.Helper()
+
+	// .git must be a directory.
+	gitInfo, err := os.Stat(filepath.Join(dir, ".git"))
+	if err != nil {
+		t.Errorf(".git missing after rollback: %v", err)
+	} else if !gitInfo.IsDir() {
+		t.Errorf(".git is not a directory after rollback (mode=%v)", gitInfo.Mode())
+	}
+
+	// .git.orig must be absent.
+	if _, err := os.Stat(filepath.Join(dir, ".git.orig")); err == nil {
+		t.Error(".git.orig still present after rollback")
+	}
+
+	// .bare must be absent.
+	if _, err := os.Stat(filepath.Join(dir, ".bare")); err == nil {
+		t.Error(".bare still present after rollback")
+	}
+
+	// Every original top-level entry must be back at the root.
+	for _, name := range originalEntries {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("original entry %q missing at root after rollback: %v", name, err)
+		}
+	}
+}
+
+
+// errInjected is the sentinel error returned by the step hook in tests.
+var errInjected = fmt.Errorf("injected test failure")
+
+// withStepHook sets convertToBareStepHook for the duration of f and restores
+// the previous value afterwards. Not safe for concurrent test use.
+func withStepHook(hook func(step string) error, f func()) {
+	prev := convertToBareStepHook
+	convertToBareStepHook = hook
+	defer func() { convertToBareStepHook = prev }()
+	f()
+}
+
+// TestConvertToBare_PostMoveRollback tests that a failure injected at each of
+// the six post-move-loop steps triggers a full rollback leaving the repo in its
+// pre-conversion state: .git is a directory, .git.orig and .bare are absent,
+// and all original top-level files are back at the root.
+func TestConvertToBare_PostMoveRollback(t *testing.T) {
+	steps := []string{
+		"mkdir-worktrees-dir",
+		"write-worktree-git",
+		"write-gitdir",
+		"write-commondir",
+		"write-head",
+		"read-tree",
+	}
+
+	for _, step := range steps {
+		step := step // capture
+		t.Run(step, func(t *testing.T) {
+			dir := t.TempDir()
+			remoteDir := t.TempDir()
+			initRepoWithRemote(t, dir, remoteDir, "main")
+
+			origEntries := []string{"README"}
+
+			var convErr error
+			withStepHook(func(s string) error {
+				if s == step {
+					return errInjected
+				}
+				return nil
+			}, func() {
+				_, convErr = ConvertToBare(dir, func(string) {})
+			})
+
+			if convErr == nil {
+				t.Fatalf("ConvertToBare should have failed at step %q but succeeded", step)
+			}
+
+			// Core assertion: on-disk state must match pre-conversion.
+			assertPreConversionState(t, dir, origEntries)
+		})
+	}
+}
+
+// TestConvertToBare_RollbackEnablesRerun verifies that after a failed
+// ConvertToBare (with full rollback), calling ConvertToBare again on the same
+// directory succeeds â i.e. rollback fully restores the pre-conversion state.
+func TestConvertToBare_RollbackEnablesRerun(t *testing.T) {
+	dir := t.TempDir()
+	remoteDir := t.TempDir()
+	initRepoWithRemote(t, dir, remoteDir, "main")
+
+	// Inject a failure at the write-worktree-git step (first step after the
+	// file-move loop). This is the earliest post-move failure site.
+	var firstErr error
+	withStepHook(func(s string) error {
+		if s == "write-worktree-git" {
+			return errInjected
+		}
+		return nil
+	}, func() {
+		_, firstErr = ConvertToBare(dir, func(string) {})
+	})
+
+	if firstErr == nil {
+		t.Fatal("first ConvertToBare should have failed but succeeded")
+	}
+
+	// Verify .git is a directory before re-run.
+	if info, err := os.Stat(filepath.Join(dir, ".git")); err != nil || !info.IsDir() {
+		t.Fatalf(".git not restored after first failure: err=%v", err)
+	}
+
+	// Re-run (no hook) must succeed.
+	worktreePathSecond, err := ConvertToBare(dir, func(string) {})
+	if err != nil {
+		t.Fatalf("second ConvertToBare after rollback failed: %v", err)
+	}
+	if worktreePathSecond == "" {
+		t.Fatal("second ConvertToBare returned empty worktree path")
+	}
+
+	// Verify git status is clean in the re-run worktree.
+	statusOut := runGitIn(t, worktreePathSecond, "status")
+	if !strings.Contains(statusOut, "nothing to commit") {
+		t.Errorf("git status after second ConvertToBare does not contain 'nothing to commit':\n%s", statusOut)
 	}
 }


### PR DESCRIPTION
## Summary

`ConvertToBare` converts a regular git repo to prism's bare+worktree layout in 6 steps. Before this fix, steps 4-6 (worktrees dir mkdir, four WriteFile calls, read-tree) returned errors without calling `rollback()`, leaving the user with a half-converted repo: `.bare/` present, files relocated under `<branch>/`, and no `.git` directory.

## Changes

**`internal/git/git.go`**
- Extended `rollback()` closure to accept a `worktreePath` argument and perform full cleanup: remove the .git gitfile pointer, move entries back from worktreePath to dir, `RemoveAll` .bare, restore .git.orig → .git
- Made `rollback()` idempotent — each step is conditional
- If rollback itself fails, emits a WARNING through the progress callback so the user gets clear recovery instructions (not silent partial state)
- Moved .git.orig cleanup to after read-tree (was before), ensuring rollback always has .git.orig to restore
- Added `convertToBareStepHook` — a package-level hook (nil in production) for deterministic fault injection in tests
- Added hook call sites at each of the six post-move error sites

**`internal/git/git_test.go`**
- Added `withStepHook` helper for test-safe hook installation
- Added `TestConvertToBare_PostMoveRollback`: 6 sub-tests covering each injection site, asserting full pre-conversion state
- Added `TestConvertToBare_RollbackEnablesRerun`: failed attempt then successful re-run on same directory
- Added `assertPreConversionState` helper

## Test results
`go test ./internal/git/ -race` — all pass
`nix build .#prism` — passes

Closes #1862