### PR TITLE
container: make skills and auth.json symlinks idempotent in StagePIAgentConfigDir

### DIFF
--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -353,7 +353,7 @@ func StagePIAgentConfigDir(slot config.RoleSlot, sessionName string) (hostDir, s
 	if home, err := os.UserHomeDir(); err == nil {
 		authTarget := filepath.Join(home, ".pi", "agent", "auth.json")
 		authLink := filepath.Join(stagingDir, "auth.json")
-		_ = os.Symlink(authTarget, authLink)
+		_ = symlinkIdempotent(authTarget, authLink)
 	}
 
 	// Copy settings.json and themes/ from ~/.pi/agent/ into the staging
@@ -386,15 +386,27 @@ func StagePIAgentConfigDir(slot config.RoleSlot, sessionName string) (hostDir, s
 			if resolved, evalErr := filepath.EvalSymlinks(skillsSrc); evalErr == nil {
 				resolvedTarget = resolved
 			}
-			// Non-fatal: ignore error if the symlink already exists or if the
-			// OS call fails for any other reason.
-			_ = os.Symlink(resolvedTarget, skillsLink)
+			// Non-fatal: remove any existing entry before creating the new
+			// symlink so that the target is always current (e.g. after a
+			// home-manager switch the resolved Nix-store path changes).
+			_ = symlinkIdempotent(resolvedTarget, skillsLink)
 		}
 		// When skillsSrc is absent (lstat failed), do nothing — no skills entry
 		// is created in the staging dir, and PI starts without skills.
 	}
 
 	return stagingDir, piAgentConfigSandboxDefault, nil
+}
+
+// symlinkIdempotent removes any existing filesystem entry at dst (file,
+// symlink, or empty directory) and then creates a symlink dst → src. Removing
+// before creating ensures the symlink target is always current — without this,
+// a pre-existing symlink at dst would cause os.Symlink to return EEXIST and
+// the target would never be updated (e.g. after a home-manager switch where
+// the resolved Nix-store path changes between calls).
+func symlinkIdempotent(src, dst string) error {
+	_ = os.Remove(dst) // ignore error — dst may not exist
+	return os.Symlink(src, dst)
 }
 
 // copyFileIfExists copies a single regular file from src to dst. It is a

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -1087,3 +1087,119 @@ func TestStagePIAgentConfigDir_SkillsDoesNotAffectOtherEntries(t *testing.T) {
 		t.Errorf("skills must be a symlink; mode = %v", skillsInfo.Mode())
 	}
 }
+
+// ── StagePIAgentConfigDir: idempotency (simulate home-manager switch) ─────────
+
+func TestStagePIAgentConfigDir_SkillsSymlink_UpdatesOnSecondCall(t *testing.T) {
+	// Simulate a home-manager switch: call StagePIAgentConfigDir twice for the
+	// same session with different resolved skills targets. After the second call
+	// the staging-dir skills symlink must point at the NEW target, not the old one.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi/agent: %v", err)
+	}
+
+	// First call: skills symlink points at oldTarget.
+	oldTarget := t.TempDir()
+	// Resolve through any OS-level symlinks (e.g. /tmp → /private/tmp on macOS)
+	// so that comparisons match what filepath.EvalSymlinks returns.
+	oldTargetResolved, err := filepath.EvalSymlinks(oldTarget)
+	if err != nil {
+		t.Fatalf("EvalSymlinks oldTarget: %v", err)
+	}
+	skillsSrc := filepath.Join(piAgentDir, "skills")
+	if err := os.Symlink(oldTarget, skillsSrc); err != nil {
+		t.Fatalf("symlink skills to oldTarget: %v", err)
+	}
+
+	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-update")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir (first call): %v", err)
+	}
+
+	skillsLink := filepath.Join(hostDir, "skills")
+	gotFirst, err := os.Readlink(skillsLink)
+	if err != nil {
+		t.Fatalf("readlink skills (first call): %v", err)
+	}
+	if gotFirst != oldTargetResolved {
+		t.Errorf("first call: skills target = %q, want %q", gotFirst, oldTargetResolved)
+	}
+
+	// Simulate a home-manager switch: repoint ~/.pi/agent/skills to newTarget.
+	newTarget := t.TempDir()
+	newTargetResolved, err := filepath.EvalSymlinks(newTarget)
+	if err != nil {
+		t.Fatalf("EvalSymlinks newTarget: %v", err)
+	}
+	if err := os.Remove(skillsSrc); err != nil {
+		t.Fatalf("remove skills symlink: %v", err)
+	}
+	if err := os.Symlink(newTarget, skillsSrc); err != nil {
+		t.Fatalf("symlink skills to newTarget: %v", err)
+	}
+
+	// Second call (same session, same staging dir).
+	_, _, err = StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-update")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir (second call): %v", err)
+	}
+
+	gotSecond, err := os.Readlink(skillsLink)
+	if err != nil {
+		t.Fatalf("readlink skills (second call): %v", err)
+	}
+	if gotSecond != newTargetResolved {
+		t.Errorf("second call: skills target = %q, want %q (symlink not updated after home-manager switch)", gotSecond, newTargetResolved)
+	}
+}
+
+func TestStagePIAgentConfigDir_AuthJSONSymlink_UpdatesOnSecondCall(t *testing.T) {
+	// auth.json target is fixed in practice, but the symlink creation must still
+	// be idempotent. Call StagePIAgentConfigDir twice and assert the symlink
+	// points at the correct target on both calls.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	piAgentDir := filepath.Join(fakeHome, ".pi", "agent")
+	if err := os.MkdirAll(piAgentDir, 0o700); err != nil {
+		t.Fatalf("mkdir ~/.pi/agent: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(piAgentDir, "auth.json"), []byte(`{"token":"v1"}`), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+
+	expectedTarget := filepath.Join(piAgentDir, "auth.json")
+
+	// First call.
+	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@auth-update")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir (first call): %v", err)
+	}
+	authLink := filepath.Join(hostDir, "auth.json")
+	got, readErr := os.Readlink(authLink)
+	if readErr != nil {
+		t.Fatalf("readlink auth.json (first call): %v", readErr)
+	}
+	if got != expectedTarget {
+		t.Errorf("first call: auth.json target = %q, want %q", got, expectedTarget)
+	}
+
+	// Second call: must not fail due to EEXIST and must leave symlink intact.
+	_, _, err = StagePIAgentConfigDir(config.RoleSlot{}, "test-session@auth-update")
+	if err != nil {
+		t.Fatalf("StagePIAgentConfigDir (second call): %v", err)
+	}
+	got2, readErr2 := os.Readlink(authLink)
+	if readErr2 != nil {
+		t.Fatalf("readlink auth.json (second call): %v", readErr2)
+	}
+	if got2 != expectedTarget {
+		t.Errorf("second call: auth.json target = %q, want %q", got2, expectedTarget)
+	}
+}


### PR DESCRIPTION
## Summary

`StagePIAgentConfigDir` was calling `os.Symlink` without first removing any existing entry at the destination — EEXIST was silently swallowed by `_ =`. For the `skills` symlink this meant that after a home-manager switch (where the resolved Nix-store path changes), the staging-dir symlink kept pointing at the old, possibly GC'd, store path. PI would lose its skills on every `nh switch`.

`sandbox_exec_home.go::makeSymlink` already handles this correctly with an `os.Remove` before `os.Symlink`. This PR mirrors that pattern via a new `symlinkIdempotent` helper.

## Changes

- **`pi_invocation.go`**: add `symlinkIdempotent(src, dst string) error` with a doc-comment explaining the remove-before-create semantics; replace both bare `os.Symlink` calls (auth.json and skills) with it.
- **`pi_invocation_test.go`**: add `TestStagePIAgentConfigDir_SkillsSymlink_UpdatesOnSecondCall` (calls twice with different skills targets, asserts symlink updates) and `TestStagePIAgentConfigDir_AuthJSONSymlink_UpdatesOnSecondCall` (same for auth.json).

## Quality gates

- `go build ./...` ✅
- `go test ./internal/container/ -race` — new tests pass; only pre-existing failures on main (macOS /tmp→/private/tmp, bwrap integration, sandbox-exec integration)
- `nix build .#prism` ✅

Closes #1878