### PR TITLE
container: fix prepareVolumeDirs off-by-one silent failure (#1876)

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -724,9 +724,14 @@ func (m *Manager) PrepareSandboxExec() ([]string, error) {
 // before buildRunArgs() is called — so that buildRunArgs() itself remains a
 // pure argument builder with no filesystem side-effects.
 //
-// Individual MkdirAll failures are logged and treated as non-fatal: if the
-// directory is still absent when podman runs, podman will produce the real
-// error. Returns a non-nil error only when multiple dirs fail.
+// Directories are classified as critical or optional:
+//   - Critical directories are unconditionally bound by the container runtime
+//     (bwrap --bind, podman --volume). A missing critical dir causes the
+//     runtime to abort at exec time with an unhelpful error, so we return an
+//     error immediately so the caller sees the real cause.
+//   - Optional directories are guarded by an os.Stat check in buildRunArgs
+//     and are skipped when absent. A failure to create them is logged but does
+//     not fail the call — the container still starts, just without that mount.
 //
 // perSessionState controls whether the per-session pi state directory
 // (~/.local/share/pi/prism-sessions/<name>/) is created. The podman path
@@ -738,41 +743,18 @@ func (m *Manager) prepareVolumeDirs(perSessionState bool) error {
 		home = os.Getenv("HOME")
 	}
 
-	var errs []string
+	// ── Critical directories ──────────────────────────────────────────────
+	// These are unconditionally bound by the container runtime. A single
+	// MkdirAll failure here is fatal — return immediately so the caller
+	// sees the real cause rather than a confusing runtime abort.
 
-	// Per-session pi state directory (podman only).
+	// Per-session pi state directory (podman only, critical because podman
+	// always binds it via --volume).
 	if perSessionState {
 		piSessionDir := filepath.Join(home, ".local", "share", "pi", "prism-sessions", m.name)
 		if err := os.MkdirAll(piSessionDir, 0o755); err != nil {
-			log.Printf("container: failed to create per-session pi state dir %q: %v", piSessionDir, err)
-			errs = append(errs, err.Error())
+			return fmt.Errorf("container: failed to create per-session pi state dir %q: %w", piSessionDir, err)
 		}
-	}
-
-	// Agent plugin/model cache.
-	piCacheDir := filepath.Join(home, ".cache", "pi")
-	if err := os.MkdirAll(piCacheDir, 0o755); err != nil {
-		log.Printf("container: failed to create pi cache dir %q: %v", piCacheDir, err)
-		errs = append(errs, err.Error())
-	}
-
-	// bun transpiler cache.
-	bunCacheDir := filepath.Join(home, ".cache", "bun")
-	if err := os.MkdirAll(bunCacheDir, 0o755); err != nil {
-		log.Printf("container: failed to create bun cache dir %q: %v", bunCacheDir, err)
-		errs = append(errs, err.Error())
-	}
-
-	// Clipboard staging directory: pre-create so that the bind-mount in
-	// buildRunArgs() is always active, even on the first paste. Without this,
-	// a first-ever paste on a fresh system would write the file host-side but
-	// the container would not see it (the bind-mount only fires when the dir
-	// exists at container spawn time). Creating it eagerly here ensures the
-	// directory always exists before buildRunArgs() runs its os.Stat check.
-	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
-	if err := os.MkdirAll(clipboardCacheDir, 0o755); err != nil {
-		log.Printf("container: failed to create clipboard staging dir %q: %v", clipboardCacheDir, err)
-		errs = append(errs, err.Error())
 	}
 
 	// Per-session host-API socket directory (both podman and bwrap, security fix #960).
@@ -789,14 +771,37 @@ func (m *Manager) prepareVolumeDirs(perSessionState bool) error {
 	if m.cfg.HostAPISockPath != "" {
 		sockDir := filepath.Dir(m.cfg.HostAPISockPath)
 		if err := os.MkdirAll(sockDir, 0o700); err != nil {
-			log.Printf("container: failed to create host-API socket dir %q: %v", sockDir, err)
-			errs = append(errs, err.Error())
+			return fmt.Errorf("container: failed to create host-API socket dir %q: %w", sockDir, err)
 		}
 	}
 
-	if len(errs) > 1 {
-		return fmt.Errorf("%d directories could not be created", len(errs))
+	// ── Optional directories ──────────────────────────────────────────────
+	// These are guarded by os.Stat in buildRunArgs and skipped when absent.
+	// Log failures but do not fail the call — the container still starts.
+
+	// Agent plugin/model cache.
+	piCacheDir := filepath.Join(home, ".cache", "pi")
+	if err := os.MkdirAll(piCacheDir, 0o755); err != nil {
+		log.Printf("container: failed to create pi cache dir %q (optional): %v", piCacheDir, err)
 	}
+
+	// bun transpiler cache.
+	bunCacheDir := filepath.Join(home, ".cache", "bun")
+	if err := os.MkdirAll(bunCacheDir, 0o755); err != nil {
+		log.Printf("container: failed to create bun cache dir %q (optional): %v", bunCacheDir, err)
+	}
+
+	// Clipboard staging directory: pre-create so that the bind-mount in
+	// buildRunArgs() is always active, even on the first paste. Without this,
+	// a first-ever paste on a fresh system would write the file host-side but
+	// the container would not see it (the bind-mount only fires when the dir
+	// exists at container spawn time). Creating it eagerly here ensures the
+	// directory always exists before buildRunArgs() runs its os.Stat check.
+	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
+	if err := os.MkdirAll(clipboardCacheDir, 0o755); err != nil {
+		log.Printf("container: failed to create clipboard staging dir %q (optional): %v", clipboardCacheDir, err)
+	}
+
 	return nil
 }
 

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -683,6 +683,110 @@ func TestPrepareVolumeDirs_SocketDirOmittedWhenNoSockPath(t *testing.T) {
 	}
 }
 
+// TestPrepareVolumeDirs_CriticalSockDirFailureReturnsError verifies that when
+// the host-API socket directory cannot be created (unwritable parent), the
+// call returns a non-nil error that names the specific directory.
+func TestPrepareVolumeDirs_CriticalSockDirFailureReturnsError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: cannot make an unwritable directory")
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Create an unwritable parent directory so that MkdirAll cannot create
+	// the subdirectory beneath it.
+	unwritable := filepath.Join(fakeHome, "unwritable")
+	if err := os.Mkdir(unwritable, 0o555); err != nil {
+		t.Fatalf("setup: mkdir %q: %v", unwritable, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unwritable, 0o755) })
+
+	sockPath := filepath.Join(unwritable, "session", "hostapi.sock")
+	m := New(Config{
+		SessionName:     "repo@feat",
+		AllocatedPort:   14000,
+		HostAPISockPath: sockPath,
+	})
+
+	err := m.prepareVolumeDirs(false)
+	if err == nil {
+		t.Fatal("prepareVolumeDirs: expected non-nil error for unwritable critical sock dir, got nil")
+	}
+	// The error should mention the directory path so callers can diagnose it.
+	wantSubstr := filepath.Join(unwritable, "session")
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Errorf("error %q does not mention the failing directory %q", err.Error(), wantSubstr)
+	}
+}
+
+// TestPrepareVolumeDirs_CriticalPerSessionDirFailureReturnsError verifies that
+// when the per-session pi state directory cannot be created (unwritable parent),
+// the call returns a non-nil error naming the specific directory.
+func TestPrepareVolumeDirs_CriticalPerSessionDirFailureReturnsError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: cannot make an unwritable directory")
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Make .local/share/pi unwritable so the per-session subdir cannot be created.
+	piBase := filepath.Join(fakeHome, ".local", "share", "pi")
+	if err := os.MkdirAll(piBase, 0o755); err != nil {
+		t.Fatalf("setup: MkdirAll %q: %v", piBase, err)
+	}
+	if err := os.Chmod(piBase, 0o555); err != nil {
+		t.Fatalf("setup: chmod %q: %v", piBase, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(piBase, 0o755) })
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+
+	err := m.prepareVolumeDirs(true) // perSessionState=true triggers the critical per-session dir
+	if err == nil {
+		t.Fatal("prepareVolumeDirs: expected non-nil error for unwritable critical per-session dir, got nil")
+	}
+	wantSubstr := filepath.Join(piBase, "prism-sessions")
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Errorf("error %q does not mention the failing directory %q", err.Error(), wantSubstr)
+	}
+}
+
+// TestPrepareVolumeDirs_OptionalCacheDirFailureDoesNotFail verifies that when
+// an optional cache directory cannot be created (unwritable parent), the call
+// succeeds — the container starts without that cache mount rather than aborting.
+func TestPrepareVolumeDirs_OptionalCacheDirFailureDoesNotFail(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root: cannot make an unwritable directory")
+	}
+
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Make .cache unwritable so all cache subdirs (pi, bun, clipboard) cannot
+	// be created — these are all optional.
+	cacheDir := filepath.Join(fakeHome, ".cache")
+	if err := os.Mkdir(cacheDir, 0o555); err != nil {
+		t.Fatalf("setup: mkdir %q: %v", cacheDir, err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cacheDir, 0o755) })
+
+	m := New(Config{
+		SessionName:   "repo@feat",
+		AllocatedPort: 14000,
+	})
+
+	// perSessionState=false: no critical sock path, no per-session dir. Only
+	// the optional cache dirs are attempted and all will fail — call must succeed.
+	if err := m.prepareVolumeDirs(false); err != nil {
+		t.Errorf("prepareVolumeDirs: optional cache dir failures should not fail the call, got: %v", err)
+	}
+}
+
 // ── auth.json overlay tests (AC-3) ───────────────────────────────────────────
 
 // TestBuildRunArgs_AuthJsonOverlayMountedWhenExists verifies that when

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"sync"
 	"time"
@@ -145,8 +144,10 @@ func (b *bwrapIsolator) Prepare(ctx context.Context, m *Manager) ([]string, erro
 	}
 
 	// Pre-create directories referenced as bind-mount sources.
+	// A non-nil error means a critical directory failed — return immediately
+	// so the caller sees the real cause rather than a confusing bwrap exec failure.
 	if err := m.prepareVolumeDirs(false); err != nil {
-		log.Printf("container: bwrap: prepareVolumeDirs partial failure: %v", err)
+		return nil, fmt.Errorf("container: bwrap: %w", err)
 	}
 
 	// Build the bwrap args. For PI sessions, BuildArgs stores any


### PR DESCRIPTION
## Problem

`prepareVolumeDirs` collected every `os.MkdirAll` failure into `errs` but only returned an error when `len(errs) > 1`. A single failure — the realistic case where the host-API socket dir cannot be created — was silently dropped. The bwrap path then continued into `BuildArgs`, which appended `--bind <sockDir> <sockDir>`, and bwrap aborted at exec time with a much less actionable error.

## Fix: Option 2 — Classify critical vs optional

**Critical directories** (unconditionally bound by the container runtime — a missing source causes the runtime to abort):
- Per-session host-API socket dir (`~/.local/state/prism/run/<session>/`)
- Per-session pi state dir (`~/.local/share/pi/prism-sessions/<session>/`, podman only)

These now `return fmt.Errorf(...)` immediately on `MkdirAll` failure. The caller sees the real cause, not a confusing bwrap exec error.

**Optional directories** (guarded by `os.Stat` in `buildRunArgs` and skipped when absent):
- `~/.cache/pi`
- `~/.cache/bun`
- `~/.cache/prism/clipboard`

These log failures with an `(optional)` suffix but do not fail the call. The container starts without that cache mount.

## Tests added

- `TestPrepareVolumeDirs_CriticalSockDirFailureReturnsError` — injects unwritable parent for the sock dir, asserts non-nil error naming the dir
- `TestPrepareVolumeDirs_CriticalPerSessionDirFailureReturnsError` — injects unwritable parent for the per-session pi dir, asserts non-nil error
- `TestPrepareVolumeDirs_OptionalCacheDirFailureDoesNotFail` — makes `.cache` unwritable, asserts call succeeds

All existing `TestPrepareVolumeDirs_*` tests continue to pass.

Closes #1876