### PR TITLE
session: cleanupHalfAliveSession writes sessions.ended_at on readiness timeout (#1881)

### DIFF
--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -659,7 +659,7 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			// releases the port and marks the row ended, and tmux.KillSession
 			// releases the pane. All three are best-effort and idempotent.
 			KillSidecar(opts.SessionName)
-			cleanupHalfAliveSession(d, opts.SessionName)
+			cleanupHalfAliveSession(d, opts.SessionName, opts.InstanceID)
 			_ = tmux.KillSession(opts.SessionName)
 			// Drop the per-session prompt file so a retry starts fresh.
 			removeInitialPrompt(opts.SessionName)
@@ -737,7 +737,12 @@ func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 // db.GroupCompleted treats the row as terminal — without that, a review
 // monitor watching the group would block indefinitely on the half-alive
 // member's "idle" state (#1051 AC-6).
-func cleanupHalfAliveSession(d *db.DB, sessionName string) {
+//
+// instanceID is the host-minted UUID pre-inserted into sessions by
+// SpawnSession (#1507). When non-empty, cleanupHalfAliveSession also writes
+// sessions.ended_at and sessions.end_state so the two tables stay in lock-step
+// (fixing the zombie-incarnation drift class described in #1881).
+func cleanupHalfAliveSession(d *db.DB, sessionName, instanceID string) {
 	st, lookupErr := d.CurrentStatus(sessionName)
 	if lookupErr == nil && st != nil {
 		// UpsertStatus is idempotent and validates the transition (idle →
@@ -749,6 +754,27 @@ func cleanupHalfAliveSession(d *db.DB, sessionName string) {
 	_ = d.ReleasePort(sessionName)
 	_ = d.SetEnded(sessionName)
 	_ = d.PurgeBusMessages(sessionName)
+
+	// Keep sessions in lock-step with agent_status: write ended_at and
+	// end_state to the sessions row so consumers that join on
+	// sessions.ended_at IS NULL do not see a zombie incarnation for every
+	// readiness-timeout (#1881).
+	//
+	// end_state "readiness-timeout" is chosen over the generic "error" to
+	// make the specific failure mode visible in audit queries and dashboards —
+	// a readiness-timeout is a distinct failure class (the agent process never
+	// reached the harness handshake) and deserves its own token.
+	//
+	// This is best-effort: if the UPDATE fails (e.g. the row was never
+	// inserted due to an earlier error, or the DB is temporarily locked),
+	// we log and continue — the other cleanup steps above have already run.
+	if instanceID != "" {
+		if updErr := d.UpdateSessionEnded(instanceID, "readiness-timeout"); updErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: cleanupHalfAliveSession: UpdateSessionEnded(%s): %v\n",
+				instanceID, updErr)
+		}
+	}
 }
 
 // spawnFullLayout delegates to Create, which handles the 3-window spawn-path

--- a/modules/programs/prism/prism/internal/session/spawn_readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_readiness_test.go
@@ -161,6 +161,76 @@ func TestSpawnSession_WritesStartupLog(t *testing.T) {
 	}
 }
 
+// TestSpawnSession_ReadinessTimeout_SetsSessionsRowEnded verifies the fix
+// for #1881: after cleanupHalfAliveSession runs on readiness-timeout,
+// the pre-inserted sessions row (which SpawnSession inserts host-side per
+// #1507) must have ended_at IS NOT NULL and end_state set to the documented
+// value "readiness-timeout".
+//
+// Prior to the fix, sessions.ended_at remained NULL even though
+// agent_status.ended_at was set, leaving a zombie incarnation row for every
+// readiness-timeout failure.
+func TestSpawnSession_ReadinessTimeout_SetsSessionsRowEnded(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~sessions-row-ended"
+	opts := SpawnOpts{
+		SessionName:      sessionName,
+		Repo:             "myrepo",
+		Worktree:         "/worktrees/myrepo-branch",
+		AgentRole:        "review-code",
+		Prompt:           "go",
+		Layout:           LayoutAgentOnly,
+		ReadinessTimeout: 100 * time.Millisecond, // short; no signal will arrive
+	}
+
+	if err := SpawnSession(d, opts); !IsReadinessTimeout(err) {
+		t.Fatalf("SpawnSession: got err=%v (IsReadinessTimeout=%v), want ReadinessTimeoutError",
+			err, IsReadinessTimeout(err))
+	}
+
+	// (a) agent_status.ended_at must be set.
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want row")
+	}
+	if st.EndedAt == nil {
+		t.Error("agent_status.ended_at IS NULL after readiness-timeout cleanup; want non-NULL")
+	}
+
+	// Retrieve the instance_id so we can look up the sessions row.
+	if st.InstanceID == nil || *st.InstanceID == "" {
+		t.Fatal("agent_status.instance_id is nil/empty; cannot verify sessions row")
+	}
+	instanceID := *st.InstanceID
+
+	// (b) sessions.ended_at must be set.
+	sess, err := d.SessionByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID(%s): %v", instanceID, err)
+	}
+	if sess == nil {
+		t.Fatalf("sessions row not found for instance_id %s", instanceID)
+	}
+	if sess.EndedAt == nil {
+		t.Error("sessions.ended_at IS NULL after readiness-timeout cleanup; want non-NULL (#1881)")
+	}
+
+	// (c) sessions.end_state must be non-nil and equal to the documented value.
+	const wantEndState = "readiness-timeout"
+	if sess.EndState == nil {
+		t.Errorf("sessions.end_state is nil, want %q (#1881)", wantEndState)
+	} else if *sess.EndState != wantEndState {
+		t.Errorf("sessions.end_state = %q, want %q (#1881)", *sess.EndState, wantEndState)
+	}
+}
+
 // TestSpawnSession_ReadinessTimeoutWritesFailureToStartupLog verifies that
 // when the readiness gate trips, the failure is recorded in the startup
 // log so the operator has a forensic trail.


### PR DESCRIPTION
## Summary

After PR #1507's FK-race fix, `SpawnSession` pre-inserts a `sessions` row keyed on the host-minted `instance_id`. When the readiness gate trips, `cleanupHalfAliveSession` called `SetEnded` (which sets `agent_status.ended_at`) but never called `UpdateSessionEnded`, leaving `sessions.ended_at` NULL forever — a zombie incarnation row for every readiness-timeout failure.

## Fix

- `cleanupHalfAliveSession` now accepts an `instanceID` parameter and calls `UpdateSessionEnded(instanceID, "readiness-timeout")` after the existing best-effort cleanup steps.
- `end_state` is `"readiness-timeout"` (not the generic `"error"`) so audit queries can distinguish this failure class. This choice is documented in a code comment.
- The `UpdateSessionEnded` call is best-effort: if it fails, a warning is logged and the function returns normally — port release, `agent_status` end, and bus purge have already completed.

## Test

New test `TestSpawnSession_ReadinessTimeout_SetsSessionsRowEnded` forces a 100ms readiness timeout (no sidecar to signal) and asserts:
- (a) `agent_status.ended_at IS NOT NULL`
- (b) `sessions.ended_at IS NOT NULL`
- (c) `sessions.end_state == "readiness-timeout"`

All existing `cleanupHalfAliveSession` tests pass with no behavioural change.

`go test ./internal/session/ -race` passes. `nix build .#prism` passes.

Closes #1881