### PR TITLE
sidecar: use goNotify in handleActivityTimeout to fix test-race class (#1842)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/inactivity_watchdog_test.go
@@ -11,6 +11,7 @@ package sidecar
 // returns true and the worker is freed.
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
 )
 
 // newReviewAgentSidecarWithActivityTimeout builds a Sidecar with
@@ -484,6 +486,104 @@ func TestToolProgressHeartbeat_GenuineStuckStillFires(t *testing.T) {
 
 	if got := waitForState(t, sc.cfg.DB, sc.cfg.SessionName, string(agent.StateError), 2*time.Second); got != string(agent.StateError) {
 		t.Fatalf("state after watchdog fire on heartbeat silence: got %q, want %q — rescue path regressed", got, agent.StateError)
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// ── #1842: goNotify registration ─────────────────────────────────────────────
+//
+// handleActivityTimeout previously spawned the parent-worker startup-failure
+// notification with a raw `go` instead of s.goNotify. The raw `go` bypassed
+// notifyWG, so tests had to sleep or poll to observe the notification — the
+// same race class that motivated goNotify in #1713/#1716.
+//
+// The fix wraps the call in s.goNotify so WaitNotifies() drains it
+// deterministically.
+
+// TestInactivityWatchdog_NotifyRegisteredWithWaitGroup verifies that when the
+// inactivity watchdog fires on a review-agent session, the parent-worker
+// startup-failure notification is tracked by notifyWG so WaitNotifies()
+// returns only after the delivery has completed — no sleeping or polling
+// required (#1842).
+func TestInactivityWatchdog_NotifyRegisteredWithWaitGroup(t *testing.T) {
+	// The parent worker session for "prism-test@worker-1842~review-1-review-goal"
+	// is "prism-test@worker-1842".
+	workerSession := "prism-test@worker-1842"
+	reviewSession := workerSession + "~review-1-review-goal"
+
+	// NewIsolated seeds the worker as an active session in the DB and starts
+	// an httptest.Server to capture delivered prompt bodies. It also sets
+	// XDG_STATE_HOME and PRISM_TEST_MODE_RESTRICT_HOSTAPI so no host-state
+	// is touched (#1608).
+	bus := sidecartest.NewIsolated(t, workerSession)
+
+	sockPath := shortSockPath(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           reviewSession,
+		Repo:                  "prism-test",
+		Worktree:              t.TempDir(),
+		DB:                    bus.DB,
+		Clock:                 clk,
+		AgentRole:             "review-goal",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		PipeReconnectTimeout:  200 * time.Millisecond,
+		ActivityTimeout:       30 * time.Second,
+		IsolationMode:         config.IsolationMode("host"),
+		Harness:               pih.New("", "", ""),
+	}
+	sc := New(cfg)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Drive to active so the watchdog timer is armed.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	if got := waitForState(t, bus.DB, sc.cfg.SessionName, string(agent.StateActive), 2*time.Second); got != string(agent.StateActive) {
+		t.Fatalf("state after turn_start: got %q, want %q", got, agent.StateActive)
+	}
+
+	// Wait for the watchdog timer that turn_start armed (#2 overall — #1 from
+	// the post-handshake touchActivity, #2 from turn_start's touchActivity).
+	timer := clk.WaitForTimerCount(2, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no activity watchdog timer registered after turn_start")
+	}
+
+	// Fire the watchdog — simulates ActivityTimeout of silence.
+	timer.Fire()
+
+	// Wait for the session to reach StateError (the DB write) before checking
+	// the notification, so we know handleActivityTimeout ran to completion.
+	if got := waitForState(t, bus.DB, sc.cfg.SessionName, string(agent.StateError), 2*time.Second); got != string(agent.StateError) {
+		t.Fatalf("state after watchdog fire: got %q, want %q", got, agent.StateError)
+	}
+
+	// WaitNotifies() blocks until every goroutine spawned via goNotify has
+	// returned — no sleep or poll required. If the notification was still
+	// spawned with a raw `go` this call would return immediately and the
+	// body assertion below would race.
+	sc.WaitNotifies()
+
+	// The parent worker must have received a notification containing the
+	// inactivity-timeout reason.
+	bodies := bus.CopyBodies()
+	if len(bodies) == 0 {
+		t.Fatal("no notification delivered to parent worker after inactivity watchdog fired")
+	}
+	found := false
+	for _, b := range bodies {
+		if strings.Contains(b, "inactivity timeout") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("notification body does not contain \"inactivity timeout\"; bodies: %v", bodies)
 	}
 
 	conn.Close()

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -111,7 +111,13 @@ func (s *Sidecar) handleActivityTimeout(timeout interface{}) {
 	// no-ops for non-review-agent session names, so workers and
 	// coordinators that opt into ActivityTimeout do not generate spurious
 	// parent notifications.
-	go s.notifyParentWorkerOnStartupFailure(fmt.Errorf("inactivity timeout: no inbound frame for %v", timeout))
+	//
+	// Use goNotify (not a raw `go`) so the goroutine is tracked by notifyWG
+	// and tests can drain in-flight notifications via WaitNotifies() without
+	// sleeping or polling (#1842).
+	s.goNotify(func() {
+		s.notifyParentWorkerOnStartupFailure(fmt.Errorf("inactivity timeout: no inbound frame for %v", timeout))
+	})
 }
 
 func (s *Sidecar) currentDBState() agent.AgentState {


### PR DESCRIPTION
## Summary

`handleActivityTimeout` in `internal/sidecar/state.go` was spawning the parent-worker startup-failure notification with a raw `go` instead of `s.goNotify`. This bypassed `notifyWG`, re-introducing the same test-race class that `goNotify` was added to fix in #1713/#1716: tests had to sleep or poll to observe the inactivity-watchdog notification.

## Changes

### `state.go`
Replace:
```go
go s.notifyParentWorkerOnStartupFailure(fmt.Errorf("inactivity timeout: no inbound frame for %v", timeout))
```
with:
```go
s.goNotify(func() {
    s.notifyParentWorkerOnStartupFailure(fmt.Errorf("inactivity timeout: no inbound frame for %v", timeout))
})
```

### `inactivity_watchdog_test.go`
Add `TestInactivityWatchdog_NotifyRegisteredWithWaitGroup`:
- Uses `sidecartest.NewIsolated` to seed a parent worker session with an httptest.Server capture point
- Drives the inactivity timeout via `testClock` (no wall-clock wait)
- Calls `sc.WaitNotifies()` deterministically — no `time.Sleep` or polling
- Asserts the notification body contains `"inactivity timeout"` and was delivered to the parent

## Acceptance Criteria

- [x] [functional] `state.go::handleActivityTimeout` no longer contains a raw `go s.notify*` call; the notification is spawned via `s.goNotify`.
- [x] [test] New test `TestInactivityWatchdog_NotifyRegisteredWithWaitGroup` drives the inactivity timeout and calls `s.WaitNotifies()` without sleeping or polling.
- [x] [regression] No existing test in `inactivity_watchdog_test.go` is weakened.
- [x] [test] `go test ./internal/sidecar/ -race` passes.
- [x] `nix build .#prism` passes.

Closes #1842