### PR TITLE
db: make MarkAllEnded and SetEnded also update sessions table atomically

### DIFF
--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -398,6 +398,219 @@ func TestSetEnded_LikeWildcardsInSessionName(t *testing.T) {
 	}
 }
 
+// insertActiveSession is a test helper that inserts an agent_status row and a
+// corresponding sessions row (with instance_id) for a session, simulating the
+// normal two-table lifecycle. Returns the instance_id that was written.
+func insertActiveSession(t *testing.T, d *db.DB, sessionName, repo, worktree string) string {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, repo, worktree, "active", nil, nil); err != nil {
+		t.Fatalf("insertActiveSession: UpsertStatus %q: %v", sessionName, err)
+	}
+	iid := uuid.New().String()
+	if err := d.SetInstanceID(sessionName, iid); err != nil {
+		t.Fatalf("insertActiveSession: SetInstanceID %q: %v", sessionName, err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    worktree,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("insertActiveSession: InsertSession %q: %v", sessionName, err)
+	}
+	return iid
+}
+
+// sessionsEndedAt queries sessions.ended_at for the given instance_id.
+// Returns nil when the row is not found or ended_at IS NULL.
+func sessionsEndedAt(t *testing.T, d *db.DB, instanceID string) *int64 {
+	t.Helper()
+	var v *int64
+	if err := d.QueryRow("SELECT ended_at FROM sessions WHERE instance_id = ?", instanceID).Scan(&v); err != nil {
+		t.Fatalf("sessionsEndedAt(%q): %v", instanceID, err)
+	}
+	return v
+}
+
+// sessionsEndState queries sessions.end_state for the given instance_id.
+// Returns "" when the row is not found or end_state IS NULL.
+func sessionsEndState(t *testing.T, d *db.DB, instanceID string) string {
+	t.Helper()
+	var v *string
+	if err := d.QueryRow("SELECT end_state FROM sessions WHERE instance_id = ?", instanceID).Scan(&v); err != nil {
+		t.Fatalf("sessionsEndState(%q): %v", instanceID, err)
+	}
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// TestSetEnded_AlsoUpdatesSessionsTable verifies that SetEnded writes ended_at
+// (non-NULL) and end_state = 'reset' to the corresponding sessions rows,
+// keeping both tables consistent after the call.
+func TestSetEnded_AlsoUpdatesSessionsTable(t *testing.T) {
+	d := openTestDB(t)
+
+	// Set up a parent session and a review child, both with sessions rows.
+	parent := "repo@feat"
+	parentIID := insertActiveSession(t, d, parent, "repo", "/wt/feat")
+
+	child := parent + "~review-1-review-goal"
+	childIID := insertActiveSession(t, d, child, "repo", "/wt/feat")
+
+	// Pre-condition: sessions.ended_at must be NULL for both.
+	if v := sessionsEndedAt(t, d, parentIID); v != nil {
+		t.Fatalf("pre-condition: parent sessions.ended_at is non-nil")
+	}
+	if v := sessionsEndedAt(t, d, childIID); v != nil {
+		t.Fatalf("pre-condition: child sessions.ended_at is non-nil")
+	}
+
+	if err := d.SetEnded(parent); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	// Both sessions rows must now have ended_at IS NOT NULL.
+	if v := sessionsEndedAt(t, d, parentIID); v == nil {
+		t.Error("parent: sessions.ended_at is nil after SetEnded")
+	}
+	if v := sessionsEndedAt(t, d, childIID); v == nil {
+		t.Error("child: sessions.ended_at is nil after SetEnded")
+	}
+
+	// end_state must be 'reset' on both rows.
+	if s := sessionsEndState(t, d, parentIID); s != "reset" {
+		t.Errorf("parent: sessions.end_state = %q, want \"reset\"", s)
+	}
+	if s := sessionsEndState(t, d, childIID); s != "reset" {
+		t.Errorf("child: sessions.end_state = %q, want \"reset\"", s)
+	}
+
+	// agent_status.ended_at must also be non-nil (existing behaviour preserved).
+	for _, name := range []string{parent, child} {
+		st, err := d.CurrentStatus(name)
+		if err != nil || st == nil {
+			t.Fatalf("CurrentStatus %q: %v", name, err)
+		}
+		if st.EndedAt == nil {
+			t.Errorf("%q: agent_status.ended_at is nil after SetEnded", name)
+		}
+	}
+}
+
+// TestMarkAllEnded_AlsoUpdatesSessionsTable verifies that MarkAllEnded writes
+// ended_at (non-NULL) and end_state = 'reset' to every sessions row that
+// corresponds to a previously-active agent_status row.
+func TestMarkAllEnded_AlsoUpdatesSessionsTable(t *testing.T) {
+	d := openTestDB(t)
+
+	// Insert two active sessions, each with a sessions row.
+	iid1 := insertActiveSession(t, d, "repo@s1", "repo", "/wt/s1")
+	iid2 := insertActiveSession(t, d, "repo@s2", "repo", "/wt/s2")
+
+	// Insert a third session that is already ended (must not be re-touched).
+	iid3 := insertActiveSession(t, d, "repo@s3", "repo", "/wt/s3")
+	if err := d.SetEnded("repo@s3"); err != nil {
+		t.Fatalf("pre-condition SetEnded repo@s3: %v", err)
+	}
+
+	// Pre-condition: sessions.ended_at must be NULL for the active two.
+	for _, iid := range []string{iid1, iid2} {
+		if v := sessionsEndedAt(t, d, iid); v != nil {
+			t.Fatalf("pre-condition: instance %q sessions.ended_at is non-nil", iid)
+		}
+	}
+
+	n, err := d.MarkAllEnded()
+	if err != nil {
+		t.Fatalf("MarkAllEnded: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("MarkAllEnded returned n=%d, want 2", n)
+	}
+
+	// Both active sessions' rows in sessions must now be ended.
+	for _, iid := range []string{iid1, iid2} {
+		if v := sessionsEndedAt(t, d, iid); v == nil {
+			t.Errorf("instance %q: sessions.ended_at is nil after MarkAllEnded", iid)
+		}
+		if s := sessionsEndState(t, d, iid); s != "reset" {
+			t.Errorf("instance %q: sessions.end_state = %q, want \"reset\"", iid, s)
+		}
+	}
+
+	// The already-ended session's sessions row must not have been re-touched.
+	// (Its ended_at and end_state were set by the earlier SetEnded call.)
+	if v := sessionsEndedAt(t, d, iid3); v == nil {
+		t.Errorf("already-ended instance %q: sessions.ended_at became nil", iid3)
+	}
+}
+
+// TestMarkAllEnded_Atomic_RollsBackOnSessionsFailure verifies that if the
+// sessions UPDATE inside MarkAllEnded fails, the agent_status UPDATE is also
+// rolled back — neither table is partially updated.
+//
+// Failure is injected by installing a BEFORE UPDATE trigger on the sessions
+// table that raises an error, then verifying that agent_status rows still have
+// ended_at IS NULL after the (expected) error return.
+func TestMarkAllEnded_Atomic_RollsBackOnSessionsFailure(t *testing.T) {
+	d := openTestDB(t)
+
+	// Insert an active session with a sessions row.
+	_ = insertActiveSession(t, d, "repo@main", "repo", "/wt/main")
+
+	// Pre-condition: agent_status.ended_at IS NULL.
+	st, err := d.CurrentStatus("repo@main")
+	if err != nil || st == nil {
+		t.Fatalf("CurrentStatus before trigger: %v", err)
+	}
+	if st.EndedAt != nil {
+		t.Fatal("pre-condition: ended_at is non-nil")
+	}
+
+	// Install a BEFORE UPDATE trigger on sessions that always raises an error.
+	// This forces the sessions UPDATE inside MarkAllEnded to fail, which should
+	// cause the whole transaction to roll back.
+	rawConn, err := sql.Open("sqlite", d.Path())
+	if err != nil {
+		t.Fatalf("raw open for trigger install: %v", err)
+	}
+	t.Cleanup(func() { rawConn.Close() })
+
+	_, err = rawConn.Exec(`
+		CREATE TRIGGER force_sessions_update_error
+		BEFORE UPDATE ON sessions
+		BEGIN
+			SELECT RAISE(ABORT, 'injected sessions update failure');
+		END`)
+	if err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	// MarkAllEnded must return an error because the trigger aborts the sessions UPDATE.
+	_, markErr := d.MarkAllEnded()
+	if markErr == nil {
+		t.Fatal("MarkAllEnded: expected error due to trigger, got nil")
+	}
+
+	// Drop the trigger so subsequent reads are not affected.
+	if _, err := rawConn.Exec("DROP TRIGGER force_sessions_update_error"); err != nil {
+		t.Fatalf("drop trigger: %v", err)
+	}
+
+	// The transaction must have been rolled back: agent_status.ended_at must
+	// still be NULL (the agent_status UPDATE was also undone).
+	st2, err := d.CurrentStatus("repo@main")
+	if err != nil || st2 == nil {
+		t.Fatalf("CurrentStatus after rollback: %v", err)
+	}
+	if st2.EndedAt != nil {
+		t.Error("agent_status.ended_at is non-nil after expected rollback — atomicity broken")
+	}
+}
+
 // TestAllActiveStatus_ExcludesEnded verifies that ended sessions are not returned.
 func TestAllActiveStatus_ExcludesEnded(t *testing.T) {
 	d := openTestDB(t)

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -309,7 +309,18 @@ WHERE session_name = ?
 // It also cascades the ended_at to any child review-agent rows whose
 // session_name matches the pattern "<sessionName>~review-%", setting
 // ended_at only on rows where it is not already set (idempotent).
-// Both the parent and child updates are performed in a single transaction.
+//
+// Both tables are updated atomically in a single transaction:
+//   - agent_status: ended_at = now for the matched rows
+//   - sessions: ended_at = now, end_state = 'reset' for the corresponding
+//     instance_id rows
+//
+// end_state is set to 'reset' rather than a lifecycle-derived value because
+// SetEnded is called in contexts where the caller does not yet have a final
+// state to report (e.g. prism cleanup, review teardown). The sessions row
+// may subsequently be overwritten by UpdateSessionEnded with a more precise
+// end_state (e.g. 'finished') — that call is idempotent with respect to
+// ended_at and simply refines end_state.
 //
 // The session name is escaped for SQL LIKE wildcards before being used as a
 // pattern prefix (using the same escaping as AllStatusesWithPrefix) so that
@@ -325,13 +336,32 @@ func (d *DB) SetEnded(sessionName string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	const q = `
+	const agentStatusQ = `
 UPDATE agent_status
 SET    ended_at = ?
 WHERE  (session_name = ? OR session_name LIKE ? || '~review-%' ESCAPE '\')
   AND  ended_at IS NULL`
-	if _, err := tx.Exec(q, now, sessionName, escaped); err != nil {
-		return fmt.Errorf("db: set ended: %w", err)
+	if _, err := tx.Exec(agentStatusQ, now, sessionName, escaped); err != nil {
+		return fmt.Errorf("db: set ended: agent_status update: %w", err)
+	}
+
+	// Also update the sessions table for the corresponding instance_id rows.
+	// end_state 'reset' is used because SetEnded is called before the caller
+	// knows the final lifecycle outcome; UpdateSessionEnded may overwrite with
+	// a more specific end_state (e.g. 'finished') in the same cleanup pass.
+	const sessionsQ = `
+UPDATE sessions
+SET    ended_at  = ?,
+       end_state = 'reset'
+WHERE  instance_id IN (
+         SELECT instance_id
+         FROM   agent_status
+         WHERE  (session_name = ? OR session_name LIKE ? || '~review-%' ESCAPE '\')
+           AND  instance_id IS NOT NULL
+       )
+  AND  ended_at IS NULL`
+	if _, err := tx.Exec(sessionsQ, now, sessionName, escaped); err != nil {
+		return fmt.Errorf("db: set ended: sessions update: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -346,23 +376,64 @@ WHERE  (session_name = ? OR session_name LIKE ? || '~review-%' ESCAPE '\')
 // throughout the codebase; state captures the last known agent state before teardown
 // and is not overwritten here.
 //
+// Both tables are updated atomically in a single transaction:
+//   - agent_status: ended_at = now for all rows where ended_at IS NULL
+//   - sessions: ended_at = now, end_state = 'reset' for the corresponding
+//     instance_id rows (matched via the instance_id column in agent_status)
+//
+// end_state is set to 'reset' because MarkAllEnded is called by `prism reset`,
+// which forcibly terminates all live sessions regardless of their lifecycle
+// state. 'reset' is more precise than 'interrupted' (which implies a pane
+// crash) and more honest than 'finished' (which implies a clean exit).
+//
 // It is used by `prism reset` to atomically close all live sessions in one
 // query rather than iterating over them individually.
 //
-// Returns the number of rows updated and any database error.
+// Returns the number of agent_status rows updated and any database error.
 // When there are no rows with ended_at IS NULL, returns (0, nil) — not an error.
 func (d *DB) MarkAllEnded() (int64, error) {
 	now := time.Now().UnixMilli()
-	res, err := d.conn.Exec(
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("db: mark all ended: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	res, err := tx.Exec(
 		"UPDATE agent_status SET ended_at = ? WHERE ended_at IS NULL",
 		now,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("db: mark all ended: %w", err)
+		return 0, fmt.Errorf("db: mark all ended: agent_status update: %w", err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
 		return 0, fmt.Errorf("db: mark all ended: rows affected: %w", err)
+	}
+
+	// Also update the sessions table for all instance_ids whose agent_status
+	// rows were just ended. end_state 'reset' is used because MarkAllEnded is
+	// invoked exclusively by `prism reset`, which forcibly terminates all live
+	// sessions — 'reset' accurately describes the cause of termination.
+	_, err = tx.Exec(`
+UPDATE sessions
+SET    ended_at  = ?,
+       end_state = 'reset'
+WHERE  instance_id IN (
+         SELECT instance_id
+         FROM   agent_status
+         WHERE  instance_id IS NOT NULL
+           AND  ended_at    = ?
+       )
+  AND  ended_at IS NULL`,
+		now, now,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("db: mark all ended: sessions update: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("db: mark all ended: commit: %w", err)
 	}
 	return n, nil
 }


### PR DESCRIPTION
## Summary

`MarkAllEnded` (called by `prism reset`) and `SetEnded` (called for single-session ends) only updated `agent_status.ended_at`. After a reset, `sessions.ended_at` stayed `NULL` indefinitely, causing table drift between the two lifecycle tables.

## Changes

**`status.go`**

- `SetEnded`: Added a second UPDATE inside the existing transaction that sets `sessions.ended_at = now` and `sessions.end_state = 'reset'` for all matched rows (matched via `instance_id`). If the `sessions` UPDATE fails, the whole transaction rolls back.
- `MarkAllEnded`: Converted from a bare `Exec` to a transaction. Added the same `sessions` UPDATE after the `agent_status` UPDATE. Returns the `agent_status` row count as before.

**`end_state` choice: `'reset'`**

- `MarkAllEnded` → `prism reset` forcibly terminates sessions regardless of state; `'reset'` names the cause precisely.
- `SetEnded` → called before the caller has a final outcome; `UpdateSessionEnded` may subsequently overwrite with `'finished'` etc. in the same cleanup pass. `'reset'` is a safe interim value.

**`db_test.go`**

Three new tests added:
- `TestSetEnded_AlsoUpdatesSessionsTable` — calls `SetEnded` on a parent with a review child; asserts `sessions.ended_at IS NOT NULL` and `end_state = 'reset'` for both.
- `TestMarkAllEnded_AlsoUpdatesSessionsTable` — inserts two active and one already-ended session; calls `MarkAllEnded`; asserts the two active sessions rows are updated and the already-ended row is not re-touched.
- `TestMarkAllEnded_Atomic_RollsBackOnSessionsFailure` — installs a BEFORE UPDATE trigger that forces the `sessions` UPDATE to fail; asserts `MarkAllEnded` returns an error and `agent_status.ended_at` is still NULL (atomicity).

A shared test helper `insertActiveSession` sets up both an `agent_status` row and a matching `sessions` row with an `instance_id` for session-pair testing.

## Test results

```
go test ./internal/db/ -race  →  ok (36s)
nix build .#prism             →  ok
```

Closes #1870