### PR TITLE
pi: restore global ~/.pi/agent/AGENTS.md (lost in opencode removal #1609)

### DIFF
--- a/modules/programs/prism/agents/global-instructions.md
+++ b/modules/programs/prism/agents/global-instructions.md
@@ -1,0 +1,76 @@
+# Global Agent Instructions
+
+## Skills
+
+When working in environments with domain-specific skills available (via the `skill` tool), err on the side of loading them. If a conversation touches a domain that has a skill, load it – even if you think you know the conventions from other context sources.
+Skills exist to prevent context drift and ensure consistency, not just for when you're uncertain. Loading a skill is cheap; missing domain-specific conventions or creating inconsistency is expensive.
+
+## Web Fetching
+
+When the webfetch tool fails with a 403 Forbidden error or similar access restrictions, use playwright-cli via the Bash tool to fetch the content with a real browser instead.
+There is a skill for playwright-cli, activate it if you need it.
+
+After using playwright-cli, delete the .playwright-cli/ directory as soon as the results are no longer needed – don't wait until the end of the session.
+
+## Pull Request Reviews
+
+`prism review <pr>` is **async** — it spawns 5 review agents in a group and
+returns immediately with a "review in progress" acknowledgement.
+Results are delivered to you via a follow-up `prism prompt` when all agents complete.
+**Do NOT block waiting for review results.** You are free to do other work
+(answer clarifications, etc.), but do NOT commit further changes, merge, or
+announce completion until the review-complete prompt arrives.
+The review-complete prompt includes a one-line summary header followed by a
+`## Per-agent findings` section with structured fields: verdict, extracted
+`<summary>` content, and extracted `<blocking_issues>` content. No file is
+written to `/tmp` — use `prism checkin <session>~review-<N>-<agent>` to read
+the full agent reasoning if needed.
+On FAIL: fix all blocking issues, commit, push, and re-run. Non-blocking
+observations on a failed round MAY be actioned alongside the fix.
+On PASS: non-blocking observations MAY be actioned if they align with repo
+conventions or add defence-in-depth at low cost. You are NOT required to
+action them — shipping the PR is not gated on non-blocking observations.
+If no review-complete prompt arrives within 30 minutes, investigate with
+`prism checkin <session>~review-<N>-review-goal`.
+After 3 full review cycles without convergence, stop and escalate to the
+coordinator via `prism escalate` — do not run a 4th cycle.
+
+## Search Scope
+
+When asked to find something without an explicit scope, ALWAYS search within the working directory only. NEVER traverse to parent directories unless the user explicitly instructs you to. If you cannot find something in the working directory, say so — do not expand the search scope on your own.
+
+## Local Environment Instructions
+
+Avoid excessive use of `cd` commands at the start of your commands, if you are already in the right working directory, there is no need to `cd` into it before your command.
+
+Use podman, not docker. Before use on Darwin, always run `podman machine start`.
+
+## Te Reo Māori Integration
+
+Ben is based in Aotearoa New Zealand and is actively building Te Reo Māori into his everyday vocabulary. Model this naturally – not performatively – by using the following words in place of their English equivalents where they fit without friction.
+
+### Core substitutions
+
+| Use this | Instead of |
+|---|---|
+| Kia ora | Hello / Hi |
+| Tēnā koe | Formal greeting |
+| Ka pai | Good / Great / Well done |
+| Āe | Yes |
+| Kāo | No |
+| Ngā mihi | Thanks / Cheers |
+
+### Normalised vocabulary
+
+Use these inline without translation – treat them as shared vocabulary:
+
+- mahi – work, tasks, activity ("the mahi here is…")
+- kōrero – talk, discussion, conversation
+- whakaaro – thought, idea, intention
+
+### Guidelines
+
+- One or two per response is plenty. Don't pepper sentences.
+- Don't translate inline unless context genuinely demands it.
+- If Ben uses Te Reo in a prompt, mirror it back. If he doesn't, still lead occasionally.
+- Never use Te Reo as decoration or performance – only where it fits naturally.

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -244,6 +244,7 @@
         home.file.".pi/agent/settings.json".text = builtins.toJSON piSettings;
         home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
         home.file.".pi/agent/coordinator-system-prompt.md".text = coordinatorSystemPrompt;
+        home.file.".pi/agent/AGENTS.md".text = builtins.readFile ./agents/global-instructions.md;
         # Custom theme derived from config.theme, deployed so pi picks it up
         # from ~/.pi/agent/themes/ at runtime. The theme name matches
         # config.theme.name and all colour values come from the system palette.


### PR DESCRIPTION
## Summary

Restores the global agent instructions block that was deleted with `opencode.nix` in commit `98ad3b79` (#1609). Pi natively supports `~/.pi/agent/AGENTS.md` as a global context file (loaded at startup for every project), so this is the direct replacement for the opencode `context = agentInstructions` mechanism.

Closes #1915

## Changes

- **`modules/programs/prism/agents/global-instructions.md`** — new file containing the lifted-and-refreshed global instructions
- **`modules/programs/prism/pi.nix`** — adds `home.file.".pi/agent/AGENTS.md".text = builtins.readFile ./agents/global-instructions.md;` alongside the existing system-prompt entries

The separate-file approach (`builtins.readFile`) was chosen over an inline heredoc to keep `pi.nix` uncluttered and make the markdown content easier to read and maintain in isolation.

## Section-by-section summary

| Section | Status | Notes |
|---|---|---|
| Skills | **Lifted verbatim** | No harness dependency |
| Web Fetching | **Lifted verbatim** | No harness dependency |
| Pull Request Reviews | **Refreshed** | See below |
| Search Scope | **Lifted verbatim** | No harness dependency |
| Local Environment Instructions | **Lifted verbatim** | Darwin `podman machine start` note kept (was templated via `lib.optionalString` in Nix; inlined as a flat instruction since the global file doesn't have access to Nix conditionals) |
| Te Reo Māori Integration | **Lifted verbatim** | Personal preference, harness-agnostic |

### Pull Request Reviews — what changed

The original text included two opencode-era artefacts that were removed:

1. **Subagent fallback invocations** — the original had a line instructing invocation of `@review-goal-subagent`, `@review-code-subagent`, etc. as parallel Task calls. These were opencode-era agent names. In the pi era the fallback is replaced by: the worker agent instructions (in `agents/worker.md`) already describe the full async `prism review` contract. The global instructions now only need to cover the high-level contract.
2. **Coordinator-only clause** — the original included a note about coordinators using `prism pr <number>`. That is coordinator-specific and belongs in `agents/coordinator.md` (where it already lives), not in the global file.

Everything else in the PR Reviews section — async behaviour, FAIL/PASS handling, 3-cycle limit, escalation via `prism escalate` — is preserved and matches the current `agents/worker.md` contracts.

## Smoke test

After `nh switch`, verify:

```
cat ~/.pi/agent/AGENTS.md | head -1
# Global Agent Instructions
```

The file contents are the rendered output of `modules/programs/prism/agents/global-instructions.md` — pasted inline below as a fallback:

```markdown
# Global Agent Instructions

## Skills
When working in environments with domain-specific skills available (via the `skill` tool), err on the side of loading them...
## Web Fetching
...
## Pull Request Reviews
`prism review <pr>` is **async** — it spawns 5 review agents in a group...
## Search Scope
...
## Local Environment Instructions
...
## Te Reo Māori Integration
...
```

(Full content in `modules/programs/prism/agents/global-instructions.md`.)

## Quality gate

`nix flake check` passes (all checks passed, both `nixosConfigurations` evaluated without error).