### PR TITLE
session: fix concurrent same-name spawn (F2) and layout-failure cleanup (F5)

### DIFF
--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,6 +35,35 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
+
+// spawnMu serialises concurrent SpawnSession calls for the same session name.
+//
+// Implementation choice: in-process advisory lock (sync.Map[string]*sync.Mutex).
+// This handles the realistic case where all SpawnSession callers (spawn, review
+// fan-out) share one process. It does NOT protect against two separate prism
+// binaries racing on the same session name — that is a cross-process race that
+// would require a DB-side conditional UPDATE (option 2 from issue #1880). For
+// the current usage pattern (all callers in one coordinator process) in-process
+// serialisation is sufficient and is the simpler implementation.
+//
+// Scope: the entire SpawnSession prologue (seed → group_id → instance_id →
+// InsertSession → AllocatePort) is protected by the lock for a given session
+// name. Releasing the lock after AllocatePort (but before the layout spawner
+// runs) is safe: once instance_id and the sessions row are written and the port
+// is allocated, the DB state is consistent and idempotent operations from
+// concurrent callers (UpsertStatusSeedRootAgentName, InsertSession via INSERT OR
+// IGNORE) become no-ops.
+var spawnMu sync.Map // key: sessionName, value: *sync.Mutex
+
+// spawnLock returns the per-session-name mutex, creating it if necessary, and
+// locks it. The caller must call the returned unlock function when the critical
+// section is complete.
+func spawnLock(sessionName string) (unlock func()) {
+	v, _ := spawnMu.LoadOrStore(sessionName, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
 
 // SpawnOpts describes a single session to create end-to-end.
 // All fields are available regardless of agent type — SpawnSession does not
@@ -448,6 +478,38 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	}
 	opts.PromptFilePath = promptFilePath
 
+	// F2 (#1880): Serialise concurrent SpawnSession calls for the same session
+	// name. Without this guard, two concurrent callers both execute the
+	// non-atomic prologue (seed → instance_id → InsertSession → AllocatePort)
+	// in parallel: SetInstanceID is an unconditional UPDATE so the last writer
+	// wins; both InsertSession calls succeed (different PKs) leaving one orphan;
+	// AllocatePort may pick the same port. The lock ensures only one caller runs
+	// the prologue at a time.
+	//
+	// After acquiring the lock, we check whether the session is already alive
+	// (agent_status row exists with a non-nil instance_id and ended_at IS NULL).
+	// If it is, the second (and later) concurrent callers return an error
+	// immediately without touching the DB — preserving the winning caller's
+	// state. This is the minimal correct behaviour: the second caller was
+	// redundant (the session already exists) and failing fast is safer than
+	// letting it overwrite the winning caller's instance_id.
+	//
+	// In-process only: cross-process races (two prism binaries spawning the
+	// same session name) are not protected here.
+	unlockSpawn := spawnLock(opts.SessionName)
+	defer unlockSpawn()
+
+	// Post-lock: check for a live session so late arrivals fail fast without
+	// corrupting the winner's DB state.
+	if existing, checkErr := d.CurrentStatus(opts.SessionName); checkErr == nil && existing != nil {
+		if existing.InstanceID != nil && *existing.InstanceID != "" && existing.EndedAt == nil {
+			startup.log("spawn-session: session already alive (instance_id=%s) — concurrent duplicate rejected",
+				*existing.InstanceID)
+			return fmt.Errorf("spawn session: %q is already alive (instance_id=%s) — concurrent spawn rejected",
+				opts.SessionName, *existing.InstanceID)
+		}
+	}
+
 	// Step 1: Seed agent_status with root_agent_name. Idempotent; later
 	// writes by the sidecar and by tmux-session-start COALESCE-preserve the
 	// value written here.
@@ -592,9 +654,28 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	}
 	if layoutErr != nil {
 		startup.log("spawn-session: layout setup FAILED: %v", layoutErr)
-		// Wrap the error with a cleanup hint. The DB row, worktree, and any
-		// sidecar process may have been created before the tmux step failed;
-		// tell the operator how to clean up side effects.
+		// F5 (#1880): Auto-clean on layout failure to match the readiness-timeout
+		// path. Both failure modes leave the same residue (pre-inserted sessions
+		// row, allocated port, prompt file, possibly a partial sidecar process);
+		// cleaning here removes operator toil and prevents stale DB rows from
+		// blocking a retry with the same session name.
+		//
+		// Cleanup primitive set (same as readiness-timeout path above):
+		//   - KillSidecar:              stops any sidecar that was started before
+		//                               the tmux step failed (spawnAgentOnlyLayout
+		//                               starts the sidecar first).
+		//   - cleanupHalfAliveSession:  marks agent_status ended, releases the
+		//                               port, purges bus messages, and writes
+		//                               sessions.ended_at (#1881).
+		//   - tmux.KillSession:         removes any partial tmux session created
+		//                               before the failure (e.g. NewSessionDetached
+		//                               succeeded but NewWindow failed).
+		//   - removeInitialPrompt:      drops the per-session prompt file so a
+		//                               retry with the same name starts fresh.
+		KillSidecar(opts.SessionName)
+		cleanupHalfAliveSession(d, opts.SessionName, opts.InstanceID)
+		_ = tmux.KillSession(opts.SessionName)
+		removeInitialPrompt(opts.SessionName)
 		return fmt.Errorf("%w — to remove side effects run: prism cleanup --yes --session %s",
 			layoutErr, opts.SessionName)
 	}

--- a/modules/programs/prism/prism/internal/session/spawn_layout_failure_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_layout_failure_test.go
@@ -1,0 +1,87 @@
+package session
+
+// Tests for F5 (#1880): when spawnFullLayout or spawnAgentOnlyLayout returns
+// an error, SpawnSession must run the same cleanup primitives as the
+// readiness-timeout path rather than returning a hint string and leaving
+// residue in the DB.
+//
+// Before the fix the layout-failure path returned:
+//   fmt.Errorf("%w — to remove side effects run: prism cleanup ...", layoutErr)
+// without calling KillSidecar / cleanupHalfAliveSession / tmux.KillSession /
+// removeInitialPrompt. The readiness-timeout path (which can fire for the same
+// partially-spawned session) DID auto-clean. The asymmetry left DB residue
+// (active agent_status row, allocated port) on every layout failure.
+//
+// The fix calls the same four cleanup primitives before returning the error,
+// leaving the DB in the same clean state as a readiness-timeout failure.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSpawnSession_LayoutFailure_CleanesUpDB verifies that when the tmux
+// step fails (forced by failTmuxBin), SpawnSession auto-cleans the DB so
+// no residue is left for a retry:
+//
+//   - no agent_status row with ended_at IS NULL (or no row at all).
+//   - no sessions row with ended_at IS NULL.
+//   - port released (harness_port IS NULL).
+func TestSpawnSession_LayoutFailure_CleansUpDB(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	// Force the tmux step to fail — spawnAgentOnlyLayout calls
+	// tmux.NewSessionDetached which will exit non-zero.
+	failTmuxBin(t, "duplicate session (injected by test)")
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch~layout-fail-cleanup"
+	opts := SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      "/worktrees/myrepo-branch",
+		AgentRole:     "review-code",
+		Prompt:        "review this PR",
+		Layout:        LayoutAgentOnly,
+		IsolationMode: "host",
+		HarnessName:   "pi",
+	}
+
+	err := SpawnSession(d, opts)
+	if err == nil {
+		t.Fatal("SpawnSession with failing tmux: got nil error, want error")
+	}
+	// The error must still contain the operator hint for diagnosability.
+	if !strings.Contains(err.Error(), "prism cleanup") {
+		t.Errorf("error %q does not contain 'prism cleanup' hint", err.Error())
+	}
+
+	// DB cleanup check (a): agent_status must be ended (ended_at IS NOT NULL)
+	// or absent entirely.
+	st, statusErr := d.CurrentStatus(sessionName)
+	if statusErr != nil {
+		t.Fatalf("CurrentStatus: %v", statusErr)
+	}
+	if st != nil && st.EndedAt == nil {
+		t.Errorf("agent_status row %q is still alive (ended_at IS NULL) after layout-failure cleanup — F5 cleanup did not run (#1880)", sessionName)
+	}
+
+	// DB cleanup check (b): sessions row must be ended or absent.
+	// The sessions row is pre-inserted by SpawnSession before the layout
+	// step, so after cleanup it must have ended_at IS NOT NULL.
+	if st != nil && st.InstanceID != nil && *st.InstanceID != "" {
+		sess, sessErr := d.SessionByInstanceID(*st.InstanceID)
+		if sessErr != nil {
+			t.Fatalf("SessionByInstanceID: %v", sessErr)
+		}
+		if sess != nil && sess.EndedAt == nil {
+			t.Errorf("sessions row for instance_id %s has ended_at IS NULL after layout-failure cleanup — zombie row will block a retry (#1880 F5)",
+				*st.InstanceID)
+		}
+	}
+
+	// DB cleanup check (c): port must be released (harness_port IS NULL).
+	if st != nil && st.HarnessPort != nil {
+		t.Errorf("harness_port = %d after layout-failure cleanup — port was not released (#1880 F5)", *st.HarnessPort)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/spawn_same_name_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_same_name_test.go
@@ -1,0 +1,117 @@
+package session
+
+// Tests for F2 (#1880): concurrent SpawnSession calls for the same session name
+// must leave the DB in a consistent state — exactly one agent_status row,
+// exactly one un-orphaned sessions row, exactly one allocated port.
+//
+// Before the in-process lock was added, two concurrent callers would both run
+// the non-atomic prologue (seed → instance_id → InsertSession → AllocatePort)
+// in parallel. SetInstanceID is an unconditional UPDATE so the last writer wins;
+// both InsertSession calls succeed with different PKs, leaving one orphaned row;
+// AllocatePort may pick the same port for both callers.
+//
+// The fix uses a per-session-name sync.Mutex (stored in spawnMu sync.Map) to
+// serialise the prologue so only one caller runs it at a time.
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestSpawnSession_Concurrent_SameName fires N goroutines all calling
+// SpawnSession with the same session name and asserts that after all calls
+// complete the DB is in a consistent state:
+//
+//   (a) exactly one agent_status row exists (keyed on opts.SessionName).
+//   (b) agent_status.instance_id is non-nil and matches exactly one sessions
+//       row whose ended_at is NULL (i.e. the row is alive).
+//   (c) no other sessions row for this session name has ended_at NULL.
+func TestSpawnSession_Concurrent_SameName(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const N = 5
+	const sessionName = "myrepo@branch~conc-same-name"
+
+	var wg sync.WaitGroup
+	errs := make([]error, N)
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			opts := SpawnOpts{
+				SessionName:   sessionName,
+				Repo:          "myrepo",
+				Worktree:      "/worktrees/myrepo-conc",
+				AgentRole:     "worker",
+				Prompt:        "go",
+				Layout:        LayoutAgentOnly,
+				IsolationMode: "host",
+				HarnessName:   "pi",
+			}
+			errs[i] = SpawnSession(d, opts)
+		}()
+	}
+	wg.Wait()
+
+	// At least one call must have succeeded. The rest may succeed or fail
+	// (e.g. tmux rejects a duplicate session name), but what matters is that
+	// the DB is consistent regardless.
+	successCount := 0
+	for _, err := range errs {
+		if err == nil {
+			successCount++
+		}
+	}
+	if successCount == 0 {
+		t.Fatal("all SpawnSession calls failed; at least one must succeed")
+	}
+
+	// (a) Exactly one agent_status row exists for the session name.
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want one agent_status row")
+	}
+
+	// (b) agent_status.instance_id is non-nil.
+	if st.InstanceID == nil || *st.InstanceID == "" {
+		t.Fatal("agent_status.instance_id is nil/empty — exactly one must be set")
+	}
+	instanceID := *st.InstanceID
+
+	// (b cont.) The sessions row for that instance_id must exist and be alive.
+	sess, err := d.SessionByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID(%s): %v", instanceID, err)
+	}
+	if sess == nil {
+		t.Fatalf("sessions row missing for instance_id %s pointed at by agent_status", instanceID)
+	}
+	if sess.EndedAt != nil {
+		t.Errorf("sessions row for instance_id %s has ended_at set (not NULL) — the winning row must be alive", instanceID)
+	}
+
+	// (c) No OTHER sessions row for this session name should have ended_at NULL.
+	// Any sessions rows inserted by losing callers must have been cleaned up
+	// (ended_at IS NOT NULL) or not exist at all.
+	allSessions, err := d.SessionsByName(sessionName)
+	if err != nil {
+		t.Fatalf("SessionsByName: %v", err)
+	}
+	for _, s := range allSessions {
+		if s.InstanceID == instanceID {
+			// This is the winning row; already verified above.
+			continue
+		}
+		if s.EndedAt == nil {
+			t.Errorf("orphaned sessions row found: instance_id=%s session_name=%s ended_at=NULL — only the winning row should be alive (#1880 F2)",
+				s.InstanceID, s.SessionName)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two correctness gaps in `SpawnSession` identified in issue #1880.

### F2 — Concurrent spawn serialisation (in-process lock)

**Choice made:** Option (1) — in-process `sync.Map[string]*sync.Mutex` advisory lock.

**Rationale:** All `SpawnSession` callers (spawn, review fan-out) share a single coordinator process. The in-process lock is the minimal correct fix. Cross-process races (two `prism` binaries for the same session name simultaneously) are documented as out-of-scope — that would require a DB-side conditional UPDATE, which is a more invasive change and not warranted by the current operational model.

**Mechanism:** A package-level `sync.Map` (key: sessionName, value: `*sync.Mutex`) serialises the entire DB prologue (seed → instance_id → InsertSession → AllocatePort) per session name. After acquiring the lock, a liveness check detects if a concurrent winner already completed the prologue — late arrivals fail fast with a clear error rather than overwriting the winner's `instance_id`.

### F5 — Layout-failure auto-cleanup

**Choice made:** Option (a) — auto-cleanup on layout failure.

Before this fix the readiness-timeout path auto-ran four cleanup primitives (KillSidecar + cleanupHalfAliveSession + tmux.KillSession + removeInitialPrompt) while the layout-failure path only returned an operator hint. Now both paths run the same cleanup primitives. The operator hint is kept as a suffix on the returned error.

The cleanup primitive set (documented in a comment on the layout-failure block):
- `KillSidecar`: stops the sidecar process that `spawnAgentOnlyLayout` starts before the tmux step
- `cleanupHalfAliveSession`: marks `agent_status` ended, releases the port, purges bus messages, and writes `sessions.ended_at` (per #1881)
- `tmux.KillSession`: removes any partial tmux session created before the failure
- `removeInitialPrompt`: drops the per-session prompt file so a retry starts fresh

## Tests added

- `TestSpawnSession_Concurrent_SameName`: fires N=5 goroutines with the same session name, asserts exactly one live `sessions` row and no orphaned rows after all calls complete.
- `TestSpawnSession_LayoutFailure_CleansUpDB`: forces tmux to fail via `failTmuxBin`, asserts `agent_status.ended_at IS NOT NULL`, `sessions.ended_at IS NOT NULL`, and `harness_port IS NULL` after the call returns.

## Existing tests

All existing `TestSpawnSession_*`, `TestCleanupHalfAliveSession_*`, and `TestSpawnSession_FullLayout_Concurrent*` tests continue to pass.

```
go test ./internal/session/ -race   ✓
go test ./internal/db/ -race        ✓
nix build .#prism                   ✓
```

Closes #1880