### PR TITLE
db: fold isolation_mode into UpsertStatusSeedRootAgentName (fix #1866)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -979,7 +979,7 @@ func TestIsCoordinatorFromDB(t *testing.T) {
 	}
 
 	// Post-migration coordinator on the conventional @main branch.
-	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/main", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator @main: %v", err)
 	}
 
@@ -987,12 +987,12 @@ func TestIsCoordinatorFromDB(t *testing.T) {
 	// root_agent_name = "coordinator" must be the deciding factor, not the
 	// branch name. This is the primary motivation for the DB-backed migration.
 	// Use a different repo name to avoid the unique-active-coordinator-per-repo constraint.
-	if err := d.UpsertStatusSeedRootAgentName("custom-repo@custom-branch", "custom-repo", "/code/custom", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("custom-repo@custom-branch", "custom-repo", "/code/custom", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator on custom branch: %v", err)
 	}
 
 	// Post-migration worker on @main-named branch (should not be detected as coordinator).
-	if err := d.UpsertStatusSeedRootAgentName("otherwork@main", "otherwork", "/code/other/main", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("otherwork@main", "otherwork", "/code/other/main", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed worker @main: %v", err)
 	}
 

--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -317,7 +317,7 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 		// plain UpsertStatus path which leaves root_agent_name as-is (NULL on
 		// insert, preserved on update).
 		if agentRole != "" {
-			if err := d.UpsertStatusSeedRootAgentName(session, repo, worktree, string(agent.StateIdle), nil, nil, agentRole, ""); err != nil {
+			if err := d.UpsertStatusSeedRootAgentName(session, repo, worktree, string(agent.StateIdle), nil, nil, agentRole, "", ""); err != nil {
 				return fmt.Errorf("event tmux-session-start: upsert status: %w", err)
 			}
 		} else {

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -692,7 +692,7 @@ func TestEventTmuxSessionStart_AgentRole_PreservesExisting(t *testing.T) {
 		t.Fatalf("open db: %v", err)
 	}
 	// Pre-seed a row with root_agent_name already set.
-	if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", worktree, "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", worktree, "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	d.Close()

--- a/modules/programs/prism/prism/cmd/list_sessions_scope_test.go
+++ b/modules/programs/prism/prism/cmd/list_sessions_scope_test.go
@@ -21,14 +21,14 @@ func TestListSessions_DefaultScope_HidesOtherRepoWorkers(t *testing.T) {
 	d := openStatsTestDB(t) // also unsets PRISM_HOST_API and sets testDBPath
 
 	// repoA sessions.
-	if err := d.UpsertStatusSeedRootAgentName("repoA@main", "repoA", "/wA/main", "active", nil, nil, "coordinator", "pi"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repoA@main", "repoA", "/wA/main", "active", nil, nil, "coordinator", "pi", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName repoA@main: %v", err)
 	}
 	if err := d.UpsertStatus("repoA@feature", "repoA", "/wA/feat", "active", nil, nil); err != nil {
 		t.Fatalf("UpsertStatus repoA@feature: %v", err)
 	}
 	// repoB sessions.
-	if err := d.UpsertStatusSeedRootAgentName("repoB@main", "repoB", "/wB/main", "active", nil, nil, "coordinator", "pi"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repoB@main", "repoB", "/wB/main", "active", nil, nil, "coordinator", "pi", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName repoB@main: %v", err)
 	}
 	if err := d.UpsertStatus("repoB@feature", "repoB", "/wB/feat", "active", nil, nil); err != nil {
@@ -100,9 +100,9 @@ func TestListSessions_DefaultScope_RunE_Output(t *testing.T) {
 	d := openStatsTestDB(t) // unsets PRISM_HOST_API, sets testDBPath
 
 	// Seed sessions for two repos.
-	_ = d.UpsertStatusSeedRootAgentName("repoA@main", "repoA", "/wA/main", "active", nil, nil, "coordinator", "pi")
+	_ = d.UpsertStatusSeedRootAgentName("repoA@main", "repoA", "/wA/main", "active", nil, nil, "coordinator", "pi", "")
 	_ = d.UpsertStatus("repoA@feature", "repoA", "/wA/feat", "active", nil, nil)
-	_ = d.UpsertStatusSeedRootAgentName("repoB@main", "repoB", "/wB/main", "active", nil, nil, "coordinator", "pi")
+	_ = d.UpsertStatusSeedRootAgentName("repoB@main", "repoB", "/wB/main", "active", nil, nil, "coordinator", "pi", "")
 	_ = d.UpsertStatus("repoB@feature", "repoB", "/wB/feat", "active", nil, nil)
 
 	// Simulate CWD inside repoA by setting PRISM_SPAWN_PATH.
@@ -166,7 +166,7 @@ func TestAllActiveStatusForRepoAndOtherCoordinators_DBLayer(t *testing.T) {
 	insert := func(sessionName, repo, rootAgent string) {
 		t.Helper()
 		if rootAgent != "" {
-			if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/wt/"+sessionName, "active", nil, nil, rootAgent, "pi"); err != nil {
+			if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/wt/"+sessionName, "active", nil, nil, rootAgent, "pi", ""); err != nil {
 				t.Fatalf("UpsertStatusSeedRootAgentName %s: %v", sessionName, err)
 			}
 		} else {

--- a/modules/programs/prism/prism/cmd/merge_test.go
+++ b/modules/programs/prism/prism/cmd/merge_test.go
@@ -36,7 +36,7 @@ func TestRunMerge_WorkerSessionIsRejected(t *testing.T) {
 		t.Fatalf("openDB: %v", err)
 	}
 	defer d.Close()
-	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	d.Close()
@@ -82,7 +82,7 @@ func TestRunMerge_CoordinatorSessionNotRejectedByWorkerGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openDB: %v", err)
 	}
-	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		d.Close()
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestRunMerge_FailsWhenInstanceIDMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("openDB: %v", err)
 	}
-	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		d.Close()
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}

--- a/modules/programs/prism/prism/cmd/review_test.go
+++ b/modules/programs/prism/prism/cmd/review_test.go
@@ -465,7 +465,7 @@ func TestRejectIfCoordinator_BlocksCoordinatorSession(t *testing.T) {
 	d := openReviewTestDB(t)
 
 	const coordSession = "nixos-config@main"
-	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordSession, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -492,7 +492,7 @@ func TestRejectIfCoordinator_AllowsWorkerSession(t *testing.T) {
 	d := openReviewTestDB(t)
 
 	const workerSession = "nixos-config@feature-branch"
-	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(workerSession, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 

--- a/modules/programs/prism/prism/cmd/review_wait_test.go
+++ b/modules/programs/prism/prism/cmd/review_wait_test.go
@@ -82,7 +82,7 @@ func TestEmitReviewWaitTerminal_AllPass(t *testing.T) {
 	const s1 = "repo@pr-1500~review-1-review-goal"
 	const s2 = "repo@pr-1500~review-1-review-code"
 	for _, s := range []string{s1, s2} {
-		if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+		if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "finished", nil, nil, "review", "", ""); err != nil {
 			t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 		}
 		linkAgentToGroup(t, d, s, groupID)
@@ -106,13 +106,13 @@ func TestEmitReviewWaitTerminal_AnyFailReturnsTerminalFail(t *testing.T) {
 	groupID, _ := d.RegisterGroup("repo@pr-1500")
 	const s1 = "repo@pr-1500~review-1-review-goal"
 	const s2 = "repo@pr-1500~review-1-review-code"
-	if err := d.UpsertStatusSeedRootAgentName(s1, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(s1, "repo", "/wt", "finished", nil, nil, "review", "", ""); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	linkAgentToGroup(t, d, s1, groupID)
 	writeAssistantEvent(t, d, s1, "<verdict>PASS</verdict>")
 
-	if err := d.UpsertStatusSeedRootAgentName(s2, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(s2, "repo", "/wt", "finished", nil, nil, "review", "", ""); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	linkAgentToGroup(t, d, s2, groupID)
@@ -138,7 +138,7 @@ func TestEmitReviewWaitTerminal_JSONShape(t *testing.T) {
 	d := openReviewWaitTestDB(t)
 	groupID, _ := d.RegisterGroup("repo@pr-1500")
 	const s = "repo@pr-1500~review-1-review-goal"
-	if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "finished", nil, nil, "review", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "finished", nil, nil, "review", "", ""); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	linkAgentToGroup(t, d, s, groupID)
@@ -181,7 +181,7 @@ func TestWaitForReviewTerminal_PollsUntilGroupCompleted(t *testing.T) {
 	d := openReviewWaitTestDB(t)
 	groupID, _ := d.RegisterGroup("repo@pr-1500")
 	const s = "repo@pr-1500~review-1-review-goal"
-	if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "active", nil, nil, "review", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(s, "repo", "/wt", "active", nil, nil, "review", "", ""); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	linkAgentToGroup(t, d, s, groupID)

--- a/modules/programs/prism/prism/cmd/reviews_test.go
+++ b/modules/programs/prism/prism/cmd/reviews_test.go
@@ -72,7 +72,7 @@ func TestReviewsList_PopulatesJSON(t *testing.T) {
 		t.Fatalf("RegisterGroup: %v", err)
 	}
 	const session1 = "nixos-config@pr-1500~review-1-review-goal"
-	if err := d.UpsertStatusSeedRootAgentName(session1, "nixos-config", "/wt", "finished", nil, nil, "review-goal", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session1, "nixos-config", "/wt", "finished", nil, nil, "review-goal", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	// Link the agent_status row to the group via raw SQL (mirrors the

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -264,7 +264,7 @@ func allocatePortForSession(sessionName, directory, harnessName string) (int, er
 			repo = sessionName[:idx]
 		}
 	}
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, directory, "idle", nil, nil, "", harnessName); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, directory, "idle", nil, nil, "", harnessName, ""); err != nil {
 		return 0, fmt.Errorf("upsert status: %w", err)
 	}
 

--- a/modules/programs/prism/prism/internal/container/concurrency_test.go
+++ b/modules/programs/prism/prism/internal/container/concurrency_test.go
@@ -27,7 +27,7 @@ func seedSession(t *testing.T, d *db.DB, sessionName, role string) {
 	t.Helper()
 	// Use UpsertStatusSeedRootAgentName to set the root_agent_name so roleFor
 	// can return the correct label.
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "repo", "/workspace", "idle", nil, nil, role, ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "repo", "/workspace", "idle", nil, nil, role, "", ""); err != nil {
 		t.Fatalf("seedSession(%q): %v", sessionName, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -4025,7 +4026,7 @@ func TestConsecutiveSidecarFailures_TieBreaker(t *testing.T) {
 func TestUpsertStatusSeedRootAgentName_Insert(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -4054,7 +4055,7 @@ func TestUpsertStatusSeedRootAgentName_Insert(t *testing.T) {
 func TestUpsertStatusSeedRootAgentName_EmptyRole(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName (empty role): %v", err)
 	}
 
@@ -4079,12 +4080,12 @@ func TestUpsertStatusSeedRootAgentName_Idempotent(t *testing.T) {
 	d := openTestDB(t)
 
 	// First call: seed with "review-code".
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code", "", ""); err != nil {
 		t.Fatalf("first UpsertStatusSeedRootAgentName: %v", err)
 	}
 
 	// Second call: write the same role — must be a no-op for root_agent_name.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "review-code", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "review-code", "", ""); err != nil {
 		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -4111,12 +4112,12 @@ func TestUpsertStatusSeedRootAgentName_PreservesExisting(t *testing.T) {
 	d := openTestDB(t)
 
 	// Seed with a known role.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
 	// Update with empty role — existing root_agent_name must survive.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "active", nil, nil, "", "", ""); err != nil {
 		t.Fatalf("update with empty role: %v", err)
 	}
 
@@ -4140,7 +4141,7 @@ func TestUpsertStatusSeedRootAgentName_SidecarWriteIdempotent(t *testing.T) {
 	d := openTestDB(t)
 
 	// Spawn-time seed: root_agent_name = "review-code", agent_name = nil.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/repo/main", "idle", nil, nil, "review-code", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -4181,11 +4182,11 @@ func TestCoordinatorForRepo(t *testing.T) {
 	defer d.Close()
 
 	// Seed a coordinator row with root_agent_name = "coordinator".
-	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/myrepo/main", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@main", "myrepo", "/code/myrepo/main", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	// Seed a worker row.
-	if err := d.UpsertStatusSeedRootAgentName("myrepo@feature", "myrepo", "/code/myrepo/feature", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("myrepo@feature", "myrepo", "/code/myrepo/feature", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 
@@ -4269,7 +4270,7 @@ func TestRootAgentName(t *testing.T) {
 	}
 
 	// Post-migration row: root_agent_name is populated — returns (name, true, nil).
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	nameCoord, rowExistsCoord, err := d.RootAgentName("repo@main")
@@ -4290,7 +4291,7 @@ func TestIsGroupMember(t *testing.T) {
 	defer d.Close()
 
 	// Seed a session and a group.
-	if err := d.UpsertStatusSeedRootAgentName("repo@worker", "repo", "/code/worker", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@worker", "repo", "/code/worker", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 	groupID, err := d.RegisterGroup("repo@worker")
@@ -4299,7 +4300,7 @@ func TestIsGroupMember(t *testing.T) {
 	}
 
 	// Seed a review agent session and assign it to the group.
-	if err := d.UpsertStatusSeedRootAgentName("repo@worker~review-1-review-goal", "repo", "/code/worker", "active", nil, nil, "review-goal", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@worker~review-1-review-goal", "repo", "/code/worker", "active", nil, nil, "review-goal", "", ""); err != nil {
 		t.Fatalf("seed review agent: %v", err)
 	}
 	if err := d.SetGroupID("repo@worker~review-1-review-goal", groupID); err != nil {
@@ -4476,10 +4477,10 @@ func TestUpsertStatusWithAgent_WorktreeUpdatedOnConflict(t *testing.T) {
 func TestUpsertStatusSeedRootAgentName_WorktreeUpdatedOnConflict(t *testing.T) {
 	d := openTestDB(t)
 
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/old/worktree", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/old/worktree", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("first UpsertStatusSeedRootAgentName: %v", err)
 	}
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/new/worktree", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/new/worktree", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -7699,6 +7700,99 @@ func TestActiveSessionsForMode_ReturnsList(t *testing.T) {
 	}
 }
 
+// TestActiveSessionCountForMode_SeedSetsMode_NullWindowClosed verifies the
+// fix for issue #1866: UpsertStatusSeedRootAgentName now accepts an
+// isolationMode argument and writes it atomically with the row insert. The
+// test simulates the race by doing what a concurrent spawn would do:
+//
+//  1. Goroutine A calls UpsertStatusSeedRootAgentName with a mode — this is the
+//     fixed seed that no longer leaves isolation_mode NULL.
+//  2. Goroutine B calls ActiveSessionCountForMode during the window that used to
+//     be between the old seed and the subsequent SetIsolationMode call.
+//  3. The count must include A's row because the seed already set the mode.
+//
+// Previously the seed did NOT write isolation_mode, so B would return 0.
+// After the fix, B returns 1.
+func TestActiveSessionCountForMode_SeedSetsMode_NullWindowClosed(t *testing.T) {
+	t.Parallel()
+	d := openTestDB(t)
+
+	// Goroutine A: seed a bwrap session — with the fix, isolation_mode is set
+	// atomically by UpsertStatusSeedRootAgentName (no separate SetIsolationMode
+	// needed for the count to be correct).
+	if err := d.UpsertStatusSeedRootAgentName(
+		"repo@race-test", "repo", "/code/repo/race-test", "idle", nil, nil, "worker", "pi", "bwrap",
+	); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	// Goroutine B: query the count in the window between seed and (hypothetical)
+	// SetIsolationMode. With the fix, isolation_mode is already set so the count
+	// must be 1.
+	count, err := d.ActiveSessionCountForMode("bwrap")
+	if err != nil {
+		t.Fatalf("ActiveSessionCountForMode: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("ActiveSessionCountForMode = %d, want 1: isolation_mode must be set atomically by UpsertStatusSeedRootAgentName (issue #1866)", count)
+	}
+
+	// Confirm that a second SetIsolationMode (idempotent) does not double-count.
+	if err := d.SetIsolationMode("repo@race-test", "bwrap"); err != nil {
+		t.Fatalf("SetIsolationMode: %v", err)
+	}
+	countAfter, err := d.ActiveSessionCountForMode("bwrap")
+	if err != nil {
+		t.Fatalf("ActiveSessionCountForMode after SetIsolationMode: %v", err)
+	}
+	if countAfter != 1 {
+		t.Errorf("ActiveSessionCountForMode after SetIsolationMode = %d, want 1 (must not double-count)", countAfter)
+	}
+}
+
+// TestActiveSessionCountForMode_ConcurrentSeedAndCount exercises the fix under
+// real goroutine concurrency (issue #1866 race detector check). Two goroutines
+// run in parallel: one seeds a row with isolation_mode set, the other queries
+// the count. The -race detector should find no data races.
+func TestActiveSessionCountForMode_ConcurrentSeedAndCount(t *testing.T) {
+	t.Parallel()
+	d := openTestDB(t)
+
+	// Seed 5 sessions concurrently and count in parallel.
+	const n = 5
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			sessName := fmt.Sprintf("repo@race-%d", i)
+			_ = d.UpsertStatusSeedRootAgentName(
+				sessName, "repo", "/code/repo/"+sessName, "idle", nil, nil, "worker", "pi", "sandbox-exec",
+			)
+		}(i)
+	}
+	// Concurrent reader goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		_, _ = d.ActiveSessionCountForMode("sandbox-exec")
+	}()
+	close(start)
+	wg.Wait()
+
+	// After all seeds complete, every row must be counted.
+	count, err := d.ActiveSessionCountForMode("sandbox-exec")
+	if err != nil {
+		t.Fatalf("ActiveSessionCountForMode: %v", err)
+	}
+	if count != n {
+		t.Errorf("ActiveSessionCountForMode = %d, want %d", count, n)
+	}
+}
+
 // TestAbtestPairsForSessions verifies that AbtestPairsForSessions returns a
 // map of session_name → abtest_pair_id for sessions that have a non-NULL
 // abtest_pair_id in spawn_inputs, and excludes sessions without one.
@@ -7782,7 +7876,7 @@ func TestUpsertStatus_PreservesHarness(t *testing.T) {
 	// Seed a row with harness='pi' via UpsertStatusSeedRootAgentName (the
 	// same path used by SpawnSession).
 	const session = "repo@pi-worker"
-	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi", ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
@@ -7848,13 +7942,13 @@ func TestUpsertStatusSeedRootAgentName_OverridesStaleHarness(t *testing.T) {
 	const session = "repo@override-branch"
 
 	// Seed the row with harness='pi' (simulating a pre-reset ended row).
-	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi", ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
 	// Simulate allocatePortForSession falling through to UpsertStatusSeedRootAgentName
 	// with the new harness ('pi') from the active profile.
-	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi", ""); err != nil {
 		t.Fatalf("override upsert: %v", err)
 	}
 
@@ -7883,12 +7977,12 @@ func TestUpsertStatusSeedRootAgentName_PreservesHarness(t *testing.T) {
 	const session = "repo@pi-branch"
 
 	// Seed the row with harness='pi' (as SpawnSession does).
-	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi"); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "pi", ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
 	// Simulate the tmux-session-start event hook calling with empty harnessName.
-	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(session, "repo", "/wt", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("second UpsertStatusSeedRootAgentName: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -132,7 +132,15 @@ func (d *DB) UpdateRootModelID(sessionName, modelID string) error {
 // so that the DB row has a non-NULL root_agent_name from the first moment.
 // The sidecar will later write the same value idempotently via
 // UpsertStatusWithRootAgent (COALESCE preserves the already-set value).
-func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state string, title *string, harnessSessionID *string, rootAgentName string, harnessName string) error {
+//
+// Invariant (isolation_mode NULL window): when isolationMode is non-empty, it
+// is written atomically with the INSERT/UPDATE so the row is never observable
+// with isolation_mode IS NULL after this call returns. This prevents
+// ActiveSessionCountForMode from undercounting when a concurrent spawn races
+// the per-mode cap check between the seed and a separate SetIsolationMode call.
+// Callers that do not know the mode (e.g. tmux-session-start hook, prism
+// switch) pass an empty string, which leaves the existing value unchanged.
+func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state string, title *string, harnessSessionID *string, rootAgentName string, harnessName string, isolationMode string) error {
 	d.checkTransition(sessionName, agent.AgentState(state), "UpsertStatusSeedRootAgentName")
 	now := time.Now().UnixMilli()
 	// When rootAgentName is empty, fall back to leaving root_agent_name as-is
@@ -159,9 +167,23 @@ func (d *DB) UpsertStatusSeedRootAgentName(sessionName, repo, worktree, state st
 	if harnessName != "" {
 		harnessNamePtr = &harnessName
 	}
+	// isolationMode follows the same CASE pattern as harnessName: when the
+	// caller supplies a non-empty value it is written atomically; when empty
+	// the existing DB value is preserved (NULL on a fresh INSERT, existing mode
+	// on UPDATE). This eliminates the isolation_mode NULL window described in
+	// issue #1866: the row is born with the mode set and ActiveSessionCountForMode
+	// will never undercount a session that is still being set up.
+	var isolationModePtr *string
+	if isolationMode != "" {
+		isolationModePtr = &isolationMode
+	}
+	// For a fresh INSERT, use the provided isolation mode (may be NULL — callers
+	// that don't know the mode leave it unset, which is acceptable for non-spawn
+	// paths like the tmux-session-start hook).
+	insertIsolationMode := isolationModePtr
 	const q = `
-INSERT INTO agent_status (session_name, repo, worktree, state, title, root_agent_name, last_seen, harness, harness_session_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO agent_status (session_name, repo, worktree, state, title, root_agent_name, last_seen, harness, harness_session_id, isolation_mode)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(session_name) DO UPDATE SET
   state              = excluded.state,
   repo               = excluded.repo,
@@ -170,8 +192,9 @@ ON CONFLICT(session_name) DO UPDATE SET
   root_agent_name    = COALESCE(excluded.root_agent_name, root_agent_name),
   last_seen          = excluded.last_seen,
   harness            = CASE WHEN ? IS NOT NULL THEN ? ELSE harness END,
-  harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id)`
-	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, insertHarness, harnessSessionID, harnessNamePtr, harnessNamePtr)
+  harness_session_id = COALESCE(excluded.harness_session_id, harness_session_id),
+  isolation_mode     = CASE WHEN ? IS NOT NULL THEN ? ELSE isolation_mode END`
+	_, err := d.conn.Exec(q, sessionName, repo, worktree, state, title, rootAgentNamePtr, now, insertHarness, harnessSessionID, insertIsolationMode, harnessNamePtr, harnessNamePtr, isolationModePtr, isolationModePtr)
 	if err != nil {
 		return fmt.Errorf("db: upsert status seed root agent name: %w", err)
 	}

--- a/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_failed_ready_test.go
@@ -59,7 +59,7 @@ func TestMonitor_FailedReadyAgent_DoesNotBlockGroupCompleted(t *testing.T) {
 
 	// Both agents start at state=idle (the seed state UpsertStatusSeedRootAgentName writes).
 	for _, sess := range []string{sessReady, sessFailed} {
-		if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x", ""); err != nil {
+		if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x", "", ""); err != nil {
 			t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
 		}
 		if err := d.SetGroupID(sess, groupID); err != nil {

--- a/modules/programs/prism/prism/internal/review/readiness_test.go
+++ b/modules/programs/prism/prism/internal/review/readiness_test.go
@@ -47,7 +47,7 @@ func openGateTestDB(t *testing.T) *db.DB {
 // to exist so CurrentStatus / QueryEvents return cleanly.
 func seedAgentRow(t *testing.T, d *db.DB, sess string) {
 	t.Helper()
-	if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "test", "/tmp", "idle", nil, nil, "review-x", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sess, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1663,7 +1663,7 @@ func TestRun_SeedsRootAgentNameAtSpawnTime(t *testing.T) {
 	for _, ag := range agents {
 		agentSession := roundPrefix + ag.Name
 		// This mirrors what review.Run does synchronously at spawn time.
-		if err := d.UpsertStatusSeedRootAgentName(agentSession, "nixos-config", worktree, "idle", nil, nil, ag.Name, ""); err != nil {
+		if err := d.UpsertStatusSeedRootAgentName(agentSession, "nixos-config", worktree, "idle", nil, nil, ag.Name, "", ""); err != nil {
 			t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", ag.Name, err)
 		}
 	}

--- a/modules/programs/prism/prism/internal/session/lost_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/lost_prompt_test.go
@@ -55,7 +55,7 @@ func openLostPromptTestDB(t *testing.T) *db.DB {
 
 func seedLostPromptSession(t *testing.T, d *db.DB, sessionName string) {
 	t.Helper()
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sessionName, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/session/meta_test.go
+++ b/modules/programs/prism/prism/internal/session/meta_test.go
@@ -58,7 +58,7 @@ func openTestDB(t *testing.T) *db.DB {
 func TestIsCoordinatorSession_DBBackedCoordinator(t *testing.T) {
 	d := openTestDB(t)
 	const sess = "nixos-config@main"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if !IsCoordinatorSession(sess, d) {
@@ -74,7 +74,7 @@ func TestIsCoordinatorSession_DBBackedWorker(t *testing.T) {
 	d := openTestDB(t)
 	// A worker session on a non-@main branch — DB value must cause false.
 	const sess = "nixos-config@feature-worker"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-worker", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-worker", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if IsCoordinatorSession(sess, d) {
@@ -87,7 +87,7 @@ func TestIsCoordinatorSession_DBBackedWorker(t *testing.T) {
 func TestIsCoordinatorSession_DBBackedWorkerBranch(t *testing.T) {
 	d := openTestDB(t)
 	const sess = "nixos-config@feature-branch"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/worktree/feature-branch", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	if IsCoordinatorSession(sess, d) {
@@ -156,7 +156,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainHeuristicWins(t *testing.T)
 
 	sess := "nixos-config@main"
 	// Seed the session with a stale root_agent_name of "worker".
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/main", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/main", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
@@ -172,7 +172,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_NonMain(t *testing.T) {
 	d := openTestDB(t)
 
 	sess := "nixos-config@feature"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "nixos-config", "/code/feature", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/session/readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/readiness_test.go
@@ -38,7 +38,7 @@ func openReadinessTestDB(t *testing.T) *db.DB {
 // SpawnSession's UpsertStatusSeedRootAgentName writes at spawn time.
 func seedSession(t *testing.T, d *db.DB, sessionName string) {
 	t.Helper()
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "test", "/tmp", "idle", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName(%q): %v", sessionName, err)
 	}
 }

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -539,7 +539,7 @@ func TestDefaultAgentForSession_DBHappyPath(t *testing.T) {
 	}
 	defer d.Close()
 
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 
@@ -560,7 +560,7 @@ func TestDefaultAgentForSession_ExplicitOverridesDB(t *testing.T) {
 	}
 	defer d.Close()
 
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, "testrepo", "/worktrees/main", "idle", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -510,9 +510,9 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		}
 	}
 
-	// Step 1: Seed agent_status with root_agent_name. Idempotent; later
-	// writes by the sidecar and by tmux-session-start COALESCE-preserve the
-	// value written here.
+	// Step 1: Seed agent_status with root_agent_name and isolation_mode.
+	// Idempotent; later writes by the sidecar and by tmux-session-start
+	// COALESCE-preserve the values written here.
 	//
 	// Resolve effective harness for DB seeding. Pi is the sole harness;
 	// if HarnessName is blank fall back to "pi" (#1612).
@@ -520,13 +520,17 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	if effectiveHarness == "" {
 		effectiveHarness = "pi"
 	}
+	// Pass the resolved isolation mode so the row is born with isolation_mode
+	// set — eliminating the NULL window between seed and SetIsolationMode
+	// (issue #1866). ActiveSessionCountForMode counts this row correctly from
+	// the moment the seed returns.
 	if err := d.UpsertStatusSeedRootAgentName(
-		opts.SessionName, opts.Repo, opts.Worktree, "idle", nil, nil, opts.AgentRole, effectiveHarness,
+		opts.SessionName, opts.Repo, opts.Worktree, "idle", nil, nil, opts.AgentRole, effectiveHarness, mode,
 	); err != nil {
 		startup.log("spawn-session: seed status FAILED: %v", err)
 		return fmt.Errorf("spawn session: seed status: %w", err)
 	}
-	startup.log("spawn-session: agent_status seeded (state=idle)")
+	startup.log("spawn-session: agent_status seeded (state=idle, isolation_mode=%q)", mode)
 
 	// Step 2: Write group_id when set (hook for Issue E — single-session
 	// spawns leave GroupID empty and this is a no-op).

--- a/modules/programs/prism/prism/internal/sidecar/host_api_wait_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_wait_test.go
@@ -115,7 +115,7 @@ func TestHostAPI_GroupsPoll_CompletedTrueAfterAllTerminal(t *testing.T) {
 		t.Fatalf("RegisterGroup: %v", err)
 	}
 	const sess = "repo@pr-1500~review-1-review-goal"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "repo", "/wt", "finished", nil, nil, "review-goal", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "repo", "/wt", "finished", nil, nil, "review-goal", "", ""); err != nil {
 		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
 	}
 	// Link to group via raw SQL (mirrors the pattern in db_test.go).

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
@@ -34,7 +34,7 @@ func newSidecarCoordinatorWithInstance(t *testing.T, sessionName, repo, instance
 	}
 	// Seed the DB so isCoordinatorSession() recognises this session as a
 	// coordinator (the merge handlers go through requireCoordinator).
-	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/tmp/"+sessionName, "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sessionName, repo, "/tmp/"+sessionName, "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator status: %v", err)
 	}
 	return New(cfg)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2592,7 +2592,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	defer d.Close()
 
 	// Happy path: post-migration coordinator row on the conventional @main branch.
-	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@main", "repo", "/code/main", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator: %v", err)
 	}
 	if !isCoordinatorSession("repo@main", d, log.Default()) {
@@ -2602,7 +2602,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	// Core value of the change: coordinator on a non-@main branch name.
 	// The DB read must identify it correctly regardless of branch name.
 	// Use a different repo name to avoid the unique-coordinator-per-repo constraint.
-	if err := d.UpsertStatusSeedRootAgentName("other-repo@custom-branch", "other-repo", "/code/custom", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("other-repo@custom-branch", "other-repo", "/code/custom", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed coordinator on custom branch: %v", err)
 	}
 	if !isCoordinatorSession("other-repo@custom-branch", d, log.Default()) {
@@ -2610,7 +2610,7 @@ func TestIsCoordinatorSession(t *testing.T) {
 	}
 
 	// Post-migration worker row: DB says false.
-	if err := d.UpsertStatusSeedRootAgentName("repo@feature", "repo", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("repo@feature", "repo", "/code/feature", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 	if isCoordinatorSession("repo@feature", d, log.Default()) {
@@ -2662,7 +2662,7 @@ func TestNotifyCoordinator_SelfNotificationSkipped_StaleRootAgentName(t *testing
 	coordinator := New(cfg)
 
 	// Seed with stale root_agent_name="worker" — simulates the bug scenario.
-	if err := d.UpsertStatusSeedRootAgentName(coordinator.cfg.SessionName, coordinator.cfg.Repo, coordinator.cfg.Worktree, "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(coordinator.cfg.SessionName, coordinator.cfg.Repo, coordinator.cfg.Worktree, "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
@@ -2698,7 +2698,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
 	defer d.Close()
 
 	sess := "myrepo@main"
-	if err := d.UpsertStatusSeedRootAgentName(sess, "myrepo", "/code/main", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(sess, "myrepo", "/code/main", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed stale worker: %v", err)
 	}
 
@@ -2708,7 +2708,7 @@ func TestIsCoordinatorSession_StaleRootAgentName_MainWins(t *testing.T) {
 
 	// Worker on a non-@main branch must still return false.
 	workerSess := "myrepo@feature"
-	if err := d.UpsertStatusSeedRootAgentName(workerSess, "myrepo", "/code/feature", "active", nil, nil, "worker", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName(workerSess, "myrepo", "/code/feature", "active", nil, nil, "worker", "", ""); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
 	if isCoordinatorSession(workerSess, d, log.Default()) {
@@ -4976,7 +4976,7 @@ func TestHostAPI_ListSessions_DefaultScope_HidesOtherRepoWorkers(t *testing.T) {
 	_ = d.UpsertStatus("repoA@feature", "repoA", "/wA/feat", "active", nil, nil)
 	// repoB coordinator: set root_agent_name via UpsertStatusSeedRootAgentName
 	// so the DB-backed path (not only the name heuristic) is exercised.
-	_ = d.UpsertStatusSeedRootAgentName("repoB@main", "repoB", "/wB/main", "active", nil, nil, "coordinator", "pi")
+	_ = d.UpsertStatusSeedRootAgentName("repoB@main", "repoB", "/wB/main", "active", nil, nil, "coordinator", "pi", "")
 	_ = d.UpsertStatus("repoB@feature", "repoB", "/wB/feat", "active", nil, nil)
 
 	sc := newSidecarWithRole(t, "repoA@main", "repoA", "coordinator", d)
@@ -5262,7 +5262,7 @@ func TestHostAPI_Cleanup_WorkerForbidden(t *testing.T) {
 func TestHostAPI_SessionNameNoAt_NoCheckinPanic(t *testing.T) {
 	d := openTestDB(t)
 	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
-	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed DB: %v", err)
 	}
 	// Session name without "@" — edge case for repoFromSession.
@@ -5560,7 +5560,7 @@ func TestHostAPI_Spawn_EmptyPromptReturns400(t *testing.T) {
 func TestHostAPI_Spawn_SidecarNoAtSign_Returns500(t *testing.T) {
 	d := openTestDB(t)
 	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
-	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", ""); err != nil {
+	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed DB: %v", err)
 	}
 	// Session name without "@" — repoFromSession will fail.


### PR DESCRIPTION
## Summary

Fixes the `isolation_mode` NULL window between the seed upsert and the subsequent `SetIsolationMode` call in the spawn path.

**Root cause:** `UpsertStatusSeedRootAgentName` did not write `isolation_mode`. A new `agent_status` row had `isolation_mode IS NULL` until `SetIsolationMode` ran (in `spawnAgentOnlyLayout` / `setupFullLayout`). Any concurrent `ActiveSessionCountForMode` call in that window returned an undercount because `WHERE isolation_mode = ?` excludes NULL rows.

## Chosen fix: Option 1 (fold into seed upsert)

Add an `isolationMode string` parameter to `UpsertStatusSeedRootAgentName`. When non-empty, it is written atomically with the INSERT/UPDATE using the same `CASE ? IS NOT NULL THEN ? ELSE isolation_mode END` pattern already used for `harnessName`. The row is born with the mode set — no NULL window.

Callers that don't know the mode (tmux-session-start hook in `event.go`, `prism switch`) pass `""`, which preserves the existing DB value via the CASE expression. The spawn path (`spawn.go`) passes the resolved `mode` (computed by `resolveLayoutIsolationMode`) as the new argument.

The subsequent `SetIsolationMode` calls in `spawnAgentOnlyLayout` / `setupFullLayout` are now idempotent for the value (row already has the correct mode); they are retained because `prism agent-run` reads `isolation_mode` from `agent_status` on startup to validate its sandbox mode.

**Invariant documented** at the `UpsertStatusSeedRootAgentName` call site in `spawn.go`: the resolved isolation mode is passed so the row is never observable with `isolation_mode IS NULL` after the seed returns.

## Tests added

- `TestActiveSessionCountForMode_SeedSetsMode_NullWindowClosed`: verifies `ActiveSessionCountForMode` returns 1 immediately after `UpsertStatusSeedRootAgentName` with a mode — no separate `SetIsolationMode` needed. Directly exercises the previously-racy window.
- `TestActiveSessionCountForMode_ConcurrentSeedAndCount`: 5 seed goroutines + 1 count goroutine race under the `-race` detector.

## Quality gates

- `go build ./...` ✅
- `go test ./internal/db/ -race` ✅
- `go test ./internal/session/ -race` ✅
- `nix build .#prism` ✅

Closes #1866