### PR TITLE
sidecar: add SQLITE_BUSY retry to review-recovery watcher

### DIFF
--- a/modules/programs/prism/prism/internal/db/retry.go
+++ b/modules/programs/prism/prism/internal/db/retry.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"strings"
+	"time"
+)
+
+// IsSQLiteBusy reports whether err is a SQLite SQLITE_BUSY or SQLITE_LOCKED
+// error. These errors indicate that a concurrent writer holds the write lock
+// and the caller should retry after a short backoff.
+//
+// The check is performed by string-matching the error message rather than
+// importing modernc.org/sqlite directly, avoiding a package-level dependency
+// on the driver in higher-level code. The modernc driver formats these errors
+// as:
+//
+//	"db: upsert status: database is locked (5) (SQLITE_BUSY)"
+//	"db: upsert status: database is locked (6) (SQLITE_LOCKED)"
+//
+// "database is locked" is common to both, so we match on that phrase.
+func IsSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") ||
+		strings.Contains(msg, "SQLITE_LOCKED") ||
+		strings.Contains(msg, "database is locked")
+}
+
+// WithBusyRetry calls fn up to attempts times, sleeping backoff between each
+// retry if fn returns an SQLITE_BUSY / SQLITE_LOCKED error. It returns the
+// last error (or nil on success). Non-BUSY errors short-circuit immediately
+// without further retries.
+//
+// The canonical call site uses attempts=3 and backoff=10ms, which matches the
+// existing inline retry in the /review pre-emptive write (host_api.go).
+func WithBusyRetry(attempts int, backoff time.Duration, fn func() error) error {
+	var last error
+	for i := 0; i < attempts; i++ {
+		last = fn()
+		if last == nil {
+			return nil
+		}
+		if !IsSQLiteBusy(last) {
+			// Non-transient failure — no point retrying.
+			return last
+		}
+		if i < attempts-1 {
+			time.Sleep(backoff)
+		}
+	}
+	return last
+}

--- a/modules/programs/prism/prism/internal/db/retry_test.go
+++ b/modules/programs/prism/prism/internal/db/retry_test.go
@@ -1,0 +1,110 @@
+package db
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestIsSQLiteBusy verifies the IsSQLiteBusy helper recognises the error
+// message patterns produced by the modernc.org/sqlite driver and the db
+// package for SQLITE_BUSY and SQLITE_LOCKED conditions.
+func TestIsSQLiteBusy(t *testing.T) {
+	cases := []struct {
+		name     string
+		errMsg   string
+		wantBusy bool
+	}{
+		{"SQLITE_BUSY", "db: upsert status: database is locked (5) (SQLITE_BUSY)", true},
+		{"SQLITE_LOCKED", "db: upsert status: database is locked (6) (SQLITE_LOCKED)", true},
+		{"database is locked only", "database is locked", true},
+		{"not found", "db: upsert status: no such table: agent_status", false},
+		{"generic error", "some other db error", false},
+		{"nil error", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			if tc.errMsg != "" {
+				err = errors.New(tc.errMsg)
+			}
+			got := IsSQLiteBusy(err)
+			if got != tc.wantBusy {
+				t.Errorf("IsSQLiteBusy(%q) = %v, want %v", tc.errMsg, got, tc.wantBusy)
+			}
+		})
+	}
+}
+
+// TestWithBusyRetry_SuccessOnFirstAttempt verifies that WithBusyRetry returns
+// nil immediately when fn succeeds on the first call.
+func TestWithBusyRetry_SuccessOnFirstAttempt(t *testing.T) {
+	calls := 0
+	err := WithBusyRetry(3, time.Millisecond, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("want 1 call, got %d", calls)
+	}
+}
+
+// TestWithBusyRetry_SuccessAfterBusy verifies that WithBusyRetry retries on
+// SQLITE_BUSY and returns nil when fn eventually succeeds.
+func TestWithBusyRetry_SuccessAfterBusy(t *testing.T) {
+	busyErr := errors.New("database is locked (5) (SQLITE_BUSY)")
+	calls := 0
+	err := WithBusyRetry(3, time.Millisecond, func() error {
+		calls++
+		if calls < 3 {
+			return busyErr
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("want nil after retry, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("want 3 calls, got %d", calls)
+	}
+}
+
+// TestWithBusyRetry_ExhaustsAttempts verifies that WithBusyRetry returns the
+// last BUSY error when all attempts are exhausted.
+func TestWithBusyRetry_ExhaustsAttempts(t *testing.T) {
+	busyErr := errors.New("database is locked (SQLITE_BUSY)")
+	calls := 0
+	err := WithBusyRetry(3, time.Millisecond, func() error {
+		calls++
+		return busyErr
+	})
+	if err == nil {
+		t.Fatal("want non-nil error, got nil")
+	}
+	if calls != 3 {
+		t.Fatalf("want 3 calls, got %d", calls)
+	}
+	if !IsSQLiteBusy(err) {
+		t.Errorf("returned error should be SQLITE_BUSY; got %v", err)
+	}
+}
+
+// TestWithBusyRetry_NonBusyNoRetry verifies that non-BUSY errors short-circuit
+// immediately without further retries.
+func TestWithBusyRetry_NonBusyNoRetry(t *testing.T) {
+	nonBusy := errors.New("some unexpected db error")
+	calls := 0
+	err := WithBusyRetry(3, time.Millisecond, func() error {
+		calls++
+		return nonBusy
+	})
+	if err != nonBusy {
+		t.Fatalf("want original error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("want 1 call (no retry on non-BUSY), got %d", calls)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/helpers.go
+++ b/modules/programs/prism/prism/internal/sidecar/helpers.go
@@ -221,25 +221,10 @@ func parseSpawnSessionName(output string) string {
 }
 
 // isSQLiteBusy reports whether err is a SQLite SQLITE_BUSY or SQLITE_LOCKED
-// error. These errors indicate that a concurrent writer holds the write lock
-// and the caller should retry after a short backoff.
-//
-// The check is performed by string-matching the error message rather than
-// importing modernc.org/sqlite directly, avoiding a package-level dependency
-// on the driver in sidecar code. The modernc driver formats these errors as:
-//
-//	"db: upsert status: database is locked (5) (SQLITE_BUSY)"
-//	"db: upsert status: database is locked (6) (SQLITE_LOCKED)"
-//
-// "database is locked" is common to both, so we match on that phrase.
+// error. Delegates to db.IsSQLiteBusy; kept as a package-local alias so
+// existing call sites in this package need not change.
 func isSQLiteBusy(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "SQLITE_BUSY") ||
-		strings.Contains(msg, "SQLITE_LOCKED") ||
-		strings.Contains(msg, "database is locked")
+	return db.IsSQLiteBusy(err)
 }
 
 // parseAllSpawnSessionNames collects all session names from the output of

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1276,24 +1276,20 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		} else if status == nil {
 			s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write skipped — no agent_status row for session %q", s.cfg.SessionName)
 		} else {
-			var lastUpsertErr error
-			for attempt := range reviewingWriteAttempts {
-				lastUpsertErr = s.cfg.DB.UpsertStatus(s.cfg.SessionName, status.Repo, status.Worktree, string(agent.StateReviewing), nil, nil)
-				if lastUpsertErr == nil {
-					break
+			// Retry on SQLITE_BUSY using the shared helper. See the block comment
+			// above for why 3 attempts × 10 ms is the right budget here.
+			var attempt int
+			upsertErr := db.WithBusyRetry(reviewingWriteAttempts, reviewingWriteBackoff, func() error {
+				err := s.cfg.DB.UpsertStatus(s.cfg.SessionName, status.Repo, status.Worktree, string(agent.StateReviewing), nil, nil)
+				if err != nil && db.IsSQLiteBusy(err) {
+					s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write SQLITE_BUSY (attempt %d/%d): %v", attempt+1, reviewingWriteAttempts, err)
 				}
-				if !isSQLiteBusy(lastUpsertErr) {
-					// Non-transient error — no point retrying.
-					break
-				}
-				s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write SQLITE_BUSY (attempt %d/%d): %v", attempt+1, reviewingWriteAttempts, lastUpsertErr)
-				if attempt < reviewingWriteAttempts-1 {
-					time.Sleep(reviewingWriteBackoff)
-				}
-			}
-			if lastUpsertErr != nil {
-				s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, lastUpsertErr)
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", lastUpsertErr))
+				attempt++
+				return err
+			})
+			if upsertErr != nil {
+				s.logger().Printf("sidecar: host-API /review: pre-emptive reviewing write failed after %d attempt(s): %v", reviewingWriteAttempts, upsertErr)
+				writeError(w, http.StatusInternalServerError, fmt.Sprintf("reviewing state write failed: %v", upsertErr))
 				return
 			}
 			// Set the in-memory flag atomically now that the DB write succeeded.

--- a/modules/programs/prism/prism/internal/sidecar/review_recovery.go
+++ b/modules/programs/prism/prism/internal/sidecar/review_recovery.go
@@ -35,8 +35,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/review"
 )
+
+// reviewRecoveryQuerier is the narrow interface used by reviewRecoveryTick
+// for its two DB calls. The concrete implementation is *db.DB; tests may
+// substitute a fake that simulates SQLITE_BUSY sequences.
+type reviewRecoveryQuerier interface {
+	LatestGroupForParent(parentSession string) (*db.GroupInfo, error)
+	GroupCompleted(groupID string) (bool, error)
+}
 
 // startReviewRecoveryWatcher launches the recovery goroutine for this
 // sidecar. It is a no-op (returns nil cancel) when the watcher is disabled
@@ -112,10 +121,15 @@ func (s *Sidecar) reviewRecoveryTick(grace time.Duration, now time.Time) {
 	// Fast path: no review in flight from this session's perspective.
 	s.mu.Lock()
 	inFlight := s.reviewingInFlight
+	qdb := s.reviewRecoveryQuerierOverride
 	s.mu.Unlock()
 	if !inFlight {
 		s.clearReviewRecoveryFirstSeen()
 		return
+	}
+	// Use the test override if present; fall back to the real DB.
+	if qdb == nil {
+		qdb = s.cfg.DB
 	}
 
 	// LatestGroupForParent (#1709 reopen) is the right query: while
@@ -125,8 +139,21 @@ func (s *Sidecar) reviewRecoveryTick(grace time.Duration, now time.Time) {
 	// "has any non-terminal member" criterion which is exactly the case the
 	// recovery watcher is designed to handle the OPPOSITE of: the stuck-but-
 	// complete group has ZERO non-terminal members by definition.
-	groupInfo, err := s.cfg.DB.LatestGroupForParent(s.cfg.SessionName)
-	if err != nil {
+	//
+	// Retry on SQLITE_BUSY: the socket-pipe reader's turn_start upsert may
+	// hold the write lock at the same instant the tick fires. Three attempts
+	// × 10 ms matches the backoff used by the /review pre-emptive write
+	// (host_api.go). See #1854.
+	const (
+		recoveryDBAttempts = 3
+		recoveryDBBackoff  = 10 * time.Millisecond
+	)
+	var groupInfo *db.GroupInfo
+	if err := db.WithBusyRetry(recoveryDBAttempts, recoveryDBBackoff, func() error {
+		var err error
+		groupInfo, err = qdb.LatestGroupForParent(s.cfg.SessionName)
+		return err
+	}); err != nil {
 		s.logger().Printf("sidecar: review-recovery: LatestGroupForParent: %v", err)
 		return
 	}
@@ -140,8 +167,12 @@ func (s *Sidecar) reviewRecoveryTick(grace time.Duration, now time.Time) {
 	}
 	groupID := groupInfo.GroupID
 
-	done, err := s.cfg.DB.GroupCompleted(groupID)
-	if err != nil {
+	var done bool
+	if err := db.WithBusyRetry(recoveryDBAttempts, recoveryDBBackoff, func() error {
+		var err error
+		done, err = qdb.GroupCompleted(groupID)
+		return err
+	}); err != nil {
 		s.logger().Printf("sidecar: review-recovery: GroupCompleted(%s): %v", groupID, err)
 		return
 	}
@@ -251,5 +282,14 @@ func (s *Sidecar) ReviewRecoveryFirstSeenForTest() map[string]time.Time {
 // deterministically without spinning a goroutine.
 func (s *Sidecar) ReviewRecoveryTickForTest(grace time.Duration, now time.Time) {
 	s.reviewRecoveryTick(grace, now)
+}
+
+// SetRecoveryQuerierForTest replaces the DB querier used by
+// reviewRecoveryTick with the given fake. Call before the first tick.
+// Only for use in tests.
+func (s *Sidecar) SetRecoveryQuerierForTest(q reviewRecoveryQuerier) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.reviewRecoveryQuerierOverride = q
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/review_recovery_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/review_recovery_test.go
@@ -26,8 +26,10 @@ package sidecar
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -309,4 +311,161 @@ func TestReviewRecoveryWatcher_IdempotentAcrossMultipleTicks(t *testing.T) {
 	if final != first {
 		t.Fatalf("after reviewingInFlight cleared: want %d deliveries (unchanged), got %d", first, final)
 	}
+}
+
+// ── SQLITE_BUSY retry tests ────────────────────────────────────────────────
+
+// busyThenSucceedQuerier is a fake reviewRecoveryQuerier whose
+// LatestGroupForParent and GroupCompleted methods return SQLITE_BUSY for the
+// first busyCalls invocations and then delegate to the real DB. This
+// simulates a transient write-lock held by the socket-pipe reader goroutine.
+type busyThenSucceedQuerier struct {
+	real      *db.DB
+	busyCalls int // total BUSY responses left across all method calls
+	calls     atomic.Int64
+}
+
+var errSQLiteBusy = errors.New("database is locked (5) (SQLITE_BUSY)")
+
+func (q *busyThenSucceedQuerier) LatestGroupForParent(parent string) (*db.GroupInfo, error) {
+	n := q.calls.Add(1)
+	if int(n) <= q.busyCalls {
+		return nil, errSQLiteBusy
+	}
+	return q.real.LatestGroupForParent(parent)
+}
+
+func (q *busyThenSucceedQuerier) GroupCompleted(groupID string) (bool, error) {
+	n := q.calls.Add(1)
+	if int(n) <= q.busyCalls {
+		return false, errSQLiteBusy
+	}
+	return q.real.GroupCompleted(groupID)
+}
+
+// TestReviewRecoveryWatcher_BusyRetry_SuccessAfterNRetries verifies that the
+// watcher recovers correctly when LatestGroupForParent returns SQLITE_BUSY
+// for the first N calls but succeeds on the (N+1)th — within the 3-attempt
+// retry budget. The grace window must remain anchored at the first-seen
+// timestamp; it must NOT be pushed out by the BUSY ticks. (#1854)
+func TestReviewRecoveryWatcher_BusyRetry_SuccessAfterNRetries(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "busy-retry-lgfp")
+	s := newWorkerSidecarForRecovery(t, fix)
+
+	// 2 BUSY calls before LatestGroupForParent succeeds — within the 3-attempt
+	// budget (attempts 1 and 2 return BUSY, attempt 3 succeeds).
+	fakeQ := &busyThenSucceedQuerier{real: fix.bus.DB, busyCalls: 2}
+	s.SetRecoveryQuerierForTest(fakeQ)
+
+	const grace = 90 * time.Second
+	now := time.Now()
+
+	// Tick 1: LatestGroupForParent retries through BUSY and succeeds.
+	// This is the first observation of complete; records first-seen, no delivery.
+	s.ReviewRecoveryTickForTest(grace, now)
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("busy-retry tick 1: want 0 deliveries, got %d", got)
+	}
+	firstSeen := s.ReviewRecoveryFirstSeenForTest()
+	if _, ok := firstSeen[fix.groupID]; !ok {
+		t.Fatalf("busy-retry tick 1: want first-seen entry for group %s, missing", fix.groupID)
+	}
+
+	// Tick 2 past grace: should deliver (BUSY budget already consumed above).
+	s.ReviewRecoveryTickForTest(grace, now.Add(grace+time.Second))
+	bodies := fix.bus.CopyBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("busy-retry tick 2 past grace: want 1 delivery, got %d", len(bodies))
+	}
+	if !strings.Contains(bodies[0], "Review complete: PR #"+fix.prNumber) {
+		t.Errorf("delivery body missing review-complete header; got: %s", bodies[0])
+	}
+}
+
+// TestReviewRecoveryWatcher_BusyRetry_FirstSeenNotReset verifies that the
+// grace window is anchored at the FIRST tick that observes the group
+// complete — NOT re-anchored on ticks where BUSY retries were needed.
+// Concretely: if tick-1 observes BUSY (then succeeds), records first-seen T,
+// then tick-2 at T+grace-1 also hits BUSY (then succeeds), the grace window
+// must still expire relative to T, not to the tick-2 timestamp. (#1854)
+func TestReviewRecoveryWatcher_BusyRetry_FirstSeenNotReset(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "busy-first-seen")
+	s := newWorkerSidecarForRecovery(t, fix)
+
+	// Each tick will hit BUSY once then succeed. The first-seen timestamp from
+	// tick-1 must be preserved across tick-2.
+	const grace = 60 * time.Second
+	now := time.Now()
+
+	// Tick 1: 1 BUSY call, then succeed. First-seen = now.
+	fakeQ1 := &busyThenSucceedQuerier{real: fix.bus.DB, busyCalls: 1}
+	s.SetRecoveryQuerierForTest(fakeQ1)
+	s.ReviewRecoveryTickForTest(grace, now)
+	fs1 := s.ReviewRecoveryFirstSeenForTest()
+	if _, ok := fs1[fix.groupID]; !ok {
+		t.Fatalf("tick 1: first-seen not recorded")
+	}
+
+	// Tick 2 inside grace: another BUSY then succeed. first-seen must be unchanged.
+	insideGrace := now.Add(grace / 2)
+	fakeQ2 := &busyThenSucceedQuerier{real: fix.bus.DB, busyCalls: 1}
+	s.SetRecoveryQuerierForTest(fakeQ2)
+	s.ReviewRecoveryTickForTest(grace, insideGrace)
+	fs2 := s.ReviewRecoveryFirstSeenForTest()
+	t1, _ := fs1[fix.groupID]
+	t2, ok2 := fs2[fix.groupID]
+	if !ok2 {
+		t.Fatalf("tick 2: first-seen entry dropped unexpectedly")
+	}
+	if !t1.Equal(t2) {
+		t.Errorf("first-seen timestamp changed: tick1=%v tick2=%v; want same (grace window must not shift)", t1, t2)
+	}
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("inside grace: want 0 deliveries, got %d", got)
+	}
+
+	// Tick 3 past grace: should deliver.
+	postGrace := now.Add(grace + time.Second)
+	s.ReviewRecoveryTickForTest(grace, postGrace)
+	if got := len(fix.bus.CopyBodies()); got != 1 {
+		t.Fatalf("past grace: want 1 delivery, got %d", got)
+	}
+}
+
+// TestReviewRecoveryWatcher_BusyRetry_GenuineErrorTerminates verifies that a
+// genuine (non-BUSY) error from LatestGroupForParent is not retried and
+// causes the tick to return without recording a first-seen entry (preserving
+// today's log-and-continue behaviour). (#1854 regression guard)
+func TestReviewRecoveryWatcher_BusyRetry_GenuineErrorTerminates(t *testing.T) {
+	fix := setupStuckReviewGroup(t, "genuine-error")
+	s := newWorkerSidecarForRecovery(t, fix)
+
+	// Fake that always returns a non-BUSY error.
+	genuineErr := errors.New("db: some unrecoverable schema error")
+	s.SetRecoveryQuerierForTest(&alwaysErrQuerier{err: genuineErr})
+
+	const grace = 90 * time.Second
+	now := time.Now()
+
+	s.ReviewRecoveryTickForTest(grace, now)
+	// No delivery, no first-seen entry.
+	if got := len(fix.bus.CopyBodies()); got != 0 {
+		t.Fatalf("want 0 deliveries on genuine error, got %d", got)
+	}
+	if seen := s.ReviewRecoveryFirstSeenForTest(); len(seen) != 0 {
+		t.Errorf("want empty first-seen map on genuine error, got %v", seen)
+	}
+}
+
+// alwaysErrQuerier is a reviewRecoveryQuerier that always returns err.
+type alwaysErrQuerier struct {
+	err error
+}
+
+func (q *alwaysErrQuerier) LatestGroupForParent(string) (*db.GroupInfo, error) {
+	return nil, q.err
+}
+
+func (q *alwaysErrQuerier) GroupCompleted(string) (bool, error) {
+	return false, q.err
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -493,6 +493,13 @@ type Sidecar struct {
 	// group_id; entries are dropped when the group transitions away or
 	// reviewingInFlight clears. Protected by mu.
 	reviewRecoveryFirstSeenComplete map[string]time.Time
+
+	// reviewRecoveryQuerierOverride, when non-nil, is used by
+	// reviewRecoveryTick instead of cfg.DB for the LatestGroupForParent and
+	// GroupCompleted calls. Tests set this field to inject a fake querier
+	// that simulates SQLITE_BUSY sequences without needing a real locked DB.
+	// Must be set before the first call to reviewRecoveryTick.
+	reviewRecoveryQuerierOverride reviewRecoveryQuerier
 }
 
 // defaultReviewRecoveryInterval is how often the worker-sidecar recovery


### PR DESCRIPTION
## Summary

Fixes the review-recovery watcher's asymmetry with the `/review` pre-emptive write: the watcher now retries `LatestGroupForParent` and `GroupCompleted` on `SQLITE_BUSY` using the same 3-attempt × 10ms backoff, and the shared retry helper is extracted so both call sites use it.

Closes #1854

## Changes

- **`internal/db/retry.go`** (new): `IsSQLiteBusy` and `WithBusyRetry` shared utility.
- **`internal/sidecar/helpers.go`**: package-local `isSQLiteBusy` now delegates to `db.IsSQLiteBusy`.
- **`internal/sidecar/host_api.go`**: inline retry loop in `/review` pre-emptive write replaced with `db.WithBusyRetry`.
- **`internal/sidecar/review_recovery.go`**: `LatestGroupForParent` and `GroupCompleted` calls wrapped with `db.WithBusyRetry` (3 × 10ms). Introduces a narrow `reviewRecoveryQuerier` interface + `reviewRecoveryQuerierOverride` field for test injection. First-seen-timestamp bookkeeping is unaffected by BUSY retries.
- **`internal/db/retry_test.go`** (new): unit tests for `IsSQLiteBusy` and `WithBusyRetry`.
- **`internal/sidecar/review_recovery_test.go`**: three new BUSY-retry tests:
  - `TestReviewRecoveryWatcher_BusyRetry_SuccessAfterNRetries` — fake DB returns BUSY for first 2 calls, success on 3rd; watcher recovers within budget.
  - `TestReviewRecoveryWatcher_BusyRetry_FirstSeenNotReset` — grace window anchored at first observation, not shifted by BUSY ticks.
  - `TestReviewRecoveryWatcher_BusyRetry_GenuineErrorTerminates` — non-BUSY error logs and returns without recording first-seen (regression guard).

## Quality gates

- `go build ./...` ✅
- `go test ./internal/sidecar/ -race` ✅
- `go test ./internal/db/ -race` ✅
- `nix build .#prism` ✅