### PR TITLE
sidecar: surface control-plane backpressure as non-200 responses

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -2297,6 +2297,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Status  string `json:"status"`
 		}
 		results := make([]sessionResult, 0, len(targets))
+		applyAnyQueueFull := false
 		for _, targetSess := range targets {
 			// Look up role to find the correct slot.
 			role, status := resolveRoleForSession(s, targetSess)
@@ -2317,9 +2318,18 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 			deliveryStatus := liveModelSwapForSession(s, targetSess, slot.Provider, slot.Model, slot.Thinking)
 			results = append(results, sessionResult{Session: targetSess, Status: deliveryStatus})
+			if deliveryStatus == "error:queue-full" {
+				applyAnyQueueFull = true
+			}
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+		// When any target's outbound channel was full, return 503 so the caller
+		// knows at least one set_model frame was dropped. Issue #1844.
+		applyHTTPStatus := http.StatusOK
+		if applyAnyQueueFull {
+			applyHTTPStatus = http.StatusServiceUnavailable
+		}
+		writeJSON(w, applyHTTPStatus, map[string]any{"results": results})
 	})
 
 	// POST /register-provider

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -2178,7 +2178,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		status := liveModelSwapForSession(s, req.Session, req.Provider, req.Model, req.Thinking)
-		writeJSON(w, http.StatusOK, map[string]string{
+		// When the outbound channel is full, return 503 so the caller knows the
+		// frame was dropped rather than silently accepting 200 OK. Issue #1844.
+		httpStatus := http.StatusOK
+		if status == "error:queue-full" {
+			httpStatus = http.StatusServiceUnavailable
+		}
+		writeJSON(w, httpStatus, map[string]string{
 			"session": req.Session,
 			"status":  status,
 		})
@@ -2403,12 +2409,22 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Status  string `json:"status"`
 		}
 		results := make([]sessionResult, 0, len(targets))
+		anyQueueFull := false
 		for _, targetSess := range targets {
 			deliveryStatus := liveRegisterProviderForSession(s, targetSess, req.Name, req.Config)
 			results = append(results, sessionResult{Session: targetSess, Status: deliveryStatus})
+			if deliveryStatus == "error:queue-full" {
+				anyQueueFull = true
+			}
 		}
 
-		writeJSON(w, http.StatusOK, map[string]any{"results": results})
+		// When any target's outbound channel was full, return 503 so the caller
+		// knows at least one frame was dropped. Issue #1844.
+		regHTTPStatus := http.StatusOK
+		if anyQueueFull {
+			regHTTPStatus = http.StatusServiceUnavailable
+		}
+		writeJSON(w, regHTTPStatus, map[string]any{"results": results})
 	})
 
 	// POST /register-provider-direct
@@ -2443,7 +2459,100 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "error:disconnected"})
 			return
 		}
-		s.RegisterProvider(req.Name, req.Config)
+		// Propagate channel-full failure as 503 so the forwarding sidecar
+		// knows the frame was dropped. Issue #1844.
+		if !s.RegisterProvider(req.Name, req.Config) {
+			s.logger().Printf("sidecar: /register-provider-direct: enqueue failed (queue full) for session %s", req.Session)
+			writeError(w, http.StatusServiceUnavailable, "outbound queue full")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "applied"})
+	})
+
+	// POST /set-active-tools
+	// Request:  {"session":"<name>","tools":["tool1","tool2",...]}
+	// Response: {"session":"<name>","status":"applied"|"error:disconnected"} | 503
+	//
+	// Enqueues a set_active_tools frame to the PI extension for the session's
+	// own harness pipe. Only targets the calling session (workers) or a named
+	// session (coordinator). Returns 503 Service Unavailable when the outbound
+	// channel is full so the caller knows the frame was dropped. Issue #1844.
+	mux.HandleFunc("/set-active-tools", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		var req struct {
+			Session string   `json:"session"`
+			Tools   []string `json:"tools"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Session == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+		// Workers may only target their own session.
+		satCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()))
+		if !satCallerIsCoordinator && req.Session != s.cfg.SessionName {
+			writeError(w, http.StatusForbidden, "workers can only call /set-active-tools for their own session")
+			return
+		}
+		if !isPipeConnected(s) {
+			writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "error:disconnected"})
+			return
+		}
+		// Return 503 when the outbound channel is full so the caller knows the
+		// frame was dropped rather than silently accepting 200 OK. Issue #1844.
+		if !s.SetActiveTools(req.Tools) {
+			s.logger().Printf("sidecar: /set-active-tools: enqueue failed (queue full) for session %s", req.Session)
+			writeError(w, http.StatusServiceUnavailable, "outbound queue full")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "applied"})
+	})
+
+	// POST /abort
+	// Request:  {"session":"<name>"}
+	// Response: {"session":"<name>","status":"applied"|"error:disconnected"} | 503
+	//
+	// Enqueues an abort frame to the PI extension for the session's own harness
+	// pipe. Only targets the calling session (workers) or a named session
+	// (coordinator). Returns 503 Service Unavailable when the outbound channel
+	// is full so the caller knows the frame was dropped. Issue #1844.
+	mux.HandleFunc("/abort", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		var req struct {
+			Session string `json:"session"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Session == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+		// Workers may only target their own session.
+		abortCallerIsCoordinator := s.cfg.AgentRole == "coordinator" || (s.cfg.AgentRole == "" && isCoordinatorSession(s.cfg.SessionName, s.cfg.DB, s.logger()))
+		if !abortCallerIsCoordinator && req.Session != s.cfg.SessionName {
+			writeError(w, http.StatusForbidden, "workers can only call /abort for their own session")
+			return
+		}
+		if !isPipeConnected(s) {
+			writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "error:disconnected"})
+			return
+		}
+		// Return 503 when the outbound channel is full so the caller knows the
+		// frame was dropped rather than silently accepting 200 OK. Issue #1844.
+		if !s.Abort() {
+			s.logger().Printf("sidecar: /abort: enqueue failed (queue full) for session %s", req.Session)
+			writeError(w, http.StatusServiceUnavailable, "outbound queue full")
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]string{"session": req.Session, "status": "applied"})
 	})
 
@@ -2608,7 +2717,12 @@ func liveModelSwapForSession(s *Sidecar, targetSess, provider, model, thinking s
 		if !isPipeConnected(s) {
 			return "error:disconnected"
 		}
-		s.SetModel(provider, model, thinking)
+		// Propagate channel-full failure as error:queue-full so the HTTP caller
+		// receives a non-200 response rather than a silent 200 OK. Issue #1844.
+		if !s.SetModel(provider, model, thinking) {
+			s.logger().Printf("sidecar: liveModelSwapForSession: enqueue failed (queue full) for %s", targetSess)
+			return "error:queue-full"
+		}
 		return "applied"
 	}
 
@@ -2626,7 +2740,12 @@ func liveRegisterProviderForSession(s *Sidecar, targetSess, name string, cfg map
 		if !isPipeConnected(s) {
 			return "error:disconnected"
 		}
-		s.RegisterProvider(name, cfg)
+		// Propagate channel-full failure as error:queue-full so the HTTP caller
+		// receives a non-200 response rather than a silent 200 OK. Issue #1844.
+		if !s.RegisterProvider(name, cfg) {
+			s.logger().Printf("sidecar: liveRegisterProviderForSession: enqueue failed (queue full) for %s", targetSess)
+			return "error:queue-full"
+		}
 		return "applied"
 	}
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2503,7 +2503,16 @@ func (s *Sidecar) flushPendingReplay() {
 
 // enqueueHarnessPipeFrame enqueues a JSONL frame for delivery to the PI
 // extension via the outbound writer goroutine. The frame must already be
-// terminated with '\n'. Returns false if no active pipe connection is open.
+// terminated with '\n'.
+//
+// Returns false when:
+//   - no active pipe connection is open (harnessPipeOutCh is nil), or
+//   - the outbound channel is full (buffered to 64) and the frame was dropped.
+//
+// Callers MUST check the return value or handle failure explicitly; this
+// function never blocks the writer. A false return means the control-plane
+// frame was NOT delivered — the caller is responsible for propagating that
+// failure to its own caller (e.g. returning a non-200 HTTP response). Issue #1844.
 func (s *Sidecar) enqueueHarnessPipeFrame(frame []byte) bool {
 	s.mu.Lock()
 	ch := s.harnessPipeOutCh
@@ -2567,7 +2576,10 @@ func (s *Sidecar) deliverPromptFrame(text, deliverAs string, replay bool) bool {
 // SetModel enqueues a set_model control frame to the PI extension.
 // Stub for P3.LIVE — the sidecar does not yet act on this internally;
 // it only forwards the frame.
-func (s *Sidecar) SetModel(provider, model, thinking string) {
+//
+// Returns false if the frame could not be enqueued (no active connection or
+// outbound channel full). Callers should propagate this as a non-200 response.
+func (s *Sidecar) SetModel(provider, model, thinking string) bool {
 	frame := struct {
 		Type     string `json:"type"`
 		Provider string `json:"provider"`
@@ -2581,12 +2593,15 @@ func (s *Sidecar) SetModel(provider, model, thinking string) {
 	}
 	b, _ := json.Marshal(frame)
 	b = append(b, '\n')
-	s.enqueueHarnessPipeFrame(b) //nolint:errcheck
+	return s.enqueueHarnessPipeFrame(b)
 }
 
 // RegisterProvider enqueues a register_provider frame to the PI extension.
 // Stub for P3.LIVE.
-func (s *Sidecar) RegisterProvider(name string, cfg map[string]any) {
+//
+// Returns false if the frame could not be enqueued (no active connection or
+// outbound channel full). Callers should propagate this as a non-200 response.
+func (s *Sidecar) RegisterProvider(name string, cfg map[string]any) bool {
 	frame := struct {
 		Type   string         `json:"type"`
 		Name   string         `json:"name"`
@@ -2598,12 +2613,15 @@ func (s *Sidecar) RegisterProvider(name string, cfg map[string]any) {
 	}
 	b, _ := json.Marshal(frame)
 	b = append(b, '\n')
-	s.enqueueHarnessPipeFrame(b) //nolint:errcheck
+	return s.enqueueHarnessPipeFrame(b)
 }
 
 // SetActiveTools enqueues a set_active_tools frame to the PI extension.
 // Stub for P3.LIVE.
-func (s *Sidecar) SetActiveTools(tools []string) {
+//
+// Returns false if the frame could not be enqueued (no active connection or
+// outbound channel full). Callers should propagate this as a non-200 response.
+func (s *Sidecar) SetActiveTools(tools []string) bool {
 	frame := struct {
 		Type  string   `json:"type"`
 		Tools []string `json:"tools"`
@@ -2613,18 +2631,21 @@ func (s *Sidecar) SetActiveTools(tools []string) {
 	}
 	b, _ := json.Marshal(frame)
 	b = append(b, '\n')
-	s.enqueueHarnessPipeFrame(b) //nolint:errcheck
+	return s.enqueueHarnessPipeFrame(b)
 }
 
 // Abort enqueues an abort frame to the PI extension.
 // Stub for P3.LIVE.
-func (s *Sidecar) Abort() {
+//
+// Returns false if the frame could not be enqueued (no active connection or
+// outbound channel full). Callers should propagate this as a non-200 response.
+func (s *Sidecar) Abort() bool {
 	frame := struct {
 		Type string `json:"type"`
 	}{Type: "abort"}
 	b, _ := json.Marshal(frame)
 	b = append(b, '\n')
-	s.enqueueHarnessPipeFrame(b) //nolint:errcheck
+	return s.enqueueHarnessPipeFrame(b)
 }
 
 // buildStdioHarnessCmd constructs the exec.Cmd used to launch the stdio

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	pih "github.com/prismatic-koi/prism/internal/harness/pi"
@@ -3115,6 +3116,49 @@ func TestControlPlane_HappyPath_Abort(t *testing.T) {
 	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
 	conn.Close()
 	_ = wait()
+}
+
+// TestControlPlane_QueueFull_ApplyProfile verifies that /apply-profile returns
+// 503 when the outbound channel of a target session is full.
+func TestControlPlane_QueueFull_ApplyProfile(t *testing.T) {
+	sc := newQueueFullSidecar(t)
+	// apply-profile is coordinator-only for scope=session targeting own session
+	// when the caller is a worker — override to coordinator so the handler proceeds.
+	sc.cfg.AgentRole = "coordinator"
+	getLogs := captureLog(sc)
+
+	// Insert a DB row for the session so resolveRoleForSession can look up the role.
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+	_ = sc.cfg.DB.SetHarness(sc.cfg.SessionName, "pi")
+
+	// Stub the profile loader so the test doesn't need a real profiles file.
+	origLoader := hostAPILoadProfiles
+	hostAPILoadProfiles = func() (*config.ProfilesFile, error) {
+		return &config.ProfilesFile{
+			Default: "base",
+			Profiles: map[string]config.ProfileEntry{
+				"base": {
+					"worker":      {Provider: "anthropic", Model: "claude-sonnet", Thinking: "none"},
+					"coordinator": {Provider: "anthropic", Model: "claude-sonnet", Thinking: "none"},
+				},
+			},
+		}, nil
+	}
+	defer func() { hostAPILoadProfiles = origLoader }()
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "base",
+		"scope":   "session",
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Failure must be logged.
+	if logs := getLogs(); !strings.Contains(logs, "queue full") {
+		t.Errorf("expected queue-full log, got: %s", logs)
+	}
 }
 
 // TestControlPlane_QueueFull_RegisterProviderDirect verifies that

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2866,3 +2867,273 @@ func TestSocketPipe_FailedRetryReview_StateChangeDoesNotFinish(t *testing.T) {
 
 // Ensure db import is used.
 var _ *db.DB
+
+// ── Issue #1844: control-plane backpressure tests ─────────────────────────────
+//
+// These tests verify that when the outbound channel (harnessPipeOutCh, buffered
+// to 64) is full, each control-plane HTTP handler returns a non-200 response
+// instead of silently accepting 200 OK.
+//
+// The full-channel state is simulated by directly setting harnessPipeOutCh to a
+// pre-filled channel (all 64 slots occupied). This is the package-internal
+// equivalent of "block the writer goroutine with a hung mock connection" because
+// the HTTP-level invariant under test is identical regardless of how the channel
+// became full.
+
+// fillOutboundChannel pre-fills s.harnessPipeOutCh to capacity with dummy frames
+// so that the next enqueueHarnessPipeFrame call returns false. The sidecar's
+// pipe-loop need not be running — we set the channel directly so isPipeConnected
+// returns true while the channel is already at capacity.
+func fillOutboundChannel(s *Sidecar) {
+	ch := make(chan []byte, 64)
+	dummy := []byte(`{"type":"noop"}` + "\n")
+	for i := 0; i < 64; i++ {
+		ch <- dummy
+	}
+	s.mu.Lock()
+	s.harnessPipeOutCh = ch
+	s.mu.Unlock()
+}
+
+// newQueueFullSidecar creates a sidecar whose outbound channel is pre-filled
+// to capacity. The pipe loop is NOT running; the test operates purely through
+// the HTTP handler surface.
+func newQueueFullSidecar(t *testing.T) *Sidecar {
+	t.Helper()
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "worker"
+	fillOutboundChannel(sc)
+	return sc
+}
+
+// TestControlPlane_QueueFull_SetModel verifies that /set-model returns 503
+// when the outbound channel is full and the failure is logged.
+func TestControlPlane_QueueFull_SetModel(t *testing.T) {
+	sc := newQueueFullSidecar(t)
+	getLogs := captureLog(sc)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-model", map[string]any{
+		"session":  sc.cfg.SessionName,
+		"provider": "anthropic",
+		"model":    "claude-3-7-sonnet",
+		"thinking": "",
+	})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Failure must be logged.
+	if logs := getLogs(); !strings.Contains(logs, "queue full") {
+		t.Errorf("expected queue-full log, got: %s", logs)
+	}
+}
+
+// TestControlPlane_HappyPath_SetModel verifies that /set-model returns 200 OK
+// when the outbound channel has space (regression guard for the queue-full change).
+func TestControlPlane_HappyPath_SetModel(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-model", map[string]any{
+		"session":  sc.cfg.SessionName,
+		"provider": "anthropic",
+		"model":    "claude-3-7-sonnet",
+		"thinking": "",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// The extension should receive the frame.
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "set_model" {
+		t.Errorf("frame type = %v, want set_model", got)
+	}
+	// Clean shutdown.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestControlPlane_QueueFull_RegisterProvider verifies that /register-provider
+// returns 503 when the outbound channel is full and the failure is logged.
+func TestControlPlane_QueueFull_RegisterProvider(t *testing.T) {
+	sc := newQueueFullSidecar(t)
+	getLogs := captureLog(sc)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/register-provider", map[string]any{
+		"session": sc.cfg.SessionName,
+		"name":    "my-provider",
+		"config":  map[string]any{"apiKey": "test"},
+		"scope":   "session",
+	})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Failure must be logged.
+	if logs := getLogs(); !strings.Contains(logs, "queue full") {
+		t.Errorf("expected queue-full log, got: %s", logs)
+	}
+}
+
+// TestControlPlane_HappyPath_RegisterProvider verifies that /register-provider
+// returns 200 OK when the outbound channel has space.
+func TestControlPlane_HappyPath_RegisterProvider(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "worker"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/register-provider", map[string]any{
+		"session": sc.cfg.SessionName,
+		"name":    "my-provider",
+		"config":  map[string]any{"apiKey": "test"},
+		"scope":   "session",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// The extension should receive the frame.
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "register_provider" {
+		t.Errorf("frame type = %v, want register_provider", got)
+	}
+	// Clean shutdown.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestControlPlane_QueueFull_SetActiveTools verifies that /set-active-tools
+// returns 503 when the outbound channel is full and the failure is logged.
+func TestControlPlane_QueueFull_SetActiveTools(t *testing.T) {
+	sc := newQueueFullSidecar(t)
+	getLogs := captureLog(sc)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-active-tools", map[string]any{
+		"session": sc.cfg.SessionName,
+		"tools":   []string{"bash", "read"},
+	})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Failure must be logged.
+	if logs := getLogs(); !strings.Contains(logs, "queue full") {
+		t.Errorf("expected queue-full log, got: %s", logs)
+	}
+}
+
+// TestControlPlane_HappyPath_SetActiveTools verifies that /set-active-tools
+// returns 200 OK when the outbound channel has space.
+func TestControlPlane_HappyPath_SetActiveTools(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "worker"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-active-tools", map[string]any{
+		"session": sc.cfg.SessionName,
+		"tools":   []string{"bash", "read"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// The extension should receive the frame.
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "set_active_tools" {
+		t.Errorf("frame type = %v, want set_active_tools", got)
+	}
+	// Clean shutdown.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestControlPlane_QueueFull_Abort verifies that /abort returns 503 when the
+// outbound channel is full and the failure is logged.
+func TestControlPlane_QueueFull_Abort(t *testing.T) {
+	sc := newQueueFullSidecar(t)
+	getLogs := captureLog(sc)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/abort", map[string]any{
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Failure must be logged.
+	if logs := getLogs(); !strings.Contains(logs, "queue full") {
+		t.Errorf("expected queue-full log, got: %s", logs)
+	}
+}
+
+// TestControlPlane_HappyPath_Abort verifies that /abort returns 200 OK when
+// the outbound channel has space.
+func TestControlPlane_HappyPath_Abort(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "worker"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/abort", map[string]any{
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// The extension should receive the frame.
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "abort" {
+		t.Errorf("frame type = %v, want abort", got)
+	}
+	// Clean shutdown.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestControlPlane_QueueFull_RegisterProviderDirect verifies that
+// /register-provider-direct returns 503 when the outbound channel is full.
+func TestControlPlane_QueueFull_RegisterProviderDirect(t *testing.T) {
+	sc := newQueueFullSidecar(t)
+	getLogs := captureLog(sc)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/register-provider-direct", map[string]any{
+		"session": sc.cfg.SessionName,
+		"name":    "my-provider",
+		"config":  map[string]any{"apiKey": "test"},
+	})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// Failure must be logged.
+	if logs := getLogs(); !strings.Contains(logs, "queue full") {
+		t.Errorf("expected queue-full log, got: %s", logs)
+	}
+}


### PR DESCRIPTION
## Summary

When `harnessPipeOutCh` (buffered to 64) is full, `enqueueHarnessPipeFrame` returns `false`. Previously `SetModel`, `RegisterProvider`, `SetActiveTools`, and `Abort` silently discarded that return value via `//nolint:errcheck`, causing HTTP callers to receive `200 OK` even when the frame was dropped.

## Changes

- **`enqueueHarnessPipeFrame`**: Added contract comment: "callers MUST check the return value or handle failure explicitly; this function never blocks the writer."
- **`SetModel`, `RegisterProvider`, `SetActiveTools`, `Abort`**: Changed return type to `bool`; propagate the `enqueueHarnessPipeFrame` result. Removed all `//nolint:errcheck` suppression.
- **`/set-model` handler**: Returns 503 Service Unavailable when the outbound channel is full (`error:queue-full` status).
- **`/register-provider` handler**: Returns 503 when any target returns `error:queue-full`.
- **`/register-provider-direct` handler**: Returns 503 on enqueue failure.
- **New `/set-active-tools` and `/abort` HTTP handlers**: New endpoints that also return 503 on enqueue failure.
- **New tests** in `sidecar_socketpipe_test.go`: queue-full path (503) and happy path (200 OK) for all four operations plus `/register-provider-direct`.

## Test results

- `go test ./internal/sidecar/ -race` passes
- `nix build .#prism` passes

Closes #1844