### PR TITLE
sidecar: wire maxLineBytes cap into socket-pipe inbound readers

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -285,6 +285,11 @@ type Config struct {
 	// path (which uses host.containers.internal), sandbox-exec runs directly on
 	// the host, so loopback-only is both correct and more secure.
 	HarnessPipeTCPPort int
+	// PipeMaxLineBytes overrides the per-frame byte cap enforced by the
+	// socket-pipe inbound reader. Zero means use socketPipeMaxLineBytes (16
+	// MiB). Set to a small value in tests to exercise boundary behaviour
+	// without allocating 16 MiB of test data.
+	PipeMaxLineBytes int
 }
 
 // seenUnknownCap is the maximum number of unique unknown event types tracked
@@ -1603,6 +1608,13 @@ const piWireProtocolVersion = 2
 // connection drop before marking the session as error. See P2.WIRE §7.2.
 const pipeDisconnectTimeout = 30 * time.Second
 
+// socketPipeMaxLineBytes is the default maximum byte length of a single JSONL
+// frame accepted from the PI extension on the socket-pipe transport. A frame
+// that exceeds this cap is treated as a protocol violation: the connection is
+// closed and a log line is emitted. Per-sidecar overrides are set via
+// Config.PipeMaxLineBytes (used in tests to avoid 16 MiB allocations).
+const socketPipeMaxLineBytes = 16 * 1024 * 1024
+
 // acceptOutcome enumerates the reasons an Accept attempt in
 // runStartupSocketPipe returned without a live connection. It is required
 // (instead of a plain bool) so that the caller can distinguish a startup
@@ -1806,7 +1818,45 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 	// After a non-shutdown drop it switches to pipeDisconnectTimeout.
 	acceptTimeout := startupTimeout
 
-	const maxLineBytes = 16 * 1024 * 1024
+	// effectiveMaxLineBytes is the per-frame byte cap for this connection.
+	// Config.PipeMaxLineBytes, when non-zero, overrides the package default
+	// (socketPipeMaxLineBytes = 16 MiB). Tests set this to a small value to
+	// exercise boundary behaviour without allocating large buffers.
+	effectiveMaxLineBytes := s.cfg.PipeMaxLineBytes
+	if effectiveMaxLineBytes <= 0 {
+		effectiveMaxLineBytes = socketPipeMaxLineBytes
+	}
+
+	// errFrameTooLong is returned by readLineLimited when a single frame
+	// exceeds effectiveMaxLineBytes — a distinct sentinel lets callers
+	// distinguish protocol violations from clean disconnect (io.EOF).
+	errFrameTooLong := errors.New("frame exceeded maxLineBytes")
+
+	// readLineLimited reads one newline-terminated line from br, enforcing a
+	// hard cap of effectiveMaxLineBytes on the frame length. It uses ReadSlice
+	// in a loop to avoid bufio.Reader growing without bound. On cap-exceeded
+	// it returns nil, errFrameTooLong; on clean disconnect it returns nil,
+	// io.EOF.
+	readLineLimited := func(br *bufio.Reader) ([]byte, error) {
+		var buf []byte
+		for {
+			slice, err := br.ReadSlice('\n')
+			buf = append(buf, slice...)
+			if len(buf) > effectiveMaxLineBytes {
+				return nil, errFrameTooLong
+			}
+			if err == nil {
+				// Found newline — done.
+				return buf, nil
+			}
+			if err == bufio.ErrBufferFull {
+				// Internal buffer is full but no newline yet; keep reading.
+				continue
+			}
+			// Any other error (io.EOF, net.OpError, etc.) — return what we have.
+			return buf, err
+		}
+	}
 
 	for {
 		// --- Wait for the extension to connect ----------------------------
@@ -1856,11 +1906,14 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 		reader := bufio.NewReader(conn)
 
 		_ = conn.SetReadDeadline(time.Now().Add(startupTimeout))
-		helloLine, err := reader.ReadBytes('\n')
+		helloLine, err := readLineLimited(reader)
 		_ = conn.SetReadDeadline(time.Time{})
 		if err != nil {
-			err2 := fmt.Errorf("sidecar: runStartupSocketPipe: reading hello: %w", err)
-			s.logger().Printf("%v", err2)
+			if errors.Is(err, errFrameTooLong) {
+				s.logger().Printf("sidecar: socket-pipe: hello frame exceeded maxLineBytes (> %d) — closing connection", effectiveMaxLineBytes)
+			} else {
+				s.logger().Printf("sidecar: runStartupSocketPipe: reading hello: %v", err)
+			}
 			_ = conn.Close()
 			connMu.Lock()
 			activeConn = nil
@@ -1991,13 +2044,19 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 		// --- Inbound frame loop -------------------------------------------
 		cleanShutdown := false
 		for {
-			line, readErr := reader.ReadBytes('\n')
+			line, readErr := readLineLimited(reader)
+			if errors.Is(readErr, errFrameTooLong) {
+				s.logger().Printf("sidecar: socket-pipe: frame exceeded maxLineBytes (> %d) — closing connection", effectiveMaxLineBytes)
+				s.mu.Lock()
+				s.flushPipeAccum()
+				s.mu.Unlock()
+				break
+			}
 			if len(line) > 0 {
 				if len(line) > 1 && line[len(line)-2] == '\r' {
 					line = append(line[:len(line)-2], '\n')
 				}
 				frameBytes := line[:len(line)-1]
-				_ = maxLineBytes
 				s.archiveInboundFrame(frameBytes)
 				if s.handlePipeFrame(frameBytes) {
 					cleanShutdown = true

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -3181,3 +3181,200 @@ func TestControlPlane_QueueFull_RegisterProviderDirect(t *testing.T) {
 		t.Errorf("expected queue-full log, got: %s", logs)
 	}
 }
+
+// ── readLineLimited / maxLineBytes cap tests ──────────────────────────────────
+
+// testMaxLineBytes is the per-test per-frame byte cap used by the _LineCap_
+// tests below. 256 bytes is large enough to accommodate the hello frame used
+// by dialAndHandshake (~82 bytes) while still being far below the 16 MiB
+// default, keeping test allocations tiny and execution fast.
+const testMaxLineBytes = 256
+
+// newSocketPipeSidecarWithLineCap creates a Sidecar configured for socket-pipe
+// testing with Config.PipeMaxLineBytes set to cap. This avoids any global
+// state mutation and is safe for parallel tests.
+func newSocketPipeSidecarWithLineCap(t *testing.T, sockPath string, cap int) *Sidecar {
+	t.Helper()
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           "testrepo@main",
+		Repo:                  "testrepo",
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "worker",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		PipeReconnectTimeout:  200 * time.Millisecond,
+		PipeMaxLineBytes:      cap,
+		Harness:               pih.New("", "", ""),
+	}
+	return New(cfg)
+}
+
+// TestSocketPipe_LineCap_OversizedFrameClosesConnection verifies that a frame
+// of PipeMaxLineBytes+1 bytes (no newline) causes the sidecar to close the
+// connection and emit a clearly-tagged log line.
+func TestSocketPipe_LineCap_OversizedFrameClosesConnection(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecarWithLineCap(t, sockPath, testMaxLineBytes)
+	getLogs := captureLog(sc)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Send a blob of testMaxLineBytes+1 bytes with no newline — exceeds the
+	// cap and must trigger a protocol-violation close.
+	oversized := make([]byte, testMaxLineBytes+1)
+	for i := range oversized {
+		oversized[i] = 'x'
+	}
+	if _, err := conn.Write(oversized); err != nil {
+		t.Fatalf("write oversized frame: %v", err)
+	}
+
+	// The sidecar must close the connection. Detect this by waiting for a
+	// read on our side to return an error (EOF / connection reset).
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	readBuf := make([]byte, 1)
+	_, readErr := conn.Read(readBuf)
+	if readErr == nil {
+		t.Error("expected connection to be closed by sidecar after oversized frame, but Read returned nil error")
+	}
+	conn.Close()
+
+	// After connection closed, reconnect and send session_shutdown so sidecar exits.
+	conn2, _ := dialAndHandshake(t, sockPath)
+	sendJSON(t, conn2, map[string]any{"type": "session_shutdown"})
+	conn2.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error: %v", err)
+	}
+
+	// The violation log line must have been emitted.
+	logs := getLogs()
+	if !strings.Contains(logs, "frame exceeded maxLineBytes") {
+		t.Errorf("expected 'frame exceeded maxLineBytes' in logs, got: %s", logs)
+	}
+	if !strings.Contains(logs, "closing connection") {
+		t.Errorf("expected 'closing connection' in logs, got: %s", logs)
+	}
+}
+
+// TestSocketPipe_LineCap_BoundaryFrameAccepted verifies that a frame of
+// exactly PipeMaxLineBytes bytes terminated by a newline is accepted and
+// processed normally (the cap is a strict greater-than comparison).
+func TestSocketPipe_LineCap_BoundaryFrameAccepted(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecarWithLineCap(t, sockPath, testMaxLineBytes)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Build a valid JSON frame of exactly testMaxLineBytes bytes (including
+	// the trailing newline). We use {"type":"unknown_cap_test","p":"<pad>"}
+	// and pad to fill exactly testMaxLineBytes bytes.
+	const frameType = "unknown_cap_test"
+	// Skeleton (no padding): {"type":"unknown_cap_test","p":""}\n
+	skeleton := `{"type":"` + frameType + `","p":"` + `"}` + "\n"
+	padLen := testMaxLineBytes - len(skeleton)
+	if padLen < 0 {
+		t.Fatalf("skeleton frame (%d bytes) already exceeds testMaxLineBytes (%d)", len(skeleton), testMaxLineBytes)
+	}
+	padding := strings.Repeat("a", padLen)
+	frame := `{"type":"` + frameType + `","p":"` + padding + `"}` + "\n"
+	if len(frame) != testMaxLineBytes {
+		t.Fatalf("frame length = %d, want %d", len(frame), testMaxLineBytes)
+	}
+
+	if _, err := conn.Write([]byte(frame)); err != nil {
+		t.Fatalf("write boundary frame: %v", err)
+	}
+
+	// Send session_shutdown and wait for clean exit.
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Errorf("runStartupSocketPipe returned error on boundary frame: %v", err)
+	}
+
+	// The boundary frame must have been persisted as an event (unknown types
+	// are stored for forward-compatibility).
+	events := getEvents(t, sc.cfg.DB, sc.cfg.SessionName)
+	found := false
+	for _, ev := range events {
+		if ev.Type == frameType {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("boundary frame of type %q not found in agent_events", frameType)
+	}
+}
+
+// TestSocketPipe_LineCap_HelloOversizedClosesConnection verifies that the
+// hello-handshake reader also enforces the cap: an oversized hello frame
+// causes the connection to be closed and a violation log line is emitted.
+func TestSocketPipe_LineCap_HelloOversizedClosesConnection(t *testing.T) {
+	// Use a cap that is smaller than the hello frame (~82 bytes) so that the
+	// very first read on the connection triggers the cap-exceeded path.
+	const helloCap = 64
+
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecarWithLineCap(t, sockPath, helloCap)
+	getLogs := captureLog(sc)
+	wait := runSocketPipeSidecar(sc)
+
+	// Wait for the socket to appear (sidecar may still be binding).
+	deadline := time.Now().Add(3 * time.Second)
+	var conn net.Conn
+	var err error
+	for {
+		conn, err = net.Dial("unix", sockPath)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for socket %s: %v", sockPath, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Send an oversized hello (no newline) — exceeds the cap before a valid
+	// hello frame can be parsed.
+	oversized := make([]byte, helloCap+1)
+	for i := range oversized {
+		oversized[i] = 'x'
+	}
+	if _, err := conn.Write(oversized); err != nil {
+		t.Fatalf("write oversized hello: %v", err)
+	}
+
+	// The sidecar must close the connection.
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	readBuf := make([]byte, 1)
+	_, readErr := conn.Read(readBuf)
+	if readErr == nil {
+		t.Error("expected connection to be closed by sidecar after oversized hello, but Read returned nil error")
+	}
+	conn.Close()
+
+	// After connection closed, reconnect the sidecar with helloCap=0 (fall back
+	// to the default 16 MiB cap) for the cleanup handshake is not needed —
+	// the sidecar will wait for a new connection within PipeReconnectTimeout
+	// (200 ms). The test just needs to wait for runStartupSocketPipe to exit
+	// (it will time out waiting for reconnect).
+	_ = wait()
+
+	// The violation log line must have been emitted.
+	logs := getLogs()
+	if !strings.Contains(logs, "frame exceeded maxLineBytes") {
+		t.Errorf("expected 'frame exceeded maxLineBytes' in logs, got: %s", logs)
+	}
+	if !strings.Contains(logs, "closing connection") {
+		t.Errorf("expected 'closing connection' in logs, got: %s", logs)
+	}
+}


### PR DESCRIPTION
## Summary

The PI socket-pipe inbound reader used `bufio.Reader.ReadBytes` with no upper bound — a misbehaving extension could allocate ~1 GiB in the sidecar before failing. The `const maxLineBytes = 16 MiB` existed but was only a dead-assignment (`_ = maxLineBytes`) suppressing the unused-const check. The hello-handshake reader had the same gap.

## Changes

- Adds `socketPipeMaxLineBytes` (16 MiB) as a named package-level constant with documentation
- Adds `Config.PipeMaxLineBytes` for per-sidecar test overrides (avoids allocating 16 MiB in tests)
- Implements `readLineLimited` using `bufio.Reader.ReadSlice` in a loop — the internal buffer never grows beyond `effectiveMaxLineBytes` bytes
- Applies `readLineLimited` to **both** the hello-handshake reader and the per-frame inbound loop
- Returns `errFrameTooLong` sentinel (not `io.EOF`) so callers distinguish protocol violations from clean disconnect
- Closes the connection and emits a tagged log line on cap-exceeded
- Removes the `_ = maxLineBytes` dead assignment

## New tests (`sidecar_socketpipe_test.go`)

- `TestSocketPipe_LineCap_OversizedFrameClosesConnection` — frame of `cap+1` bytes (no newline) triggers close + violation log
- `TestSocketPipe_LineCap_BoundaryFrameAccepted` — frame of exactly `cap` bytes + newline is accepted and persisted
- `TestSocketPipe_LineCap_HelloOversizedClosesConnection` — oversized hello triggers close + violation log on the handshake path

Tests use `Config.PipeMaxLineBytes=256` (or 64 for the hello test) to keep allocations tiny.

Closes #1845