### PR TITLE
sidecar: fix notifyCoordinator doc-comment to match actual behaviour

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -191,10 +191,8 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 // noise — 5 notifications per review round, none of which the coordinator
 // needs to act on.
 //
-// Retry policy: up to 3 POST attempts with exponential backoff (500ms, 1s).
-// SID validation (GET /session) is performed before each attempt. If GET /session
-// returns an empty list, delivery fails immediately (no retry). If GET /session
-// fails with a network or non-200 error, the retry policy applies.
+// Delivery is a single attempt via promptdelivery.DeliverToSession; there is
+// no retry loop or backoff in this function.
 func (s *Sidecar) notifyCoordinator() {
 	// Self-notification guard: if this session IS the coordinator, skip.
 	// DB-backed: check root_agent_name == "coordinator" for self.


### PR DESCRIPTION
## Summary

The doc-comment on `notifyCoordinator` described a retry policy that was never implemented:

```
// Retry policy: up to 3 POST attempts with exponential backoff (500ms, 1s).
// SID validation (GET /session) is performed before each attempt. If GET /session
// returns an empty list, delivery fails immediately (no retry). If GET /session
// fails with a network or non-200 error, the retry policy applies.
```

Investigation confirmed this is **branch (2)**: no retry policy exists anywhere. `promptdelivery.DeliverToSession` has no retry loop, no backoff, no `GET /session` probe.

**Decision: delete the misleading comment.** The policy was never implemented and there is no operational driver to add it now. The comment is replaced with a one-line accurate description of what actually happens.

## Changes

- Replace the 4-line retry fiction with: `// Delivery is a single attempt via promptdelivery.DeliverToSession; there is no retry loop or backoff in this function.`

## No behavioural change

Comment-only fix. No code logic was modified.

Closes #1850