### PR TITLE
profiles: add anthropic-opus-medium profile (opus-4-7 + medium thinking across all roles)

### DIFF
--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -113,6 +113,19 @@
               };
             };
 
+            anthropic-opus-medium = profileFromSlots {
+              _default = slot "worker" {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-7";
+                thinking = "medium";
+              };
+              coordinator = slot "coordinator" {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-7";
+                thinking = "medium";
+              };
+            };
+
             anthropic-opus = profileFromSlots {
               coordinator = slot "coordinator" {
                 provider = "anthropic";


### PR DESCRIPTION
## Summary

Adds a new `anthropic-opus-medium` profile to `modules/programs/prism/profiles.nix` where every pi role gets `provider = "anthropic"`, `model = "anthropic/claude-opus-4-7"`, and `thinking = "medium"`.

The profile uses the same `profileFromSlots` pattern as the existing `anthropic-opus` profile — `coordinator` is spelled out explicitly so its `systemPromptPath` resolves to `coordinator.md` (not `worker.md` via `_default`). The `_default` slot covers all other roles (worker, ac, retro, investigate, review-goal, review-code, review-security, review-qa, review-context).

## Smoke test

After `nh switch`:

```bash
jq '.profiles."anthropic-opus-medium"' ~/.config/prism/profiles.json
# Should show 10 role entries each with model claude-opus-4-7 and thinking medium.
# coordinator's systemPromptPath ends in coordinator.md; worker's ends in worker.md; etc.
```

Closes #1925