### PR TITLE
sidecar: fix test isolation — redirect XDG_STATE_HOME in all sidecar-constructing helpers

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/host_api_cleanup_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_cleanup_test.go
@@ -22,6 +22,8 @@ import (
 // caller supplies the script body (which is wrapped in a `#!/bin/sh` header).
 func newSidecarWithCleanupStub(t *testing.T, sessionName, repo, role, scriptBody string) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
 	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\n"+scriptBody+"\n"), 0o755); err != nil {

--- a/modules/programs/prism/prism/internal/sidecar/notify_escalated_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_escalated_test.go
@@ -17,6 +17,13 @@ import (
 // event has already informed the coordinator and a finished notification
 // would be a duplicate, false signal.
 func TestNotifyCoordinator_EscalatedSuppressed(t *testing.T) {
+	// Redirect XDG_STATE_HOME so any sidecar writes (touchDashboardSentinel,
+	// socket paths, etc.) stay within a temp directory and never touch the
+	// developer's real prism state. Also activate the host-API socket guard
+	// so promptdelivery refuses to dial any real host socket.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
+
 	d := openTestDB(t)
 
 	coordSID := "coord-sid-escalated-suppressed"

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_harness_pipe_tcp_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_harness_pipe_tcp_test.go
@@ -51,6 +51,8 @@ func allocateFreePort(t *testing.T) int {
 // path).
 func newTCPPortSidecar(t *testing.T, port int) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_livemodel_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_livemodel_test.go
@@ -32,6 +32,8 @@ import (
 // harnessNameForSession can return "pi".
 func newPISidecar(t *testing.T, sockPath, sessionName, agentRole string, d *db.DB) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	if d == nil {
 		d = openTestDB(t)
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
@@ -20,6 +20,8 @@ import (
 // rows under. Mirrors newSidecarWithRole but adds the InstanceID field.
 func newSidecarCoordinatorWithInstance(t *testing.T, sessionName, repo, instanceID string, d *db.DB) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: sessionName,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_pi_prompt_test.go
@@ -41,6 +41,8 @@ func containsAll(s string, subs ...string) bool {
 // and suitable for hostAPIHandler tests.
 func newPiSidecarForHostAPITest(t *testing.T, sessionName, repo, role string, d *db.DB) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: sessionName,

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_init_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_init_test.go
@@ -21,6 +21,8 @@ import (
 // a PI coordinator session.
 func newSocketPipeCoordinatorSidecar(t *testing.T, sockPath string) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{
@@ -42,6 +44,8 @@ func newSocketPipeCoordinatorSidecar(t *testing.T, sockPath string) *Sidecar {
 // testing with AgentRole=worker. This matches a PI worker session.
 func newSocketPipeWorkerSidecar(t *testing.T, sockPath string) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -54,6 +54,11 @@ func shortSockPath(t *testing.T) string {
 // The caller must set cfg.HarnessPipeSockPath before calling runStartupSocketPipe.
 func newSocketPipeSidecar(t *testing.T, sockPath string) *Sidecar {
 	t.Helper()
+	// Redirect XDG_STATE_HOME so sidecar writes (touchDashboardSentinel,
+	// socket paths, etc.) never escape to the developer's real prism state.
+	// Also activate the host-API socket guard.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{
@@ -747,6 +752,8 @@ func TestSocketPipe_UnknownFramePersisted(t *testing.T) {
 // TestSocketPipe_NeitherSocketNorTCP verifies that a sidecar with no socket
 // path and no TCP port returns an error immediately.
 func TestSocketPipe_NeitherSocketNorTCP(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{
@@ -1300,6 +1307,8 @@ func TestSocketPipe_ReconnectAfterDrop(t *testing.T) {
 // TestSocketPipe_ReconnectTimeout verifies that if no reconnect arrives within
 // pipeDisconnectTimeout, the sidecar transitions to error state and exits.
 func TestSocketPipe_ReconnectTimeout(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	sockPath := shortSockPath(t)
 
 	// Use a very short StartupConnectTimeout so the test does not need to wait
@@ -1354,6 +1363,8 @@ func TestSocketPipe_ReconnectTimeout(t *testing.T) {
 // listener block is ever moved back to after the transport-shape switch, the
 // host-API socket will not yet exist at that point and this test will fail.
 func TestSocketPipe_HostAPISockCreatedBeforeDispatch(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	// Two short-prefix socket paths: one for the harness pipe, one for the
 	// host-API listener.  Both must fit within the 104-char POSIX limit.
 	pipeSockPath := shortSockPath(t)
@@ -1432,6 +1443,8 @@ func TestSocketPipe_HostAPISockCreatedBeforeDispatch(t *testing.T) {
 // connection without a session_shutdown don't block for 30s.
 func newSocketPipeSidecarWithClock(t *testing.T, sockPath string) (*Sidecar, *testClock) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{
@@ -3195,6 +3208,8 @@ const testMaxLineBytes = 256
 // state mutation and is safe for parallel tests.
 func newSocketPipeSidecarWithLineCap(t *testing.T, sockPath string, cap int) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_stdio_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_stdio_test.go
@@ -133,6 +133,8 @@ type legacyFakeHarness struct {
 // h is the Harness to use; pass nil to use the PI adapter (has FrameNormaliser).
 func newStdioSidecar(t *testing.T, mode string, h harness.Harness) *Sidecar {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	t.Setenv("PRISM_FAKE_STDIO_HARNESS", mode)
 
 	exe, err := os.Executable()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -297,6 +297,8 @@ func openTestDB(t *testing.T) *db.DB {
 
 func newTestSidecar(t *testing.T) (*Sidecar, *testClock) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	d := openTestDB(t)
 
@@ -1853,6 +1855,8 @@ func TestServerConnected_SilentlyIgnored(t *testing.T) {
 // coordinator notifications; pass nil to use the package default.
 func newWorkerSidecar(t *testing.T, d *db.DB, httpClient *http.Client) (*Sidecar, *testClock) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: "test-repo@feature",
@@ -2064,6 +2068,8 @@ func TestNotifyCoordinator_NoNotificationOnInterrupted(t *testing.T) {
 }
 
 func TestNotifyCoordinator_SelfNotificationSkipped(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	// Use a coordinator sidecar (session name matches "<repo>@main").
 	d := openTestDB(t)
 	clk := newTestClock()
@@ -2399,6 +2405,8 @@ func TestNotifyCoordinator_EndedCoordinatorSkipped(t *testing.T) {
 //
 // This is the primary regression test for issue #817.
 func TestNotifyCoordinator_ReviewAgentSuppressed(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 
 	coordSID := "coord-sid-review-suppressed"
@@ -2648,6 +2656,8 @@ func TestIsCoordinatorSession(t *testing.T) {
 // (e.g. from an SSE inference race) does NOT receive a self-notification when
 // transitioning to finished. The @main heuristic must win over the stale value.
 func TestNotifyCoordinator_SelfNotificationSkipped_StaleRootAgentName(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{
@@ -3921,6 +3931,8 @@ func TestSubagentFinish_NoRootAgent_NoSpuriousFinished(t *testing.T) {
 // message. This is the fix for #555.
 func newWorkerSidecarWithRole(t *testing.T, d *db.DB, httpClient *http.Client, role string) (*Sidecar, *testClock) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	cfg := Config{
 		SessionName: "test-repo@feature",
@@ -4107,6 +4119,8 @@ func TestRootAgentPreset_MultipleReviewRounds(t *testing.T) {
 // (rootAgent="coordinator") that invokes subagents transitions to finished
 // correctly when the coordinator writes its final message.
 func TestRootAgentPreset_CoordinatorSession(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	clk := newTestClock()
 	cfg := Config{
@@ -4351,6 +4365,8 @@ func TestSubagentFinish_ToolOnlyFinalTurn_IdlePathStillWorks(t *testing.T) {
 // verifies COALESCE semantics: subsequent state transitions must not overwrite
 // the already-set values.
 func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	t.Run("seeded when AgentRole is set", func(t *testing.T) {
 		clk := newTestClock()
 		d := openTestDB(t)
@@ -4504,6 +4520,8 @@ func TestRootAgentName_SeededFromAgentRole(t *testing.T) {
 // COALESCE(excluded.root_agent_name, root_agent_name) with the sidecar value
 // taking precedence.
 func TestRootAgentName_SelfCorrectedFromSSEInference(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	d := openTestDB(t)
 	cfg := Config{
@@ -8198,6 +8216,8 @@ func TestBuildNotifyPromptBody_IncludesTextAndModel(t *testing.T) {
 // and HTTP client with the parent worker.
 func newReviewAgentSidecar(t *testing.T, parentSession string, d *db.DB, httpClient *http.Client) (*Sidecar, *testClock) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	clk := newTestClock()
 	reviewSession := parentSession + "~review-1-review-goal"
 	cfg := Config{
@@ -8597,6 +8617,8 @@ func (b *blockingHarness) Subscribe(ctx context.Context) (<-chan harness.Harness
 // no parent row exists — that's fine for these tests).
 func newBwrapSidecarWithTimeout(t *testing.T, timeout time.Duration) (*Sidecar, *db.DB) {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	cfg := Config{
 		SessionName:           "test-repo@feature~review-1-review-goal",
@@ -8653,6 +8675,8 @@ func TestStartupConnectTimeout_FiresWhenFirstEventNeverReceived(t *testing.T) {
 // first SSE event has been received (firstEventLogged = true), the timeout
 // goroutine is a no-op — even if the connection later drops and retries.
 func TestStartupConnectTimeout_DoesNotFireAfterFirstEvent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	// Use a real sidecar with a very short timeout to ensure the goroutine runs.
 	const timeout = 20 * time.Millisecond
 
@@ -9573,6 +9597,8 @@ func TestHostAPI_Review_PreEmptiveWriteBestEffortOnMissingRow(t *testing.T) {
 // the markers must be sourced from "whatever signal the bwrap sidecar uses
 // to detect opencode readiness" — for bwrap that is the first SSE event.
 func TestBwrapTimingMarkers_FirstEvent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	cfg := Config{
 		SessionName: "test-repo@feature",
@@ -9609,6 +9635,8 @@ func TestBwrapTimingMarkers_FirstEvent(t *testing.T) {
 // the first SSE event. AC #4 (#1052): mirrors the existing podman line at
 // sidecar.go:489 so the bwrap and podman timelines have the same shape.
 func TestBwrapTimingMarkers_PromptDelivered(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	cfg := Config{
 		SessionName:   "test-repo@feature",
@@ -9637,6 +9665,8 @@ func TestBwrapTimingMarkers_PromptDelivered(t *testing.T) {
 // gated on InitialPrompt != "" because there is no prompt to attribute time
 // to in that case — emitting the line would be misleading.
 func TestBwrapTimingMarkers_NoPromptDelivered(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	cfg := Config{
 		SessionName: "test-repo@feature",
@@ -9665,6 +9695,8 @@ func TestBwrapTimingMarkers_NoPromptDelivered(t *testing.T) {
 // events must NOT emit duplicate markers — this would otherwise pollute the
 // log on every reconnect and make the timeline ambiguous.
 func TestBwrapTimingMarkers_OnlyOnFirstEvent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
 	d := openTestDB(t)
 	cfg := Config{
 		SessionName: "test-repo@feature",


### PR DESCRIPTION
## Summary

Fixes #1927.

TestNotifyInvestigatorCompletion_NoHostBusLeak was failing intermittently when the suite was run with -count=N. A preceding test that constructs a Sidecar without redirecting XDG_STATE_HOME triggers background goroutines (e.g. touchDashboardSentinel, notification delivery) that write to the real XDG_STATE_HOME/prism/ path, causing the flaky assertion.

## Offending tests identified

Every test helper that constructed a sidecar.Sidecar via New(cfg) without redirecting XDG_STATE_HOME to a temp directory was an offender:

- notify_escalated_test.go: TestNotifyCoordinator_EscalatedSuppressed
- sidecar_socketpipe_test.go: newSocketPipeSidecar, newSocketPipeSidecarWithClock, newSocketPipeSidecarWithLineCap, plus inline-constructor tests calling sc.Run
- sidecar_socketpipe_init_test.go: newSocketPipeCoordinatorSidecar, newSocketPipeWorkerSidecar
- sidecar_harness_pipe_tcp_test.go: newTCPPortSidecar
- sidecar_stdio_test.go: newStdioSidecar
- sidecar_test.go: newTestSidecar, newWorkerSidecar, newWorkerSidecarWithRole, newReviewAgentSidecar, newBwrapSidecarWithTimeout, and several inline-constructor tests
- host_api_cleanup_test.go, sidecar_livemodel_test.go, sidecar_merge_test.go, sidecar_pi_prompt_test.go

## Fix

Added t.Setenv("XDG_STATE_HOME", t.TempDir()) and t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1") to each offending helper function and individual test body. This is the inline equivalent of sidecartest.NewIsolated isolation contract per AGENTS.md Test-suite isolation issue #1608.

Note: newSidecarWithRole and newSidecarWithRoleAndBinary were intentionally NOT modified — they are called by tests that deliberately set their own XDG_STATE_HOME before calling the helper (e.g. TestHostAPI_Feedback_* and TestHostAPI_Logs_*). Modifying those helpers would override the tests' own path and break them.

## Verification

- go test ./internal/sidecar/ -race -count=5 passes cleanly (no TestNotifyInvestigatorCompletion_NoHostBusLeak flake)
- go test ./internal/sidecar/ -race -count=1 passes
- nix build .#prism passes

Closes #1927