### PR TITLE
db: extend Prune to cover sessions/agent_status/session_groups (#1871)

### DIFF
--- a/modules/programs/prism/prism/internal/db/maintenance.go
+++ b/modules/programs/prism/prism/internal/db/maintenance.go
@@ -5,34 +5,135 @@ import (
 	"time"
 )
 
-// Prune deletes agent_events older than olderThan, and delivered or failed
-// bus_messages older than olderThan. It does NOT delete agent_status rows or
-// undelivered/unfailed bus_messages.
+// Prune deletes rows older than olderThan from the prism database. All
+// deletions execute inside a single transaction; if any individual DELETE
+// fails the transaction is rolled back and the database is left in its
+// pre-Prune state.
 //
-// harness_frames is pruned separately via PruneHarnessFrames so callers can
-// pick a different (typically shorter) retention window for the raw wire
-// archive — the JSONL frames are voluminous on a busy session, while
-// agent_events stays at the historical 90-day default.
+// Tables that Prune touches:
+//
+//   - agent_events       — rows with created_at < threshold.
+//   - bus_messages       — rows that have been delivered (delivered_at
+//                          IS NOT NULL AND delivered_at < threshold) or
+//                          permanently failed (failed_at IS NOT NULL AND
+//                          failed_at < threshold). Undelivered, unfailed
+//                          messages are never pruned.
+//   - sessions           — rows with ended_at IS NOT NULL AND
+//                          ended_at < threshold. Live sessions (ended_at
+//                          IS NULL) are never pruned.
+//   - spawn_outcome      — pruned indirectly via ON DELETE CASCADE from
+//                          sessions(instance_id). Prune does not issue
+//                          an explicit DELETE against this table.
+//   - spawn_inputs       — pruned indirectly via ON DELETE CASCADE from
+//                          sessions(instance_id). Prune does not issue
+//                          an explicit DELETE against this table.
+//   - agent_status       — rows with ended_at IS NOT NULL AND
+//                          ended_at < threshold AND no live counterpart
+//                          in sessions (i.e. no sessions row sharing the
+//                          same instance_id has ended_at IS NULL). The
+//                          live-counterpart guard avoids deleting the
+//                          status row for a session that was restarted
+//                          under the same instance_id.
+//   - session_groups     — rows whose members are all gone, i.e. no
+//                          surviving sessions or agent_status row still
+//                          references the group_id. This runs last so
+//                          that the preceding DELETEs have already
+//                          removed every referencing row that they can.
+//
+// Tables that Prune deliberately does NOT touch:
+//
+//   - harness_frames     — pruned separately via PruneHarnessFrames so
+//                          callers can pick a different (typically
+//                          shorter) retention window for the raw wire
+//                          archive. The JSONL frames are voluminous on
+//                          a busy session, while agent_events stays at
+//                          the historical 90-day default.
+//   - pending_merges     — operational ledger for the local serial merge
+//                          queue. Rows are short-lived (queued → merged
+//                          or failed within a single PR cycle) and the
+//                          table is not expected to accrete.
+//   - schema_version     — a single-row table tracking the live schema
+//                          version. Pruning it would break startup.
+//
+// Atomicity: all DELETEs run inside one transaction with PRAGMA
+// foreign_keys = ON (set at connection time in Open). The cascade from
+// sessions to spawn_outcome / spawn_inputs and the SET NULL behaviour
+// on agent_status.group_id / sessions.group_id all participate in the
+// same transaction; a failure on any single DELETE rolls the entire
+// Prune back.
 func (d *DB) Prune(olderThan time.Duration) error {
 	threshold := time.Now().Add(-olderThan).UnixMilli()
 
-	if _, err := d.conn.Exec(
+	tx, err := d.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("db: prune: begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.Exec(
 		"DELETE FROM agent_events WHERE created_at < ?", threshold,
 	); err != nil {
 		return fmt.Errorf("db: prune agent_events: %w", err)
 	}
 
-	if _, err := d.conn.Exec(
+	if _, err := tx.Exec(
 		"DELETE FROM bus_messages WHERE delivered_at IS NOT NULL AND delivered_at < ?", threshold,
 	); err != nil {
 		return fmt.Errorf("db: prune bus_messages (delivered): %w", err)
 	}
 
-	if _, err := d.conn.Exec(
+	if _, err := tx.Exec(
 		"DELETE FROM bus_messages WHERE failed_at IS NOT NULL AND failed_at < ?", threshold,
 	); err != nil {
 		return fmt.Errorf("db: prune bus_messages (failed): %w", err)
 	}
 
+	// sessions: ON DELETE CASCADE removes the matching spawn_outcome and
+	// spawn_inputs rows; ON DELETE SET NULL clears group_id on any
+	// remaining agent_status rows that still reference a now-deleted
+	// session's group_id.
+	if _, err := tx.Exec(
+		"DELETE FROM sessions WHERE ended_at IS NOT NULL AND ended_at < ?", threshold,
+	); err != nil {
+		return fmt.Errorf("db: prune sessions: %w", err)
+	}
+
+	// agent_status: only delete rows that are themselves ended AND have no
+	// live counterpart in sessions (a sessions row sharing the same
+	// instance_id with ended_at IS NULL). The NOT EXISTS guard protects
+	// against deleting the status row of a session that was restarted
+	// under the same instance_id between threshold and now.
+	if _, err := tx.Exec(`
+DELETE FROM agent_status
+WHERE ended_at IS NOT NULL
+  AND ended_at < ?
+  AND NOT EXISTS (
+    SELECT 1 FROM sessions
+    WHERE sessions.instance_id = agent_status.instance_id
+      AND sessions.ended_at IS NULL
+  )`, threshold,
+	); err != nil {
+		return fmt.Errorf("db: prune agent_status: %w", err)
+	}
+
+	// session_groups: delete any group with no surviving members. A
+	// group has members when at least one sessions row OR one
+	// agent_status row still references its group_id. After the
+	// preceding sessions and agent_status DELETEs above, any group
+	// whose members were all pruned is now orphaned and safe to remove.
+	if _, err := tx.Exec(`
+DELETE FROM session_groups
+WHERE group_id NOT IN (
+    SELECT group_id FROM sessions      WHERE group_id IS NOT NULL
+    UNION
+    SELECT group_id FROM agent_status  WHERE group_id IS NOT NULL
+)`,
+	); err != nil {
+		return fmt.Errorf("db: prune session_groups: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("db: prune: commit: %w", err)
+	}
 	return nil
 }

--- a/modules/programs/prism/prism/internal/db/maintenance_test.go
+++ b/modules/programs/prism/prism/internal/db/maintenance_test.go
@@ -1,0 +1,442 @@
+package db_test
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	_ "modernc.org/sqlite"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// openMaintenanceTestDB is a local helper that mirrors openTestDB in db_test.go
+// but is named distinctly to avoid duplicate-symbol collisions if the helper in
+// db_test.go is ever renamed or refactored by a parallel branch. It opens a
+// fresh DB in a per-test tempdir and registers Close on cleanup.
+func openMaintenanceTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+// rawExec opens a second connection to the test DB and executes a statement.
+// Used to backdate `ended_at` / `created_at` columns in test setup (there is
+// no public API for this), and to install BEFORE-DELETE triggers for the
+// rollback test.
+func rawExec(t *testing.T, d *db.DB, query string, args ...any) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", d.Path())
+	if err != nil {
+		t.Fatalf("rawExec open: %v", err)
+	}
+	defer rawConn.Close()
+	if _, err := rawConn.Exec(query, args...); err != nil {
+		t.Fatalf("rawExec %q: %v", query, err)
+	}
+}
+
+// countRows returns the row count of the given table.
+func countRows(t *testing.T, d *db.DB, table string) int {
+	t.Helper()
+	var n int
+	if err := d.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// rowExists reports whether a row matching the WHERE clause exists.
+func rowExists(t *testing.T, d *db.DB, query string, args ...any) bool {
+	t.Helper()
+	var n int
+	if err := d.QueryRow(query, args...).Scan(&n); err != nil {
+		t.Fatalf("rowExists %q: %v", query, err)
+	}
+	return n > 0
+}
+
+// TestPrune_AllAffectedTables exercises every table that Prune now touches:
+// agent_events, bus_messages (delivered + failed), sessions (with cascade
+// to spawn_outcome and spawn_inputs), agent_status (with the live-counterpart
+// guard), and session_groups (orphan removal).
+//
+// Setup: populate the DB with one old row and one recent row in every
+// affected table, plus one agent_status row whose ended_at is old but whose
+// instance_id still has a live sessions counterpart (must be preserved by
+// the guard).
+//
+// Assertions after a Prune with a 24h threshold:
+//   - old rows in each pruned table are gone.
+//   - recent rows are preserved.
+//   - spawn_outcome / spawn_inputs cascade-deletes left no orphans.
+//   - the protected agent_status row (live counterpart) was preserved.
+//   - the empty session_group was deleted, the still-referenced group survived.
+//   - existing agent_events / bus_messages pruning behaviour is unchanged.
+func TestPrune_AllAffectedTables(t *testing.T) {
+	d := openMaintenanceTestDB(t)
+
+	old := time.Now().Add(-48 * time.Hour).UnixMilli() // > 24h ago
+	recent := time.Now().UnixMilli()
+
+	// ── agent_events ────────────────────────────────────────────────
+	oldEventID := uuid.New().String()
+	newEventID := uuid.New().String()
+	if err := d.WriteEvent(db.Event{
+		ID: oldEventID, SessionName: "repo@main", Repo: "repo",
+		Worktree: "/wt", Type: "state_change", Payload: "{}",
+		CreatedAt: time.Now().Add(-48 * time.Hour),
+	}); err != nil {
+		t.Fatalf("WriteEvent old: %v", err)
+	}
+	if err := d.WriteEvent(db.Event{
+		ID: newEventID, SessionName: "repo@main", Repo: "repo",
+		Worktree: "/wt", Type: "state_change", Payload: "{}",
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteEvent new: %v", err)
+	}
+
+	// ── bus_messages ────────────────────────────────────────────────
+	// Insert four messages: old-delivered, recent-delivered, old-failed,
+	// recent-failed. The two "old" rows should be deleted; the two "recent"
+	// rows should be preserved. Also insert one undelivered (NULL) message
+	// to verify the existing "never delete undelivered" contract.
+	oldDeliveredID := uuid.New().String()
+	recentDeliveredID := uuid.New().String()
+	oldFailedID := uuid.New().String()
+	recentFailedID := uuid.New().String()
+	pendingID := uuid.New().String()
+	rawExec(t, d, `
+INSERT INTO bus_messages (id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at, failed_at)
+VALUES
+  (?, 'a', 'b', NULL, 'r', 't', 'normal', ?, ?, NULL),
+  (?, 'a', 'b', NULL, 'r', 't', 'normal', ?, ?, NULL),
+  (?, 'a', 'b', NULL, 'r', 't', 'normal', ?, NULL, ?),
+  (?, 'a', 'b', NULL, 'r', 't', 'normal', ?, NULL, ?),
+  (?, 'a', 'b', NULL, 'r', 't', 'normal', ?, NULL, NULL)`,
+		oldDeliveredID, old, old,
+		recentDeliveredID, recent, recent,
+		oldFailedID, old, old,
+		recentFailedID, recent, recent,
+		pendingID, old, // pending: sent ages ago but never delivered/failed
+	)
+
+	// ── session_groups + sessions + agent_status + spawn_inputs + spawn_outcome
+	//
+	// Group A: contains an OLD ended session. After Prune, both the session and
+	//          the only agent_status row that references the group are gone, so
+	//          the group itself should be removed.
+	// Group B: contains a RECENT ended session whose status row also references
+	//          the group. The group must be preserved.
+	groupA, err := d.RegisterGroup("parentA")
+	if err != nil {
+		t.Fatalf("RegisterGroup A: %v", err)
+	}
+	groupB, err := d.RegisterGroup("parentB")
+	if err != nil {
+		t.Fatalf("RegisterGroup B: %v", err)
+	}
+
+	// ----- old session in group A -----
+	iidOld := uuid.New().String()
+	if err := d.UpsertStatus("oldsess", "repo", "/wt/old", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus oldsess: %v", err)
+	}
+	if err := d.SetInstanceID("oldsess", iidOld); err != nil {
+		t.Fatalf("SetInstanceID oldsess: %v", err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID: iidOld, SessionName: "oldsess", Repo: "repo",
+		Worktree: "/wt/old", Harness: "pi", GroupID: &groupA,
+		StartedAt: time.Now().Add(-72 * time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertSession oldsess: %v", err)
+	}
+	if err := d.UpdateSessionEnded(iidOld, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded oldsess: %v", err)
+	}
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID: iidOld, CreatedAt: time.Now().Add(-72 * time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs oldsess: %v", err)
+	}
+	if err := d.WriteSpawnOutcome(iidOld); err != nil {
+		t.Fatalf("WriteSpawnOutcome oldsess: %v", err)
+	}
+	// Backdate sessions.ended_at and agent_status.ended_at + tie to groupA.
+	rawExec(t, d, "UPDATE sessions SET ended_at = ? WHERE instance_id = ?", old, iidOld)
+	rawExec(t, d, "UPDATE agent_status SET ended_at = ?, group_id = ? WHERE session_name = ?", old, groupA, "oldsess")
+
+	// ----- recent session in group B -----
+	iidRecent := uuid.New().String()
+	if err := d.UpsertStatus("recentsess", "repo", "/wt/recent", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus recentsess: %v", err)
+	}
+	if err := d.SetInstanceID("recentsess", iidRecent); err != nil {
+		t.Fatalf("SetInstanceID recentsess: %v", err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID: iidRecent, SessionName: "recentsess", Repo: "repo",
+		Worktree: "/wt/recent", Harness: "pi", GroupID: &groupB,
+		StartedAt: time.Now().Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertSession recentsess: %v", err)
+	}
+	if err := d.UpdateSessionEnded(iidRecent, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded recentsess: %v", err)
+	}
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID: iidRecent, CreatedAt: time.Now().Add(-2 * time.Hour).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs recentsess: %v", err)
+	}
+	if err := d.WriteSpawnOutcome(iidRecent); err != nil {
+		t.Fatalf("WriteSpawnOutcome recentsess: %v", err)
+	}
+	rawExec(t, d, "UPDATE agent_status SET group_id = ? WHERE session_name = ?", groupB, "recentsess")
+
+	// ----- a live session (never ended) -----
+	_ = insertActiveSession(t, d, "livesess", "repo", "/wt/live")
+
+	// ----- agent_status with the live-counterpart guard -----
+	// "protsess" was ended ages ago, but a live sessions row exists for the
+	// same instance_id (simulating a restart). The protected agent_status row
+	// must NOT be deleted.
+	iidShared := uuid.New().String()
+	if err := d.UpsertStatus("protsess", "repo", "/wt/prot", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus protsess: %v", err)
+	}
+	if err := d.SetInstanceID("protsess", iidShared); err != nil {
+		t.Fatalf("SetInstanceID protsess: %v", err)
+	}
+	// Live sessions row sharing the same instance_id.
+	if err := d.InsertSession(db.Session{
+		InstanceID: iidShared, SessionName: "protsess", Repo: "repo",
+		Worktree: "/wt/prot", Harness: "pi",
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InsertSession protsess (live): %v", err)
+	}
+	// Backdate the agent_status.ended_at to before the threshold.
+	rawExec(t, d, "UPDATE agent_status SET ended_at = ? WHERE session_name = ?", old, "protsess")
+
+	// ----- a completely orphaned session_group (no members anywhere) -----
+	orphanGroup, err := d.RegisterGroup("parentOrphan")
+	if err != nil {
+		t.Fatalf("RegisterGroup orphan: %v", err)
+	}
+
+	// ── pre-Prune sanity counts ─────────────────────────────────────
+	if got, want := countRows(t, d, "sessions"), 4; got != want {
+		t.Fatalf("pre-prune sessions count: got %d, want %d", got, want)
+	}
+	if got, want := countRows(t, d, "spawn_outcome"), 2; got != want {
+		t.Fatalf("pre-prune spawn_outcome count: got %d, want %d", got, want)
+	}
+	if got, want := countRows(t, d, "spawn_inputs"), 2; got != want {
+		t.Fatalf("pre-prune spawn_inputs count: got %d, want %d", got, want)
+	}
+	if got, want := countRows(t, d, "session_groups"), 3; got != want {
+		t.Fatalf("pre-prune session_groups count: got %d, want %d", got, want)
+	}
+
+	// ── run Prune ───────────────────────────────────────────────────
+	if err := d.Prune(24 * time.Hour); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+
+	// ── post-Prune assertions ───────────────────────────────────────
+
+	// agent_events: old gone, new preserved.
+	if rowExists(t, d, "SELECT COUNT(*) FROM agent_events WHERE id = ?", oldEventID) {
+		t.Error("agent_events: old row still present after prune")
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM agent_events WHERE id = ?", newEventID) {
+		t.Error("agent_events: recent row missing after prune")
+	}
+
+	// bus_messages: old-delivered + old-failed gone; recent + pending preserved.
+	for _, id := range []string{oldDeliveredID, oldFailedID} {
+		if rowExists(t, d, "SELECT COUNT(*) FROM bus_messages WHERE id = ?", id) {
+			t.Errorf("bus_messages: old row %q still present", id)
+		}
+	}
+	for _, id := range []string{recentDeliveredID, recentFailedID, pendingID} {
+		if !rowExists(t, d, "SELECT COUNT(*) FROM bus_messages WHERE id = ?", id) {
+			t.Errorf("bus_messages: row %q was pruned (should be preserved)", id)
+		}
+	}
+
+	// sessions: old gone, recent + live + protsess preserved.
+	if rowExists(t, d, "SELECT COUNT(*) FROM sessions WHERE instance_id = ?", iidOld) {
+		t.Error("sessions: old row still present after prune")
+	}
+	for _, iid := range []string{iidRecent, iidShared} {
+		if !rowExists(t, d, "SELECT COUNT(*) FROM sessions WHERE instance_id = ?", iid) {
+			t.Errorf("sessions: row %q missing after prune", iid)
+		}
+	}
+
+	// Cascade: spawn_outcome and spawn_inputs for the old session must be gone.
+	if rowExists(t, d, "SELECT COUNT(*) FROM spawn_outcome WHERE instance_id = ?", iidOld) {
+		t.Error("spawn_outcome: row for old session still present (cascade did not fire)")
+	}
+	if rowExists(t, d, "SELECT COUNT(*) FROM spawn_inputs WHERE instance_id = ?", iidOld) {
+		t.Error("spawn_inputs: row for old session still present (cascade did not fire)")
+	}
+	// Recent session's spawn_outcome / spawn_inputs survive.
+	if !rowExists(t, d, "SELECT COUNT(*) FROM spawn_outcome WHERE instance_id = ?", iidRecent) {
+		t.Error("spawn_outcome: row for recent session was pruned")
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM spawn_inputs WHERE instance_id = ?", iidRecent) {
+		t.Error("spawn_inputs: row for recent session was pruned")
+	}
+
+	// No orphans: every spawn_outcome/spawn_inputs row must point to a live
+	// sessions row.
+	if rowExists(t, d, `
+SELECT COUNT(*) FROM spawn_outcome so
+LEFT JOIN sessions s ON so.instance_id = s.instance_id
+WHERE s.instance_id IS NULL`) {
+		t.Error("spawn_outcome has rows without a matching sessions row (orphans)")
+	}
+	if rowExists(t, d, `
+SELECT COUNT(*) FROM spawn_inputs si
+LEFT JOIN sessions s ON si.instance_id = s.instance_id
+WHERE s.instance_id IS NULL`) {
+		t.Error("spawn_inputs has rows without a matching sessions row (orphans)")
+	}
+
+	// agent_status: old "oldsess" row gone, protected "protsess" row
+	// preserved (because a live sessions row shares its instance_id), recent
+	// + live still present.
+	if rowExists(t, d, "SELECT COUNT(*) FROM agent_status WHERE session_name = 'oldsess'") {
+		t.Error("agent_status: oldsess row still present after prune")
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM agent_status WHERE session_name = 'protsess'") {
+		t.Error("agent_status: protsess row deleted despite live sessions counterpart")
+	}
+	for _, name := range []string{"recentsess", "livesess"} {
+		if !rowExists(t, d, "SELECT COUNT(*) FROM agent_status WHERE session_name = ?", name) {
+			t.Errorf("agent_status: %q row missing after prune", name)
+		}
+	}
+
+	// session_groups: groupA (all members gone) and orphanGroup gone, groupB
+	// (recentsess still references it) preserved.
+	for _, gid := range []string{groupA, orphanGroup} {
+		if rowExists(t, d, "SELECT COUNT(*) FROM session_groups WHERE group_id = ?", gid) {
+			t.Errorf("session_groups: orphan group %q still present", gid)
+		}
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM session_groups WHERE group_id = ?", groupB) {
+		t.Error("session_groups: groupB removed despite live member references")
+	}
+
+	// No orphan session_groups: every surviving group must still have at least
+	// one referencing row in sessions or agent_status.
+	if rowExists(t, d, `
+SELECT COUNT(*) FROM session_groups sg
+WHERE NOT EXISTS (SELECT 1 FROM sessions     WHERE group_id = sg.group_id)
+  AND NOT EXISTS (SELECT 1 FROM agent_status WHERE group_id = sg.group_id)`) {
+		t.Error("session_groups has orphan rows after prune")
+	}
+}
+
+// TestPrune_AtomicRollback verifies that a failure on one DELETE inside Prune
+// rolls back every other DELETE — partial pruning is never observable.
+//
+// Failure is injected by installing a BEFORE-DELETE trigger on agent_status
+// that always raises an error. agent_status is pruned after sessions, so a
+// successful rollback must restore the sessions, agent_events and
+// bus_messages rows that would otherwise have been deleted before the
+// agent_status DELETE fired.
+func TestPrune_AtomicRollback(t *testing.T) {
+	d := openMaintenanceTestDB(t)
+
+	old := time.Now().Add(-48 * time.Hour).UnixMilli()
+
+	// agent_events that Prune would otherwise delete.
+	oldEventID := uuid.New().String()
+	if err := d.WriteEvent(db.Event{
+		ID: oldEventID, SessionName: "repo@main", Repo: "repo",
+		Worktree: "/wt", Type: "state_change", Payload: "{}",
+		CreatedAt: time.Now().Add(-48 * time.Hour),
+	}); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+
+	// bus_messages (delivered) that Prune would otherwise delete.
+	oldBusID := uuid.New().String()
+	rawExec(t, d, `
+INSERT INTO bus_messages (id, from_session, to_session, repo, text, urgency, sent_at, delivered_at)
+VALUES (?, 'a', 'b', 'r', 't', 'normal', ?, ?)`, oldBusID, old, old)
+
+	// sessions + agent_status that Prune would otherwise delete.
+	iid := uuid.New().String()
+	if err := d.UpsertStatus("oldsess", "repo", "/wt/old", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID("oldsess", iid); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID: iid, SessionName: "oldsess", Repo: "repo",
+		Worktree: "/wt/old", Harness: "pi",
+		StartedAt: time.Now().Add(-72 * time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	if err := d.UpdateSessionEnded(iid, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded: %v", err)
+	}
+	rawExec(t, d, "UPDATE sessions SET ended_at = ? WHERE instance_id = ?", old, iid)
+	rawExec(t, d, "UPDATE agent_status SET ended_at = ? WHERE session_name = ?", old, "oldsess")
+
+	// Install a BEFORE-DELETE trigger on agent_status that always raises.
+	rawConn, err := sql.Open("sqlite", d.Path())
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	t.Cleanup(func() { rawConn.Close() })
+	if _, err := rawConn.Exec(`
+		CREATE TRIGGER force_agent_status_delete_error
+		BEFORE DELETE ON agent_status
+		BEGIN
+			SELECT RAISE(ABORT, 'injected agent_status delete failure');
+		END`); err != nil {
+		t.Fatalf("create trigger: %v", err)
+	}
+
+	// Prune must return an error.
+	if err := d.Prune(24 * time.Hour); err == nil {
+		t.Fatal("Prune: expected error from injected trigger, got nil")
+	}
+
+	// Drop the trigger so post-rollback assertions are not affected.
+	if _, err := rawConn.Exec("DROP TRIGGER force_agent_status_delete_error"); err != nil {
+		t.Fatalf("drop trigger: %v", err)
+	}
+
+	// Every pre-Prune row must still exist — the transaction rolled back.
+	if !rowExists(t, d, "SELECT COUNT(*) FROM agent_events WHERE id = ?", oldEventID) {
+		t.Error("agent_events: old row missing after rollback — atomicity broken")
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM bus_messages WHERE id = ?", oldBusID) {
+		t.Error("bus_messages: old row missing after rollback — atomicity broken")
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM sessions WHERE instance_id = ?", iid) {
+		t.Error("sessions: old row missing after rollback — atomicity broken")
+	}
+	if !rowExists(t, d, "SELECT COUNT(*) FROM agent_status WHERE session_name = 'oldsess'") {
+		t.Error("agent_status: old row missing after rollback — atomicity broken")
+	}
+}


### PR DESCRIPTION
## Summary

`Prune` previously only covered `agent_events` and `bus_messages`, leaving `sessions`, `spawn_outcome`, `spawn_inputs`, `agent_status` and `session_groups` to accrete indefinitely. On long-running prism installs this becomes the slow-DB endgame described in the issue.

This PR:

- Wraps all of Prune in a single transaction so partial failures roll back the entire pass.
- Adds DELETEs for `sessions` (cascading to `spawn_outcome` / `spawn_inputs` via existing FK ON DELETE CASCADE), `agent_status` (with a `NOT EXISTS (… sessions live counterpart)` guard so restarted-under-same-instance-id rows are preserved), and `session_groups` (only orphans — no surviving session or agent_status references the group).
- Rewrites the doc-comment to enumerate every table Prune touches and every table it deliberately leaves alone (`harness_frames` has its own `PruneHarnessFrames`; `pending_merges` is operational; `schema_version` would break startup).

## Tests

Two new tests in `internal/db/maintenance_test.go`:

- `TestPrune_AllAffectedTables` populates every affected table with old + recent rows, plus an `agent_status` row whose `ended_at` is old but whose `instance_id` has a live `sessions` counterpart (must be preserved by the guard) and a fully-orphan `session_groups` row. Asserts old rows are gone, recent rows survive, cascade fired, and no orphan `spawn_outcome` / `spawn_inputs` / `session_groups` rows remain.
- `TestPrune_AtomicRollback` installs a BEFORE-DELETE trigger on `agent_status` and asserts that every preceding DELETE (agent_events, bus_messages, sessions) was reverted when the agent_status DELETE aborted.

Existing `TestPrune` (agent_events + bus_messages regression) continues to pass.

## Verification

- `go build ./...` — clean.
- `go test ./internal/db/ -race` — passes (60s).
- `go test ./...` — full suite passes.
- `nix build .#prism` — succeeds from repo root.

Closes #1871