### PR TITLE
db: batch N+1 queries in GroupResults and ReviewGroupsList

### DIFF
--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -237,44 +237,82 @@ WHERE group_id = ? AND ended_at IS NULL`
 		return nil, fmt.Errorf("db: group results: iterate statuses: %w", err)
 	}
 
-	// For each member, fetch the last msg_assistant event payload.
-	for name, r := range results {
-		const msgQ = `
-SELECT payload FROM agent_events
-WHERE session_name = ? AND type = 'msg_assistant'
-ORDER BY created_at DESC, rowid DESC
-LIMIT 1`
-		var payload string
-		err := d.conn.QueryRow(msgQ, name).Scan(&payload)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("db: group results: last message for %q: %w", name, err)
-		}
-		r.LastMessage = payload
+	if len(results) == 0 {
+		return results, nil
+	}
 
-		// Fetch the startup_error event reason when present. This is written by
-		// writeStartupError in the sidecar when WaitHealthy or CreateSession
-		// fails, allowing the review monitor to distinguish a no-start failure
-		// from a mid-run crash (#1222).
-		const startupErrQ = `
-SELECT payload FROM agent_events
-WHERE session_name = ? AND type = 'startup_error'
-ORDER BY created_at DESC, rowid DESC
-LIMIT 1`
-		var startupErrPayload string
-		seErr := d.conn.QueryRow(startupErrQ, name).Scan(&startupErrPayload)
-		if seErr == nil && startupErrPayload != "" {
-			// Extract the "reason" field from the JSON payload.
-			var p struct {
-				Reason string `json:"reason"`
-			}
-			if jsonErr := json.Unmarshal([]byte(startupErrPayload), &p); jsonErr == nil && p.Reason != "" {
-				r.StartupError = p.Reason
-			} else {
-				r.StartupError = startupErrPayload
+	// Batched event fetch: pull every msg_assistant and startup_error event
+	// for the entire member set in a single query, ordered so that the most
+	// recent row per (session_name, type) comes first. The Go-side reduction
+	// below keeps only that first row per pair (#1868 F7 — replaces the
+	// previous N+1 shape of 2 QueryRow calls per member).
+	names := make([]string, 0, len(results))
+	for name := range results {
+		names = append(names, name)
+	}
+	placeholders := strings.Repeat("?,", len(names))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+	eventQ := `
+SELECT session_name, type, payload
+FROM agent_events
+WHERE session_name IN (` + placeholders + `)
+  AND type IN ('msg_assistant', 'startup_error')
+ORDER BY session_name ASC, type ASC, created_at DESC, rowid DESC`
+	args := make([]any, 0, len(names))
+	for _, n := range names {
+		args = append(args, n)
+	}
+	eventRows, err := d.conn.Query(eventQ, args...)
+	if err != nil {
+		return nil, fmt.Errorf("db: group results: query events: %w", err)
+	}
+	defer eventRows.Close()
+
+	// seenLatest tracks which (session_name, type) pairs we have already
+	// recorded the most-recent row for. ORDER BY puts the most recent first
+	// within each (session_name, type) partition, so we accept the first row
+	// we see for each pair and ignore the rest.
+	seenLatest := make(map[string]struct{}, 2*len(names))
+	for eventRows.Next() {
+		var sessName, evtType, payload string
+		if err := eventRows.Scan(&sessName, &evtType, &payload); err != nil {
+			return nil, fmt.Errorf("db: group results: scan event: %w", err)
+		}
+		key := sessName + "\x00" + evtType
+		if _, seen := seenLatest[key]; seen {
+			continue
+		}
+		seenLatest[key] = struct{}{}
+
+		r, ok := results[sessName]
+		if !ok {
+			// Defensive: should be impossible because the IN list is built
+			// from the results keys.
+			continue
+		}
+		switch evtType {
+		case "msg_assistant":
+			r.LastMessage = payload
+		case "startup_error":
+			// Extract the "reason" field from the JSON payload. This is
+			// written by writeStartupError in the sidecar when WaitHealthy
+			// or CreateSession fails, allowing the review monitor to
+			// distinguish a no-start failure from a mid-run crash (#1222).
+			if payload != "" {
+				var p struct {
+					Reason string `json:"reason"`
+				}
+				if jsonErr := json.Unmarshal([]byte(payload), &p); jsonErr == nil && p.Reason != "" {
+					r.StartupError = p.Reason
+				} else {
+					r.StartupError = payload
+				}
 			}
 		}
-
-		results[name] = r
+		results[sessName] = r
+	}
+	if err := eventRows.Err(); err != nil {
+		return nil, fmt.Errorf("db: group results: iterate events: %w", err)
 	}
 
 	return results, nil
@@ -459,28 +497,60 @@ func (d *DB) ReviewGroupsList(limit int) ([]ReviewGroupSummary, error) {
 		return nil, fmt.Errorf("db: review groups list: iterate: %w", err)
 	}
 
-	// Populate members for each group. Doing this as a second per-group
-	// query rather than a single JOIN keeps the row-construction logic in
-	// queryStatuses untouched and the ledger query simple.
+	// Initialise per-group slices so groups with zero members still produce
+	// non-nil empty Members / AgentStates (preserving the prior shape).
 	for i := range out {
-		members, mErr := d.GroupMembersForGroup(out[i].GroupID)
-		if mErr != nil {
-			return nil, fmt.Errorf("db: review groups list: members for %s: %w", out[i].GroupID, mErr)
+		out[i].Members = []string{}
+		out[i].AgentStates = []string{}
+	}
+
+	if len(out) == 0 {
+		return out, nil
+	}
+
+	// Batched member fetch: pull every agent_status row for the full group
+	// set in one query (#1868 F8 — replaces the previous per-group
+	// GroupMembersForGroup loop). The IN-list approach is used in lieu of
+	// a JOIN so the row-construction logic in queryStatuses is reusable
+	// unchanged. Ordered by group_id, session_name so the per-group slices
+	// below are stable.
+	idxByGroup := make(map[string]int, len(out))
+	nonTerminalByGroup := make(map[string]int, len(out))
+	groupIDs := make([]any, 0, len(out))
+	for i := range out {
+		idxByGroup[out[i].GroupID] = i
+		groupIDs = append(groupIDs, out[i].GroupID)
+	}
+	placeholders := strings.Repeat("?,", len(groupIDs))
+	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
+	memberQ := `
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+FROM agent_status
+WHERE group_id IN (` + placeholders + `)
+ORDER BY group_id ASC, session_name ASC`
+	members, mErr := d.queryStatuses(memberQ, groupIDs...)
+	if mErr != nil {
+		return nil, fmt.Errorf("db: review groups list: batched members: %w", mErr)
+	}
+	for _, m := range members {
+		if m.GroupID == nil {
+			continue // defensive: should not happen given the WHERE clause
 		}
-		out[i].Members = make([]string, 0, len(members))
-		out[i].AgentStates = make([]string, 0, len(members))
-		nonTerminal := 0
-		for _, m := range members {
-			out[i].Members = append(out[i].Members, m.SessionName)
-			out[i].AgentStates = append(out[i].AgentStates, m.State)
-			if !isTerminalState(m.State) && m.EndedAt == nil {
-				nonTerminal++
-			}
+		idx, ok := idxByGroup[*m.GroupID]
+		if !ok {
+			continue
 		}
+		out[idx].Members = append(out[idx].Members, m.SessionName)
+		out[idx].AgentStates = append(out[idx].AgentStates, m.State)
+		if !isTerminalState(m.State) && m.EndedAt == nil {
+			nonTerminalByGroup[*m.GroupID]++
+		}
+	}
+	for i := range out {
 		switch {
-		case len(members) == 0:
+		case len(out[i].Members) == 0:
 			out[i].GroupState = "empty"
-		case nonTerminal == 0:
+		case nonTerminalByGroup[out[i].GroupID] == 0:
 			out[i].GroupState = "completed"
 		default:
 			out[i].GroupState = "in-progress"

--- a/modules/programs/prism/prism/internal/db/groups_query_count_test.go
+++ b/modules/programs/prism/prism/internal/db/groups_query_count_test.go
@@ -1,0 +1,486 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// ── Counting driver ──────────────────────────────────────────────────────────
+//
+// countingDriver wraps modernc.org/sqlite to count every QueryContext call
+// observed at the database/sql ↔ driver boundary. It is used by the
+// query-count invariant tests for #1868: it lets us assert that
+// GroupResults and ReviewGroupsList issue a bounded number of SQL
+// queries regardless of input size, regardless of whether database/sql
+// dispatches via the QueryerContext fast path or via PrepareContext +
+// Stmt.QueryContext.
+//
+// Exec / ExecContext calls are also counted (separately) so that test
+// failure messages can distinguish "missed a SELECT" from "added an
+// UPDATE somewhere".
+
+type queryCounter struct {
+	queries atomic.Int64
+	execs   atomic.Int64
+}
+
+func (c *queryCounter) reset() {
+	c.queries.Store(0)
+	c.execs.Store(0)
+}
+
+// activeCounter is the counter the current registered counting driver
+// reports into. It is settable per-test via withCounter so that tests
+// do not see each other's traffic, but the driver itself is process-wide
+// (database/sql.Register cannot be undone).
+var activeCounter atomic.Pointer[queryCounter]
+
+func currentCounter() *queryCounter {
+	c := activeCounter.Load()
+	if c == nil {
+		return &queryCounter{} // null sink during teardown / cross-test windows
+	}
+	return c
+}
+
+const countingDriverName = "sqlite-counting"
+
+var registerCountingDriverOnce sync.Once
+
+func ensureCountingDriverRegistered() {
+	registerCountingDriverOnce.Do(func() {
+		// Resolve the real driver by opening a throwaway connection.
+		realDB, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			panic(fmt.Sprintf("ensureCountingDriverRegistered: sql.Open(sqlite): %v", err))
+		}
+		realDriver := realDB.Driver()
+		_ = realDB.Close()
+		sql.Register(countingDriverName, &cDriver{real: realDriver})
+	})
+}
+
+// withCounter installs c as the active counter for the duration of the
+// test, restoring the previous counter on cleanup.
+func withCounter(t *testing.T, c *queryCounter) {
+	t.Helper()
+	prev := activeCounter.Swap(c)
+	t.Cleanup(func() { activeCounter.Store(prev) })
+}
+
+type cDriver struct{ real driver.Driver }
+
+func (d *cDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.real.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &cConn{real: c}, nil
+}
+
+// cConn wraps a sqlite driver.Conn. We implement the rich interface set
+// (QueryerContext, ExecerContext, ConnPrepareContext, ConnBeginTx) so
+// database/sql can use its fast paths AND so the prepared-statement path
+// also flows through our wrappers.
+
+type cConn struct{ real driver.Conn }
+
+func (c *cConn) Prepare(query string) (driver.Stmt, error) {
+	s, err := c.real.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	return &cStmt{real: s, query: query}, nil
+}
+
+func (c *cConn) Close() error              { return c.real.Close() }
+func (c *cConn) Begin() (driver.Tx, error) { return c.real.Begin() } //nolint:staticcheck
+
+func (c *cConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if p, ok := c.real.(driver.ConnPrepareContext); ok {
+		s, err := p.PrepareContext(ctx, query)
+		if err != nil {
+			return nil, err
+		}
+		return &cStmt{real: s, query: query}, nil
+	}
+	return c.Prepare(query)
+}
+
+func (c *cConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.real.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	return c.real.Begin() //nolint:staticcheck
+}
+
+func (c *cConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	currentCounter().queries.Add(1)
+	if q, ok := c.real.(driver.QueryerContext); ok {
+		return q.QueryContext(ctx, query, args)
+	}
+	// Fall back to prepare + query.
+	stmt, err := c.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	if qc, ok := stmt.(driver.StmtQueryContext); ok {
+		return qc.QueryContext(ctx, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+func (c *cConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	currentCounter().execs.Add(1)
+	if e, ok := c.real.(driver.ExecerContext); ok {
+		return e.ExecContext(ctx, query, args)
+	}
+	stmt, err := c.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+	if ec, ok := stmt.(driver.StmtExecContext); ok {
+		return ec.ExecContext(ctx, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+// Ping forwards to the underlying driver when supported. modernc.org/sqlite
+// implements driver.Pinger; without forwarding, database/sql falls back to a
+// trivial impl that doesn't actually round-trip — fine for our purposes, but
+// implementing it correctly avoids surprises.
+func (c *cConn) Ping(ctx context.Context) error {
+	if p, ok := c.real.(driver.Pinger); ok {
+		return p.Ping(ctx)
+	}
+	return nil
+}
+
+// cStmt wraps a driver.Stmt and counts QueryContext / ExecContext invocations
+// from the database/sql prepared-statement path.
+
+type cStmt struct {
+	real  driver.Stmt
+	query string
+}
+
+func (s *cStmt) Close() error  { return s.real.Close() }
+func (s *cStmt) NumInput() int { return s.real.NumInput() }
+
+func (s *cStmt) Exec(args []driver.Value) (driver.Result, error) { //nolint:staticcheck
+	currentCounter().execs.Add(1)
+	return s.real.Exec(args) //nolint:staticcheck
+}
+
+func (s *cStmt) Query(args []driver.Value) (driver.Rows, error) { //nolint:staticcheck
+	currentCounter().queries.Add(1)
+	return s.real.Query(args) //nolint:staticcheck
+}
+
+func (s *cStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	currentCounter().execs.Add(1)
+	if ec, ok := s.real.(driver.StmtExecContext); ok {
+		return ec.ExecContext(ctx, args)
+	}
+	// database/sql will retry via the value-based path on ErrSkip.
+	return nil, driver.ErrSkip
+}
+
+func (s *cStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	currentCounter().queries.Add(1)
+	if qc, ok := s.real.(driver.StmtQueryContext); ok {
+		return qc.QueryContext(ctx, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+// openCountedDB opens a fresh DB using the counting driver and returns a
+// *DB plus the counter. Schema / migrations are applied via openAndConfigure
+// before the counter is returned, so setup traffic is not measured by the
+// caller's assertions; the caller should call counter.reset() immediately
+// before the operation under test if other test-setup traffic intervenes.
+func openCountedDB(t *testing.T) (*DB, *queryCounter) {
+	t.Helper()
+	ensureCountingDriverRegistered()
+
+	c := &queryCounter{}
+	withCounter(t, c)
+
+	path := filepath.Join(t.TempDir(), "qcount.db")
+	dsn := "file:" + path +
+		"?_pragma=busy_timeout(5000)" +
+		"&_pragma=journal_mode(WAL)" +
+		"&_pragma=foreign_keys(1)"
+	conn, err := sql.Open(countingDriverName, dsn)
+	if err != nil {
+		t.Fatalf("sql.Open(counting): %v", err)
+	}
+	conn, err = openAndConfigure(conn)
+	if err != nil {
+		t.Fatalf("openAndConfigure: %v", err)
+	}
+	d := &DB{conn: conn, path: path}
+	t.Cleanup(func() { d.Close() })
+	return d, c
+}
+
+// seedGroupWithMembers registers a group, inserts `n` member sessions,
+// associates each with the group, and writes one msg_assistant + one
+// startup_error event per member so the batched event-fetch has data
+// to reduce.
+func seedGroupWithMembers(t *testing.T, d *DB, n int) (groupID string, sessions []string) {
+	t.Helper()
+	groupID, err := d.RegisterGroup("nixos-config@feature")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	sessions = make([]string, n)
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("nixos-config@feature~review-1-agent-%d", i)
+		sessions[i] = name
+		if err := d.UpsertStatus(name, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", name, err)
+		}
+		if err := d.QueryRow(
+			"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+			groupID, name,
+		).Scan(new(int)); err != nil {
+			t.Fatalf("set group_id for %s: %v", name, err)
+		}
+		now := time.Now()
+		if err := d.WriteEvent(Event{
+			ID:          fmt.Sprintf("evt-msg-%d-%s", i, name),
+			SessionName: name,
+			Repo:        "nixos-config",
+			Worktree:    "/wt",
+			Type:        "msg_assistant",
+			Payload:     fmt.Sprintf(`{"content":"<verdict>PASS</verdict> #%d"}`, i),
+			CreatedAt:   now,
+		}); err != nil {
+			t.Fatalf("WriteEvent msg_assistant: %v", err)
+		}
+		if err := d.WriteEvent(Event{
+			ID:          fmt.Sprintf("evt-startup-%d-%s", i, name),
+			SessionName: name,
+			Repo:        "nixos-config",
+			Worktree:    "/wt",
+			Type:        "startup_error",
+			Payload:     fmt.Sprintf(`{"reason":"boom %d"}`, i),
+			CreatedAt:   now,
+		}); err != nil {
+			t.Fatalf("WriteEvent startup_error: %v", err)
+		}
+	}
+	return groupID, sessions
+}
+
+// ── F7: GroupResults query-count invariant ───────────────────────────────────
+
+// TestGroupResults_QueryCountBounded asserts that GroupResults issues at
+// most 2 SQL queries regardless of member count (#1868 F7). The previous
+// implementation issued 2 QueryRow calls per member after the initial
+// status fetch, growing linearly with the group size.
+func TestGroupResults_QueryCountBounded(t *testing.T) {
+	const memberCount = 8
+	d, counter := openCountedDB(t)
+	groupID, _ := seedGroupWithMembers(t, d, memberCount)
+
+	counter.reset()
+	results, err := d.GroupResults(groupID)
+	if err != nil {
+		t.Fatalf("GroupResults: %v", err)
+	}
+	if got := len(results); got != memberCount {
+		t.Fatalf("GroupResults: got %d results, want %d", got, memberCount)
+	}
+	queries := counter.queries.Load()
+	if queries > 2 {
+		t.Fatalf("GroupResults issued %d queries for %d members; want ≤ 2 (#1868 F7)", queries, memberCount)
+	}
+	// Sanity: assert per-member fields are populated so we know the
+	// batched fetch actually wired data through.
+	for name, r := range results {
+		if r.LastMessage == "" {
+			t.Errorf("LastMessage for %q is empty; batched event reduction missed msg_assistant", name)
+		}
+		if r.StartupError == "" {
+			t.Errorf("StartupError for %q is empty; batched event reduction missed startup_error", name)
+		}
+	}
+}
+
+// TestGroupResults_QueryCountConstantInN verifies the bound holds across two
+// very different member counts — proves the cost is constant in N, not just
+// "small enough at N=8".
+func TestGroupResults_QueryCountConstantInN(t *testing.T) {
+	for _, n := range []int{1, 16} {
+		n := n
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			d, counter := openCountedDB(t)
+			groupID, _ := seedGroupWithMembers(t, d, n)
+			counter.reset()
+			if _, err := d.GroupResults(groupID); err != nil {
+				t.Fatalf("GroupResults: %v", err)
+			}
+			if got := counter.queries.Load(); got > 2 {
+				t.Fatalf("GroupResults issued %d queries for n=%d; want ≤ 2", got, n)
+			}
+		})
+	}
+}
+
+// ── F8: ReviewGroupsList query-count invariant ───────────────────────────────
+
+// TestReviewGroupsList_QueryCountBounded asserts that ReviewGroupsList
+// issues at most 2 SQL queries regardless of group count (#1868 F8).
+// The previous implementation called GroupMembersForGroup once per group.
+func TestReviewGroupsList_QueryCountBounded(t *testing.T) {
+	const groupCount = 6
+	const membersPerGroup = 3
+	d, counter := openCountedDB(t)
+
+	allGroupIDs := make([]string, 0, groupCount)
+	for g := 0; g < groupCount; g++ {
+		parent := fmt.Sprintf("nixos-config@feat-%d", g)
+		gid, err := d.RegisterGroup(parent)
+		if err != nil {
+			t.Fatalf("RegisterGroup: %v", err)
+		}
+		allGroupIDs = append(allGroupIDs, gid)
+		for m := 0; m < membersPerGroup; m++ {
+			name := fmt.Sprintf("%s~review-1-agent-%d", parent, m)
+			if err := d.UpsertStatus(name, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+				t.Fatalf("UpsertStatus %s: %v", name, err)
+			}
+			if err := d.QueryRow(
+				"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+				gid, name,
+			).Scan(new(int)); err != nil {
+				t.Fatalf("set group_id for %s: %v", name, err)
+			}
+		}
+	}
+
+	counter.reset()
+	got, err := d.ReviewGroupsList(0)
+	if err != nil {
+		t.Fatalf("ReviewGroupsList: %v", err)
+	}
+	if len(got) != groupCount {
+		t.Fatalf("ReviewGroupsList: got %d groups, want %d", len(got), groupCount)
+	}
+	for _, s := range got {
+		if len(s.Members) != membersPerGroup {
+			t.Errorf("group %s: got %d members, want %d", s.GroupID, len(s.Members), membersPerGroup)
+		}
+		if s.GroupState != "completed" {
+			t.Errorf("group %s: GroupState = %q, want \"completed\"", s.GroupID, s.GroupState)
+		}
+	}
+	if q := counter.queries.Load(); q > 2 {
+		t.Fatalf("ReviewGroupsList issued %d queries for %d groups; want ≤ 2 (#1868 F8)", q, groupCount)
+	}
+}
+
+// TestReviewGroupsList_QueryCountConstantInN proves the bound is constant
+// in the number of groups, not "small enough at N=6".
+func TestReviewGroupsList_QueryCountConstantInN(t *testing.T) {
+	for _, n := range []int{1, 12} {
+		n := n
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			d, counter := openCountedDB(t)
+			for g := 0; g < n; g++ {
+				parent := fmt.Sprintf("nixos-config@feat-%d", g)
+				gid, err := d.RegisterGroup(parent)
+				if err != nil {
+					t.Fatalf("RegisterGroup: %v", err)
+				}
+				name := fmt.Sprintf("%s~review-1-agent", parent)
+				if err := d.UpsertStatus(name, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+					t.Fatalf("UpsertStatus: %v", err)
+				}
+				if err := d.QueryRow(
+					"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+					gid, name,
+				).Scan(new(int)); err != nil {
+					t.Fatalf("set group_id: %v", err)
+				}
+			}
+			counter.reset()
+			if _, err := d.ReviewGroupsList(0); err != nil {
+				t.Fatalf("ReviewGroupsList: %v", err)
+			}
+			if q := counter.queries.Load(); q > 2 {
+				t.Fatalf("ReviewGroupsList issued %d queries for n=%d; want ≤ 2", q, n)
+			}
+		})
+	}
+}
+
+// TestReviewGroupsList_EmptyGroupsBatched verifies the batched path produces
+// the same shape as the pre-batch loop for the edge case where some groups
+// have no members and some do. GroupState rolls up to "empty" only when the
+// group has zero members.
+func TestReviewGroupsList_EmptyGroupsBatched(t *testing.T) {
+	d, _ := openCountedDB(t)
+
+	// Group 1: empty.
+	emptyParent := "nixos-config@empty"
+	emptyGID, err := d.RegisterGroup(emptyParent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Group 2: one finished member.
+	fullParent := "nixos-config@full"
+	fullGID, err := d.RegisterGroup(fullParent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	const fullSession = "nixos-config@full~review-1-agent"
+	if err := d.UpsertStatus(fullSession, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.QueryRow(
+		"UPDATE agent_status SET group_id = ? WHERE session_name = ? RETURNING 1",
+		fullGID, fullSession,
+	).Scan(new(int)); err != nil {
+		t.Fatalf("set group_id: %v", err)
+	}
+
+	got, err := d.ReviewGroupsList(0)
+	if err != nil {
+		t.Fatalf("ReviewGroupsList: %v", err)
+	}
+	byID := map[string]ReviewGroupSummary{}
+	for _, s := range got {
+		byID[s.GroupID] = s
+	}
+	if got, want := byID[emptyGID].GroupState, "empty"; got != want {
+		t.Errorf("empty group: GroupState = %q, want %q", got, want)
+	}
+	if got := byID[emptyGID].Members; got == nil {
+		t.Errorf("empty group: Members is nil; want non-nil empty slice (shape compat)")
+	} else if len(got) != 0 {
+		t.Errorf("empty group: Members = %v, want empty", got)
+	}
+	if got, want := byID[fullGID].GroupState, "completed"; got != want {
+		t.Errorf("full group: GroupState = %q, want %q", got, want)
+	}
+	if got, want := byID[fullGID].Members, []string{fullSession}; len(got) != 1 || got[0] != want[0] {
+		t.Errorf("full group: Members = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Closes #1868.

## Summary

Two N+1 query patterns in `internal/db/groups.go` are replaced with batched queries.

### F7 — `GroupResults` (was: 1 + 2N queries, now: ≤ 2)

The previous implementation fetched group members in one query, then for each member issued two `QueryRow` calls — one for the most-recent `msg_assistant` event, one for the most-recent `startup_error` event. For a typical 4-reviewer group that meant 9 queries; for an 8-member group, 17 queries.

The new implementation issues one batched `WHERE session_name IN (...) AND type IN ('msg_assistant','startup_error')` query and reduces in Go to the most-recent row per (session_name, type) pair. The fetch is ordered so the most-recent row per partition comes first, and the reduction simply accepts the first row seen per pair. Total query count is bounded at 2 regardless of member count.

### F8 — `ReviewGroupsList` (was: 1 + N queries, now: ≤ 2)

The previous implementation fetched groups in one query then called `GroupMembersForGroup` once per group, scanning `agent_status` N times. For a deployment with months of review history that's `O(num_groups × num_agent_status_rows)`.

The new implementation issues one batched `WHERE group_id IN (...)` query against `agent_status` (reusing `queryStatuses` for row construction so the per-column scan logic stays in one place), then groups rows by `group_id` in Go. Total query count is bounded at 2 regardless of group count. The previous comment on lines 463-464 acknowledging the N+1 trade-off is replaced with one describing the batched shape.

## Verification

A new internal `package db` test file installs a counting driver in front of `modernc.org/sqlite` and asserts the query-count invariant for both functions across multiple N values, plus a shape-compat test that mixes empty and populated groups. The counting driver wraps the driver at the `database/sql/driver` boundary so both the `QueryerContext` fast path and the `PrepareContext` + `Stmt.QueryContext` path are caught.

Sanity check that the new tests are not vacuous: re-running them against the pre-fix `groups.go` produces:

```
GroupResults issued 17 queries for 8 members; want ≤ 2 (#1868 F7)
GroupResults issued 33 queries for n=16; want ≤ 2
ReviewGroupsList issued 7 queries for 6 groups; want ≤ 2 (#1868 F8)
ReviewGroupsList issued 13 queries for n=12; want ≤ 2
```

…all of which pass after the fix.

## Quality gates

- `cd modules/programs/prism/prism && go build ./...` — clean
- `cd modules/programs/prism/prism && go test ./... -race` — all packages pass (including the pre-existing `TestGroupResults`, `TestGroupResults_ExcludesEndedRows`, `TestGroupResults_StartupError`)
- `nix build .#prism` from the repo root — succeeds

## Out of scope

- Adding the missing indexes called out in the audit (separate issue).
- A broader sweep for other N+1 patterns in the package — only F7 and F8 are addressed per the spec.