### PR TITLE
sidecar: wire exec.CommandContext + per-endpoint WithTimeout into 7 host-API handlers

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -24,6 +25,37 @@ import (
 	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
 	prismsession "github.com/prismatic-koi/prism/internal/session"
 )
+
+// statusClientClosedRequest is the de-facto HTTP status code (popularised by
+// nginx and HAProxy) returned when the client closes the connection before
+// the server has finished processing the request. Issue #1847 documents this
+// as the response status when a host-API handler's context is cancelled
+// because the caller disconnected (as opposed to the per-endpoint timeout
+// firing, which uses 504 Gateway Timeout).
+const statusClientClosedRequest = 499
+
+// contextErrStatus reports, for a context that has fired, the HTTP status code
+// that the host-API handler should return. It distinguishes a per-endpoint
+// timeout (deadline exceeded → 504 Gateway Timeout) from a client disconnect
+// or other cancellation (→ 499 Client Closed Request). The boolean is false
+// when the context has not fired — in that case the caller falls through to
+// the normal subprocess-failure path so it can surface the underlying error.
+//
+// This helper is used by the host-API handlers that wrap r.Context() with
+// context.WithTimeout and exec.CommandContext (issue #1847). When the child
+// is killed by context cancellation, os/exec returns an error like
+// "signal: killed" which says nothing about *why*; the caller's ctx.Err() is
+// the authoritative signal.
+func contextErrStatus(ctx context.Context) (int, bool) {
+	err := ctx.Err()
+	if err == nil {
+		return 0, false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout, true
+	}
+	return statusClientClosedRequest, true
+}
 
 // hostAPIServeLogsTail writes the last n lines of the log file to w.
 // When n == 0, the response body is empty.
@@ -923,9 +955,23 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// Deliver via prism prompt on the host.
 		args := []string{"prompt", req.Session, "--prompt", req.Prompt}
 		s.logger().Printf("sidecar: host-API /prompt: prism prompt %s <omitted>", req.Session)
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 5 min. `prism prompt` writes one bus event and
+		// (in pi-harness mode) waits for the harness side to ACK delivery; the
+		// host side can stall on a wedged tmux/pi pipe, but 5 min is a generous
+		// outer bound that still surfaces a true hang. On timeout we return
+		// 504 Gateway Timeout; on client disconnect we return 499 (the de-facto
+		// "client closed request" code used by nginx/HAProxy).
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /prompt: context fired (%v): killed child after %v", ctx.Err(), 5*time.Minute)
+				writeError(w, status, fmt.Sprintf("prompt delivery aborted: %v", ctx.Err()))
+				return
+			}
 			s.logger().Printf("sidecar: host-API /prompt: %v: %s", err, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("prompt delivery failed: %v", err))
 			return
@@ -1164,9 +1210,22 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		logArgs = append(logArgs, "--repo", ownRepo)
 		s.logger().Printf("sidecar: host-API /spawn: prism %s", strings.Join(logArgs, " "))
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 10 min. `prism spawn` can legitimately take a
+		// while — it creates a git worktree, sets up a tmux session, and may
+		// pull a container image on first use. 10 min is the documented outer
+		// bound (issue #1847). On timeout returns 504 Gateway Timeout; on
+		// client disconnect returns 499 ("client closed request").
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /spawn: context fired (%v): killed child after %v", ctx.Err(), 10*time.Minute)
+				writeError(w, status, fmt.Sprintf("spawn aborted: %v", ctx.Err()))
+				return
+			}
 			s.logger().Printf("sidecar: host-API /spawn: %v: %s", err, out)
 			msg := fmt.Sprintf("spawn failed: %v", err)
 			if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
@@ -1532,7 +1591,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		s.logger().Printf("sidecar: host-API /cleanup: prism %s", strings.Join(args, " "))
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 5 min. `prism cleanup` removes git worktrees,
+		// archives session state, and may run `git` operations that touch the
+		// network on detached worktrees. 5 min is a comfortable upper bound;
+		// anything longer is a hang. On timeout returns 504 Gateway Timeout;
+		// on client disconnect returns 499.
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		var stdoutBuf, stderrBuf bytes.Buffer
 		cmd.Stdout = &stdoutBuf
 		cmd.Stderr = &stderrBuf
@@ -1540,6 +1607,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		stdoutStr := stdoutBuf.String()
 		stderrStr := stderrBuf.String()
 		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /cleanup: context fired (%v): killed child after %v", ctx.Err(), 5*time.Minute)
+				writeJSON(w, status, map[string]any{
+					"error":  fmt.Sprintf("cleanup aborted: %v", ctx.Err()),
+					"stdout": stdoutStr,
+					"stderr": stderrStr,
+				})
+				return
+			}
 			s.logger().Printf("sidecar: host-API /cleanup: %v: stdout=%q stderr=%q", err, stdoutStr, stderrStr)
 			// Forward stdout and stderr alongside the error so the caller can
 			// surface the underlying cause (e.g. archive collision) instead of
@@ -1587,9 +1663,21 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		args := []string{"switch", "--path", worktreePath}
 		s.logger().Printf("sidecar: host-API /switch: prism %s", strings.Join(args, " "))
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 30 s. `prism switch` issues a single tmux
+		// switch-client command and exits — it should complete in well under
+		// a second. 30 s is the documented outer bound (issue #1847). On
+		// timeout returns 504 Gateway Timeout; on client disconnect returns 499.
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		out, switchErr := cmd.CombinedOutput()
 		if switchErr != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /switch: context fired (%v): killed child after %v", ctx.Err(), 30*time.Second)
+				writeError(w, status, fmt.Sprintf("switch aborted: %v", ctx.Err()))
+				return
+			}
 			s.logger().Printf("sidecar: host-API /switch: %v: %s", switchErr, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("switch failed: %v", switchErr))
 			return
@@ -1808,11 +1896,23 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		s.logger().Printf("sidecar: host-API /event: kind=%s session=%s", req.Kind, req.Session)
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 30 s. `prism event` writes one row to the host
+		// DB and exits — it should complete in well under a second. 30 s is
+		// the documented outer bound (issue #1847). On timeout returns 504
+		// Gateway Timeout; on client disconnect returns 499.
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		// Propagate PRISM_SESSION_NAME so that any internal lookup resolves correctly.
 		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+req.Session)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /event: context fired (%v): killed child after %v", ctx.Err(), 30*time.Second)
+				writeError(w, status, fmt.Sprintf("event write aborted: %v", ctx.Err()))
+				return
+			}
 			s.logger().Printf("sidecar: host-API /event: %v: %s", err, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("event write failed: %v\n%s", err, strings.TrimSpace(string(out))))
 			return
@@ -2058,13 +2158,25 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			args = append(args, "--to", req.To)
 		}
 		s.logger().Printf("sidecar: host-API /escalate: from=%s to=%s", fromSession, req.To)
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 30 s. `prism escalate` writes one bus event
+		// and may best-effort prompt the coordinator; it should return well
+		// inside a second. 30 s is the documented outer bound (issue #1847).
+		// On timeout returns 504 Gateway Timeout; on client disconnect returns 499.
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		// PRISM_SESSION_NAME tells the host-side `prism escalate` which session
 		// is calling, bypassing the CWD walk that would otherwise resolve to
 		// the sidecar's own working directory.
 		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+fromSession, "PRISM_HOST_API=")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /escalate: context fired (%v): killed child after %v", ctx.Err(), 30*time.Second)
+				writeError(w, status, fmt.Sprintf("escalate aborted: %v", ctx.Err()))
+				return
+			}
 			s.logger().Printf("sidecar: host-API /escalate: %v: %s", err, out)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("escalate failed: %v\n%s", err, strings.TrimSpace(string(out))))
 			return
@@ -2113,12 +2225,23 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			args = append(args, "--name", req.Name)
 		}
 		s.logger().Printf("sidecar: host-API /investigate: from=%s", fromSession)
-		cmd := exec.Command(prismBinary(), args...)
+
+		// Per-endpoint timeout: 10 min. `prism investigate` spawns a new
+		// session — same shape as /spawn, so the bound matches. On timeout
+		// returns 504 Gateway Timeout; on client disconnect returns 499.
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		// PRISM_SESSION_NAME tells the host-side `prism investigate` which session
 		// is invoking, bypassing the CWD walk.
 		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+fromSession, "PRISM_HOST_API=")
 		out, err := cmd.Output()
 		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /investigate: context fired (%v): killed child after %v", ctx.Err(), 10*time.Minute)
+				writeError(w, status, fmt.Sprintf("investigate aborted: %v", ctx.Err()))
+				return
+			}
 			s.logger().Printf("sidecar: host-API /investigate: %v", err)
 			writeError(w, http.StatusInternalServerError, fmt.Sprintf("investigate failed: %v", err))
 			return

--- a/modules/programs/prism/prism/internal/sidecar/host_api_exec_context_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_exec_context_test.go
@@ -1,0 +1,355 @@
+// Tests for the per-endpoint exec.CommandContext + WithTimeout wiring added
+// for issue #1847. Without this wiring, a hung subprocess (e.g. `gh` blocked
+// on the network, a wedged `prism spawn`) would pin the host-API handler
+// goroutine indefinitely.
+//
+// Each test spawns a stub `prism` binary that sleeps for far longer than the
+// test will wait, then drives the handler with a request whose context the
+// test cancels before the child can return. The handler must:
+//
+//   1. Kill the child when the context fires.
+//   2. Return promptly (well under the per-endpoint timeout).
+//   3. Return the documented status code: 499 ("client closed request") for
+//      caller-cancellation, 504 Gateway Timeout when the per-endpoint
+//      WithTimeout deadline elapses.
+//
+// We exercise the caller-cancellation (499) path because forcing the 504 path
+// would require waiting for the smallest per-endpoint timeout (30 s for
+// /switch /event /escalate). The kill mechanism and the contextErrStatus
+// branch are identical on both code paths — the only difference is which
+// sentinel ctx.Err() returns. The kill-on-context is the part this issue is
+// about.
+//
+// The stub also writes its own PID to a sentinel file so the test can verify
+// the child process is no longer running after the handler returns.
+
+package sidecar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// sleepForeverStub writes a shell script that records its PID to pidFile,
+// then sleeps for 600 s. 600 s is far longer than any test will wait but
+// short enough that a forgotten orphan is reaped by the OS within the test
+// suite's run. Returns the path to the executable stub.
+func sleepForeverStub(t *testing.T, pidFile string) string {
+	t.Helper()
+	stubPath := filepath.Join(t.TempDir(), "prism-sleep-stub")
+	// `exec sleep 600` replaces the shell with sleep so the recorded PID
+	// matches the long-running process the test wants to verify is killed.
+	// (Without exec, the shell's PID is recorded but the child sleep — which
+	// owns the process group — has a different PID, and the kill check
+	// becomes ambiguous.)
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' \"$$\" > %s\nexec sleep 600\n", pidFile)
+	if err := os.WriteFile(stubPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write sleep-forever stub: %v", err)
+	}
+	return stubPath
+}
+
+// newSidecarWithSleepStub returns a sidecar configured with the sleep-forever
+// stub binary. pidFile is the path the stub will write its PID to before
+// blocking. The sidecar is otherwise identical to newSidecarWithRoleAndBinary.
+func newSidecarWithSleepStub(t *testing.T, sessionName, repo, role, pidFile string, d *db.DB) *Sidecar {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
+	stubPath := sleepForeverStub(t, pidFile)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     sessionName,
+		Repo:            repo,
+		Worktree:        "/tmp/" + sessionName,
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       role,
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	return New(cfg)
+}
+
+// waitForPidFile blocks until pidFile exists and contains a parseable PID,
+// or fails the test after timeout. Returns the recorded PID.
+func waitForPidFile(t *testing.T, pidFile string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err == nil && len(data) > 0 {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("pid file %q never appeared within %v", pidFile, timeout)
+	return 0
+}
+
+// assertProcessKilled polls until the process with the given pid is gone, or
+// fails after timeout. We use kill(pid, 0) which returns ESRCH when the
+// process no longer exists. This is more reliable than wait/waitpid because
+// the stub is not our child — the sidecar's exec.Cmd reaped it already.
+func assertProcessKilled(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if err == syscall.ESRCH {
+			return // gone
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Last-ditch: if the process is still around at the deadline, that's a
+	// real regression — log its /proc status if available, then fail.
+	statusBytes, _ := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if len(statusBytes) > 0 {
+		// Print just the first few lines so the failure message is readable.
+		lines := strings.SplitN(string(statusBytes), "\n", 5)
+		t.Fatalf("process pid=%d still alive after %v; /proc status (first lines):\n%s",
+			pid, timeout, strings.Join(lines, "\n"))
+	}
+	t.Fatalf("process pid=%d still alive after %v (no /proc entry)", pid, timeout)
+}
+
+// endpointCase describes one host-API handler that issue #1847 wired up with
+// exec.CommandContext + WithTimeout. The role, sessionName, and body fields
+// are picked to make the request reach the exec path (i.e. pass any
+// pre-shell-out auth/validation gates).
+type endpointCase struct {
+	name        string // subtest name
+	path        string // "/prompt", "/spawn", etc.
+	method      string // always http.MethodPost for these
+	role        string // "worker" or "coordinator"
+	sessionName string
+	repo        string
+	body        string
+}
+
+// TestHostAPI_ExecContext_KillsChildOnCancel exercises the 7 host-API
+// handlers wired up by issue #1847 (every site listed in the issue except
+// /review, which already used CommandContext as the reference shape). For
+// each endpoint:
+//
+//   - Start the handler with a request whose context will be cancelled.
+//   - Wait until the stub has recorded its PID (proves the exec actually ran).
+//   - Cancel the request context.
+//   - Assert the handler returns within a small wall-clock budget.
+//   - Assert the handler returns 499 (the documented "client closed request"
+//     code at every site).
+//   - Assert the child process is no longer alive.
+//
+// This is the AC: "When the context fires (timeout or client disconnect),
+// the child process is killed and the handler returns a documented non-200
+// status."
+func TestHostAPI_ExecContext_KillsChildOnCancel(t *testing.T) {
+	cases := []endpointCase{
+		{
+			name:        "prompt",
+			path:        "/prompt",
+			method:      http.MethodPost,
+			role:        "coordinator",
+			sessionName: "myrepo@main",
+			repo:        "myrepo",
+			// Cross-session (not == own session) so the handler takes the
+			// exec.Command path rather than the same-session pipe path.
+			body: `{"session":"myrepo@worker-x","prompt":"hi"}`,
+		},
+		{
+			name:        "spawn",
+			path:        "/spawn",
+			method:      http.MethodPost,
+			role:        "coordinator",
+			sessionName: "myrepo@main",
+			repo:        "myrepo",
+			body:        `{"branch":"feature-x","prompt":"do the thing"}`,
+		},
+		{
+			name:        "cleanup",
+			path:        "/cleanup",
+			method:      http.MethodPost,
+			role:        "coordinator",
+			sessionName: "myrepo@main",
+			repo:        "myrepo",
+			body:        `{"session":"myrepo@feature-x","yes":true}`,
+		},
+		{
+			name:        "switch",
+			path:        "/switch",
+			method:      http.MethodPost,
+			role:        "coordinator",
+			sessionName: "myrepo@main",
+			repo:        "myrepo",
+			body:        `{"session":"myrepo@feature-x"}`,
+		},
+		{
+			name:        "event",
+			path:        "/event",
+			method:      http.MethodPost,
+			role:        "coordinator",
+			sessionName: "myrepo@main",
+			repo:        "myrepo",
+			body:        `{"kind":"state-change","session":"myrepo@feature-x"}`,
+		},
+		{
+			name:        "escalate",
+			path:        "/escalate",
+			method:      http.MethodPost,
+			role:        "worker",
+			sessionName: "myrepo@feature-x",
+			repo:        "myrepo",
+			body:        `{"prompt":"halp"}`,
+		},
+		{
+			name:        "investigate",
+			path:        "/investigate",
+			method:      http.MethodPost,
+			role:        "worker",
+			sessionName: "myrepo@feature-x",
+			repo:        "myrepo",
+			body:        `{"prompt":"look into this"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// No t.Parallel: newSidecarWithSleepStub calls t.Setenv, which is
+			// incompatible with t.Parallel. The whole suite still finishes
+			// quickly because each subtest waits a few hundred ms at most.
+
+			d := openTestDB(t)
+			pidFile := filepath.Join(t.TempDir(), "child.pid")
+			sc := newSidecarWithSleepStub(t, tc.sessionName, tc.repo, tc.role, pidFile, d)
+
+			// /switch resolves the target session's worktree from the DB
+			// before shelling out, so we must seed an agent_status row for
+			// the target. Without this the handler returns 500 before exec.
+			if tc.path == "/switch" {
+				if err := d.UpsertStatus("myrepo@feature-x", "myrepo", "/tmp/myrepo-feature-x", "active", nil, nil); err != nil {
+					t.Fatalf("seed switch target session: %v", err)
+				}
+			}
+
+			// Drive the handler in a goroutine so we can synchronise on the
+			// pid file before triggering cancellation. A direct
+			// runWithCancelledContext call cancels on a timer, which races
+			// with stub startup on a loaded test runner.
+			handler := sc.hostAPIHandler()
+			req := newHostAPIRequest(t, tc.method, tc.path, tc.body)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+
+			done := make(chan struct{})
+			start := time.Now()
+			go func() {
+				handler.ServeHTTP(rr, req)
+				close(done)
+			}()
+
+			// Wait for the stub to record its PID — proves exec actually
+			// reached the subprocess. 5 s is generous; the stub is a tiny
+			// shell script.
+			pid := waitForPidFile(t, pidFile, 5*time.Second)
+
+			// Trigger client-disconnect.
+			cancel()
+
+			// The handler must return promptly. 5 s is far smaller than the
+			// smallest per-endpoint WithTimeout (30 s for /switch /event
+			// /escalate) so a pass here means the kill went through the
+			// r.Context() cancellation, not the WithTimeout deadline.
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("handler %s did not return within 5 s of context cancellation", tc.path)
+			}
+			elapsed := time.Since(start)
+
+			// Documented non-200: 499 ("client closed request") for the
+			// client-cancellation path. See contextErrStatus in host_api.go.
+			if rr.Code != statusClientClosedRequest {
+				t.Errorf("%s: status = %d, body = %q; want %d (client closed request)",
+					tc.path, rr.Code, rr.Body.String(), statusClientClosedRequest)
+			}
+
+			// Sanity: handler returned well before any per-endpoint timeout
+			// could have fired.
+			if elapsed > 10*time.Second {
+				t.Errorf("%s: handler took %v to return; expected sub-second after cancel", tc.path, elapsed)
+			}
+
+			// And the child is gone.
+			assertProcessKilled(t, pid, 5*time.Second)
+		})
+	}
+}
+
+// TestContextErrStatus_DeadlineExceededReturns504 verifies the timeout branch
+// of the helper used by every wired-up handler. The 504 path is unit-tested
+// here (rather than driven end-to-end through a handler, which would require
+// waiting for the smallest per-endpoint deadline of 30 s) so that the AC
+// "504 Gateway Timeout for timeout" is exercised in CI on every run.
+func TestContextErrStatus_DeadlineExceededReturns504(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	// Wait for the deadline to definitely have fired.
+	<-ctx.Done()
+	time.Sleep(2 * time.Millisecond)
+
+	status, ok := contextErrStatus(ctx)
+	if !ok {
+		t.Fatalf("contextErrStatus: ok=false on a context whose deadline has elapsed; want ok=true")
+	}
+	if status != http.StatusGatewayTimeout {
+		t.Errorf("contextErrStatus on deadline-exceeded: status = %d, want %d (504 Gateway Timeout)",
+			status, http.StatusGatewayTimeout)
+	}
+}
+
+// TestContextErrStatus_CancelReturns499 verifies the client-disconnect branch
+// of the helper.
+func TestContextErrStatus_CancelReturns499(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status, ok := contextErrStatus(ctx)
+	if !ok {
+		t.Fatalf("contextErrStatus: ok=false on a cancelled context; want ok=true")
+	}
+	if status != statusClientClosedRequest {
+		t.Errorf("contextErrStatus on cancel: status = %d, want %d (client closed request)",
+			status, statusClientClosedRequest)
+	}
+}
+
+// TestContextErrStatus_LiveContextReturnsFalse verifies the no-context-error
+// branch: when ctx.Err() is nil the helper returns ok=false so the caller
+// knows to fall through to the normal subprocess-failure path.
+func TestContextErrStatus_LiveContextReturnsFalse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	status, ok := contextErrStatus(ctx)
+	if ok {
+		t.Fatalf("contextErrStatus on live context: ok=true (status=%d); want ok=false", status)
+	}
+}


### PR DESCRIPTION
Closes #1847

## Summary

Of the 8 subprocess invocations in `internal/sidecar/host_api.go`, only `/review` (the reference shape) used `exec.CommandContext` with an explicit timeout. The other 7 — `/prompt`, `/spawn`, `/cleanup`, `/switch`, `/event`, `/escalate`, `/investigate` — used bare `exec.Command`, so a hung child (e.g. \`gh\` waiting on the network, a wedged \`prism spawn\`) would pin the host-API handler goroutine indefinitely.

## Change

Each of the 7 handlers now:

1. Wraps \`r.Context()\` with \`context.WithTimeout\` using a per-endpoint deadline documented in a code comment at the call site:

   | Endpoint | Timeout | Justification |
   |----------|---------|---------------|
   | \`/switch\` | 30 s | single tmux switch-client command |
   | \`/event\` | 30 s | one DB row write |
   | \`/escalate\` | 30 s | one bus event + best-effort prompt |
   | \`/prompt\` | 5 min | one bus event + harness ACK |
   | \`/cleanup\` | 5 min | worktree + archive removal |
   | \`/spawn\` | 10 min | worktree + tmux + first-use image pull |
   | \`/investigate\` | 10 min | same shape as /spawn |

2. Uses \`exec.CommandContext(ctx, ...)\` so the child is killed when the context fires.

3. Distinguishes the two cancellation modes via a new \`contextErrStatus\` helper:
   - **deadline exceeded** → \`504 Gateway Timeout\`
   - **client cancelled** → \`499 Client Closed Request\` (the de-facto nginx/HAProxy code)

## Tests

- \`TestHostAPI_ExecContext_KillsChildOnCancel\` is a parameterised test that drives each of the 7 handlers with a sleep-forever stub binary and a request whose context is cancelled after the stub has recorded its PID. It asserts:
  - the handler returns \`499\` well inside the per-endpoint \`WithTimeout\` deadline (i.e. cancellation took effect), and
  - the child process is reaped (via \`kill(pid, 0)\` → \`ESRCH\`).
- \`TestContextErrStatus_DeadlineExceededReturns504\` and \`TestContextErrStatus_CancelReturns499\` cover the helper directly so the 504 branch is exercised without waiting for the 30 s minimum endpoint deadline.
- Pre-existing happy-path tests for \`/cleanup\`, \`/escalate\`, \`/event\`, \`/prompt\` continue to pass.

## Local verification

\`\`\`
$ go build ./... && go test ./... -count=1   # all green
$ go test ./internal/sidecar/ -race -count=1 # ok, 101 s
$ nix build .#prism                          # ok
\`\`\`

## Heads-up

Per the spawn prompt, another worker (issue #1848, bounding JSON request bodies) is queued to land on \`host_api.go\` right after this PR merges and will rebase on top.