### PR TITLE
sidecar: bound coordinator-lifetime message-tracking maps

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/bounded_map.go
+++ b/modules/programs/prism/prism/internal/sidecar/bounded_map.go
@@ -1,0 +1,121 @@
+package sidecar
+
+// bounded_map.go — bounded insertion-order LRU map used to cap the
+// per-message tracking structures on Sidecar (writtenMessages,
+// textByMessage, msgCreatedAtMs, ttftByMessage). Issue #1846.
+//
+// Background: coordinator sidecars run for days or weeks. The four
+// message-tracking maps above were previously unbounded `map[string]T`
+// values that grew for every message ID observed for the lifetime of the
+// process. Abandoned messages (tool-only turns, agent interruptions) were
+// never cleaned up, so on a busy coordinator the maps accreted hundreds of
+// entries per day — linear growth on a long-lived process.
+//
+// The pattern mirrors `deliveryDedup` (delivery_dedup.go): a `map` for O(1)
+// lookup combined with a doubly-linked `list` recording insertion order so
+// the oldest key can be evicted in O(1) when the bound is hit. Unlike
+// `deliveryDedup`, callers may overwrite an existing key with a new value
+// without refreshing its position — `set` on an existing key keeps the
+// original insertion-order slot. This matches the call-site semantics: a
+// streaming `textByMessage` update for an in-flight message should not
+// prolong the entry's lifetime relative to other in-flight messages.
+//
+// boundedMap is NOT safe for concurrent use. All call sites in this
+// package access the message-tracking maps under `Sidecar.mu`, so the
+// outer lock is sufficient — adding a second mutex would only complicate
+// the code without buying anything.
+
+import "container/list"
+
+// boundedMap is a generic insertion-order LRU map with a fixed capacity.
+// V is the value type; keys are always strings (the message ID).
+//
+// Zero value is not usable; construct with newBoundedMap. When the map is
+// at capacity and a new key is set, the oldest key (by insertion order) is
+// evicted. Setting an existing key updates the value in place without
+// changing its position in the eviction order.
+//
+// Eviction is O(1) amortised per insert.
+type boundedMap[V any] struct {
+	cap  int
+	m    map[string]*list.Element
+	keys *list.List // front=oldest, back=newest
+}
+
+// boundedMapEntry is the value stored in each list element. We keep the
+// key alongside the value so eviction (which pops the front of the list)
+// can remove the corresponding map entry without a reverse lookup.
+type boundedMapEntry[V any] struct {
+	key string
+	val V
+}
+
+// newBoundedMap constructs an empty bounded map with the given capacity.
+// A non-positive capacity disables eviction (the map grows without bound)
+// and is intended for tests only — production callers should always pass
+// a positive bound.
+func newBoundedMap[V any](capacity int) *boundedMap[V] {
+	return &boundedMap[V]{
+		cap:  capacity,
+		m:    make(map[string]*list.Element),
+		keys: list.New(),
+	}
+}
+
+// get returns the value for key and whether it was present. The zero value
+// is returned when the key is absent.
+func (b *boundedMap[V]) get(key string) (V, bool) {
+	if el, ok := b.m[key]; ok {
+		return el.Value.(*boundedMapEntry[V]).val, true
+	}
+	var zero V
+	return zero, false
+}
+
+// has reports whether key is present.
+func (b *boundedMap[V]) has(key string) bool {
+	_, ok := b.m[key]
+	return ok
+}
+
+// set inserts or updates key. On a fresh insert that would exceed the
+// capacity, the oldest key is evicted first. On an update to an existing
+// key, the value is replaced in place — position in the eviction order is
+// not refreshed.
+func (b *boundedMap[V]) set(key string, val V) {
+	if el, ok := b.m[key]; ok {
+		el.Value.(*boundedMapEntry[V]).val = val
+		return
+	}
+	if b.cap > 0 && b.keys.Len() >= b.cap {
+		oldest := b.keys.Front()
+		if oldest != nil {
+			entry := oldest.Value.(*boundedMapEntry[V])
+			b.keys.Remove(oldest)
+			delete(b.m, entry.key)
+		}
+	}
+	entry := &boundedMapEntry[V]{key: key, val: val}
+	b.m[key] = b.keys.PushBack(entry)
+}
+
+// del removes key. No-op if absent.
+func (b *boundedMap[V]) del(key string) {
+	if el, ok := b.m[key]; ok {
+		b.keys.Remove(el)
+		delete(b.m, key)
+	}
+}
+
+// len returns the number of entries currently tracked.
+func (b *boundedMap[V]) len() int {
+	return b.keys.Len()
+}
+
+// messageTrackingCap is the per-map capacity for the four message-tracking
+// maps on Sidecar (writtenMessages, textByMessage, msgCreatedAtMs,
+// ttftByMessage). Sized generously at 4096 — well above any realistic
+// short-conversation working set, so eviction does not perturb normal
+// behaviour, while keeping the worst-case footprint bounded to a few MiB
+// per map even with full-text payloads. Issue #1846.
+const messageTrackingCap = 4096

--- a/modules/programs/prism/prism/internal/sidecar/bounded_map_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/bounded_map_test.go
@@ -1,0 +1,155 @@
+package sidecar
+
+// bounded_map_test.go — unit tests for the generic insertion-order LRU
+// map used to cap the per-message tracking structures on Sidecar
+// (writtenMessages / textByMessage / msgCreatedAtMs / ttftByMessage).
+// Issue #1846.
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestBoundedMap_SetAndGet(t *testing.T) {
+	b := newBoundedMap[string](8)
+	b.set("a", "alpha")
+	if v, ok := b.get("a"); !ok || v != "alpha" {
+		t.Errorf("get(\"a\") = (%q, %v), want (\"alpha\", true)", v, ok)
+	}
+	if v, ok := b.get("missing"); ok || v != "" {
+		t.Errorf("get(\"missing\") = (%q, %v), want (\"\", false)", v, ok)
+	}
+}
+
+func TestBoundedMap_HasAndLen(t *testing.T) {
+	b := newBoundedMap[int](8)
+	if b.has("a") {
+		t.Errorf("has on empty map = true, want false")
+	}
+	if b.len() != 0 {
+		t.Errorf("len on empty map = %d, want 0", b.len())
+	}
+	b.set("a", 1)
+	b.set("b", 2)
+	if !b.has("a") || !b.has("b") {
+		t.Errorf("has(a)=%v has(b)=%v, want both true", b.has("a"), b.has("b"))
+	}
+	if b.len() != 2 {
+		t.Errorf("len after 2 sets = %d, want 2", b.len())
+	}
+}
+
+func TestBoundedMap_Delete(t *testing.T) {
+	b := newBoundedMap[int](8)
+	b.set("a", 1)
+	b.set("b", 2)
+	b.del("a")
+	if b.has("a") {
+		t.Errorf("has(\"a\") after del = true, want false")
+	}
+	if b.len() != 1 {
+		t.Errorf("len after del = %d, want 1", b.len())
+	}
+	// del on missing key is a no-op.
+	b.del("missing")
+	if b.len() != 1 {
+		t.Errorf("len after del missing = %d, want 1", b.len())
+	}
+}
+
+func TestBoundedMap_UpdateInPlaceDoesNotChangeLenOrPosition(t *testing.T) {
+	// Setting an existing key updates the value but does NOT refresh its
+	// position in the eviction order — this is the documented behaviour
+	// for streaming text-part updates where re-setting the same in-flight
+	// message-id should not prolong its retention relative to others.
+	b := newBoundedMap[string](3)
+	b.set("a", "1")
+	b.set("b", "2")
+	b.set("c", "3")
+	// Overwrite "a" — len must not grow, value must update.
+	b.set("a", "updated")
+	if b.len() != 3 {
+		t.Errorf("len after update = %d, want 3", b.len())
+	}
+	if v, _ := b.get("a"); v != "updated" {
+		t.Errorf("get(\"a\") after update = %q, want \"updated\"", v)
+	}
+	// Adding "d" must still evict "a" (because position was not refreshed).
+	b.set("d", "4")
+	if b.has("a") {
+		t.Errorf("after update-a + add-d, has(\"a\") = true, want false (position should not have been refreshed)")
+	}
+	if !b.has("b") || !b.has("c") || !b.has("d") {
+		t.Errorf("has(b,c,d) = (%v,%v,%v), all want true", b.has("b"), b.has("c"), b.has("d"))
+	}
+}
+
+func TestBoundedMap_EvictsOldestWhenAtCapacity(t *testing.T) {
+	b := newBoundedMap[int](3)
+	b.set("a", 1)
+	b.set("b", 2)
+	b.set("c", 3)
+	if b.len() != 3 {
+		t.Fatalf("len after 3 sets = %d, want 3", b.len())
+	}
+	b.set("d", 4)
+	if b.len() != 3 {
+		t.Errorf("len after eviction = %d, want 3", b.len())
+	}
+	if b.has("a") {
+		t.Errorf("has(\"a\") after eviction = true, want false")
+	}
+	if !b.has("b") || !b.has("c") || !b.has("d") {
+		t.Errorf("has(b,c,d) = (%v,%v,%v), all want true", b.has("b"), b.has("c"), b.has("d"))
+	}
+}
+
+// TestBoundedMap_NeverExceedsCapacity is the headline AC #1 check: after
+// many inserts the map size must never exceed the bound.
+func TestBoundedMap_NeverExceedsCapacity(t *testing.T) {
+	const cap = 64
+	b := newBoundedMap[int](cap)
+	for i := 0; i < cap*100; i++ {
+		b.set("k-"+strconv.Itoa(i), i)
+		if got := b.len(); got > cap {
+			t.Fatalf("len = %d after %d inserts, exceeds cap %d", got, i+1, cap)
+		}
+	}
+	if got := b.len(); got != cap {
+		t.Errorf("final len = %d, want %d", got, cap)
+	}
+}
+
+func TestBoundedMap_NonPositiveCapacityIsUnbounded(t *testing.T) {
+	// cap <= 0 disables eviction. Test-only convenience.
+	b := newBoundedMap[int](0)
+	for i := 0; i < 1000; i++ {
+		b.set("k-"+strconv.Itoa(i), i)
+	}
+	if b.len() != 1000 {
+		t.Errorf("len with cap=0 after 1000 inserts = %d, want 1000", b.len())
+	}
+}
+
+func TestBoundedMap_DeleteAllowsReinsertionWithoutEviction(t *testing.T) {
+	// del must remove the key from both the map AND the list; otherwise a
+	// subsequent re-set of the same key would either double-count or fail
+	// to evict on overflow.
+	b := newBoundedMap[int](3)
+	b.set("a", 1)
+	b.set("b", 2)
+	b.set("c", 3)
+	b.del("b")
+	if b.len() != 2 {
+		t.Fatalf("len after del = %d, want 2", b.len())
+	}
+	b.set("d", 4)
+	if b.len() != 3 {
+		t.Errorf("len after re-fill = %d, want 3", b.len())
+	}
+	// "a" must still be present — del("b") opened a slot so "d" should
+	// not have triggered eviction of "a".
+	if !b.has("a") {
+		t.Errorf("has(\"a\") after del(b) + set(d) = false, want true (no eviction expected)")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -689,10 +689,10 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 	info := payload.Properties.Info
 
 	if info.Role == "user" {
-		if s.writtenMessages[info.ID] {
+		if s.writtenMessages.has(info.ID) {
 			return
 		}
-		text := s.textByMessage[info.ID]
+		text, _ := s.textByMessage.get(info.ID)
 		if text == "" {
 			return
 		}
@@ -730,8 +730,8 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 			"agent":     agentName,
 			"model":     model,
 		}, nil)
-		s.writtenMessages[info.ID] = true
-		delete(s.textByMessage, info.ID)
+		s.writtenMessages.set(info.ID, true)
+		s.textByMessage.del(info.ID)
 
 	} else if info.Role == "assistant" {
 		// Store time.created for TTFT computation as soon as we see any
@@ -741,8 +741,8 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 		// subsequent message.updated events for the same message don't
 		// overwrite the original created time.
 		if info.Time != nil && info.Time.Created != nil {
-			if _, alreadyStored := s.msgCreatedAtMs[info.ID]; !alreadyStored {
-				s.msgCreatedAtMs[info.ID] = *info.Time.Created
+			if !s.msgCreatedAtMs.has(info.ID) {
+				s.msgCreatedAtMs.set(info.ID, *info.Time.Created)
 			}
 		}
 
@@ -751,10 +751,10 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 			return
 		}
 
-		if s.writtenMessages[info.ID] {
+		if s.writtenMessages.has(info.ID) {
 			return
 		}
-		text := s.textByMessage[info.ID]
+		text, _ := s.textByMessage.get(info.ID)
 		if text == "" {
 			return
 		}
@@ -903,15 +903,15 @@ func (s *Sidecar) handleMessageUpdated(evt harness.HarnessEvent) {
 			}
 		}
 
-		if ttft, ok := s.ttftByMessage[info.ID]; ok && ttft > 0 {
+		if ttft, ok := s.ttftByMessage.get(info.ID); ok && ttft > 0 {
 			eventPayload["ttftMs"] = ttft
 		}
 
 		s.writeEvent("msg_assistant", eventPayload, nil)
-		s.writtenMessages[info.ID] = true
-		delete(s.textByMessage, info.ID)
-		delete(s.msgCreatedAtMs, info.ID)
-		delete(s.ttftByMessage, info.ID)
+		s.writtenMessages.set(info.ID, true)
+		s.textByMessage.del(info.ID)
+		s.msgCreatedAtMs.del(info.ID)
+		s.ttftByMessage.del(info.ID)
 	}
 }
 
@@ -949,16 +949,16 @@ func (s *Sidecar) handleMessagePartUpdated(evt harness.HarnessEvent) {
 	switch part.Type {
 	case "text":
 		if part.Text != "" {
-			s.textByMessage[part.MessageID] = part.Text
+			s.textByMessage.set(part.MessageID, part.Text)
 		}
 		// Capture TTFT from the first text part with a time.start timestamp.
 		// Only record once per message (first text part wins).
-		if _, alreadyRecorded := s.ttftByMessage[part.MessageID]; !alreadyRecorded {
+		if !s.ttftByMessage.has(part.MessageID) {
 			if part.Time != nil && part.Time.Start != nil {
-				if createdAt, ok := s.msgCreatedAtMs[part.MessageID]; ok {
+				if createdAt, ok := s.msgCreatedAtMs.get(part.MessageID); ok {
 					ttft := *part.Time.Start - createdAt
 					if ttft > 0 {
-						s.ttftByMessage[part.MessageID] = int64(ttft)
+						s.ttftByMessage.set(part.MessageID, int64(ttft))
 					}
 				}
 			}

--- a/modules/programs/prism/prism/internal/sidecar/message_tracking_bound_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/message_tracking_bound_test.go
@@ -1,0 +1,144 @@
+package sidecar
+
+// message_tracking_bound_test.go — acceptance-criteria tests for the
+// bounded-LRU treatment of the four per-message tracking maps on Sidecar
+// (writtenMessages / textByMessage / msgCreatedAtMs / ttftByMessage).
+// Issue #1846.
+
+import (
+	"strconv"
+	"testing"
+)
+
+// TestMessageTrackingMaps_BoundedAfterFlood is AC #1: after many more inserts
+// than the cap, none of the four maps exceed the cap. This drives the real
+// HandleEvent pipeline (not the boundedMap helper directly), so it also
+// guards against any future call-site that bypasses the bounded type.
+func TestMessageTrackingMaps_BoundedAfterFlood(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Generate (cap * 3) abandoned assistant messages. Each one feeds the
+	// "first message.updated with time.created" path (populating
+	// msgCreatedAtMs) followed by a text part (populating textByMessage and
+	// ttftByMessage). We deliberately omit the final time.completed event
+	// so writtenMessages, textByMessage, msgCreatedAtMs, and ttftByMessage
+	// all retain entries — this is the exact leak the issue describes.
+	//
+	// To populate writtenMessages we then emit a completed user message
+	// (which writes to writtenMessages and not the others) for each ID.
+	const flood = messageTrackingCap * 3
+
+	for i := range flood {
+		id := "msg-" + strconv.Itoa(i)
+		created := float64(1000 + i)
+		start := created + 10
+
+		// 1) message.updated assistant with time.created — populates msgCreatedAtMs.
+		sc.HandleEvent(makeSSE("message.updated", map[string]any{
+			"info": map[string]any{
+				"id":   id,
+				"role": "assistant",
+				"time": map[string]*float64{
+					"created": &created,
+				},
+			},
+		}))
+
+		// 2) message.part.updated text — populates textByMessage and ttftByMessage.
+		sc.HandleEvent(makeSSE("message.part.updated", map[string]any{
+			"part": map[string]any{
+				"type":      "text",
+				"messageID": id,
+				"text":      "partial-" + id,
+				"time": map[string]*float64{
+					"start": &start,
+				},
+			},
+		}))
+
+		// 3) Completed user message with a different ID — populates writtenMessages.
+		userID := "user-" + strconv.Itoa(i)
+		sendEvents(sc, makeUserMessage(userID, "worker", "hello"))
+	}
+
+	if got := sc.writtenMessages.len(); got > messageTrackingCap {
+		t.Errorf("writtenMessages.len = %d, want <= %d", got, messageTrackingCap)
+	}
+	if got := sc.textByMessage.len(); got > messageTrackingCap {
+		t.Errorf("textByMessage.len = %d, want <= %d", got, messageTrackingCap)
+	}
+	if got := sc.msgCreatedAtMs.len(); got > messageTrackingCap {
+		t.Errorf("msgCreatedAtMs.len = %d, want <= %d", got, messageTrackingCap)
+	}
+	if got := sc.ttftByMessage.len(); got > messageTrackingCap {
+		t.Errorf("ttftByMessage.len = %d, want <= %d", got, messageTrackingCap)
+	}
+
+	// All four maps should be at or very near the cap after flood >> cap.
+	// (writtenMessages collects user-msg IDs; the other three collect the
+	// abandoned-assistant IDs.) We expect each map to be at least 95% of
+	// the cap — the exact value is sensitive to interleaved del() calls
+	// from completed user messages, which can free a slot per iteration.
+	const nearSaturated = messageTrackingCap * 95 / 100
+	if got := sc.writtenMessages.len(); got < nearSaturated {
+		t.Errorf("writtenMessages.len = %d, want >= %d (near-saturated)", got, nearSaturated)
+	}
+	if got := sc.textByMessage.len(); got < nearSaturated {
+		t.Errorf("textByMessage.len = %d, want >= %d (near-saturated)", got, nearSaturated)
+	}
+	if got := sc.msgCreatedAtMs.len(); got < nearSaturated {
+		t.Errorf("msgCreatedAtMs.len = %d, want >= %d (near-saturated)", got, nearSaturated)
+	}
+	if got := sc.ttftByMessage.len(); got < nearSaturated {
+		t.Errorf("ttftByMessage.len = %d, want >= %d (near-saturated)", got, nearSaturated)
+	}
+}
+
+// TestMessageTrackingMaps_ShortConversationNoEviction is AC #2: a normal
+// 10-turn conversation must not trigger eviction. writtenMessages
+// accumulates every completed user + assistant message; the streaming maps
+// (textByMessage / msgCreatedAtMs / ttftByMessage) are drained on
+// completion so they stay empty between turns.
+func TestMessageTrackingMaps_ShortConversationNoEviction(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	const turns = 10
+
+	for i := range turns {
+		userID := "user-" + strconv.Itoa(i)
+		asstID := "asst-" + strconv.Itoa(i)
+		sendEvents(sc, makeUserMessage(userID, "worker", "hello "+userID))
+		sendEvents(sc, makeAssistantMessage(asstID, "worker", "reply "+asstID))
+	}
+
+	// writtenMessages: one entry per user + assistant message = 2 * turns.
+	if got := sc.writtenMessages.len(); got != 2*turns {
+		t.Errorf("writtenMessages.len after %d turns = %d, want %d", turns, got, 2*turns)
+	}
+	// All other maps are cleared on completion, so they should be empty.
+	if got := sc.textByMessage.len(); got != 0 {
+		t.Errorf("textByMessage.len after %d completed turns = %d, want 0", turns, got)
+	}
+	if got := sc.msgCreatedAtMs.len(); got != 0 {
+		t.Errorf("msgCreatedAtMs.len after %d completed turns = %d, want 0", turns, got)
+	}
+	if got := sc.ttftByMessage.len(); got != 0 {
+		t.Errorf("ttftByMessage.len after %d completed turns = %d, want 0", turns, got)
+	}
+
+	// Sanity: every message ID emitted should still be present in
+	// writtenMessages (no premature eviction).
+	for i := range turns {
+		userID := "user-" + strconv.Itoa(i)
+		asstID := "asst-" + strconv.Itoa(i)
+		if !sc.writtenMessages.has(userID) {
+			t.Errorf("writtenMessages missing user message %q after %d turns (premature eviction)", userID, turns)
+		}
+		if !sc.writtenMessages.has(asstID) {
+			t.Errorf("writtenMessages missing assistant message %q after %d turns (premature eviction)", asstID, turns)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -320,20 +320,31 @@ type Sidecar struct {
 	manualDenial    bool
 	compacting      bool
 	harnessSessionID string
-	writtenMessages map[string]bool // dedup message.updated writes
-	textByMessage   map[string]string
+	// writtenMessages dedupes message.updated writes. Bounded LRU
+	// (messageTrackingCap entries) — coordinator sidecars run for days, so
+	// the previous unbounded map leaked entries linearly with message volume
+	// (issue #1846). Entries are never explicitly deleted, only evicted on
+	// overflow in strict insertion order.
+	writtenMessages *boundedMap[bool]
+	// textByMessage accumulates streamed text-part updates for an in-flight
+	// assistant or user message; the entry is consumed and deleted when the
+	// message completes. Bounded LRU (messageTrackingCap entries) so that
+	// messages abandoned mid-turn (agent interrupted, tool-only turns that
+	// hit the text=="" early return) cannot accumulate without bound. The
+	// cap is sized so a normal conversation's working set is never evicted.
+	textByMessage *boundedMap[string]
 	// msgCreatedAtMs tracks the time.created timestamp (ms since epoch) for
 	// in-flight assistant messages. Used to compute TTFT when the first text
 	// part arrives. Keyed by message ID; entries are deleted when the message
-	// is written (same lifecycle as textByMessage). Messages abandoned mid-turn
-	// (e.g. agent interrupted) are not cleaned up; this matches the existing
-	// textByMessage behaviour and is acceptable for short-lived sidecar processes.
-	msgCreatedAtMs map[string]float64
+	// is written (same lifecycle as textByMessage). Bounded LRU
+	// (messageTrackingCap entries) — see textByMessage for the leak class
+	// this closes (issue #1846).
+	msgCreatedAtMs *boundedMap[float64]
 	// ttftByMessage tracks the computed TTFT (ms) for each assistant message,
 	// set when the first text part with a time.start timestamp arrives.
 	// Zero means "not yet seen" or "unavailable". Keyed by message ID.
-	// Same lifecycle / leak characteristics as msgCreatedAtMs above.
-	ttftByMessage map[string]int64
+	// Same lifecycle as msgCreatedAtMs above, same bounded-LRU treatment.
+	ttftByMessage *boundedMap[int64]
 	// container is set when running in container mode.
 	// Protected by mu.
 	container *containerMgr
@@ -540,10 +551,10 @@ func New(cfg Config) *Sidecar {
 	s := &Sidecar{
 		cfg:             cfg,
 		harness:         cfg.Harness,
-		writtenMessages: make(map[string]bool),
-		textByMessage:   make(map[string]string),
-		msgCreatedAtMs:  make(map[string]float64),
-		ttftByMessage:   make(map[string]int64),
+		writtenMessages: newBoundedMap[bool](messageTrackingCap),
+		textByMessage:   newBoundedMap[string](messageTrackingCap),
+		msgCreatedAtMs:  newBoundedMap[float64](messageTrackingCap),
+		ttftByMessage:   newBoundedMap[int64](messageTrackingCap),
 		seenUnknown:     make(map[string]bool),
 		promptDedup:     newDeliveryDedup(deliveryDedupCapacity),
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -7857,7 +7857,7 @@ func TestTransitionCause_RootAgentIdleDebounce(t *testing.T) {
 		},
 	})
 	// Seed text so the message write proceeds.
-	sc.textByMessage["msg-001"] = "hello"
+	sc.textByMessage.set("msg-001", "hello")
 	sc.HandleEvent(evt)
 
 	timer := clk.LastTimer()


### PR DESCRIPTION
Closes #1846

## Problem

The four per-message tracking maps on `Sidecar`
(`writtenMessages`, `textByMessage`, `msgCreatedAtMs`, `ttftByMessage`)
accreted entries for the lifetime of the process. Coordinator sidecars
run for days or weeks, so this was linear unbounded growth on a
long-lived process. The comment at `sidecar.go:322-325` acknowledged the
leak but defended it as "acceptable for short-lived sidecar processes"
— which coordinator sidecars are not.

## Fix

Introduce a generic insertion-order LRU `boundedMap[V]` (modelled on
the existing `deliveryDedup` pattern) and use it for all four maps with
a per-map cap of 4096 entries.

- O(1) amortised eviction per insert (map + doubly-linked list).
- Re-`set` on an existing key updates the value in place without
  refreshing position — matches the streaming `textByMessage` semantics
  where the same in-flight message-id is set multiple times.
- 4096 is generous enough that a normal conversation's working set is
  never evicted, but small enough to bound the worst-case footprint to a
  few MiB per map.

Updates the `sidecar.go:322-325` comment to remove the "short-lived"
assertion and document the new bound.

## Tests

- `bounded_map_test.go` — unit tests for the generic LRU helper:
  set/get/has/len/del, in-place updates do not refresh position, never
  exceeds capacity under flood, delete frees a slot, non-positive
  capacity disables eviction (test-only).
- `message_tracking_bound_test.go` — end-to-end ACs driven through
  `HandleEvent`:
  - `TestMessageTrackingMaps_BoundedAfterFlood`: 3× cap unique
    abandoned-assistant + completed-user messages, every map stays at
    or below `messageTrackingCap`.
  - `TestMessageTrackingMaps_ShortConversationNoEviction`: 10-turn
    conversation, `writtenMessages` retains every id, the streaming
    maps are drained on completion.

## Verification

- `go build ./...` clean
- `go test ./... -race` — all packages pass, including
  `internal/sidecar` (139s with race)
- `nix build .#prism` clean

## Acceptance criteria

- [x] [functional] All four maps have a bounded maximum entry count
      (`messageTrackingCap = 4096`); flood test asserts the bound.
- [x] [functional] 10-turn conversation retains every entry; regression
      test asserts no premature eviction.
- [x] [performance] Eviction is O(1) amortised per insert (map +
      `container/list` doubly-linked list).
- [x] [functional] Comment at `sidecar.go:322-325` updated to remove
      the "short-lived" assertion and document the new bound.
- [x] [functional] `go test ./internal/sidecar/ -race` passes.
- [x] [functional] `nix build .#prism` passes.