### PR TITLE
sidecar: early-return unknown-event handler once cap reached

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -108,12 +108,15 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 		s.handleMessagePartUpdated(evt)
 	default:
 		// Gap 6: log unknown event types once per unique type.
+		// Fast-path: once the cap is reached we never log or mutate the map
+		// again, so skip the map lookup and len() on every subsequent event.
+		if s.seenUnknownCapReached {
+			return
+		}
 		if !s.seenUnknown[eventType] {
 			if len(s.seenUnknown) >= seenUnknownCap {
-				if !s.seenUnknownCapReached {
-					s.seenUnknownCapReached = true
-					s.logger().Printf("sidecar: unknown-event log cap reached")
-				}
+				s.seenUnknownCapReached = true
+				s.logger().Printf("sidecar: unknown-event log cap reached")
 			} else {
 				s.seenUnknown[eventType] = true
 				s.logger().Printf("sidecar: event: %s (unhandled — unknown event type)", eventType)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -8155,6 +8155,78 @@ func TestUnknownEventType_CapReachedOnce(t *testing.T) {
 	}
 }
 
+// TestUnknownEventType_PostCapFastPath verifies that once seenUnknownCapReached
+// is set to true, subsequent unknown events do not mutate the seenUnknown map
+// or emit further log lines — the early-return fast-path is taken.
+func TestUnknownEventType_PostCapFastPath(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+	getLogs := captureLog(sc)
+
+	_ = sc.cfg.DB.UpsertStatus(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil)
+
+	// Fill exactly to cap so the next unique event will flip seenUnknownCapReached.
+	for i := range seenUnknownCap {
+		sc.HandleEvent(makeSSE(fmt.Sprintf("fastpath.fill.%d", i), map[string]any{}))
+	}
+	if sc.seenUnknownCapReached {
+		t.Fatalf("seenUnknownCapReached set prematurely after %d unique types", seenUnknownCap)
+	}
+	if len(sc.seenUnknown) != seenUnknownCap {
+		t.Fatalf("seenUnknown len = %d after fill, want %d", len(sc.seenUnknown), seenUnknownCap)
+	}
+
+	// One more unique type — this trips the cap.
+	sc.HandleEvent(makeSSE("fastpath.trip", map[string]any{}))
+	if !sc.seenUnknownCapReached {
+		t.Fatalf("seenUnknownCapReached not set after exceeding cap")
+	}
+	mapLenAfterTrip := len(sc.seenUnknown)
+	if mapLenAfterTrip != seenUnknownCap {
+		t.Fatalf("seenUnknown len = %d after trip, want %d (no write on trip event)", mapLenAfterTrip, seenUnknownCap)
+	}
+
+	// Snapshot the unknown-event-specific log counts at this point. Subsequent
+	// unknown events must not append further "unhandled" or "cap reached" lines.
+	// (HandleEvent always emits a generic "sidecar: event: <type>" trace line
+	// before the switch — that is not part of the unknown-event handler and is
+	// expected to grow on every call.)
+	logsAfterTrip := getLogs()
+	unhandledBefore := strings.Count(logsAfterTrip, "unhandled — unknown event type")
+	capLinesBefore := strings.Count(logsAfterTrip, "sidecar: unknown-event log cap reached")
+
+	// Fire many more unknown events — both repeats of seen types and brand-new types.
+	// The fast-path must take all of them: no map mutation, no unknown-event log output.
+	for i := range 100 {
+		sc.HandleEvent(makeSSE(fmt.Sprintf("fastpath.post.%d", i), map[string]any{}))
+		sc.HandleEvent(makeSSE("fastpath.fill.0", map[string]any{})) // repeat of seen
+	}
+
+	// Map state must be unchanged — the early-return skipped both the lookup
+	// and the write path.
+	if len(sc.seenUnknown) != mapLenAfterTrip {
+		t.Errorf("seenUnknown len = %d after post-cap events, want %d (no mutation expected)",
+			len(sc.seenUnknown), mapLenAfterTrip)
+	}
+	if _, ok := sc.seenUnknown["fastpath.post.0"]; ok {
+		t.Errorf("post-cap event type fastpath.post.0 was written into seenUnknown; fast-path not taken")
+	}
+
+	// The unknown-event handler must have emitted nothing further: the "unhandled"
+	// and "cap reached" line counts are unchanged from the snapshot taken right
+	// after the cap was tripped.
+	logsAfterPostEvents := getLogs()
+	unhandledAfter := strings.Count(logsAfterPostEvents, "unhandled — unknown event type")
+	capLinesAfter := strings.Count(logsAfterPostEvents, "sidecar: unknown-event log cap reached")
+	if unhandledAfter != unhandledBefore {
+		t.Errorf("'unhandled' log lines grew after cap: before=%d after=%d (fast-path should not log)",
+			unhandledBefore, unhandledAfter)
+	}
+	if capLinesAfter != capLinesBefore {
+		t.Errorf("'cap reached' log lines grew after cap: before=%d after=%d (must fire exactly once)",
+			capLinesBefore, capLinesAfter)
+	}
+}
+
 // TestBuildNotifyPromptBody_IncludesTextAndModel verifies that the notification
 // body still carries the prompt text and, when a model is known, the split
 // provider/model identifiers. Model is preferred from RootModelID, falling


### PR DESCRIPTION
## Summary

`internal/sidecar/events.go` (HandleEvent unknown-event handler, ~line 111): after `seenUnknownCapReached` is set to true, every subsequent unknown event still executed a map read (`!s.seenUnknown[eventType]`) and a `len()` call before hitting the inner no-op branch. A misbehaving harness emitting unknown event types at high frequency paid this cost on every event — pure waste in the per-event hot path.

## Change

Add an early return on `s.seenUnknownCapReached` at the top of the `default` switch case:

\`\`\`go
default:
    if s.seenUnknownCapReached {
        return
    }
    if !s.seenUnknown[eventType] {
        ...
    }
\`\`\`

Because the early return guarantees we only reach the rate-limit branch when the cap flag is false, the redundant inner `if !s.seenUnknownCapReached` guard around the cap-reached log line can be dropped: the cap line still fires exactly once, on the event that flips the flag.

## Tests

New: `TestUnknownEventType_PostCapFastPath` — fills `seenUnknown` exactly to the cap, trips the cap with one more unique type, snapshots the unhandled / cap-reached log-line counts, then fires 200 more unknown events (mix of new and repeated types) and asserts:

- `seenUnknown` map length is unchanged after the post-cap burst,
- the brand-new post-cap type is **not** present in the map (proves the lookup-and-write path was skipped),
- the \"unhandled\" log-line count did not grow,
- the \"cap reached\" log-line count did not grow.

Existing `TestUnknownEventType_LoggedOnce`, `_MultipleTypes`, `_CapReached`, `_CapReachedOnce` continue to pass — pre-cap behaviour is unchanged.

## Verification

\`\`\`
cd modules/programs/prism/prism
go build ./...                           # clean
go test ./internal/sidecar/ -race        # ok, 84.2s
go test ./...                            # all packages ok

cd <repo-root>
nix build .#prism                        # ok
\`\`\`

## Out of scope (per spec)

- Changing `seenUnknownCap` value.
- Restructuring the unknown-event handling more broadly.

Closes #1853