### PR TITLE
sidecar: early-return in unknown-event handler after cap reached

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -108,12 +108,17 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 		s.handleMessagePartUpdated(evt)
 	default:
 		// Gap 6: log unknown event types once per unique type.
+		// Fast-path: once the cap has been reached, skip the map lookup
+		// and len() call entirely. A misbehaving harness emitting unknown
+		// event types at high frequency would otherwise pay that cost on
+		// every event.
+		if s.seenUnknownCapReached {
+			return
+		}
 		if !s.seenUnknown[eventType] {
 			if len(s.seenUnknown) >= seenUnknownCap {
-				if !s.seenUnknownCapReached {
-					s.seenUnknownCapReached = true
-					s.logger().Printf("sidecar: unknown-event log cap reached")
-				}
+				s.seenUnknownCapReached = true
+				s.logger().Printf("sidecar: unknown-event log cap reached")
 			} else {
 				s.seenUnknown[eventType] = true
 				s.logger().Printf("sidecar: event: %s (unhandled — unknown event type)", eventType)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -8155,6 +8155,52 @@ func TestUnknownEventType_CapReachedOnce(t *testing.T) {
 	}
 }
 
+// TestUnknownEventType_PostCapFastPath verifies that once
+// seenUnknownCapReached is set, further unknown events do not mutate the
+// seenUnknown map. This pins the post-cap fast-path: the handler returns
+// before touching the map, so its size and contents are frozen at the
+// moment the cap was tripped.
+func TestUnknownEventType_PostCapFastPath(t *testing.T) {
+	sc, _ := newTestSidecar(t)
+
+	// Fill until the cap is tripped. The flag flips on the first new type
+	// that arrives after the map is full, so send cap+1 unique types.
+	for i := range seenUnknownCap + 1 {
+		sc.HandleEvent(makeSSE(fmt.Sprintf("pre.cap.%d", i), map[string]any{}))
+	}
+	if !sc.seenUnknownCapReached {
+		t.Fatalf("expected seenUnknownCapReached=true after %d unique types", seenUnknownCap+1)
+	}
+
+	// Snapshot the map: post-cap events must not mutate it.
+	snapshotLen := len(sc.seenUnknown)
+	snapshot := make(map[string]bool, snapshotLen)
+	for k, v := range sc.seenUnknown {
+		snapshot[k] = v
+	}
+
+	// Hammer the handler with both already-seen and brand-new unknown
+	// types. The fast-path must short-circuit before any map access.
+	for i := range 100 {
+		sc.HandleEvent(makeSSE(fmt.Sprintf("post.cap.new.%d", i), map[string]any{}))
+		sc.HandleEvent(makeSSE("pre.cap.0", map[string]any{})) // already-seen
+	}
+
+	if got := len(sc.seenUnknown); got != snapshotLen {
+		t.Errorf("seenUnknown size changed post-cap: got %d, want %d", got, snapshotLen)
+	}
+	for k, v := range sc.seenUnknown {
+		if snapshot[k] != v {
+			t.Errorf("seenUnknown[%q] mutated post-cap: got %v, want %v", k, v, snapshot[k])
+		}
+	}
+	for k := range snapshot {
+		if _, ok := sc.seenUnknown[k]; !ok {
+			t.Errorf("seenUnknown[%q] removed post-cap", k)
+		}
+	}
+}
+
 // TestBuildNotifyPromptBody_IncludesTextAndModel verifies that the notification
 // body still carries the prompt text and, when a model is known, the split
 // provider/model identifiers. Model is preferred from RootModelID, falling


### PR DESCRIPTION
## Summary

After the `seenUnknown` map hits its cap, every subsequent unknown event in `HandleEvent`'s default arm was still doing a map lookup and a `len()` call before falling through the inner return. A misbehaving harness emitting unknown event types at high frequency pays that cost on every event. Pure micro-perf + clarity fix.

## Change

`internal/sidecar/events.go` — add an early-return on `s.seenUnknownCapReached` so the handler short-circuits before touching the map:

```go
if s.seenUnknownCapReached {
    return
}
if !s.seenUnknown[eventType] {
    ...
}
```

With the early-return in place, the inner `if !s.seenUnknownCapReached` guard around setting the flag and emitting the cap-reached log line is dead code (the outer guard already proves the flag is false), so it has been removed. The "log cap reached" line still fires exactly once on the cap transition.

## Test

Added `TestUnknownEventType_PostCapFastPath` in `sidecar_test.go` which fills the cap, snapshots the `seenUnknown` map, hammers the handler with a mix of already-seen and brand-new unknown types, and asserts the map is byte-for-byte unchanged afterwards. This pins the post-cap fast-path: no map mutation occurs after the cap is tripped.

The pre-existing `TestUnknownEventType_*` tests continue to pass unchanged, verifying behaviour before and at the cap-reached transition.

## Verification

- `go build ./...` from `modules/programs/prism/prism/` — ✅
- `go test ./...` from `modules/programs/prism/prism/` — ✅
- `go test ./internal/sidecar/ -race` — ✅
- `nix build .#prism` from the repo root — ✅

Closes #1853