### PR TITLE
sidecar: skip NoHostBusLeak test when XDG_STATE_HOME is unset

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
@@ -459,12 +459,22 @@ func TestInvestigatorNoIntermediatePings(t *testing.T) {
 func TestNotifyInvestigatorCompletion_NoHostBusLeak(t *testing.T) {
 	// Capture the real XDG_STATE_HOME *before* NewIsolated redirects it.
 	// We need to record this now so we can verify it's untouched after the test.
+	//
+	// Unlike the other tests in this file, this one *intentionally* references
+	// the real host path: its whole purpose is to prove that NewIsolated
+	// prevents writes from leaking to ~/.local/state/prism/ on the developer's
+	// host (the exact failure mode of issue #1608). Refactoring this to
+	// t.TempDir() would degenerate the test into "an empty temp dir stays
+	// empty", which proves nothing about the host-leak invariant.
+	//
+	// In sandboxed environments where XDG_STATE_HOME is unset (notably the
+	// nix-build sandbox where HOME=/homeless-shelter), there is no meaningful
+	// host path to protect — skip rather than fall back to UserHomeDir, which
+	// would resolve to /homeless-shelter/.local/state and reintroduce the
+	// inconsistency this test was meant to guard against (see issue #1857).
 	realXDGStateHome := os.Getenv("XDG_STATE_HOME")
 	if realXDGStateHome == "" {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			realXDGStateHome = home + "/.local/state"
-		}
+		t.Skip("test requires XDG_STATE_HOME to be set; it verifies that NewIsolated does not leak writes to the real host state directory, which is only meaningful when a real host path exists")
 	}
 	realPrismDir := realXDGStateHome + "/prism"
 


### PR DESCRIPTION
Closes #1857.

## Summary

`TestNotifyInvestigatorCompletion_NoHostBusLeak` in `internal/sidecar/notify_investigate_test.go` is the only test in that file that doesn't fully isolate via `sidecartest.NewIsolated` — it intentionally references the real host `$XDG_STATE_HOME` to verify that `NewIsolated` prevents writes from leaking to the developer's real `~/.local/state/prism/` directory (the #1608 failure mode).

Previously, when `XDG_STATE_HOME` was unset, the test fell back to `os.UserHomeDir() + \"/.local/state\"`. In the nix-build homeless-shelter sandbox that resolves to `/homeless-shelter/.local/state`, which is exactly the inconsistency that motivated the homeless-shelter CI gate.

## Choice: option (1) — skip with comment

The issue offered two viable shapes:
1. `t.Skip` when `XDG_STATE_HOME` is unset, with a comment.
2. Refactor to `t.Setenv(\"XDG_STATE_HOME\", t.TempDir())` matching the rest of the file.

I chose **(1)** because the test's invariant is fundamentally about the *real production path*. Refactoring it to `t.TempDir()` would degenerate the assertion into \"an empty temp dir stays empty\" — which would still pass, but would no longer prove anything about the host-leak invariant the test was written to guard against. The original `NewIsolated` change (#1608/#1611) added this test specifically because session-name collisions with a live coordinator slug could escape isolation; verifying that requires checking the *actual* host path the leak would have written to.

Option (2) would silently weaken the test. Option (1) keeps the strong assertion when run on a dev machine where it's meaningful and skips cleanly in the sandbox where it isn't.

The new skip message names the invariant; an in-source comment block explains why this test can't be isolated like its siblings and references both #1608 (origin) and #1857 (this fix).

## Verification

- `HOME=/homeless-shelter XDG_STATE_HOME= go test ./internal/sidecar/ -run TestNotifyInvestigatorCompletion_NoHostBusLeak -v` → SKIP (was: passed via UserHomeDir fallback).
- `XDG_STATE_HOME=\"\$HOME/.local/state\" go test ./internal/sidecar/ -run TestNotifyInvestigatorCompletion_NoHostBusLeak -v` → PASS (assertion still exercised on dev hosts).
- `go test ./internal/sidecar/ -race` → ok (91.8s).
- `go test ./...` → all packages green.
- `nix build .#prism` → ok.
- `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'` → ok (homeless-shelter signal).

## Scope

Single test file; no production code touched. The broader audit of the other 12 sidecar test files that don't use `NewIsolated` is explicitly out of scope per the issue.