### PR TITLE
sidecar: cap host-API request bodies (issue #1848)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/helpers.go
+++ b/modules/programs/prism/prism/internal/sidecar/helpers.go
@@ -2,12 +2,68 @@ package sidecar
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// ── host-API request decoding ────────────────────────────────────────────────
+//
+// decodeRequestJSON wraps r.Body in an http.MaxBytesReader sized to maxBytes,
+// constructs a json.Decoder with DisallowUnknownFields enabled, and decodes
+// the body into req. It is the single entry point used by every POST handler
+// in host_api.go so that body-size caps and strict-field decoding are applied
+// consistently across the surface (issue #1848).
+//
+// On success it returns (0, nil) and the caller proceeds with req.
+//
+// On failure it returns one of:
+//
+//   - (http.StatusRequestEntityTooLarge, err) when the body exceeds maxBytes.
+//     Detected via errors.As against *http.MaxBytesError, which the Go runtime
+//     surfaces from the wrapped reader.
+//   - (http.StatusBadRequest, err) for every other decode failure (malformed
+//     JSON, type mismatch, unknown field with DisallowUnknownFields, etc.).
+//
+// 413 vs 400 trade-off (AC #3): when DisallowUnknownFields is enabled we can
+// always tell a body-cap overflow from any other decode error because the
+// runtime wraps the cap-exceeded condition in *http.MaxBytesError before the
+// decoder ever sees it. We therefore return 413 on cap overflow and 400 on
+// every other parse error — the two are distinguishable, so we use the more
+// informative status.
+//
+// allowUnknownFields, when true, disables DisallowUnknownFields. This is for
+// the rare handler that must accept forward-compatible trailing fields; every
+// such call site must justify the deviation in a code comment (AC #4).
+func decodeRequestJSON(w http.ResponseWriter, r *http.Request, req any, maxBytes int64, allowUnknownFields bool) (int, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+	dec := json.NewDecoder(r.Body)
+	if !allowUnknownFields {
+		dec.DisallowUnknownFields()
+	}
+	if err := dec.Decode(req); err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			return http.StatusRequestEntityTooLarge, err
+		}
+		return http.StatusBadRequest, err
+	}
+	return 0, nil
+}
+
+// Body-size caps for host-API POST handlers (issue #1848). 1 MiB is the
+// default for every endpoint; /prompt is bumped to 16 MiB because prompts may
+// legitimately carry file attachments and worker-spawn context (see
+// the call site at mux.HandleFunc("/prompt", ...)). Any other deviation must
+// be justified in a code comment at the call site.
+const (
+	defaultMaxBodyBytes int64 = 1 << 20  // 1 MiB
+	promptMaxBodyBytes  int64 = 16 << 20 // 16 MiB
 )
 
 func strPtr(s string) *string {

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -782,8 +782,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// Issue #1685.
 			DeliveryID string `json:"delivery_id,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /prompt uses the bumped 16 MiB body cap (issue #1848): worker spawn
+		// prompts may legitimately embed file attachments and large context
+		// blobs, so the default 1 MiB ceiling is too tight for this surface.
+		if status, err := decodeRequestJSON(w, r, &req, promptMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {
@@ -1024,10 +1027,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			ModelVariantOverrides string   `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
 			Abtest                []string `json:"abtest"`                  // two-element array of profile names; see #1330
 		}
-		dec := json.NewDecoder(r.Body)
-		dec.DisallowUnknownFields()
-		if err := dec.Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /spawn body cap: default 1 MiB (issue #1848). DisallowUnknownFields
+		// is applied via decodeRequestJSON — already strict on this endpoint.
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 
@@ -1365,8 +1368,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Timeout  string   `json:"timeout"`
 			Rebase   bool     `json:"rebase"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /review body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.PRNumber == "" {
@@ -1556,8 +1560,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Yes     bool   `json:"yes"`
 			JSON    bool   `json:"json"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /cleanup body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {
@@ -1644,8 +1649,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			Session string `json:"session"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /switch body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {
@@ -1707,8 +1713,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			PR    int     `json:"pr"`
 			Title *string `json:"title"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /merge body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.PR <= 0 {
@@ -1791,8 +1798,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			PR int `json:"pr"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /merges/cancel body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.PR <= 0 {
@@ -1864,8 +1872,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Session string            `json:"session"`
 			Args    map[string]string `json:"args"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /event body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 
@@ -1947,8 +1956,11 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		var entry feedback.Entry
-		if err := json.NewDecoder(r.Body).Decode(&entry); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /feedback body cap: default 1 MiB (issue #1848). DisallowUnknownFields
+		// is enabled because feedback.Entry is a closed schema co-owned by this
+		// repo (cmd/feedback.go and internal/feedback) — no external producers.
+		if status, err := decodeRequestJSON(w, r, &entry, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if strings.TrimSpace(entry.Text) == "" {
@@ -2130,8 +2142,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			To     string `json:"to,omitempty"`
 			From   string `json:"from,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /escalate body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if strings.TrimSpace(req.Prompt) == "" {
@@ -2201,8 +2214,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			From   string `json:"from,omitempty"`
 			Name   string `json:"name,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /investigate body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if strings.TrimSpace(req.Prompt) == "" {
@@ -2271,8 +2285,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Model    string `json:"model"`
 			Thinking string `json:"thinking"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /set-model body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {
@@ -2337,8 +2352,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Scope   string `json:"scope"`
 			Session string `json:"session"` // only for scope=session
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /apply-profile body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Profile == "" {
@@ -2472,8 +2488,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Scope   string         `json:"scope"`
 			Session string         `json:"session"` // only for scope=session
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /register-provider body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Name == "" {
@@ -2576,8 +2593,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Name    string         `json:"name"`
 			Config  map[string]any `json:"config"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /register-provider-direct body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {
@@ -2618,8 +2636,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Session string   `json:"session"`
 			Tools   []string `json:"tools"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /set-active-tools body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {
@@ -2661,8 +2680,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		var req struct {
 			Session string `json:"session"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		// /abort body cap: default 1 MiB (issue #1848).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
 			return
 		}
 		if req.Session == "" {

--- a/modules/programs/prism/prism/internal/sidecar/host_api_body_cap_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_body_cap_test.go
@@ -1,0 +1,196 @@
+package sidecar
+
+// Tests for the host-API request-body size cap (issue #1848).
+//
+// Every POST handler in host_api.go now wraps r.Body in
+// http.MaxBytesReader via the package-local decodeRequestJSON helper. The
+// default cap is 1 MiB; /prompt is bumped to 16 MiB because worker spawn
+// prompts may legitimately carry file attachments and large context.
+//
+// AC #3 picks the more informative status code: when the cap is exceeded the
+// handler returns 413 Request Entity Too Large. (We can distinguish a cap
+// overflow from any other decode error because the runtime wraps the
+// overflow in *http.MaxBytesError before the json.Decoder ever sees it.)
+//
+// AC #5 requires that the test post a >cap body to each affected endpoint
+// and assert the documented status. We exercise every route covered by the
+// helper change.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// oversizeJSONPayload returns a JSON object whose serialised size is strictly
+// greater than capBytes — the body MUST exceed the supplied cap.
+//
+// The payload shape is {"junk":"<padding>"}. The field name `junk` is
+// deliberately unknown to every host-API request schema, so this body cannot
+// reach business logic regardless of the cap outcome — it either trips
+// http.MaxBytesReader first (status 413, which is what we assert) or, if it
+// were small enough to fit, would trip DisallowUnknownFields (status 400).
+//
+// With ≥128 bytes of headroom past the cap the MaxBytesReader trips first:
+// the decoder must stream the entire quoted-string value to learn what is
+// inside `"junk"`, and that streaming exceeds the cap well before the
+// closing quote arrives. Empirically verified against encoding/json +
+// net/http on Go 1.26.
+//
+// The padding string is built once, in memory, so a 17 MiB payload takes
+// ~17 MiB of heap during the test — bounded and well inside the test
+// runner's budget.
+func oversizeJSONPayload(t *testing.T, capBytes int) string {
+	t.Helper()
+	// The JSON wrapper {"junk":""} is 11 bytes; pad past the cap with 128
+	// bytes of headroom so the test is insensitive to small framing
+	// off-by-ones and so the MaxBytesReader trips reliably ahead of the
+	// decoder's unknown-field check.
+	const (
+		wrapperBytes = 11
+		headroom     = 128
+	)
+	pad := strings.Repeat("x", capBytes-wrapperBytes+headroom)
+	return `{"junk":"` + pad + `"}`
+}
+
+// TestHostAPI_BodyCap_Default verifies that every POST handler bound to the
+// 1 MiB default body cap rejects a >1 MiB body with HTTP 413. The case table
+// covers every route except /prompt (which has its own 16 MiB cap and is
+// tested in TestHostAPI_BodyCap_Prompt below).
+func TestHostAPI_BodyCap_Default(t *testing.T) {
+	d := openTestDB(t)
+	// Use a coordinator session so the handlers that gate on
+	// requireCoordinator (e.g. /spawn, /merge, /escalate, /investigate)
+	// reach the decode step before the role check fires. The body-cap
+	// behaviour we are asserting lives in decodeRequestJSON, which runs
+	// before the role check inside each handler.
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo",
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", d)
+
+	// Slightly over the 1 MiB cap (oversizeJSONPayload adds 128 bytes of
+	// headroom to ensure MaxBytesReader trips ahead of the decoder's
+	// unknown-field check).
+	body := oversizeJSONPayload(t, 1<<20)
+
+	// Every route bound to defaultMaxBodyBytes. /prompt is tested separately
+	// because it uses promptMaxBodyBytes (16 MiB).
+	routes := []string{
+		"/spawn",
+		"/review",
+		"/cleanup",
+		"/switch",
+		"/merge",
+		"/merges/cancel",
+		"/event",
+		"/feedback",
+		"/escalate",
+		"/investigate",
+		"/set-model",
+		"/apply-profile",
+		"/register-provider",
+		"/register-provider-direct",
+		"/set-active-tools",
+		"/abort",
+	}
+	for _, route := range routes {
+		t.Run(route, func(t *testing.T) {
+			rr := doHostAPI(t, sc, http.MethodPost, route, body)
+			if rr.Code != http.StatusRequestEntityTooLarge {
+				t.Errorf("POST %s with >1 MiB body: status = %d, body = %q, want 413",
+					route, rr.Code, truncateForLog(rr.Body.String(), 200))
+			}
+		})
+	}
+}
+
+// TestHostAPI_BodyCap_Prompt verifies the elevated /prompt cap. The endpoint
+// must:
+//
+//  1. Reject a body just over 16 MiB with HTTP 413 (cap enforcement).
+//  2. Accept a body well over the 1 MiB default (proving the cap really is
+//     higher for /prompt; we use 2 MiB which is in the middle of the legal
+//     window).
+//
+// The "accept" assertion here is "decode succeeds" — i.e. the handler reaches
+// the next layer of validation (which then 400s on missing fields, etc.).
+// What we explicitly do NOT want to see for the 2 MiB body is a 413.
+func TestHostAPI_BodyCap_Prompt(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo",
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", d)
+
+	// Slightly over the 16 MiB /prompt cap → must 413.
+	overBody := oversizeJSONPayload(t, 16<<20)
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt", overBody)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("POST /prompt with >16 MiB body: status = %d, body = %q, want 413",
+			rr.Code, truncateForLog(rr.Body.String(), 200))
+	}
+
+	// 2 MiB body — well above the 1 MiB default, well below the 16 MiB cap.
+	// We deliberately use a valid schema-shaped body so the cap is the only
+	// gate we exercise: any unknown field would also be rejected with 400
+	// (DisallowUnknownFields), which would muddle the signal.
+	pad := strings.Repeat("x", (2<<20)-64)
+	okBody := `{"session":"test-repo@main","prompt":"` + pad + `"}`
+	rr = doHostAPI(t, sc, http.MethodPost, "/prompt", okBody)
+	if rr.Code == http.StatusRequestEntityTooLarge {
+		t.Errorf("POST /prompt with 2 MiB body: got 413, want decode to succeed "+
+			"(any non-413 status; body = %q)", truncateForLog(rr.Body.String(), 200))
+	}
+}
+
+// TestHostAPI_BodyCap_DisallowUnknownFields verifies that every POST handler
+// has DisallowUnknownFields enabled (AC #4). A small valid-shape body with one
+// stray field must return 400 across the board.
+func TestHostAPI_BodyCap_DisallowUnknownFields(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarCoordinatorWithInstance(t, "test-repo@main", "test-repo",
+		"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", d)
+
+	// The strayField is unknown to every host-API request schema.
+	const body = `{"strayUnknownField_issue1848":"reject me"}`
+
+	routes := []string{
+		"/prompt",
+		"/spawn",
+		"/review",
+		"/cleanup",
+		"/switch",
+		"/merge",
+		"/merges/cancel",
+		"/event",
+		"/feedback",
+		"/escalate",
+		"/investigate",
+		"/set-model",
+		"/apply-profile",
+		"/register-provider",
+		"/register-provider-direct",
+		"/set-active-tools",
+		"/abort",
+	}
+	for _, route := range routes {
+		t.Run(route, func(t *testing.T) {
+			rr := doHostAPI(t, sc, http.MethodPost, route, body)
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("POST %s with stray unknown field: status = %d, body = %q, want 400 (DisallowUnknownFields)",
+					route, rr.Code, truncateForLog(rr.Body.String(), 200))
+			}
+			if !strings.Contains(rr.Body.String(), "unknown field") {
+				t.Errorf("POST %s with stray unknown field: body = %q, want error mentioning \"unknown field\"",
+					route, truncateForLog(rr.Body.String(), 200))
+			}
+		})
+	}
+}
+
+// truncateForLog clips long bodies so test failure messages stay readable.
+// Used only for diagnostic output; not part of any assertion.
+func truncateForLog(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...[truncated]"
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_merge_test.go
@@ -95,12 +95,19 @@ func TestHostAPI_Merge_EnqueuesRowWithSidecarIdentity(t *testing.T) {
 	}
 }
 
-// TestHostAPI_Merge_ClientIdentityIsIgnored verifies that the proxy contract
-// is "trust the sidecar, not the client": the request body intentionally has
-// no session_name / instance_id field, so even if a misbehaving client tried
-// to set them, the sidecar would still use its own values. (Asserted
-// indirectly by passing an arbitrary title and verifying that DB identity
-// matches the sidecar config.)
+// TestHostAPI_Merge_ClientIdentityIsIgnored verifies the proxy contract
+// "trust the sidecar, not the client": the request body has no
+// session_name / instance_id field on the schema, so the sidecar always uses
+// its own values when writing the pending_merges row. Verified by posting a
+// minimal valid body and asserting the DB row's identity matches the
+// sidecar's own config.
+//
+// Note: as of issue #1848, all host-API POST handlers run with
+// DisallowUnknownFields, so a body that *did* contain stray identity fields
+// (the pre-#1848 spoof attempt) would now be rejected with 400 before it ever
+// reached the merge logic — the identity-spoof property is preserved
+// (strengthened, in fact) by strict decoding. The companion test
+// TestHostAPI_Merge_StrayClientFields_Rejected covers that path explicitly.
 func TestHostAPI_Merge_ClientIdentityIsIgnored(t *testing.T) {
 	d := openTestDB(t)
 	const (
@@ -109,10 +116,8 @@ func TestHostAPI_Merge_ClientIdentityIsIgnored(t *testing.T) {
 	)
 	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", instance, d)
 
-	// Body contains stray fields that are not part of the schema; they must
-	// be ignored.
 	rr := doHostAPI(t, sc, http.MethodPost, "/merge",
-		`{"pr": 99, "title": null, "session_name": "evil@spoofed", "instance_id": "spoofed"}`)
+		`{"pr": 99, "title": null}`)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
 	}
@@ -121,8 +126,36 @@ func TestHostAPI_Merge_ClientIdentityIsIgnored(t *testing.T) {
 		t.Fatalf("PendingMergeByPR: %v", err)
 	}
 	if row == nil || row.SessionName != sess || row.InstanceID != instance {
-		t.Errorf("row identity = (%v, %v), want (%q, %q) — sidecar must ignore client-supplied identity",
+		t.Errorf("row identity = (%v, %v), want (%q, %q) — sidecar must use its own identity",
 			row.SessionName, row.InstanceID, sess, instance)
+	}
+}
+
+// TestHostAPI_Merge_StrayClientFields_Rejected verifies the strict-decoding
+// contract added in issue #1848: a /merge request body that contains stray
+// fields (e.g. an attempt to spoof session_name or instance_id) is rejected
+// with HTTP 400 by DisallowUnknownFields before any merge work happens.
+func TestHostAPI_Merge_StrayClientFields_Rejected(t *testing.T) {
+	d := openTestDB(t)
+	const (
+		sess     = "test-repo@main"
+		instance = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+	sc := newSidecarCoordinatorWithInstance(t, sess, "test-repo", instance, d)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/merge",
+		`{"pr": 99, "title": null, "session_name": "evil@spoofed", "instance_id": "spoofed"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	// And: the malformed-spoof request must NOT have caused a DB row to be
+	// written under either the real or spoofed identity.
+	row, err := d.PendingMergeByPR(99)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row != nil {
+		t.Errorf("PendingMergeByPR(99) = %+v, want nil — rejected request must not write a row", row)
 	}
 }
 


### PR DESCRIPTION
## Summary

Every POST handler in `internal/sidecar/host_api.go` was reading its request body with a bare `json.NewDecoder(r.Body).Decode(...)` — no `http.MaxBytesReader` anywhere in the package. Only `/spawn` had `DisallowUnknownFields` enabled. A malformed or hostile in-sandbox caller writing a multi-GiB JSON blob would force the decoder to stream-allocate until OOM. The Unix socket is filesystem-permissioned to the user so blast radius is bounded, but defence-in-depth and consistency with normal HTTP-daemon practice argue for a per-handler cap.

## What changed

- New helper `decodeRequestJSON` in `internal/sidecar/helpers.go` that wraps `r.Body` in `http.MaxBytesReader`, enables `DisallowUnknownFields` by default, and returns either `(413, *http.MaxBytesError)` on cap overflow or `(400, decode-error)` on every other parse failure.
- All 17 `json.NewDecoder(r.Body).Decode(...)` call sites in `host_api.go` migrated to the helper. Each site has a one-line code comment naming its cap.
- Caps:
  - **1 MiB** default (`defaultMaxBodyBytes`) on every endpoint.
  - **16 MiB** on `/prompt` (`promptMaxBodyBytes`) — worker spawn prompts may legitimately carry file attachments and large context blobs.

## 413 vs 400 — implementer's choice

AC #3 permits either status. I picked **413 Request Entity Too Large** for the cap-overflow path because `errors.As` against `*http.MaxBytesError` reliably distinguishes a cap overflow from every other decoder error — the runtime wraps the overflow in that sentinel type before the decoder ever sees it. So the two errors are not indistinguishable in practice, and the more informative status is achievable. Every other decode failure (malformed JSON, type mismatch, unknown field) returns 400.

## DisallowUnknownFields — back-compat note

AC #4 permits per-handler opt-out for back-compat. I opted to enable strict decoding on all 17 sites: the host-API surface is internal (Unix-socket-bound, called only by the prism CLI and sidecar's own subprocesses), so there is no third-party producer to break. One existing test (`TestHostAPI_Merge_ClientIdentityIsIgnored`) relied on silent stray-field tolerance to assert an identity-spoof property; I updated it to assert the strengthened contract (stray fields now 400 before any merge work happens) and added a companion test `TestHostAPI_Merge_StrayClientFields_Rejected` that pins the spoof-rejection path explicitly.

## Tests

- `TestHostAPI_BodyCap_Default` — posts a >1 MiB body to every default-cap route (16 routes) and asserts 413.
- `TestHostAPI_BodyCap_Prompt` — asserts `/prompt` 413s on a >16 MiB body and *accepts* a 2 MiB body (proving the cap is genuinely higher than the default — no 413 leaks through).
- `TestHostAPI_BodyCap_DisallowUnknownFields` — posts a stray-field body to all 17 POST handlers and asserts 400 with an `unknown field` error message.

## Verification

```
go build ./...                                           # clean
go test ./internal/sidecar/ -race -count=1               # ok  (91s)
go test ./...                                            # all green
nix build .#prism                                        # ok
```

Closes #1848