### PR TITLE
sidecar: add DashboardSink hook to suppress $XDG_STATE_HOME writes in tests (#1851)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/dashboard.go
+++ b/modules/programs/prism/prism/internal/sidecar/dashboard.go
@@ -8,11 +8,81 @@ import (
 	"time"
 )
 
+// DashboardSink is the test-isolation hook for the two filesystem/socket
+// side-effects performed on every Sidecar state change:
+//
+//   - PushEvent: connect to the persistent dashboard Unix socket under
+//     $XDG_STATE_HOME/prism/bus/ and write a JSON push frame.
+//   - TouchSentinel: ensure the $XDG_STATE_HOME/prism/bus/.dashboard.signal
+//     file exists and bump its mtime so the popup dashboard's poller refreshes.
+//
+// Both default to writing under $XDG_STATE_HOME (falling back to
+// os.UserHomeDir()+"/.local/state" when unset). In the nix build sandbox
+// (HOME=/homeless-shelter) the fallback path is unwritable, which makes any
+// test that constructs a Sidecar without first redirecting $XDG_STATE_HOME a
+// homeless-shelter footgun — see issue #1851 and the AGENTS.md note about
+// PR #1455.
+//
+// Production callers leave Config.DashboardSink nil; New() then installs the
+// production sink (productionDashboardSink) which preserves the historical
+// behaviour exactly: PushEvent dials the dashboard socket in a goroutine,
+// TouchSentinel runs inline. Tests that construct a Sidecar via
+// sidecartest.NewIsolated get a no-op sink so no filesystem or socket I/O is
+// attempted regardless of how $HOME / $XDG_STATE_HOME are configured.
+//
+// The hook is read once at New() time and never mutated thereafter, so it is
+// safe to call without holding s.mu.
+type DashboardSink interface {
+	// PushEvent is invoked from writeStateChangeWithSID on every state
+	// transition. Implementations MUST NOT block the caller — the production
+	// implementation dispatches the actual dial+write on a goroutine.
+	PushEvent(sessionName, state, title string)
+	// TouchSentinel is invoked inline from writeStateChangeWithSID on every
+	// state transition. Implementations should be cheap; the production
+	// implementation performs an os.MkdirAll + os.Chtimes pair.
+	TouchSentinel()
+}
+
+// productionDashboardSink is the default DashboardSink installed by New() when
+// Config.DashboardSink is nil. It preserves the pre-#1851 behaviour exactly:
+// PushEvent is dispatched on a goroutine (fire-and-forget) and TouchSentinel
+// runs inline.
+type productionDashboardSink struct{}
+
+// PushEvent implements DashboardSink by spawning the historical fire-and-
+// forget goroutine that dials the dashboard socket.
+func (productionDashboardSink) PushEvent(sessionName, state, title string) {
+	go pushDashboardEvent(sessionName, state, title)
+}
+
+// TouchSentinel implements DashboardSink by invoking the historical inline
+// touch.
+func (productionDashboardSink) TouchSentinel() {
+	touchDashboardSentinel()
+}
+
+// noopDashboardSink is a DashboardSink that does nothing. It is the sink that
+// sidecartest.NewIsolated installs so tests cannot accidentally touch
+// $XDG_STATE_HOME-derived paths or dial host sockets.
+type noopDashboardSink struct{}
+
+// PushEvent implements DashboardSink as a no-op.
+func (noopDashboardSink) PushEvent(sessionName, state, title string) {}
+
+// TouchSentinel implements DashboardSink as a no-op.
+func (noopDashboardSink) TouchSentinel() {}
+
+// NoopDashboardSink returns a DashboardSink whose methods do nothing. It is
+// exported so test helpers outside this package (notably
+// sidecartest.NewIsolated) can install it on a Config without re-deriving the
+// type.
+func NoopDashboardSink() DashboardSink { return noopDashboardSink{} }
+
 // pushDashboardEvent connects to the persistent dashboard Unix socket and sends
 // a JSON push event with the session name, new state, and title. It is
 // fire-and-forget: any error (socket absent, connection refused, write failure)
 // is silently discarded. Must NOT be called with s.mu held (it is called via
-// goroutine from writeStateChangeWithSID).
+// goroutine from productionDashboardSink.PushEvent).
 func pushDashboardEvent(sessionName, state, title string) {
 	sockPath := dashboardSocketPath()
 	conn, err := net.DialTimeout("unix", sockPath, 500*time.Millisecond)
@@ -51,6 +121,17 @@ func dashboardSocketPath() string {
 
 // touchDashboardSentinel creates or updates the dashboard sentinel file's
 // modification time, causing the dashboard's watcher to refresh.
+//
+// Test-isolation contract: this function calls os.MkdirAll on a path derived
+// from $XDG_STATE_HOME (or os.UserHomeDir()+"/.local/state" when unset). In
+// the nix build sandbox HOME=/homeless-shelter, which is unwritable — any
+// test that drives a Sidecar state change without first redirecting
+// $XDG_STATE_HOME will fail in CI with the homeless-shelter signature
+// described in AGENTS.md. Tests MUST go through sidecartest.NewIsolated to
+// avoid touching $XDG_STATE_HOME paths. NewIsolated installs a no-op
+// DashboardSink (NoopDashboardSink()) which bypasses both this function and
+// pushDashboardEvent entirely. See issue #1851 for the footgun analysis and
+// the original PR #1455 for the failure shape this contract prevents.
 func touchDashboardSentinel() {
 	stateHome := os.Getenv("XDG_STATE_HOME")
 	if stateHome == "" {

--- a/modules/programs/prism/prism/internal/sidecar/dashboard_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/dashboard_test.go
@@ -1,0 +1,261 @@
+package sidecar
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// countingDashboardSink is a test double for DashboardSink that counts the
+// number of times each method has been invoked.
+type countingDashboardSink struct {
+	pushCount  atomic.Int64
+	touchCount atomic.Int64
+}
+
+func (c *countingDashboardSink) PushEvent(sessionName, state, title string) {
+	c.pushCount.Add(1)
+}
+func (c *countingDashboardSink) TouchSentinel() {
+	c.touchCount.Add(1)
+}
+
+// TestNew_DefaultDashboardSink_IsProduction verifies the regression AC:
+// production behaviour is unchanged when no DashboardSink is configured. When
+// the test-mode guard is not set, New() must install productionDashboardSink
+// so the historical pushDashboardEvent+touchDashboardSentinel pair fires from
+// writeStateChangeWithSID exactly as before.
+//
+// We do not exercise the production sink against the real filesystem here
+// (that would require a real $HOME); we only assert the wiring choice.
+func TestNew_DefaultDashboardSink_IsProduction(t *testing.T) {
+	// Ensure the test-mode guard is NOT set so the production branch is taken.
+	// The outer test process may have it unset already, but we use Setenv to
+	// the empty string via Unsetenv-equivalent: t.Setenv("", "") is invalid,
+	// so use os.Unsetenv and rely on t.Cleanup to restore.
+	prev, had := os.LookupEnv("PRISM_TEST_MODE_RESTRICT_HOSTAPI")
+	_ = os.Unsetenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI")
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", prev)
+		} else {
+			_ = os.Unsetenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI")
+		}
+	})
+	// Also redirect XDG_STATE_HOME to a tempdir so even though the production
+	// sink is wired in, any incidental construction-time path resolution stays
+	// sandboxed. We are not calling writeStateChange here.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	d := openTestDB(t)
+	sc := New(Config{
+		SessionName: "prism-test@invoker-default-sink",
+		Repo:        "prism-test",
+		DB:          d,
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+	})
+	if _, ok := sc.cfg.DashboardSink.(productionDashboardSink); !ok {
+		t.Fatalf("Config.DashboardSink: got %T, want productionDashboardSink", sc.cfg.DashboardSink)
+	}
+}
+
+// TestNew_TestModeGuard_InstallsNoopSink verifies that when the
+// PRISM_TEST_MODE_RESTRICT_HOSTAPI env guard is set (as sidecartest.NewIsolated
+// does), New() auto-installs the no-op DashboardSink. This is the wiring AC for
+// sidecartest.NewIsolated — without it, tests that bypass NewIsolated and only
+// set the guard env var would still touch $XDG_STATE_HOME-derived paths via
+// the state-change side-effects.
+func TestNew_TestModeGuard_InstallsNoopSink(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv(sidecartest.EnvRestrictHostAPI, "1")
+
+	d := openTestDB(t)
+	sc := New(Config{
+		SessionName: "prism-test@invoker-noop-guard",
+		Repo:        "prism-test",
+		DB:          d,
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+	})
+	if _, ok := sc.cfg.DashboardSink.(noopDashboardSink); !ok {
+		t.Fatalf("Config.DashboardSink under test-mode guard: got %T, want noopDashboardSink", sc.cfg.DashboardSink)
+	}
+}
+
+// TestNew_ExplicitDashboardSink_Preserved verifies that a caller-supplied
+// DashboardSink is preserved unchanged by New() — the auto-install logic must
+// not stomp on an explicit injection. This guarantees test setups can mix the
+// guard env with a counting sink for assertion.
+func TestNew_ExplicitDashboardSink_Preserved(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv(sidecartest.EnvRestrictHostAPI, "1")
+
+	d := openTestDB(t)
+	sink := &countingDashboardSink{}
+	sc := New(Config{
+		SessionName:   "prism-test@invoker-explicit-sink",
+		Repo:          "prism-test",
+		DB:            d,
+		HarnessName:   "pi",
+		Harness:       pih.New("", "", ""),
+		DashboardSink: sink,
+	})
+	if sc.cfg.DashboardSink != sink {
+		t.Fatalf("Config.DashboardSink: explicit sink not preserved (got %T)", sc.cfg.DashboardSink)
+	}
+}
+
+// TestWriteStateChange_NoopSink_NoFilesystemEffects is the headline AC for
+// issue #1851. It simulates the homeless-shelter sandbox by setting
+// HOME=/homeless-shelter via t.Setenv and constructs a Sidecar via
+// sidecartest.NewIsolated. It then forces a state change through the public
+// writeStateChange path and asserts that:
+//
+//   - the call does not panic;
+//   - no .dashboard.signal file exists anywhere under the simulated HOME (the
+//     directory is unwritable, so any os.MkdirAll attempt would fail loudly
+//     in CI; the test asserts no attempt was made by checking that the
+//     directory was never created); and
+//   - the dashboard sink installed on the Sidecar is the no-op sink (which is
+//     what stops the side-effect at source).
+//
+// This is the regression guard for the footgun: if a future change removed
+// the auto-install logic or routed touchDashboardSentinel around the sink,
+// this test would fail.
+func TestWriteStateChange_NoopSink_NoFilesystemEffects(t *testing.T) {
+	// Simulate the nix-sandbox HOME. We do this BEFORE NewIsolated so that
+	// any code path inside NewIsolated which (hypothetically) fell back to
+	// os.UserHomeDir() would also be exposed. NewIsolated then sets
+	// XDG_STATE_HOME to a tempdir, which is what production-style callers do.
+	homelessShelter := "/homeless-shelter"
+	t.Setenv("HOME", homelessShelter)
+
+	invoker := "prism-test@invoker-homeless-shelter"
+	bus := sidecartest.NewIsolated(t, invoker)
+
+	// Sanity check: XDG_STATE_HOME points at the tempdir, not the simulated
+	// HOME. dashboardSocketPath/touchDashboardSentinel both consult
+	// XDG_STATE_HOME first, so the failure mode they guard against is the
+	// fallback to $HOME/.local/state when XDG_STATE_HOME is unset. We probe
+	// the fallback by also unsetting XDG_STATE_HOME on the Sidecar's
+	// goroutine path: not possible here without racing, so instead we rely
+	// on the no-op sink being installed and never calling the real helpers.
+	if bus.XDGStateHome == "" {
+		t.Fatal("sidecartest.NewIsolated: XDGStateHome empty")
+	}
+
+	cfg := Config{
+		SessionName: invoker,
+		Repo:        "prism-test",
+		DB:          bus.DB,
+		Clock:       newTestClock(),
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	// AC: the no-op sink is wired in by the test-mode guard.
+	if _, ok := sc.cfg.DashboardSink.(noopDashboardSink); !ok {
+		t.Fatalf("under NewIsolated: DashboardSink = %T, want noopDashboardSink", sc.cfg.DashboardSink)
+	}
+
+	// Force a state change. writeStateChange dedupes against lastState, so we
+	// pick a non-zero target and assert the call returns without touching the
+	// filesystem. The harness session ID is nil; that path is exercised by
+	// writeEvent below, which does write to the test DB — that is expected.
+	sc.writeStateChange(agent.StateActive)
+
+	// Assert the side-effect path did NOT create the .dashboard.signal file
+	// under the simulated HOME. The path the production sink would have used
+	// (had XDG_STATE_HOME been unset) is $HOME/.local/state/prism/bus/. We
+	// also check $XDG_STATE_HOME/prism/bus/.dashboard.signal — the no-op
+	// sink must not write there either.
+	homeSignalDir := filepath.Join(homelessShelter, ".local", "state", "prism", "bus")
+	if _, err := os.Stat(homeSignalDir); err == nil {
+		t.Errorf("no-op DashboardSink leaked: created %s under simulated HOME", homeSignalDir)
+	} else if !os.IsNotExist(err) && !strings.Contains(err.Error(), "permission denied") {
+		// "not exist" or "permission denied" are both acceptable signals that
+		// no MkdirAll was attempted. Any other error is unexpected.
+		t.Errorf("unexpected Stat error on %s: %v", homeSignalDir, err)
+	}
+
+	xdgSignal := filepath.Join(bus.XDGStateHome, "prism", "bus", ".dashboard.signal")
+	if _, err := os.Stat(xdgSignal); err == nil {
+		t.Errorf("no-op DashboardSink leaked: created %s under XDG_STATE_HOME", xdgSignal)
+	}
+}
+
+// TestWriteStateChange_ProductionSink_FiresBothHooks verifies the regression
+// AC end-to-end: when the production sink is wired in (no test-mode guard),
+// writeStateChangeWithSID invokes both PushEvent and TouchSentinel exactly
+// once per state transition. We use a countingDashboardSink to observe the
+// calls without exercising the real filesystem/socket paths.
+//
+// This is the structural twin of TestWriteStateChange_NoopSink_NoFilesystemEffects:
+// together they assert that wiring through the sink preserves call ordering
+// and call counts compared to the pre-#1851 inline code.
+func TestWriteStateChange_ProductionSink_FiresBothHooks(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	d := openTestDB(t)
+	sink := &countingDashboardSink{}
+	sc := New(Config{
+		SessionName:   "prism-test@invoker-production-fires",
+		Repo:          "prism-test",
+		Worktree:      "/tmp/test-worktree",
+		DB:            d,
+		Clock:         newTestClock(),
+		HarnessName:   "pi",
+		Harness:       pih.New("", "", ""),
+		DashboardSink: sink,
+	})
+
+	sc.writeStateChange(agent.StateActive)
+	if got := sink.pushCount.Load(); got != 1 {
+		t.Errorf("PushEvent calls after one state change: got %d, want 1", got)
+	}
+	if got := sink.touchCount.Load(); got != 1 {
+		t.Errorf("TouchSentinel calls after one state change: got %d, want 1", got)
+	}
+
+	// Same-state dedup: writeStateChange must NOT re-invoke the sink for a
+	// repeated state (regression: state.go's lastState dedup is upstream of
+	// the sink calls).
+	sc.writeStateChange(agent.StateActive)
+	if got := sink.pushCount.Load(); got != 1 {
+		t.Errorf("PushEvent after dedup'd state change: got %d, want 1", got)
+	}
+	if got := sink.touchCount.Load(); got != 1 {
+		t.Errorf("TouchSentinel after dedup'd state change: got %d, want 1", got)
+	}
+
+	// Distinct state transitions each fire the sink once.
+	sc.writeStateChange(agent.StateFinished)
+	if got := sink.pushCount.Load(); got != 2 {
+		t.Errorf("PushEvent after second state change: got %d, want 2", got)
+	}
+	if got := sink.touchCount.Load(); got != 2 {
+		t.Errorf("TouchSentinel after second state change: got %d, want 2", got)
+	}
+}
+
+// TestProductionDashboardSink_PushEvent_IsNonBlocking verifies that the
+// production sink's PushEvent returns promptly even when the dashboard socket
+// is absent. The historical pre-#1851 code dispatched a goroutine and
+// returned immediately; the post-#1851 wrapper must preserve that contract.
+func TestProductionDashboardSink_PushEvent_IsNonBlocking(t *testing.T) {
+	// Point XDG_STATE_HOME at a tempdir with no socket; PushEvent's
+	// goroutine will dial and fail in 500ms, but the caller must return
+	// immediately.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	sink := productionDashboardSink{}
+	// If this blocks, the test will hang and `go test` will time it out.
+	sink.PushEvent("prism-test@invoker-nonblock", "active", "title")
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -290,6 +290,19 @@ type Config struct {
 	// MiB). Set to a small value in tests to exercise boundary behaviour
 	// without allocating 16 MiB of test data.
 	PipeMaxLineBytes int
+	// DashboardSink, when non-nil, is the test-isolation hook used by
+	// writeStateChangeWithSID to perform the two dashboard side-effects
+	// (socket push and sentinel touch). When nil, New() installs the
+	// production sink (productionDashboardSink), which preserves the
+	// historical behaviour exactly: PushEvent dispatches a fire-and-forget
+	// goroutine that dials $XDG_STATE_HOME/prism/bus/dashboard.sock, and
+	// TouchSentinel runs an inline os.MkdirAll+os.Chtimes pair.
+	//
+	// sidecartest.NewIsolated installs NoopDashboardSink() so that tests
+	// constructed via the isolation helper never touch $XDG_STATE_HOME-derived
+	// paths, even when $HOME is unwritable (e.g. /homeless-shelter in the nix
+	// sandbox). See dashboard.go and issue #1851 for the footgun analysis.
+	DashboardSink DashboardSink
 }
 
 // seenUnknownCap is the maximum number of unique unknown event types tracked
@@ -547,6 +560,21 @@ func New(cfg Config) *Sidecar {
 	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = defaultNotifyHTTPClient
+	}
+	if cfg.DashboardSink == nil {
+		// Auto-install the no-op sink when the test-mode guard is active. The
+		// guard env var (sidecartest.EnvRestrictHostAPI = "PRISM_TEST_MODE_
+		// RESTRICT_HOSTAPI") is set by sidecartest.NewIsolated so any Sidecar
+		// constructed within an isolated test automatically skips the
+		// dashboard side-effects — even if the test forgets to set
+		// DashboardSink explicitly. Production callers do not set this env
+		// var and so receive the unchanged productionDashboardSink behaviour.
+		// See issue #1851 for the homeless-shelter footgun this closes.
+		if os.Getenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI") != "" {
+			cfg.DashboardSink = noopDashboardSink{}
+		} else {
+			cfg.DashboardSink = productionDashboardSink{}
+		}
 	}
 	s := &Sidecar{
 		cfg:             cfg,

--- a/modules/programs/prism/prism/internal/sidecar/sidecartest/sidecartest.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecartest/sidecartest.go
@@ -12,6 +12,12 @@
 //     host socket — a guard env var (PRISM_TEST_MODE_RESTRICT_HOSTAPI) is set
 //     automatically, causing DeliverToSession to refuse socket paths outside
 //     the test's tempdir.
+//   - The dashboard side-effects on state change (sidecar.touchDashboardSentinel
+//     and sidecar.pushDashboardEvent, both of which derive paths from
+//     $XDG_STATE_HOME / $HOME) are suppressed: sidecar.New() consults the same
+//     PRISM_TEST_MODE_RESTRICT_HOSTAPI guard set by NewIsolated and installs a
+//     no-op DashboardSink when it is set. See issue #1851 for the
+//     homeless-shelter footgun this closes.
 //
 // Session names used in test fixtures must NOT use real coordinator slugs
 // (e.g. "nixos-config@main"). Use "prism-test@invoker-<testname>" instead so
@@ -34,12 +40,20 @@ import (
 )
 
 // EnvRestrictHostAPI is the environment variable name that, when set to any
-// non-empty value, causes promptdelivery.deliverViaSidecarSocket to refuse to
-// dial any socket path that does not reside under the process's
-// $XDG_STATE_HOME directory. It is set automatically by NewIsolated.
+// non-empty value:
+//
+//   - causes promptdelivery.deliverViaSidecarSocket to refuse to dial any
+//     socket path that does not reside under the process's $XDG_STATE_HOME
+//     directory; and
+//   - causes sidecar.New() to install a no-op DashboardSink when
+//     Config.DashboardSink is nil, so writeStateChangeWithSID does not touch
+//     $XDG_STATE_HOME-derived paths (issue #1851).
+//
+// It is set automatically by NewIsolated.
 //
 // This is a test-mode guard that prevents future regressions where new
-// transport paths accidentally escape the test's tempdir isolation.
+// transport paths or state-change side-effects accidentally escape the test's
+// tempdir isolation.
 const EnvRestrictHostAPI = "PRISM_TEST_MODE_RESTRICT_HOSTAPI"
 
 // Bus is the in-process test bus for a single isolated sidecar test. It

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -193,11 +193,17 @@ func (s *Sidecar) writeStateChangeWithSID(state agent.AgentState, harnessSession
 	s.lastState = state
 	// Push to the persistent dashboard socket (fire-and-forget, non-blocking).
 	// Also touch the sentinel for the popup dashboard which still polls it.
+	//
+	// Both calls are routed through s.cfg.DashboardSink so test setups (via
+	// sidecartest.NewIsolated) can install a no-op sink and avoid touching
+	// $XDG_STATE_HOME-derived paths. Production sessions get the default
+	// productionDashboardSink which preserves the historical fire-and-forget
+	// goroutine for PushEvent and the inline TouchSentinel. See issue #1851.
 	sessionName := s.cfg.SessionName
 	title := s.lastTitle
 	stateStr := string(state)
-	go pushDashboardEvent(sessionName, stateStr, title)
-	touchDashboardSentinel()
+	s.cfg.DashboardSink.PushEvent(sessionName, stateStr, title)
+	s.cfg.DashboardSink.TouchSentinel()
 }
 
 func (s *Sidecar) writeEvent(eventType string, payload any, harnessSessionID *string) {


### PR DESCRIPTION
Closes #1851.

## Problem

`writeStateChangeWithSID` synchronously called `touchDashboardSentinel`
(`os.MkdirAll` on an `$XDG_STATE_HOME`-derived path) and spawned
`pushDashboardEvent` on every state transition. Any test that constructed
a `Sidecar` without first redirecting `$XDG_STATE_HOME` via
`sidecartest.NewIsolated` (12 of 25 test files at audit) would silently
regress to the homeless-shelter failure class (PR #1455 shape) on the next
nix-sandbox build.

## Fix

Implement option (1) from the issue — a documented test-overridable hook:

- New ``DashboardSink`` interface in ``internal/sidecar/dashboard.go``:
  ```go
  type DashboardSink interface {
      PushEvent(sessionName, state, title string)
      TouchSentinel()
  }
  ```
- ``productionDashboardSink`` preserves the historical behaviour exactly:
  ``PushEvent`` spawns the fire-and-forget goroutine that dials the
  dashboard socket; ``TouchSentinel`` runs the inline ``os.MkdirAll`` +
  ``os.Chtimes`` pair.
- ``noopDashboardSink`` is a no-op (also exposed via ``NoopDashboardSink()``).
- ``Config.DashboardSink`` is the injection point. ``New()`` installs
  ``productionDashboardSink`` by default — so production behaviour is
  unchanged.
- ``sidecartest.NewIsolated`` already sets
  ``PRISM_TEST_MODE_RESTRICT_HOSTAPI``; ``New()`` now consults the same env
  guard and installs ``noopDashboardSink`` when it is set, so every
  ``Sidecar`` constructed within an isolated test automatically skips
  both side-effects even when the test file does not know to set
  ``DashboardSink`` itself. Explicit ``Config.DashboardSink`` values are
  preserved (regression test included).

A comment near ``touchDashboardSentinel`` now documents the test-isolation
contract per the AC:

> tests MUST go through ``sidecartest.NewIsolated`` to avoid touching
> ``$XDG_STATE_HOME`` paths.

## Tests

New ``internal/sidecar/dashboard_test.go``:

| Test | AC |
| ---- | --- |
| ``TestNew_DefaultDashboardSink_IsProduction`` | regression |
| ``TestNew_TestModeGuard_InstallsNoopSink`` | functional (hook + ``NewIsolated`` wiring) |
| ``TestNew_ExplicitDashboardSink_Preserved`` | hook injection |
| ``TestWriteStateChange_NoopSink_NoFilesystemEffects`` | **headline AC**: simulates ``HOME=/homeless-shelter`` via ``t.Setenv``, constructs via ``sidecartest.NewIsolated``, forces a state change, asserts no ``.dashboard.signal`` file appears under either the simulated HOME or ``\$XDG_STATE_HOME`` |
| ``TestWriteStateChange_ProductionSink_FiresBothHooks`` | regression (call count + dedup) |
| ``TestProductionDashboardSink_PushEvent_IsNonBlocking`` | regression (non-blocking contract) |

## Verification

- ``go build ./...`` and ``go test ./...`` pass.
- ``go test ./internal/sidecar/ -race`` passes both with ``\$HOME`` unset
  and with ``HOME=/`` (path-restricted home, per AC).
- ``nix build .#prism`` passes.
- ``nix build .#prism`` with ``runChecks = true`` (the homeless-shelter
  CI gate) passes locally.

## Out of scope

Per the issue's Out of scope section, the complementary CI grep for
``*_test.go`` files in ``internal/sidecar/`` that construct a Sidecar
without importing ``sidecartest`` is not included.