### PR TITLE
sidecar: document s.mu-protected fields written by upsertState (#1855)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -128,6 +128,12 @@ func (s *Sidecar) currentDBState() agent.AgentState {
 	return agent.AgentState(st.State)
 }
 
+// upsertState writes the session's current state (and optional title /
+// harness session ID) to the DB. Must be called with s.mu held.
+//
+// Writes (s.mu-protected fields): s.lastTitle (when title is non-nil and
+// non-empty). All other persistence happens via s.cfg.DB and is not
+// s.mu-protected struct state.
 func (s *Sidecar) upsertState(state agent.AgentState, title *string, harnessSessionID *string) {
 	// Track the most recently seen title for dashboard push events.
 	if title != nil && *title != "" {


### PR DESCRIPTION
## Summary

`upsertState` writes `s.lastTitle` inside its body, but its previous doc-comment ("must be called with s.mu held") did not enumerate which s.mu-protected struct fields it touches. A future contributor reading just the function signature would not see that this function is on the `s.lastTitle` write path.

This PR adds a brief doc-comment block above `upsertState` that:

- Restates the `s.mu`-held precondition.
- Explicitly enumerates the s.mu-protected writes (currently just `s.lastTitle`, conditional on a non-empty `title` argument).
- Notes that all other persistence happens via `s.cfg.DB` and is not s.mu-protected struct state — so the field-enumeration is exhaustive, not a partial sample.

## Scope

Pure documentation. No code change. No behavioural change. No new tests.

I scanned the function body for any other direct struct-field writes; `s.lastTitle` is the only one. All other side effects are DB calls (`UpsertStatusWithRootAgent`, `UpsertStatus`) and logger writes.

## Quality gates

- `go build ./...` — pass
- `go test ./internal/sidecar/ -race` — pass
- `go test ./...` — pass
- `nix build .#prism` — pass

Closes #1855