### PR TITLE
sidecar: replace PI Shutdown 100ms wall-sleep with abort-frame ack channel

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -32,6 +32,7 @@ package sidecar
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -71,6 +72,16 @@ const IdleDebounce = 2 * time.Second
 // writeStartupError. This mirrors the WaitHealthy/CreateSession timeout
 // mechanism added in #1011 for the podman path.
 const DefaultStartupConnectTimeout = 5 * time.Minute
+
+// DefaultShutdownDrainTimeout is the upper bound on how long Shutdown waits
+// for the socket-pipe writer goroutine to flush the final abort frame onto
+// the wire before tearing down the connection. On a healthy connection the
+// writer signals completion within a single scheduler tick (well under 10ms);
+// the bound only matters when the writer is blocked (e.g. the PI extension
+// has stopped reading from its end of the socket).
+//
+// Configurable via Config.ShutdownDrainTimeout (issue #1849).
+const DefaultShutdownDrainTimeout = 250 * time.Millisecond
 
 // ReconnectRecoveryDelay is the window the sidecar waits after a reconnect
 // (detected via server.connected while in active state) before concluding
@@ -236,6 +247,14 @@ type Config struct {
 	// to pipeDisconnectTimeout (30s) when zero. Set to a small value in tests
 	// to avoid real wall-clock waits on the reconnect path.
 	PipeReconnectTimeout time.Duration
+	// ShutdownDrainTimeout is the upper bound Shutdown waits for the socket-pipe
+	// writer goroutine to flush the final abort frame to the PI extension before
+	// tearing down the connection. On a healthy connection the ack fires within
+	// a scheduler tick, so this bound only applies when the writer is blocked
+	// (e.g. the extension stopped reading). Defaults to DefaultShutdownDrainTimeout
+	// (250ms) when zero. Set to a small value in tests to assert the bounded
+	// fallback path (issue #1849).
+	ShutdownDrainTimeout time.Duration
 	// ActivityTimeout is the duration of inbound-frame silence after which the
 	// sidecar force-transitions the session to StateError with note="inactivity
 	// timeout" (#1709). The watchdog is reset on every inbound frame received
@@ -441,6 +460,14 @@ type Sidecar struct {
 	// on set (before the goroutine starts); after that only the writer goroutine
 	// reads from it; callers enqueue via enqueueHarnessPipeFrame.
 	harnessPipeOutCh chan []byte
+	// harnessPipeAbortAck, when non-nil, is closed by the socket-pipe writer
+	// goroutine immediately after processing an abort frame (i.e. after the
+	// write attempt completes, whether or not the underlying conn was healthy).
+	// Shutdown installs this channel before enqueueing the final abort frame so
+	// it can wait for the actual flush instead of sleeping unconditionally
+	// (issue #1849). The writer clears it back to nil after closing so a
+	// second close cannot occur. Protected by s.mu.
+	harnessPipeAbortAck chan struct{}
 
 	// pipeAccum accumulates msg_assistant text fragments between turn_start and
 	// turn_end for the socket-pipe transport. On turn_end, the accumulated text
@@ -1134,18 +1161,52 @@ func (s *Sidecar) Shutdown() {
 	s.harnessPipeConn = nil
 	s.mu.Unlock()
 	if pipeOutCh != nil {
-		abortFrame := []byte(`{"type":"abort"}` + "\n")
+		// Install an ack channel before enqueueing the abort frame so the
+		// writer goroutine can signal completion. The writer closes (and
+		// nils) harnessPipeAbortAck after the abort frame's write attempt
+		// finishes — see runStartupSocketPipe's writer loop. Issue #1849.
+		ackCh := make(chan struct{})
+		s.mu.Lock()
+		s.harnessPipeAbortAck = ackCh
+		s.mu.Unlock()
+		drainTimeout := s.cfg.ShutdownDrainTimeout
+		if drainTimeout <= 0 {
+			drainTimeout = DefaultShutdownDrainTimeout
+		}
 		select {
-		case pipeOutCh <- abortFrame:
-			// Give the writer goroutine a brief moment to flush the frame
-			// onto the wire before the connection is torn down. Bounded so
-			// shutdown never blocks longer than a couple of seconds even if
-			// the extension is unresponsive.
-			time.Sleep(100 * time.Millisecond)
+		case pipeOutCh <- abortFrameBytes:
+			// Wait for the writer goroutine to flush the abort frame onto
+			// the wire (it closes ackCh after the write attempt completes,
+			// regardless of whether the underlying conn was healthy). Bound
+			// the wait by ShutdownDrainTimeout so an unresponsive writer
+			// (e.g. blocked on a stalled conn) cannot stall Shutdown longer
+			// than the documented budget.
+			select {
+			case <-ackCh:
+				// Healthy path — writer acked the flush.
+			case <-time.After(drainTimeout):
+				s.logger().Printf("sidecar: Shutdown: abort-frame flush timed out after %s; tearing down connection anyway", drainTimeout)
+				// Clear the ack channel so a late writer iteration does not
+				// attempt to close a channel we have already abandoned. We
+				// don't close ackCh ourselves — it just becomes garbage.
+				s.mu.Lock()
+				if s.harnessPipeAbortAck == ackCh {
+					s.harnessPipeAbortAck = nil
+				}
+				s.mu.Unlock()
+			}
 		default:
 			// Outbound queue full or no longer accepting — fall through to
 			// the connection close. handlePipeFrame's connection-dropped
 			// handler will mark the session error if PI exits unexpectedly.
+			// The ack channel was installed speculatively; clear it so a
+			// stray writer iteration on an unrelated abort frame does not
+			// close it under us.
+			s.mu.Lock()
+			if s.harnessPipeAbortAck == ackCh {
+				s.harnessPipeAbortAck = nil
+			}
+			s.mu.Unlock()
 		}
 	}
 	if pipeConn != nil {
@@ -1675,6 +1736,12 @@ const pipeDisconnectTimeout = 30 * time.Second
 // Config.PipeMaxLineBytes (used in tests to avoid 16 MiB allocations).
 const socketPipeMaxLineBytes = 16 * 1024 * 1024
 
+// abortFrameBytes is the canonical wire encoding of the abort frame. Both
+// Shutdown's clean-shutdown path and the /abort host-API endpoint serialise to
+// these exact bytes; the socket-pipe writer goroutine compares against this
+// value to detect when an ack on harnessPipeAbortAck is owed (issue #1849).
+var abortFrameBytes = []byte(`{"type":"abort"}` + "\n")
+
 // acceptOutcome enumerates the reasons an Accept attempt in
 // runStartupSocketPipe returned without a live connection. It is required
 // (instead of a plain bool) so that the caller can distinguish a startup
@@ -1858,13 +1925,26 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 			connMu.Lock()
 			c := activeConn
 			connMu.Unlock()
-			if c == nil {
-				continue
+			if c != nil {
+				if _, err := c.Write(frame); err != nil {
+					s.logger().Printf("sidecar: runStartupSocketPipe: write outbound frame: %v", err)
+					// Don't return — the reader loop will detect the drop and
+					// reconnect. The writer stays alive for the next connection.
+				}
 			}
-			if _, err := c.Write(frame); err != nil {
-				s.logger().Printf("sidecar: runStartupSocketPipe: write outbound frame: %v", err)
-				// Don't return — the reader loop will detect the drop and
-				// reconnect. The writer stays alive for the next connection.
+			// If this was an abort frame (either from Shutdown or from a
+			// /abort host-API call), signal any waiter on harnessPipeAbortAck.
+			// We close-and-clear under s.mu so a second consumer can install a
+			// fresh ack channel for a subsequent abort and so the close cannot
+			// race with a concurrent Shutdown installing a new channel.
+			// Issue #1849.
+			if bytes.Equal(frame, abortFrameBytes) {
+				s.mu.Lock()
+				if s.harnessPipeAbortAck != nil {
+					close(s.harnessPipeAbortAck)
+					s.harnessPipeAbortAck = nil
+				}
+				s.mu.Unlock()
 			}
 		}
 	}()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
@@ -1,0 +1,284 @@
+package sidecar
+
+// Tests for the Shutdown abort-frame flush path (issue #1849).
+//
+// Background: the socket-pipe transport's clean-shutdown path enqueues a final
+// {"type":"abort"} frame onto harnessPipeOutCh so the PI extension can flush
+// state to disk before the connection is torn down. The original implementation
+// followed the enqueue with an unconditional 100ms time.Sleep to give the writer
+// goroutine "a brief moment" to flush — that added 100ms of wall latency to
+// every SIGTERM regardless of whether the writer had already drained.
+//
+// The current implementation replaces the sleep with an ack signal: the writer
+// goroutine closes harnessPipeAbortAck after the abort frame's write attempt
+// completes. Shutdown selects on the ack or on time.After(ShutdownDrainTimeout)
+// — defaulting to DefaultShutdownDrainTimeout (250ms) — so:
+//
+//   - Healthy connection: Shutdown returns within a scheduler tick of the
+//     flush (well under 100ms).
+//   - Unhealthy connection (writer blocked on a stalled conn / queue full):
+//     Shutdown returns within ShutdownDrainTimeout.
+//
+// These tests assert both bounds.
+
+import (
+	"bufio"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestShutdown_AbortFlush_HealthyPath_FastAck verifies that on a healthy
+// connection (writer goroutine responsive, conn able to accept writes),
+// Shutdown returns very quickly after the abort frame is acked by the writer
+// — well under the previous 100ms hard sleep and well under the 250ms
+// ShutdownDrainTimeout bound. Issue #1849 AC: "On a healthy connection,
+// Shutdown returns within ~10ms of the abort frame being flushed".
+func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	// Drain frames from the conn in the background so the writer's
+	// c.Write(abortFrame) returns immediately. Without a concurrent reader the
+	// kernel send buffer would absorb the small frame anyway, but explicitly
+	// reading guarantees we're not measuring buffer-fill latency on a slow CI
+	// runner.
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			if _, err := rd.ReadBytes('\n'); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait until the sidecar has installed the outbound channel — Shutdown
+	// only enters the abort-flush block when harnessPipeOutCh is non-nil, and
+	// runStartupSocketPipe sets it after the listener binds. dialAndHandshake
+	// already proves the listener is up and the handshake completed, so the
+	// channel is in place. Belt-and-braces: poll briefly.
+	waitForOutChNonNil(t, sc, 2*time.Second)
+
+	start := time.Now()
+	sc.Shutdown()
+	elapsed := time.Since(start)
+
+	// 50ms is a conservative cap for a single in-process channel send +
+	// writer-goroutine ack close; in practice this completes in well under
+	// 1ms. We deliberately do NOT assert < 10ms because CI runners under load
+	// can easily blow past that without indicating a real regression. The
+	// important invariant is "well under the old 100ms hard sleep".
+	if elapsed > 50*time.Millisecond {
+		t.Errorf("Shutdown took %s on a healthy connection; expected well under 50ms (old hard-sleep was 100ms)", elapsed)
+	}
+	t.Logf("healthy-path Shutdown latency: %s", elapsed)
+
+	_ = conn.Close()
+	<-readerDone
+	_ = wait()
+}
+
+// TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout verifies that
+// when the writer goroutine cannot flush the abort frame (because a prior
+// frame is wedged on a stalled conn), Shutdown still returns within the
+// documented ShutdownDrainTimeout bound. Issue #1849 AC: "On an unhealthy
+// connection (writer goroutine blocked, conn stalled), Shutdown returns
+// within a bounded wait time (≤ 250ms, or the documented ShutdownDrainTimeout)".
+func TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	// Use a small ShutdownDrainTimeout so the test runs quickly while still
+	// exercising the bounded-wait branch. The default would be 250ms; 100ms
+	// here keeps total runtime tight.
+	sc.cfg.ShutdownDrainTimeout = 100 * time.Millisecond
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	// Note: we do NOT drain frames from conn. The writer goroutine will
+	// successfully write the hello_ack (already done during handshake) but
+	// once we stall the writer below, the abort frame cannot be acked.
+
+	waitForOutChNonNil(t, sc, 2*time.Second)
+
+	// Artificially stall the writer goroutine by filling the outbound channel
+	// with a large frame that the writer will block trying to write. The
+	// kernel send buffer for a Unix socket is bounded (typically 208KB on
+	// Linux); we don't read from the peer side, so once the buffer fills the
+	// writer's c.Write blocks indefinitely.
+	//
+	// Direct enqueue via enqueueHarnessPipeFrame ensures we exercise the same
+	// channel the writer drains. We push a large payload to maximise the
+	// chance of filling the send buffer regardless of platform tuning.
+	bigPayload := make([]byte, 512*1024) // 512 KiB
+	for i := range bigPayload {
+		bigPayload[i] = 'x'
+	}
+	bigFrame := append([]byte(`{"type":"msg_assistant","text":"`), bigPayload...)
+	bigFrame = append(bigFrame, []byte(`"}`+"\n")...)
+	// enqueueHarnessPipeFrame uses a non-blocking send; one frame will land,
+	// the writer will pick it up and block on c.Write. Subsequent enqueues
+	// fill the channel buffer. We only need one to wedge the writer.
+	if !sc.enqueueHarnessPipeFrame(bigFrame) {
+		t.Fatal("enqueueHarnessPipeFrame returned false on first enqueue")
+	}
+	// Give the writer a chance to pick up the wedge frame and block on Write.
+	time.Sleep(50 * time.Millisecond)
+
+	// Now invoke Shutdown. The abort frame will be queued behind the wedged
+	// frame; the writer can't process it, so harnessPipeAbortAck will never
+	// be closed via the normal path. Shutdown must fall back to the timeout
+	// and proceed.
+	start := time.Now()
+	sc.Shutdown()
+	elapsed := time.Since(start)
+
+	// Lower bound: the timeout must actually be respected (not 0).
+	// Upper bound: timeout + slack for goroutine scheduling and the rest of
+	// Shutdown's teardown work. 250ms slack is generous but keeps the test
+	// stable on slow CI.
+	if elapsed < 90*time.Millisecond {
+		t.Errorf("Shutdown returned in %s — earlier than the configured 100ms ShutdownDrainTimeout; the bound is not being honoured", elapsed)
+	}
+	if elapsed > 100*time.Millisecond+250*time.Millisecond {
+		t.Errorf("Shutdown took %s; expected ≤ %s (drain timeout 100ms + 250ms slack)", elapsed, 350*time.Millisecond)
+	}
+	t.Logf("unhealthy-path Shutdown latency: %s (drain timeout 100ms)", elapsed)
+
+	_ = conn.Close()
+	// Closing the conn unblocks the writer's c.Write; outCh will drain and
+	// runStartupSocketPipe will return.
+	_ = wait()
+}
+
+// TestShutdown_AbortFlush_DefaultTimeoutApplies verifies that when
+// Config.ShutdownDrainTimeout is left at zero, Shutdown uses
+// DefaultShutdownDrainTimeout (250ms) as the upper bound. We don't actually
+// wait the full 250ms — we just assert that the constant is what's
+// documented and that Shutdown honours it on a healthy path (returning fast,
+// not waiting the default).
+func TestShutdown_AbortFlush_DefaultTimeoutApplies(t *testing.T) {
+	if DefaultShutdownDrainTimeout != 250*time.Millisecond {
+		t.Errorf("DefaultShutdownDrainTimeout = %s, want 250ms (AC: ≤ 250ms)", DefaultShutdownDrainTimeout)
+	}
+
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	// Leave sc.cfg.ShutdownDrainTimeout at its zero value — the default
+	// should kick in. A healthy-path Shutdown must still return quickly
+	// (well under the default) because the writer acks promptly.
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			if _, err := rd.ReadBytes('\n'); err != nil {
+				return
+			}
+		}
+	}()
+	waitForOutChNonNil(t, sc, 2*time.Second)
+
+	start := time.Now()
+	sc.Shutdown()
+	elapsed := time.Since(start)
+	if elapsed >= DefaultShutdownDrainTimeout {
+		t.Errorf("Shutdown took %s on a healthy connection with default timeout; the default should be an upper bound, not a floor", elapsed)
+	}
+
+	_ = conn.Close()
+	<-readerDone
+	_ = wait()
+}
+
+// TestShutdown_AbortFlush_AckArrivesAfterFlush verifies that the writer
+// goroutine actually delivers the abort frame onto the wire (the ack is not a
+// no-op signalled before the write).
+func TestShutdown_AbortFlush_AckArrivesAfterFlush(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	// Capture every frame received on the wire while Shutdown runs.
+	var (
+		mu     sync.Mutex
+		frames []map[string]any
+	)
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			line, err := rd.ReadBytes('\n')
+			if len(line) > 0 {
+				var m map[string]any
+				if jerr := json.Unmarshal(line, &m); jerr == nil {
+					mu.Lock()
+					frames = append(frames, m)
+					mu.Unlock()
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	waitForOutChNonNil(t, sc, 2*time.Second)
+
+	sc.Shutdown()
+
+	// Closing the listener / conn from sidecar's side will cause the reader
+	// goroutine to see EOF. Give it a moment to capture any pending frame.
+	_ = conn.Close()
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reader goroutine did not finish within 2s of Shutdown")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	sawAbort := false
+	for _, f := range frames {
+		if f["type"] == "abort" {
+			sawAbort = true
+			break
+		}
+	}
+	if !sawAbort {
+		t.Errorf("abort frame was not observed on the wire; received frames: %v", frames)
+	}
+
+	_ = wait()
+}
+
+// waitForOutChNonNil polls s.harnessPipeOutCh under the lock until it becomes
+// non-nil (i.e. runStartupSocketPipe has installed the writer goroutine) or
+// the deadline elapses. Fails the test on timeout.
+func waitForOutChNonNil(t *testing.T, s *Sidecar, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		s.mu.Lock()
+		ch := s.harnessPipeOutCh
+		s.mu.Unlock()
+		if ch != nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("harnessPipeOutCh did not become non-nil within %s", timeout)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+


### PR DESCRIPTION
Closes #1849.

## Problem

`sidecar.go`'s socket-pipe Shutdown path ended every clean PI shutdown with an unconditional `time.Sleep(100 * time.Millisecond)` after enqueueing the final `{"type":"abort"}` frame. The accompanying comment claimed a bound of "a couple of seconds" — the code disagreed. The hard sleep added 100ms of wall latency to every SIGTERM regardless of whether the writer goroutine had already flushed the frame, dominating teardown time in CI / test contexts that spawn-and-shutdown many sidecars.

## Approach — shape #1 (acknowledged write)

I went with the ack-channel option from the issue body — it bounds Shutdown's wait to the actual flush latency on a healthy connection while preserving a hard upper bound on an unhealthy one. The other two shapes either couple Shutdown to the conn directly (#2) or pick an empirical timeout without a proper signal (#3).

### Changes to `internal/sidecar/sidecar.go`

- New constant `DefaultShutdownDrainTimeout = 250 * time.Millisecond` (matches the AC's ≤ 250ms bound).
- New `Config.ShutdownDrainTimeout time.Duration` field for tests and operational tuning.
- New private field `Sidecar.harnessPipeAbortAck chan struct{}` (protected by `s.mu`).
- New package-level `abortFrameBytes` so Shutdown's clean-shutdown path and the writer goroutine's "is this an abort?" check share one source of truth (the `/abort` host-API endpoint already serialises to the same bytes).
- The socket-pipe writer goroutine now closes `harnessPipeAbortAck` (then nils it under the lock) after the abort-frame write attempt completes — whether or not the underlying `c.Write` succeeded. The behaviour change is intentional: even if the conn is gone, the writer has "processed" the frame as far as it can, so the ack fires and Shutdown proceeds.
- Shutdown installs the ack channel before enqueueing the abort frame, then `select`s on `<-ackCh` or `<-time.After(drainTimeout)`. On timeout it logs and clears the ack channel under the lock so a late writer iteration cannot close a channel we've abandoned. On the `default:` branch (outbound queue full) it also clears the ack channel.

The writer-loop diff also reshapes the `if c == nil { continue }` early-return into a nested `if c != nil { ... write ... }` so the ack-on-abort logic runs even when there's no live conn (which is the unhealthy case Shutdown most needs to escape from).

### New tests — `internal/sidecar/sidecar_shutdown_abort_flush_test.go`

Four tests cover the ACs:

1. `TestShutdown_AbortFlush_HealthyPath_FastAck` — Shutdown returns in **well under 50ms** (locally ~1ms) on a healthy conn with a peer that drains frames. AC: "well under 100ms when the writer is responsive".
2. `TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout` — sets `ShutdownDrainTimeout = 100ms`, wedges the writer goroutine on a stalled conn by pre-enqueueing a 512KiB frame the peer never reads, and asserts Shutdown returns within `timeout + 250ms slack`. AC: "Shutdown returns within a bounded wait time (≤ 250ms, or the documented `ShutdownDrainTimeout`)".
3. `TestShutdown_AbortFlush_DefaultTimeoutApplies` — asserts `DefaultShutdownDrainTimeout == 250ms` and that the default is an upper bound, not a floor, when `Config.ShutdownDrainTimeout` is left zero.
4. `TestShutdown_AbortFlush_AckArrivesAfterFlush` — asserts the abort frame is actually observed on the wire by the peer before Shutdown returns (the ack isn't a no-op signal fired before the write).

The tests use the existing `newSocketPipeSidecar` / `runSocketPipeSidecar` / `dialAndHandshake` helpers, which set `XDG_STATE_HOME=t.TempDir()` and `PRISM_TEST_MODE_RESTRICT_HOSTAPI=1` — matching the isolation contract documented in `sidecartest`.

## Verification

```
$ go build ./...                                              # OK
$ go test ./internal/sidecar/ -race -count=1                  # ok (~97s)
$ go test ./...                                               # all packages OK
$ go vet ./...                                                # clean
$ nix build .#prism                                           # OK
$ nix build --impure ... { runChecks = true; }                # OK (homeless-shelter sandbox)
```

Per-test latency observed locally:

```
healthy-path Shutdown latency: 1.018349ms
unhealthy-path Shutdown latency: 101.13817ms (drain timeout 100ms)
```

The 100ms regression budget on every SIGTERM is gone.