### PR TITLE
prism reset: clear pi conversation resume state (#1947)

### DIFF
--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -8,9 +8,14 @@ package cmd
 //  2. Stop and remove all podman containers whose names match the "prism-" prefix.
 //  3. Mark all non-ended rows in agent_status as ended (sets ended_at = now;
 //     state is intentionally left at its last known value — ended_at IS NULL
-//     is the canonical "active session" filter throughout the codebase).
+//     is the canonical "active session" filter throughout the codebase) AND
+//     clear the per-session pi conversation resume pointer
+//     (agent_status.harness_session_id) on every row, so the next switch into
+//     a previously-active project starts pi with a fresh conversation
+//     (issue #1947).
 //  4. Kill all sidecar processes and remove stale run files (PID, ready)
-//     from ~/.local/state/prism/run/.
+//     from ~/.local/state/prism/run/, and remove the per-session pi-agent
+//     transcript JSONL subtree (issue #1947).
 //  5. (Unless --no-launch) invoke `prism launch` to restart the server.
 //
 // Flags:
@@ -45,8 +50,10 @@ var resetCmd = &cobra.Command{
 Steps (each attempted independently):
   1. Kill the tmux server (all sessions and panes).
   2. Stop and remove all podman containers with the "prism-" name prefix.
-  3. Mark all non-ended rows in agent_status as ended.
-  4. Terminate all sidecar processes (reads PID files from ~/.local/state/prism/run/).
+  3. Mark all non-ended rows in agent_status as ended and clear the pi
+     conversation resume pointer (harness_session_id) on every row.
+  4. Terminate all sidecar processes (reads PID files from
+     ~/.local/state/prism/run/) and remove pi-agent transcript JSONLs.
   5. Invoke prism launch to restart (skipped with --no-launch).`,
 	Args: cobra.NoArgs,
 	RunE: runReset,
@@ -113,6 +120,16 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		proglog.Warnf("[prism reset] sidecar cleanup: %v (continuing)\n", err)
 	}
 
+	// ── Step 4b: Remove pi-agent transcript JSONLs ────────────────────────────
+	// Reset means forget: drop the on-disk pi session JSONLs so that even if
+	// a stale harness_session_id somehow survived (e.g. an external writer),
+	// piResolveResumeSession returns false and pi starts a fresh chat.
+	// See issue #1947.
+	fmt.Println("Removing pi-agent transcript JSONLs...")
+	if err := resetClearPiTranscripts(); err != nil {
+		proglog.Warnf("[prism reset] transcript cleanup: %v (continuing)\n", err)
+	}
+
 	fmt.Println("Reset complete.")
 
 	// ── Step 5: Launch ────────────────────────────────────────────────────────
@@ -166,8 +183,12 @@ func resetIsolators() error {
 	return firstErr
 }
 
-// resetMarkDBEnded opens the prism DB and calls MarkAllEnded to update all
-// non-ended agent_status rows.
+// resetMarkDBEnded opens the prism DB, calls MarkAllEnded to update all
+// non-ended agent_status rows, then calls ClearAllResumePointers to wipe the
+// per-session pi conversation resume pointer (harness_session_id) on every
+// row. The two operations are independent (different columns) but conceptually
+// paired by `prism reset`: end every session, then forget the resume pointer
+// (issue #1947).
 func resetMarkDBEnded() error {
 	d, err := openDB()
 	if err != nil {
@@ -183,6 +204,17 @@ func resetMarkDBEnded() error {
 		fmt.Println("  no active sessions in DB.")
 	} else {
 		fmt.Printf("  marked %d session(s) as ended.\n", n)
+	}
+
+	// Wipe per-row resume pointers (harness_session_id). This is the DB-side
+	// half of the issue #1947 fix; the FS-side half lives in
+	// resetClearPiTranscripts.
+	cleared, err := d.ClearAllResumePointers()
+	if err != nil {
+		return err
+	}
+	if cleared > 0 {
+		fmt.Printf("  cleared pi resume pointer on %d row(s).\n", cleared)
 	}
 	return nil
 }
@@ -244,4 +276,96 @@ func resetKillSidecars() error {
 		fmt.Printf("  sent termination signal to %d sidecar(s).\n", killed)
 	}
 	return nil
+}
+
+// resetClearPiTranscripts removes the per-session pi-agent transcript JSONL
+// subtree under each per-session run directory, and the sandbox-exec staging
+// HOME equivalent. This is the filesystem-side half of the issue #1947 fix
+// (the DB-side half is ClearAllResumePointers, called from resetMarkDBEnded).
+//
+// Layouts walked (all defensively skipped when missing):
+//
+//   bwrap:
+//     $XDG_STATE_HOME/prism/run/<sessionDirHash>/pi-agent/sessions/
+//
+//   sandbox-exec (Darwin):
+//     $XDG_STATE_HOME/prism/sessions/<instanceID>/home/.pi/agent/sessions/
+//
+//   host:
+//     ~/.pi/agent/sessions/  — NOT touched here. Host mode is already safe
+//     because `prism switch` leaves opts.HarnessSessionID empty (see
+//     internal/session/session.go ~line 181-182), so the host-mode
+//     buildDirectAgentCmd never appends --session even if a transcript
+//     remains on disk. Wiping ~/.pi/agent/sessions/ would also touch state
+//     belonging to non-prism pi invocations — strictly out of scope.
+//
+// In every layout only the inner `.../sessions/` subtree is removed; the
+// enclosing per-session directory (`<sessionDirHash>` or `<instanceID>/home`)
+// is preserved because other state may live alongside the transcripts.
+//
+// All path joins are anchored at $XDG_STATE_HOME/prism/{run,sessions}/, so
+// the walk never traverses outside the prism state root.
+func resetClearPiTranscripts() error {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolve home dir: %w", err)
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	prismRoot := filepath.Join(stateHome, "prism")
+
+	removed := 0
+	// Bwrap layout: prism/run/<sessionDirHash>/pi-agent/sessions/
+	removed += removePiSessionsSubtree(filepath.Join(prismRoot, "run"), "pi-agent", "sessions")
+
+	// Sandbox-exec layout: prism/sessions/<instanceID>/home/.pi/agent/sessions/
+	removed += removePiSessionsSubtree(filepath.Join(prismRoot, "sessions"), "home", ".pi", "agent", "sessions")
+
+	if removed == 0 {
+		fmt.Println("  no pi-agent transcript subtrees found.")
+	} else {
+		fmt.Printf("  removed %d pi-agent transcript subtree(s).\n", removed)
+	}
+	return nil
+}
+
+// removePiSessionsSubtree iterates over the immediate children of parent (each
+// expected to be a per-session directory like `<sessionDirHash>` or
+// `<instanceID>`) and removes the `subPath...` subtree under each child. The
+// child directory itself is preserved; only the inner subtree goes.
+//
+// Missing parent / missing subtree / non-dir child are silent no-ops — reset
+// is best-effort and must never abort the rest of the pipeline.
+//
+// Returns the number of child directories under which a subtree was actually
+// removed (i.e. the subtree existed before the call).
+func removePiSessionsSubtree(parent string, subPath ...string) int {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return 0 // parent missing — nothing to do
+	}
+	removed := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		child := filepath.Join(parent, entry.Name())
+		target := filepath.Join(append([]string{child}, subPath...)...)
+		// Confirm the target is inside the parent root — belt-and-braces
+		// against a malformed entry name like "..". filepath.Join cleans
+		// the path so any traversal would surface here.
+		rel, err := filepath.Rel(parent, target)
+		if err != nil || rel == "" || rel == "." || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		if _, err := os.Stat(target); err != nil {
+			continue // subtree absent under this child
+		}
+		if err := os.RemoveAll(target); err == nil {
+			removed++
+		}
+	}
+	return removed
 }

--- a/modules/programs/prism/prism/cmd/reset_resume_e2e_test.go
+++ b/modules/programs/prism/prism/cmd/reset_resume_e2e_test.go
@@ -1,0 +1,257 @@
+package cmd
+
+// End-to-end seam test for the issue #1947 fix.
+//
+// Pins the post-reset invariant: given a DB row with a non-empty
+// harness_session_id AND a transcript JSONL on disk (bwrap layout), after the
+// `prism reset` DB + FS code paths run, neither half of pi_invocation.go's
+// `--session <id>` injection trigger remains:
+//
+//   (1) DB:  CurrentStatus.HarnessSessionID is nil (so cmd/agent_run.go feeds
+//       the empty string into container.Config.HarnessSessionID).
+//   (2) FS:  the transcript JSONL is gone (so piResolveResumeSession returns
+//       false even when called with a stale UUID).
+//   (3) PIInvocation: with HarnessSessionID="" the helper short-circuits and
+//       does not append --session at all (issue #1838 contract).
+//
+// Host-mode is pinned separately: it does not consume harness_session_id from
+// the DB on the spawn/switch paths (internal/session/session.go:181-182), so
+// the reset code path is a no-op for it w.r.t. the resume pointer \u2014 covered
+// by TestResetClearPiTranscripts_NoSubtreeUnderHashIsNoOp (no bwrap subtree
+// for a host-mode session means nothing is touched).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/db"
+	prismSession "github.com/prismatic-koi/prism/internal/session"
+)
+
+// TestReset_E2E_NoSessionFlagAfterReset is the AC8 end-to-end invariant:
+// reset \u2192 (DB cleared + FS cleared) \u2192 PIInvocation does NOT emit --session.
+func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	// Some downstream helpers (piResumeSessionsRoot host fallback,
+	// SandboxExecStagingHomePath) consult $HOME via os.UserHomeDir(). Pin
+	// it to a tempdir too so we never touch the real home.
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		sessionName      = "myrepo@feature"
+		worktree         = "/home/user/code/myrepo/feature"
+		harnessSessionID = "019e00ed-aaaa-bbbb-cccc-deadbeef1947"
+	)
+
+	// ---- Seed DB ----
+	dbFile := filepath.Join(stateHome, "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	if err := d.UpsertStatus(sessionName, "myrepo", worktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(sessionName, harnessSessionID); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+	// Pre-condition: DB has the SID.
+	preStatus, _ := d.CurrentStatus(sessionName)
+	if preStatus == nil || preStatus.HarnessSessionID == nil || *preStatus.HarnessSessionID != harnessSessionID {
+		t.Fatalf("pre-condition: DB HarnessSessionID = %v, want %q", preStatus, harnessSessionID)
+	}
+	d.Close()
+
+	// ---- Seed FS (bwrap layout) ----
+	// <stateHome>/prism/run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl
+	hash := prismSession.SessionDirName(sessionName)
+	transcriptDir := filepath.Join(stateHome, "prism", "run", hash, "pi-agent", "sessions",
+		"--home-user-code-myrepo-feature--")
+	if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
+		t.Fatalf("mkdir transcriptDir: %v", err)
+	}
+	transcript := filepath.Join(transcriptDir, "2026-05-22T03-04-05-000Z_"+harnessSessionID+".jsonl")
+	if err := os.WriteFile(transcript, []byte(`{"type":"session"}`), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	// Plant a sibling file under the hashDir that must survive the reset.
+	hashDir := filepath.Join(stateHome, "prism", "run", hash)
+	siblingPath := filepath.Join(hashDir, "agent-run.log")
+	if err := os.WriteFile(siblingPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write sibling: %v", err)
+	}
+
+	// Pre-condition: piResolveResumeSession would succeed right now.
+	preCfg := container.Config{
+		SessionName:             sessionName,
+		Worktree:                worktree,
+		HarnessSessionID:        harnessSessionID,
+		PIAgentConfigHostDir:    "/some/host/stage",
+		PIAgentConfigSandboxDir: "/run/prism/pi-agent",
+	}
+	if !container.ResolvePIResumeSession(preCfg) {
+		t.Fatalf("pre-condition: ResolvePIResumeSession = false, want true (transcript should be discoverable)")
+	}
+
+	// ---- Run the reset code paths ----
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+	if err := resetMarkDBEnded(); err != nil {
+		t.Fatalf("resetMarkDBEnded: %v", err)
+	}
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	// ---- Post-conditions ----
+
+	// (1) DB: HarnessSessionID is now nil.
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	postStatus, _ := d2.CurrentStatus(sessionName)
+	if postStatus == nil {
+		t.Fatalf("CurrentStatus post-reset: row missing")
+	}
+	if postStatus.HarnessSessionID != nil {
+		t.Errorf("post-reset DB HarnessSessionID = %q, want nil",
+			*postStatus.HarnessSessionID)
+	}
+	// And the row was marked ended.
+	if postStatus.EndedAt == nil {
+		t.Errorf("post-reset DB EndedAt = nil, want non-nil")
+	}
+
+	// (2) FS: transcript JSONL gone, hashDir + sibling preserved.
+	if _, err := os.Stat(transcript); !os.IsNotExist(err) {
+		t.Errorf("transcript still present (stat err=%v)", err)
+	}
+	if _, err := os.Stat(hashDir); err != nil {
+		t.Errorf("hashDir removed: %v", err)
+	}
+	if _, err := os.Stat(siblingPath); err != nil {
+		t.Errorf("sibling file removed: %v", err)
+	}
+
+	// (3) container.ResolvePIResumeSession returns false post-reset, even
+	//     when invoked with the stale UUID. This proves the FS half of the
+	//     guard: even if cmd/agent_run.go somehow forwarded a non-empty SID,
+	//     PIInvocation would skip --session because the transcript is gone.
+	if container.ResolvePIResumeSession(preCfg) {
+		t.Errorf("post-reset: ResolvePIResumeSession = true, want false")
+	}
+
+	// (4) The realistic post-reset path \u2014 cmd/agent_run.go feeds
+	//     status.HarnessSessionID into container.Config. With the DB row now
+	//     carrying nil, that lowers to "". PIInvocation must NOT contain
+	//     --session in its args.
+	postCfg := container.Config{
+		SessionName:             sessionName,
+		Worktree:                worktree,
+		HarnessSessionID:        "", // mirrors what cmd/agent_run.go would set
+		PIAgentConfigHostDir:    "/some/host/stage",
+		PIAgentConfigSandboxDir: "/run/prism/pi-agent",
+		InitialPrompt:           "hello after reset",
+	}
+	args := container.PIInvocation(postCfg)
+	for i, a := range args {
+		if a == "--session" {
+			t.Errorf("PIInvocation post-reset emitted --session at args[%d]; full args=%v", i, args)
+		}
+	}
+	// Sanity: the InitialPrompt still rides as the final positional.
+	if len(args) == 0 || args[len(args)-1] != "hello after reset" {
+		t.Errorf("PIInvocation args missing trailing initial prompt; got %v", args)
+	}
+}
+
+// TestReset_E2E_HostModeUnchanged pins AC4: host mode is incidentally safe.
+// It does not rely on the reset code path because `prism switch` already
+// leaves opts.HarnessSessionID empty for host mode (see
+// internal/session/session.go:181-182). The test mirrors that contract by
+// constructing a host-mode container.Config (no PIAgentConfig* dirs, no
+// InstanceID) and verifying PIInvocation does not emit --session even when
+// transcripts and a DB SID still exist on disk.
+//
+// In other words: the reset fix changes bwrap / sandbox-exec behaviour; it
+// does NOT regress host mode, which was already correct.
+func TestReset_E2E_HostModeUnchanged(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("HOME", t.TempDir())
+
+	const (
+		sessionName      = "host@main"
+		worktree         = "/home/user/host-repo/main"
+		harnessSessionID = "019e00ed-1111-2222-3333-444444444444"
+	)
+
+	// Plant a host-mode transcript at ~/.pi/agent/sessions/<encoded-cwd>/...
+	// (resetClearPiTranscripts intentionally does NOT touch this.)
+	home := os.Getenv("HOME")
+	hostTranscriptDir := filepath.Join(home, ".pi", "agent", "sessions", "--home-user-host-repo-main--")
+	if err := os.MkdirAll(hostTranscriptDir, 0o700); err != nil {
+		t.Fatalf("mkdir host transcript: %v", err)
+	}
+	hostTranscript := filepath.Join(hostTranscriptDir, "2026-05-22_"+harnessSessionID+".jsonl")
+	if err := os.WriteFile(hostTranscript, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write host transcript: %v", err)
+	}
+
+	// Run the FS-side reset.
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	// AC4(a): the host-mode transcript is preserved (out of scope).
+	if _, err := os.Stat(hostTranscript); err != nil {
+		t.Errorf("host-mode transcript was removed by reset; reset must not touch ~/.pi/agent/sessions/: %v", err)
+	}
+
+	// AC4(b): the host-mode invocation path that cmd does not feed
+	// HarnessSessionID into (mirrors internal/session.buildDirectAgentCmd's
+	// opts.HarnessSessionID="" contract). PIInvocation should not emit
+	// --session for a Config with empty HarnessSessionID regardless of
+	// what is on disk.
+	hostCfg := container.Config{
+		SessionName: sessionName,
+		Worktree:    worktree,
+		// HarnessSessionID intentionally empty \u2014 host-mode switch/spawn path.
+	}
+	args := container.PIInvocation(hostCfg)
+	for i, a := range args {
+		if a == "--session" {
+			t.Errorf("PIInvocation host-mode emitted --session at args[%d]; full args=%v", i, args)
+		}
+	}
+	// Even if a caller did populate the host config with a SID, host mode
+	// resolves to ~/.pi/agent/sessions/, so the transcript is still there and
+	// resume WOULD succeed (intentional \u2014 the host-mode resume path is the
+	// regression guard described in AC5 / #1838).
+	hostCfgWithSID := container.Config{
+		SessionName:      sessionName,
+		Worktree:         worktree,
+		HarnessSessionID: harnessSessionID,
+	}
+	if !container.ResolvePIResumeSession(hostCfgWithSID) {
+		t.Errorf("AC5 regression: host-mode resume should still work after reset (the transcript survives, the host path doesn't auto-fetch the SID from the DB)")
+	}
+	// And if it does get the SID, PIInvocation appends --session per #1838.
+	argsWithSID := container.PIInvocation(hostCfgWithSID)
+	foundSession := false
+	for i, a := range argsWithSID {
+		if a == "--session" && i+1 < len(argsWithSID) && argsWithSID[i+1] == harnessSessionID {
+			foundSession = true
+			break
+		}
+	}
+	if !foundSession {
+		t.Errorf("AC5 regression: PIInvocation should append --session %s when host-mode transcript exists; got %v",
+			harnessSessionID, argsWithSID)
+	}
+}

--- a/modules/programs/prism/prism/cmd/reset_transcripts_test.go
+++ b/modules/programs/prism/prism/cmd/reset_transcripts_test.go
@@ -1,0 +1,199 @@
+package cmd
+
+// Tests for the issue #1947 reset transcript-wipe code path.
+//
+// resetClearPiTranscripts removes the per-session pi-agent transcript JSONL
+// subtree under each per-session run directory (bwrap layout) and under each
+// sandbox-exec instance staging HOME. The enclosing per-session directory
+// must be preserved \u2014 only the inner `.../sessions/` subtree is removed.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResetClearPiTranscripts_RemovesBwrapSubtreePreservesParent is the
+// primary AC2 test for the bwrap layout:
+//
+//   <stateHome>/prism/run/<sessionDirHash>/pi-agent/sessions/...
+//
+// After resetClearPiTranscripts, the inner `pi-agent/sessions/` subtree is
+// gone, but the enclosing <sessionDirHash>/ directory is preserved (other
+// state like agent-run.log, *-sidecar.pid, hostapi.sock may live there).
+func TestResetClearPiTranscripts_RemovesBwrapSubtreePreservesParent(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	// Synthesise two per-session dirs under prism/run/ with the canonical layout:
+	//   <hash>/pi-agent/sessions/--<encoded-cwd>--/<ts>_<uuid>.jsonl
+	// and one sibling file under <hash>/ that must be preserved.
+	hashes := []string{"abc123def456", "feedfacecafe"}
+	for _, h := range hashes {
+		hashDir := filepath.Join(stateHome, "prism", "run", h)
+		// Plant a sibling file that MUST be preserved.
+		if err := os.MkdirAll(hashDir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", hashDir, err)
+		}
+		sibling := filepath.Join(hashDir, "agent-run.log")
+		if err := os.WriteFile(sibling, []byte("log content"), 0o600); err != nil {
+			t.Fatalf("write sibling: %v", err)
+		}
+		// Plant the transcript subtree to be removed.
+		transcriptDir := filepath.Join(hashDir, "pi-agent", "sessions", "--home-u-repo--")
+		if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
+			t.Fatalf("mkdir transcripts %s: %v", transcriptDir, err)
+		}
+		transcript := filepath.Join(transcriptDir, "2026-05-22_019e00ed-1234.jsonl")
+		if err := os.WriteFile(transcript, []byte(`{"type":"session"}`), 0o600); err != nil {
+			t.Fatalf("write transcript: %v", err)
+		}
+	}
+
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	for _, h := range hashes {
+		hashDir := filepath.Join(stateHome, "prism", "run", h)
+
+		// (a) The hashDir itself MUST still exist (other state may live here).
+		if _, err := os.Stat(hashDir); err != nil {
+			t.Errorf("sessionDirHash %q was removed but must be preserved: %v", h, err)
+		}
+
+		// (b) The sibling file under hashDir MUST still exist.
+		sibling := filepath.Join(hashDir, "agent-run.log")
+		if _, err := os.Stat(sibling); err != nil {
+			t.Errorf("sibling file %s under %q was removed: %v", sibling, h, err)
+		}
+
+		// (c) The pi-agent/sessions/ subtree MUST be gone.
+		subtree := filepath.Join(hashDir, "pi-agent", "sessions")
+		if _, err := os.Stat(subtree); !os.IsNotExist(err) {
+			t.Errorf("pi-agent/sessions/ subtree under %q was not removed (stat err=%v)", h, err)
+		}
+	}
+}
+
+// TestResetClearPiTranscripts_RemovesSandboxExecSubtree exercises the
+// sandbox-exec layout:
+//
+//   <stateHome>/prism/sessions/<instanceID>/home/.pi/agent/sessions/...
+//
+// The `<instanceID>/home/` directory is preserved (the staging HOME root); only
+// the `.pi/agent/sessions/` subtree under it is removed.
+func TestResetClearPiTranscripts_RemovesSandboxExecSubtree(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	const instanceID = "11111111-2222-3333-4444-555555555555"
+	homeDir := filepath.Join(stateHome, "prism", "sessions", instanceID, "home")
+	sessionsDir := filepath.Join(homeDir, ".pi", "agent", "sessions", "--home-u-repo--")
+	if err := os.MkdirAll(sessionsDir, 0o700); err != nil {
+		t.Fatalf("mkdir sessionsDir: %v", err)
+	}
+	transcript := filepath.Join(sessionsDir, "2026-05-22_uuid.jsonl")
+	if err := os.WriteFile(transcript, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	// Plant a sibling file in the staging HOME that MUST be preserved.
+	sibling := filepath.Join(homeDir, ".gitconfig")
+	if err := os.WriteFile(sibling, []byte("[user]"), 0o600); err != nil {
+		t.Fatalf("write sibling: %v", err)
+	}
+
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	// The staging HOME root must remain.
+	if _, err := os.Stat(homeDir); err != nil {
+		t.Errorf("staging HOME %s removed but must be preserved: %v", homeDir, err)
+	}
+	// The sibling file must remain.
+	if _, err := os.Stat(sibling); err != nil {
+		t.Errorf("sibling .gitconfig removed: %v", err)
+	}
+	// The .pi/agent/sessions subtree must be gone.
+	wiped := filepath.Join(homeDir, ".pi", "agent", "sessions")
+	if _, err := os.Stat(wiped); !os.IsNotExist(err) {
+		t.Errorf(".pi/agent/sessions/ not removed (stat err=%v)", err)
+	}
+}
+
+// TestResetClearPiTranscripts_MissingDirsAreNoOp verifies the defensive
+// no-op contract: when neither prism/run/ nor prism/sessions/ exists,
+// resetClearPiTranscripts returns nil and does not create them.
+func TestResetClearPiTranscripts_MissingDirsAreNoOp(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts on empty stateHome: %v", err)
+	}
+
+	// Neither directory should have been created as a side effect.
+	for _, d := range []string{
+		filepath.Join(stateHome, "prism", "run"),
+		filepath.Join(stateHome, "prism", "sessions"),
+	} {
+		if _, err := os.Stat(d); !os.IsNotExist(err) {
+			t.Errorf("directory %s materialised by resetClearPiTranscripts (err=%v)", d, err)
+		}
+	}
+}
+
+// TestResetClearPiTranscripts_NoSubtreeUnderHashIsNoOp verifies that a
+// <sessionDirHash> directory without a pi-agent/sessions/ subtree (e.g. a
+// host-mode session, or a fresh dir with only agent-run.log) is left alone
+// without error.
+func TestResetClearPiTranscripts_NoSubtreeUnderHashIsNoOp(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	hashDir := filepath.Join(stateHome, "prism", "run", "deadbeefcafe")
+	if err := os.MkdirAll(hashDir, 0o700); err != nil {
+		t.Fatalf("mkdir hashDir: %v", err)
+	}
+	keep := filepath.Join(hashDir, "agent-run.log")
+	if err := os.WriteFile(keep, []byte("log"), 0o600); err != nil {
+		t.Fatalf("write keep: %v", err)
+	}
+
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	if _, err := os.Stat(hashDir); err != nil {
+		t.Errorf("hashDir removed: %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("keep file removed: %v", err)
+	}
+}
+
+// TestResetClearPiTranscripts_NonDirChildIsSkipped guards against a stray
+// regular file under prism/run/ being interpreted as a session dir. The
+// helper must filepath.Join(parent, ...) → stat → skip without erroring.
+func TestResetClearPiTranscripts_NonDirChildIsSkipped(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	runDir := filepath.Join(stateHome, "prism", "run")
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		t.Fatalf("mkdir runDir: %v", err)
+	}
+	stray := filepath.Join(runDir, "stray-file.txt")
+	if err := os.WriteFile(stray, []byte("oops"), 0o600); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+
+	if err := resetClearPiTranscripts(); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	if _, err := os.Stat(stray); err != nil {
+		t.Errorf("stray file removed unexpectedly: %v", err)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/clear_resume_pointers_test.go
+++ b/modules/programs/prism/prism/internal/db/clear_resume_pointers_test.go
@@ -1,0 +1,193 @@
+package db_test
+
+// Tests for ClearAllResumePointers (issue #1947).
+//
+// ClearAllResumePointers wipes agent_status.harness_session_id on every row
+// so that the next `prism switch` into a previously-active project does not
+// resume the pre-reset pi conversation. It is the DB-side half of the
+// `prism reset` resume-wipe; the FS-side half lives in cmd/reset.go.
+
+import (
+	"testing"
+)
+
+// TestClearAllResumePointers_ClearsEveryRow verifies that ClearAllResumePointers
+// sets harness_session_id to NULL on every row that previously held a value,
+// regardless of whether the row is active or already ended.
+func TestClearAllResumePointers_ClearsEveryRow(t *testing.T) {
+	d := openTestDB(t)
+
+	// Three sessions: two active (one with a SID, one without), one ended (with a SID).
+	// All three must come out with harness_session_id == nil.
+	active1 := "repo@active1"
+	active2 := "repo@active2"
+	ended := "repo@ended"
+
+	_ = insertActiveSession(t, d, active1, "repo", "/wt/active1")
+	_ = insertActiveSession(t, d, active2, "repo", "/wt/active2")
+	_ = insertActiveSession(t, d, ended, "repo", "/wt/ended")
+
+	// Plant a HarnessSessionID on active1 and ended; leave active2 NULL.
+	if err := d.UpdateHarnessSessionID(active1, "019e00ed-aaaa-bbbb-cccc-111111111111"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID active1: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(ended, "019e00ed-aaaa-bbbb-cccc-222222222222"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID ended: %v", err)
+	}
+
+	// Pre-condition assertions.
+	st1, _ := d.CurrentStatus(active1)
+	if st1 == nil || st1.HarnessSessionID == nil || *st1.HarnessSessionID == "" {
+		t.Fatalf("pre-condition: active1 HarnessSessionID = %v, want non-empty", st1)
+	}
+	st2, _ := d.CurrentStatus(active2)
+	if st2 == nil || st2.HarnessSessionID != nil {
+		t.Fatalf("pre-condition: active2 HarnessSessionID = %v, want nil", st2)
+	}
+	stE, _ := d.CurrentStatus(ended)
+	if stE == nil || stE.HarnessSessionID == nil {
+		t.Fatalf("pre-condition: ended HarnessSessionID nil, want non-empty")
+	}
+
+	// Run the clear.
+	n, err := d.ClearAllResumePointers()
+	if err != nil {
+		t.Fatalf("ClearAllResumePointers: %v", err)
+	}
+	// Two rows actually had a value; the count reports those.
+	if n != 2 {
+		t.Errorf("ClearAllResumePointers returned n=%d, want 2 (only previously-non-NULL rows are counted)", n)
+	}
+
+	// Post-condition: every row has harness_session_id == nil.
+	for _, name := range []string{active1, active2, ended} {
+		st, err := d.CurrentStatus(name)
+		if err != nil {
+			t.Fatalf("CurrentStatus %q: %v", name, err)
+		}
+		if st == nil {
+			t.Fatalf("CurrentStatus %q: row missing", name)
+		}
+		if st.HarnessSessionID != nil {
+			t.Errorf("session %q: HarnessSessionID = %q, want nil after ClearAllResumePointers",
+				name, *st.HarnessSessionID)
+		}
+	}
+}
+
+// TestClearAllResumePointers_EmptyTable verifies the no-op case: when no rows
+// exist, ClearAllResumePointers returns (0, nil).
+func TestClearAllResumePointers_EmptyTable(t *testing.T) {
+	d := openTestDB(t)
+
+	n, err := d.ClearAllResumePointers()
+	if err != nil {
+		t.Fatalf("ClearAllResumePointers on empty table: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("ClearAllResumePointers on empty table returned n=%d, want 0", n)
+	}
+}
+
+// TestClearAllResumePointers_AllNullTable verifies that when every row already
+// has harness_session_id NULL, ClearAllResumePointers returns (0, nil) — the
+// WHERE clause filters out rows with nothing to clear.
+func TestClearAllResumePointers_AllNullTable(t *testing.T) {
+	d := openTestDB(t)
+
+	_ = insertActiveSession(t, d, "repo@no-sid-1", "repo", "/wt/1")
+	_ = insertActiveSession(t, d, "repo@no-sid-2", "repo", "/wt/2")
+
+	n, err := d.ClearAllResumePointers()
+	if err != nil {
+		t.Fatalf("ClearAllResumePointers: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("ClearAllResumePointers returned n=%d, want 0 when all rows already NULL", n)
+	}
+}
+
+// TestMarkAllEnded_DoesNotClearHarnessSessionID is a contract test for the
+// MarkAllEnded ↔ ClearAllResumePointers separation (issue #1947). MarkAllEnded
+// must keep its narrow responsibility (end every row); it must NOT mutate
+// harness_session_id — that is ClearAllResumePointers' job. If a future
+// refactor folds the two together, that is a deliberate design decision and
+// this test should be deleted with explicit acknowledgement; an accidental
+// change should fail here.
+func TestMarkAllEnded_DoesNotClearHarnessSessionID(t *testing.T) {
+	d := openTestDB(t)
+
+	const name = "repo@end-but-keep-sid"
+	_ = insertActiveSession(t, d, name, "repo", "/wt/end")
+	const sid = "019e00ed-7777-8888-9999-aaaaaaaaaaaa"
+	if err := d.UpdateHarnessSessionID(name, sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	if _, err := d.MarkAllEnded(); err != nil {
+		t.Fatalf("MarkAllEnded: %v", err)
+	}
+
+	st, _ := d.CurrentStatus(name)
+	if st == nil {
+		t.Fatalf("CurrentStatus: row missing")
+	}
+	if st.EndedAt == nil {
+		t.Errorf("EndedAt = nil after MarkAllEnded, want non-nil")
+	}
+	if st.HarnessSessionID == nil {
+		t.Errorf("HarnessSessionID = nil after MarkAllEnded; MarkAllEnded must NOT clear it (issue #1947)")
+	} else if *st.HarnessSessionID != sid {
+		t.Errorf("HarnessSessionID = %q, want %q (unchanged by MarkAllEnded)", *st.HarnessSessionID, sid)
+	}
+}
+
+// TestClearAllResumePointers_LeavesOtherColumnsAlone verifies the targeted
+// nature of the wipe: state, ended_at, instance_id, last_seen, etc. are all
+// preserved. Only harness_session_id changes.
+func TestClearAllResumePointers_LeavesOtherColumnsAlone(t *testing.T) {
+	d := openTestDB(t)
+
+	const name = "repo@only-sid"
+	iid := insertActiveSession(t, d, name, "repo", "/wt/only-sid")
+	if err := d.UpdateHarnessSessionID(name, "019e00ed-1111-2222-3333-444444444444"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	before, _ := d.CurrentStatus(name)
+	if before == nil {
+		t.Fatalf("CurrentStatus before: row missing")
+	}
+
+	if _, err := d.ClearAllResumePointers(); err != nil {
+		t.Fatalf("ClearAllResumePointers: %v", err)
+	}
+
+	after, _ := d.CurrentStatus(name)
+	if after == nil {
+		t.Fatalf("CurrentStatus after: row missing")
+	}
+
+	if after.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID = %q, want nil", *after.HarnessSessionID)
+	}
+	if after.State != before.State {
+		t.Errorf("State changed: before=%q, after=%q", before.State, after.State)
+	}
+	if after.SessionName != before.SessionName {
+		t.Errorf("SessionName changed: before=%q, after=%q", before.SessionName, after.SessionName)
+	}
+	if after.Repo != before.Repo {
+		t.Errorf("Repo changed: before=%q, after=%q", before.Repo, after.Repo)
+	}
+	if after.Worktree != before.Worktree {
+		t.Errorf("Worktree changed: before=%q, after=%q", before.Worktree, after.Worktree)
+	}
+	if after.InstanceID == nil || *after.InstanceID != iid {
+		t.Errorf("InstanceID = %v, want %q", after.InstanceID, iid)
+	}
+	// EndedAt must remain nil (session was active).
+	if after.EndedAt != nil {
+		t.Errorf("EndedAt = %v, want nil (session was active)", after.EndedAt)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -412,6 +412,13 @@ WHERE  instance_id IN (
 // It is used by `prism reset` to atomically close all live sessions in one
 // query rather than iterating over them individually.
 //
+// MarkAllEnded is intentionally narrow: it only stamps ended_at / end_state.
+// It does NOT clear harness_session_id — the per-session pi conversation
+// resume pointer is wiped by the sibling method ClearAllResumePointers,
+// which `prism reset` calls immediately after MarkAllEnded. Keeping the two
+// concerns separate means MarkAllEnded can be reused by any future caller
+// that wants to bulk-end rows without altering resume semantics (issue #1947).
+//
 // Returns the number of agent_status rows updated and any database error.
 // When there are no rows with ended_at IS NULL, returns (0, nil) — not an error.
 func (d *DB) MarkAllEnded() (int64, error) {
@@ -457,6 +464,44 @@ WHERE  instance_id IN (
 
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("db: mark all ended: commit: %w", err)
+	}
+	return n, nil
+}
+
+// ClearAllResumePointers clears the per-session pi conversation resume
+// pointer (agent_status.harness_session_id) on every row in agent_status.
+// It is the FS-companion-free, DB-side half of the `prism reset` resume-wipe
+// (issue #1947): after this call, no row carries a UUID that would cause
+// the next `prism switch` / `prism agent-run` to append `--session <uuid>`
+// to the pi invocation (see internal/container/pi_invocation.go).
+//
+// Relationship to MarkAllEnded:
+//   - MarkAllEnded stamps ended_at / end_state (it ends sessions).
+//   - ClearAllResumePointers wipes harness_session_id (it forgets conversations).
+//
+// `prism reset` calls MarkAllEnded then ClearAllResumePointers — the order
+// does not matter (the columns are independent), but the call site documents
+// reset's intent: end every session, then forget the resume pointer.
+//
+// The column is set to NULL (rather than the empty string) so that the
+// COALESCE in UpsertStatusSeedRootAgentName treats it as "no override" on
+// the next upsert — exactly mirroring the pre-#1838 "fresh row" semantics.
+// CurrentStatus / scanStatus already map a NULL column to a nil *string in
+// the Status struct.
+//
+// Returns the number of rows whose harness_session_id was actually cleared
+// (i.e. previously non-NULL) and any database error. Rows that were already
+// NULL are not counted. Returns (0, nil) on an empty / all-NULL table.
+func (d *DB) ClearAllResumePointers() (int64, error) {
+	res, err := d.conn.Exec(
+		"UPDATE agent_status SET harness_session_id = NULL WHERE harness_session_id IS NOT NULL",
+	)
+	if err != nil {
+		return 0, fmt.Errorf("db: clear all resume pointers: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("db: clear all resume pointers: rows affected: %w", err)
 	}
 	return n, nil
 }


### PR DESCRIPTION
Closes #1947

## Problem

`prism reset` did not actually reset pi conversations. After reset, the next session entry resumed the pre-reset chat because two pieces of state survived:

1. **`agent_status.harness_session_id`** — `MarkAllEnded` only stamped `ended_at`. The `COALESCE` in `UpsertStatusSeedRootAgentName` then preserved the old UUID across `prism switch`.
2. **Per-session pi-agent transcript JSONLs** under `$XDG_STATE_HOME/prism/run/<sessionDirHash>/pi-agent/sessions/`. `resetKillSidecars` walked `run/` but only removed `*-sidecar.ready` files.

On next launch, `cmd/agent_run.go` re-read `status.HarnessSessionID`, forwarded it into `container.Config`, and `pi_invocation.go` appended `--session <uuid>`. The transcript was still on disk, so pi resumed.

Bwrap and sandbox-exec were affected; host mode was incidentally safe (host's `switch` path already leaves `opts.HarnessSessionID` empty).

## Fix

### Option chosen: sibling DB method (not extending `MarkAllEnded`)

Added `ClearAllResumePointers` on `*DB` (`internal/db/status.go`) which NULLs `harness_session_id` on every row. Called from `resetMarkDBEnded` immediately after `MarkAllEnded`. The sibling-method shape (rather than folding into `MarkAllEnded`) keeps `MarkAllEnded`'s responsibility narrow (ends sessions) and makes the reset-specific resume-wipe semantics explicit at the call site. Doc-comments on both methods cross-reference the relationship; a regression test (`TestMarkAllEnded_DoesNotClearHarnessSessionID`) pins that contract.

The column is set to `NULL` rather than empty string so `COALESCE(excluded.harness_session_id, harness_session_id)` in `UpsertStatusSeedRootAgentName` treats it as "no override" — mirroring pre-#1838 fresh-row semantics. `scanStatus` already maps NULL to `*string == nil`.

### FS clearing

Added `resetClearPiTranscripts` in `cmd/reset.go`. It walks `$XDG_STATE_HOME/prism/{run,sessions}/` and removes only the inner `.../sessions/` subtree under each per-session dir. The enclosing directory is preserved.

### Sandbox-exec verification result

Confirmed during implementation: sandbox-exec transcripts live at `$XDG_STATE_HOME/prism/sessions/<instanceID>/home/.pi/agent/sessions/`, **not** under `prism/run/<sessionDirHash>/`. This is the second layout `resetClearPiTranscripts` handles, in the same pass. The discrepancy is documented in the doc-comment for `resetClearPiTranscripts` and the layout-walking helper `removePiSessionsSubtree`.

Layouts covered:

| mode         | path walked                                                                 |
|--------------|-----------------------------------------------------------------------------|
| bwrap        | `$XDG_STATE_HOME/prism/run/<sessionDirHash>/pi-agent/sessions/`             |
| sandbox-exec | `$XDG_STATE_HOME/prism/sessions/<instanceID>/home/.pi/agent/sessions/`      |
| host         | `~/.pi/agent/sessions/` — **not touched** (out of scope per issue)         |

Host mode `~/.pi/agent/sessions/` is intentionally not touched: host mode is already safe by the `opts.HarnessSessionID = ""` contract in `internal/session/session.go:181-182`, and wiping `~/.pi/` would also affect non-prism pi invocations.

## Tests

New tests pinning each AC:

- `internal/db/clear_resume_pointers_test.go`
  - `TestClearAllResumePointers_ClearsEveryRow` — both active and ended rows are cleared.
  - `TestClearAllResumePointers_EmptyTable` / `_AllNullTable` — no-op cases.
  - `TestClearAllResumePointers_LeavesOtherColumnsAlone` — targeted wipe.
  - `TestMarkAllEnded_DoesNotClearHarnessSessionID` — contract guard for the sibling-method separation.

- `cmd/reset_transcripts_test.go`
  - `TestResetClearPiTranscripts_RemovesBwrapSubtreePreservesParent` — bwrap layout, sibling files preserved.
  - `TestResetClearPiTranscripts_RemovesSandboxExecSubtree` — sandbox-exec staging-HOME layout.
  - `TestResetClearPiTranscripts_MissingDirsAreNoOp` / `_NoSubtreeUnderHashIsNoOp` / `_NonDirChildIsSkipped` — defensive cases.

- `cmd/reset_resume_e2e_test.go`
  - `TestReset_E2E_NoSessionFlagAfterReset` — full seam: seed DB SID + on-disk transcript, run reset code path, assert `PIInvocation` does NOT emit `--session` and `ResolvePIResumeSession` returns false.
  - `TestReset_E2E_HostModeUnchanged` — pins AC4 + AC5: host-mode transcripts under `~/.pi/agent/sessions/` survive reset and the host-mode resume-on-reboot path introduced by #1838 still works.

All tests use `t.Setenv("XDG_STATE_HOME", t.TempDir())` and `t.Setenv("HOME", t.TempDir())` per the AGENTS.md isolation conventions.

## Verification

```
$ go build ./...
$ go test ./... -race          # passes
$ go vet ./...                 # clean
$ nix build .#prism            # passes
$ nix build --impure --no-link \
    --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
                                # passes (homeless-shelter signal)
```

## Out-of-scope follow-ups

- **Option 2** from the investigator report (`resume_requested` opt-in flag with schema migration) — file as a follow-up if desired.
- Transcript age-based expiry policy outside of `prism reset`.
