### PR TITLE
hyprland: pin configType to hyprlang and drop unused hy3 layout

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -19,9 +19,6 @@
     deviceLocation = "office";
     desktop = {
       theme = "everforest";
-      hyprland = {
-        layout = "dwindle";
-      };
       waybar.enable = false;
       wallpaper.variant = "enso-6colour";
     };
@@ -120,7 +117,6 @@
     monitor = [
       "DP-3,5120x1440@239.76Hz,0x0,1"
     ];
-    plugin.hy3.autotile.trigger_width = 1280;
   };
 
   # List packages installed in system profile. To search, run:

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -19,20 +19,9 @@ in
       enable = lib.mkEnableOption "enable the Hyprland desktop module" // {
         default = true;
       };
-      layout = lib.mkOption {
-        type = lib.types.enum [
-          "dwindle"
-          "hy3"
-        ];
-        default = "dwindle";
-        description = "sets the default layout for Hyprland";
-      };
     };
   };
   config = lib.mkIf pkgs.stdenv.isLinux (
-    let
-      layout = config.nx.desktop.hyprland.layout;
-    in
     lib.mkMerge [
       {
         # enable for system
@@ -68,6 +57,7 @@ in
           in
           {
             enable = true;
+            configType = "hyprlang";
             settings = {
               exec-once =
                 let
@@ -142,14 +132,7 @@ in
                   in
                   "${lib.concatStringsSep " " rgbaColors} 45deg";
                 "col.inactive_border" = "rgba(${builtins.substring 1 6 (theme.bg2)}ff)";
-                layout = layout;
-              };
-              plugin = {
-                hy3 = lib.mkIf (layout == "hy3") {
-                  autotile = {
-                    enable = true;
-                  };
-                };
+                layout = "dwindle";
               };
               cursor = {
                 inactive_timeout = 5;
@@ -226,9 +209,6 @@ in
                 "SUPER SHIFT, J, movewindow, d"
                 "SUPER SHIFT, K, movewindow, u"
                 "SUPER SHIFT, L, movewindow, r"
-                # hy3
-                (lib.mkIf (layout == "hy3") "SUPER SHIFT, B, exec, hyprctl dispatch hy3:makegroup h")
-                (lib.mkIf (layout == "hy3") "SUPER SHIFT, V, exec, hyprctl dispatch hy3:makegroup v")
                 # switch workspace
                 "SUPER, 1, workspace, 1"
                 "SUPER, 2, workspace, 2"
@@ -349,9 +329,6 @@ in
               enable = true;
             };
             xwayland.enable = true;
-            plugins = [
-              (lib.mkIf (layout == "hy3") pkgs.hyprlandPlugins.hy3)
-            ];
           };
       }
       {


### PR DESCRIPTION
Defensive holding-pattern PR ahead of the upcoming Hyprland `hyprlang` → `lua` migration. Two scoped changes only:

1. **Pin `configType = "hyprlang"`** explicitly inside the home-manager `wayland.windowManager.hyprland` block. Home Manager flips this default to `"lua"` at `home.stateVersion >= 26.05`; our machines are on `25.11` today, so this is a no-op now but prevents a future stateVersion bump from quietly switching us to lua before the migration PR lands.

2. **Drop the unused `hy3` layout option.** The `nx.desktop.hyprland.layout` enum only ever had `dwindle` and `hy3`, and `hy3` is no longer used. The remaining `dwindle` value is inlined into `general.layout`. This removes:
   - The `layout` option block and the `let layout = …; in` wrapper.
   - The `plugin.hy3` block.
   - The two `hy3:makegroup` binds.
   - The `plugins = [ … hy3 … ];` entry (the only plugin, so the line is removed entirely).
   - The per-machine `plugin.hy3.autotile.trigger_width` setting in `machines/navi`.

The full `hyprlang` → `lua` migration will land as a separate PR.

## Verification

- `rg -n hy3 --type nix` → no matches.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel --no-link` → exit 0.
- `nix build .#nixosConfigurations.tui.config.system.build.toplevel --no-link` → exit 0.
- `nixfmt` clean.