### PR TITLE
ssh: migrate programs.ssh.matchBlocks → programs.ssh.settings

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -25,18 +25,18 @@ in
         home-manager.users.${username} = {
           programs.ssh = {
             enable = true;
-            matchBlocks = {
+            settings = {
               "github.com" = {
-                user = "git";
-                hostname = "github.com";
-                port = 22;
-                identityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
+                User = "git";
+                HostName = "github.com";
+                Port = 22;
+                IdentityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
               };
               "gitlab.com" = {
-                user = "git";
-                hostname = "gitlab.com";
-                port = 22;
-                identityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
+                User = "git";
+                HostName = "gitlab.com";
+                Port = 22;
+                IdentityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
               };
             };
           };

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -8,10 +8,10 @@ let
   username = config.nx.username;
   homeDir = config.home-manager.users.${username}.home.homeDirectory;
   cloudflaredBlock = {
-    proxyCommand = "${pkgs.cloudflared}/bin/cloudflared access ssh --hostname %h.$CLOUDFLARED_DOMAIN";
-    user = username;
-    port = 22;
-    identityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
+    ProxyCommand = "${pkgs.cloudflared}/bin/cloudflared access ssh --hostname %h.$CLOUDFLARED_DOMAIN";
+    User = username;
+    Port = 22;
+    IdentityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
   };
 in
 {
@@ -40,18 +40,14 @@ in
             enable = true;
             # https://github.com/nix-community/home-manager/blob/77f348da3176dc68b20a73dab94852a417daf361/modules/programs/ssh.nix#L633C17-L641
             enableDefaultConfig = false; # deprecated, setting to false silences warning
-            matchBlocks = {
+            settings = {
               "*" = lib.mkMerge [
                 {
                   # don't ask to check host key for new hosts
-                  extraOptions = {
-                    StrictHostKeyChecking = "accept-new";
-                  };
+                  StrictHostKeyChecking = "accept-new";
                 }
                 (lib.mkIf config.nx.programs.ssh.enableWorkKeys {
-                  extraOptions = {
-                    Include = "${homeDir}/.ssh/workconfig";
-                  };
+                  Include = "${homeDir}/.ssh/workconfig";
                 })
               ];
               "node0" = cloudflaredBlock;
@@ -59,10 +55,10 @@ in
               "node2" = cloudflaredBlock;
               "node3" = cloudflaredBlock;
               "nas0" = {
-                hostname = "10.87.42.200";
-                port = 220;
-                user = username;
-                identityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
+                HostName = "10.87.42.200";
+                Port = 220;
+                User = username;
+                IdentityFile = "${homeDir}/.ssh/prismatic-koi-ed25519";
               };
             };
           };


### PR DESCRIPTION
Clears two Home Manager deprecation warnings emitted at `nh switch` time:

```
evaluation warning: ben profile: `programs.ssh.matchBlocks` defined in
  `…/modules/programs/git.nix' and `…/modules/programs/ssh.nix' is deprecated.
  Use `programs.ssh.settings`.
evaluation warning: ben profile: `programs.ssh.matchBlocks.*.extraOptions` defined
  in `…/modules/programs/git.nix' and `…/modules/programs/ssh.nix' is deprecated.
  Move these OpenSSH options to `programs.ssh.settings.*` using upstream directive
  names.
```

Replaces `matchBlocks` with `settings` in `modules/programs/ssh.nix` and `modules/programs/git.nix`, and renames the per-host directive keys to the upstream OpenSSH PascalCase names (`HostName`, `User`, `Port`, `IdentityFile`, `ProxyCommand`). The `"*"` host block still combines `StrictHostKeyChecking = "accept-new"` with the optional `workconfig` `Include` (guarded by `enableWorkKeys`) via `lib.mkMerge` — directives are now top-level rather than nested under `extraOptions`. `enableDefaultConfig = false;` is left in place since it silences a separate deprecation warning.

**No behaviour change.** The rendered `~/.ssh/config` contains the same `Host` blocks and the same directive values as before — verified by evaluating `home-manager.users.ben.home.file.".ssh/config".text` on the `navi` configuration; every directive value present today (`HostName 10.87.42.200`, `Port 220`, `ProxyCommand …cloudflared…`, `StrictHostKeyChecking accept-new`, `IdentityFile …prismatic-koi-ed25519`, etc.) still appears in the output. The only on-disk diff is directive casing (`HostName` vs `hostname`), which OpenSSH treats as equivalent.

`nix build` of `nixosConfigurations.{navi,tui}.config.system.build.toplevel` succeeds with no `matchBlocks`/`extraOptions` warnings. `darwinConfigurations.m4mac.system` evaluates cleanly (no such warnings); the build itself can only complete on an `aarch64-darwin` host since `Brewfile.drv` is platform-locked, which is a pre-existing host constraint unrelated to this change.

`rg -n 'matchBlocks|extraOptions' --type nix` from the repo root prints no matches.
