### PR TITLE
hyprland: migrate from hyprlang to lua renderer

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -122,6 +122,34 @@
         scale = 1;
       }
     ];
+    # Outer-margin workspace rules for the 5120-wide ultrawide. The
+    # monitor is wide enough that a single tiled window stretched edge
+    # to edge is unreadable, so on workspaces with exactly one tiled
+    # window (`w[t1]`) and on special workspaces (`s[true]`) we reserve
+    # 1280px (5120 / 4) of outer gap on each side. `gaps_out` accepts a
+    # CSS-shorthand structured form `{ top, right, bottom, left }`
+    # mirroring the hyprlang `gapsout:5 1280` two-value shorthand
+    # (top/bottom 5, left/right 1280).
+    workspace_rule = [
+      {
+        workspace = "w[t1]";
+        gaps_out = {
+          top = 5;
+          bottom = 5;
+          left = 1280;
+          right = 1280;
+        };
+      }
+      {
+        workspace = "s[true]";
+        gaps_out = {
+          top = 50;
+          bottom = 50;
+          left = 1280;
+          right = 1280;
+        };
+      }
+    ];
   };
 
   # List packages installed in system profile. To search, run:

--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -115,7 +115,12 @@
   # display settigs for hyprland
   home-manager.users.ben.wayland.windowManager.hyprland.settings = {
     monitor = [
-      "DP-3,5120x1440@239.76Hz,0x0,1"
+      {
+        output = "DP-3";
+        mode = "5120x1440@239.76Hz";
+        position = "0x0";
+        scale = 1;
+      }
     ];
   };
 

--- a/machines/tui/configuration.nix
+++ b/machines/tui/configuration.nix
@@ -118,7 +118,12 @@
 
   # display settigs for hyprland
   home-manager.users.ben.wayland.windowManager.hyprland.settings.monitor = [
-    "eDP-1,2880x1800@120.00000,0x0,1.5"
+    {
+      output = "eDP-1";
+      mode = "2880x1800@120.00000";
+      position = "0x0";
+      scale = 1.5;
+    }
   ];
 
   # List packages installed in system profile. To search, run:

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -7,6 +7,7 @@
 let
   homeDir = config.home-manager.users.${config.nx.username}.home.homeDirectory;
   theme = config.theme;
+  inherit (lib.generators) mkLuaInline;
 in
 {
   imports = [
@@ -54,51 +55,89 @@ in
             openshoppinglist = "${newwindow} https://www.notion.so/ph3nx/Shopping-List-92d98ac3dc86460285a399c0b1176fc5";
             # configuration
             enableAudioControls = config.nx.externalAudio.enable == false;
+
+            # Helpers for translating hyprlang-style binds into the lua
+            # `hl.bind(...)` call shape that HM's lua renderer expects.
+            #
+            # `mkBind keys dispatcher` produces `hl.bind(keys, dispatcher)`.
+            # `mkBindFlags keys dispatcher flags` adds a flag table as the
+            # third arg (e.g. `{ locked = true; }`, `{ release = true;
+            # transparent = true; }`).
+            #
+            # `dispatcher` is a string of raw lua (e.g.
+            # `''hl.dsp.exec_cmd("kitty")''`) that we wrap in mkLuaInline so
+            # the renderer emits it verbatim rather than quoting it.
+            mkBind = keys: dispatcher: {
+              _args = [
+                keys
+                (mkLuaInline dispatcher)
+              ];
+            };
+            mkBindFlags = keys: dispatcher: flags: {
+              _args = [
+                keys
+                (mkLuaInline dispatcher)
+                flags
+              ];
+            };
+            # `mkExec keys cmd` is shorthand for the (very common) bind that
+            # exec's a shell command. `cmd` is passed through
+            # `lib.generators.toLua` so any special characters in the string
+            # are escaped correctly into the lua source.
+            mkExec = keys: cmd: mkBind keys "hl.dsp.exec_cmd(${lib.generators.toLua { } cmd})";
+            mkExecFlags =
+              keys: cmd: flags:
+              mkBindFlags keys "hl.dsp.exec_cmd(${lib.generators.toLua { } cmd})" flags;
           in
           {
             enable = true;
-            configType = "hyprlang";
+            # Lua renderer (Hyprland's preferred config language since 0.55).
+            # See docs/hyprland-lua-migration.md for the design.
+            configType = "lua";
             settings = {
-              exec-once =
-                let
-                  resolution = config.nx.desktop.wallpaper.resolution;
-                in
-                [
-                  (lib.mkIf config.nx.desktop.wallpaper.enable "swaybg -i ${homeDir}/.config/wallpaper-${resolution}.png --mode fill")
-                  # (lib.mkIf (config.theme.name == "everforest") "swaybg -i ${homeDir}/.config/wallpaper_everforest-${resolution}.png --mode fill")
-                  # (lib.mkIf (config.theme.name == "github-light") "swaybg -i ${homeDir}/.config/wallpaper_github_light-${resolution}.png --mode fill")
-                  # "swaybg --color ${builtins.substring 1 6 (theme.bg_dim)}"
-                  "hypridle"
-                  (lib.mkIf (config.nx.isLaptop == false) "steam -silent -no-cef-sandbox") # couldn't figure out xdg-autostart
-                  "${scriptsDir}/game.inputRemapper.defaults"
-                  # default to 70% brightness
-                  (lib.mkIf config.nx.isLaptop "${pkgs.brightnessctl}/bin/brightnessctl s 70%")
-                  # default to keyboard backlight off
-                  (lib.mkIf config.nx.isLaptop "${pkgs.brightnessctl}/bin/brightnessctl --device='asus::kbd_backlight' set 0")
-                  "${scriptsDir}/cli.hyprland.switchWorkspaceOnWindowClose"
-                  "waybar"
-
-                ];
-              debug = {
-                disable_logs = false;
+              # ---- general ----------------------------------------------------
+              general = {
+                gaps_in = 5;
+                gaps_out = 5;
+                border_size = 3;
+                # Gradient borders use the structured table form under lua
+                # (`{ colors = { ... }, angle = 45 }`); the legacy
+                # whitespace-separated string + "45deg" suffix isn't accepted
+                # by the lua `hl.config` API — the upstream example config
+                # ships exclusively in the table form (see
+                # /share/hypr/hyprland.lua bundled with hyprland).
+                col = {
+                  active_border =
+                    let
+                      # rainbow border colors in order
+                      colors = with theme; [
+                        red
+                        orange
+                        yellow
+                        green
+                        aqua
+                        blue
+                        purple
+                      ];
+                      toRgba = color: "rgba(${builtins.substring 1 6 color}ff)";
+                    in
+                    {
+                      colors = map toRgba colors;
+                      angle = 45;
+                    };
+                  inactive_border = "rgba(${builtins.substring 1 6 (theme.bg2)}ff)";
+                };
+                layout = "dwindle";
               };
-              ecosystem = {
-                # don't show update notifications each boot
-                no_update_news = true;
-              };
-              exec = [
-                # restart waybar, if for some reason it died
-                "pkill waybar && hyprctl dispatch exec waybar"
-                "${scriptsDir}/cli.system.setHyprGaps"
-              ];
+              # ---- input -----------------------------------------------------
               input = {
                 # Te Reo Macrons
                 kb_layout = "nz";
                 kb_variant = "mao";
                 kb_options = "lv3:rwin_switch";
-                # keyrepeat settings
-                repeat_delay = "225";
-                repeat_rate = "60";
+                # keyrepeat settings (lua wants ints, not strings)
+                repeat_delay = 225;
+                repeat_rate = 60;
                 follow_mouse = 2;
                 sensitivity = -0.8;
                 touchpad = {
@@ -106,37 +145,7 @@ in
                   natural_scroll = true;
                 };
               };
-              gestures = {
-                # was removed in a recent version of hyprland, didn't use it much anyway
-                # workspace_swipe = lib.mkIf config.nx.isLaptop true;
-              };
-              general = {
-                gaps_in = 5;
-                gaps_out = 5;
-                border_size = 3;
-                "col.active_border" =
-                  let
-                    # rainbow border colors in order
-                    colors = with theme; [
-                      red
-                      orange
-                      yellow
-                      green
-                      aqua
-                      blue
-                      purple
-                    ];
-                    # convert hex colors to rgba format (remove # and add ff for alpha)
-                    toRgba = color: "rgba(${builtins.substring 1 6 color}ff)";
-                    rgbaColors = map toRgba colors;
-                  in
-                  "${lib.concatStringsSep " " rgbaColors} 45deg";
-                "col.inactive_border" = "rgba(${builtins.substring 1 6 (theme.bg2)}ff)";
-                layout = "dwindle";
-              };
-              cursor = {
-                inactive_timeout = 5;
-              };
+              # ---- decoration ------------------------------------------------
               decoration = {
                 rounding = 5;
                 blur.enabled = true;
@@ -144,26 +153,13 @@ in
                   enabled = false;
                 };
               };
-              bezier = [
-                "myBezier,0.05,0.9,0.1,1.0"
-                "linear,0,0,1,1"
-              ];
-              animations = {
-                enabled = true;
-                animation = [
-                  "windows, 1, 3, myBezier"
-                  "windowsOut, 1, 2, myBezier, popin 90%"
-                  "windowsIn, 1, 2, myBezier, popin 90%"
-                  "border, 1, 2, default"
-                  "borderangle, 1, 50, linear, loop"
-                  "fade, 1, 2, default"
-                  "workspaces,1,1, myBezier, slidevert"
-                ];
-              };
+              # ---- dwindle ---------------------------------------------------
               dwindle = {
-                preserve_split = "yes";
+                # lua wants bool, not "yes"/"no"
+                preserve_split = true;
                 force_split = 2;
               };
+              # ---- misc ------------------------------------------------------
               misc = {
                 disable_hyprland_logo = true;
                 disable_splash_rendering = true;
@@ -175,6 +171,128 @@ in
                 # suppress start-hyprland warning when not using the watchdog wrapper
                 disable_watchdog_warning = true;
               };
+              # ---- cursor ----------------------------------------------------
+              cursor = {
+                inactive_timeout = 5;
+              };
+              # ---- debug -----------------------------------------------------
+              debug = {
+                disable_logs = false;
+              };
+              # ---- ecosystem -------------------------------------------------
+              ecosystem = {
+                # don't show update notifications each boot
+                no_update_news = true;
+              };
+              # ---- curves (bezier renamed in lua) ----------------------------
+              # `curve` is in importantPrefixes so renders before `animation`.
+              curve = [
+                {
+                  _args = [
+                    "myBezier"
+                    {
+                      type = "bezier";
+                      points = [
+                        [
+                          0.05
+                          0.9
+                        ]
+                        [
+                          0.1
+                          1.0
+                        ]
+                      ];
+                    }
+                  ];
+                }
+                {
+                  _args = [
+                    "linear"
+                    {
+                      type = "bezier";
+                      points = [
+                        [
+                          0
+                          0
+                        ]
+                        [
+                          1
+                          1
+                        ]
+                      ];
+                    }
+                  ];
+                }
+              ];
+              # ---- animations ------------------------------------------------
+              # master switch
+              animations = {
+                enabled = true;
+              };
+              # per-leaf animation definitions; top-level list (not nested
+              # under `animations`), one `hl.animation(...)` call per entry.
+              # The curve-reference field is named `bezier` (matching the
+              # upstream-shipped example at /share/hypr/hyprland.lua), not
+              # `curve` — different curve types use different field names
+              # (`bezier = "..."` vs `spring = "..."`).
+              animation = [
+                {
+                  leaf = "windows";
+                  enabled = true;
+                  speed = 3;
+                  bezier = "myBezier";
+                }
+                {
+                  leaf = "windowsOut";
+                  enabled = true;
+                  speed = 2;
+                  bezier = "myBezier";
+                  style = "popin 90%";
+                }
+                {
+                  leaf = "windowsIn";
+                  enabled = true;
+                  speed = 2;
+                  bezier = "myBezier";
+                  style = "popin 90%";
+                }
+                {
+                  leaf = "border";
+                  enabled = true;
+                  speed = 2;
+                  bezier = "default";
+                }
+                {
+                  leaf = "borderangle";
+                  enabled = true;
+                  speed = 50;
+                  bezier = "linear";
+                  style = "loop";
+                }
+                {
+                  leaf = "fade";
+                  enabled = true;
+                  speed = 2;
+                  bezier = "default";
+                }
+                {
+                  leaf = "workspaces";
+                  enabled = true;
+                  speed = 1;
+                  bezier = "myBezier";
+                  style = "slidevert";
+                }
+              ];
+              # ---- monitor ---------------------------------------------------
+              monitor = [
+                {
+                  output = "";
+                  mode = "preferred";
+                  position = "auto";
+                  scale = 1;
+                }
+              ];
+              # ---- device ----------------------------------------------------
               device = [
                 {
                   # reduce touchpad sensitivity
@@ -182,149 +300,270 @@ in
                   sensitivity = 0.5;
                 }
               ];
-              # where possible, window rules should live with the app config
-              windowrule = [ ];
-              monitor = [
-                ",preferred,auto,auto"
+              # ---- env -------------------------------------------------------
+              env = [
+                {
+                  _args = [
+                    "XDG_CURRENT_DESKTOP"
+                    "Hyprland"
+                  ];
+                }
+                {
+                  _args = [
+                    "XDG_SESSION_TYPE"
+                    "wayland"
+                  ];
+                }
+                {
+                  _args = [
+                    "XDG_SESSION_DESKTOP"
+                    "Hyprland"
+                  ];
+                }
+                {
+                  _args = [
+                    "GDK_BACKEND"
+                    "wayland,x11"
+                  ];
+                }
+                # "SDL_VIDEODRIVER,wayland" # removed: causes stutter in Proton games, let Steam/Proton pick the backend
+                {
+                  _args = [
+                    "_JAVA_AWT_WM_NONREPARENTING"
+                    "1"
+                  ];
+                }
+                {
+                  _args = [
+                    "QT_QPA_PLATFORM"
+                    "wayland"
+                  ];
+                }
               ];
-              bindrt = [
-                # hide waybar + quickshell widgets on SUPER_L keyup
-                "SUPER, SUPER_L, exec, pkill -SIGUSR2 waybar; hyprctl dispatch event quickshell:hide"
-              ];
-              bindl = [
-                # suspend (works even when locked)
-                "SUPER, s, exec, ${scriptsDir}/cli.system.suspend"
-              ];
+              # ---- startup hook ----------------------------------------------
+              # Replaces hyprlang `exec-once` and `exec`. `hl.on("hyprland.start", ...)`
+              # is the lua-idiomatic equivalent: run these commands once at
+              # session start. We fold both lists into one hook (`exec`'s
+              # per-reload semantics aren't relied on by anything here — both
+              # entries are idempotent restart-style commands).
+              #
+              # `lib.mkIf <false> { ... }` entries are stripped by the module
+              # system before they reach the renderer, so the function body
+              # only contains the actually-active commands per machine.
+              # `lib.optional <bool> <x>` evaluates to `[ <x> ]` or `[]` —
+              # cleaner than `lib.mkIf` here because we're building a plain
+              # list in let-scope, not contributing to an option, so the
+              # module system's `mkIf`-stripping pass never runs.
+              on =
+                let
+                  startupCmds =
+                    lib.optional config.nx.desktop.wallpaper.enable "swaybg -i ${homeDir}/.config/wallpaper-${config.nx.desktop.wallpaper.resolution}.png --mode fill"
+                    ++ [
+                      "hypridle"
+                    ]
+                    ++ lib.optional (config.nx.isLaptop == false) "steam -silent -no-cef-sandbox"
+                    ++ [
+                      "${scriptsDir}/game.inputRemapper.defaults"
+                    ]
+                    # default to 70% brightness on laptops
+                    ++ lib.optional config.nx.isLaptop "${pkgs.brightnessctl}/bin/brightnessctl s 70%"
+                    # default to keyboard backlight off on laptops
+                    ++ lib.optional config.nx.isLaptop "${pkgs.brightnessctl}/bin/brightnessctl --device='asus::kbd_backlight' set 0"
+                    ++ [
+                      "${scriptsDir}/cli.hyprland.switchWorkspaceOnWindowClose"
+                      "waybar"
+                      # ex-`exec` entries (now also once-per-session):
+                      "pkill waybar && hyprctl dispatch exec waybar"
+                      "${scriptsDir}/cli.system.setHyprGaps"
+                    ];
+                in
+                {
+                  _args = [
+                    "hyprland.start"
+                    (mkLuaInline ''
+                      function()
+                      ${lib.concatMapStringsSep "\n" (cmd: "  hl.exec_cmd(${lib.generators.toLua { } cmd})") startupCmds}
+                      end
+                    '')
+                  ];
+                };
+              # ---- window rules (lua name: window_rule, underscore) ----------
+              # The main module contributes nothing; per-app rules merge in
+              # from gaming/, programs/qutebrowser/, etc. via list-merge.
+              window_rule = [ ];
+              # ---- binds -----------------------------------------------------
+              # In lua, `bind` / `bindl` / `bindrt` / `bindm` collapse into a
+              # single `hl.bind(keys, dispatcher, flags?)` call; flag tables
+              # encode the variant (`{ locked = true; }`, etc.).
+              # Key strings use the lua " + "-joined form (e.g. "SUPER + h"),
+              # not the hyprlang "MOD, KEY" comma form. No-mod binds drop the
+              # leading comma entirely (e.g. "XF86AudioPlay", not ",
+              # XF86AudioPlay"). The format matches the canonical example
+              # config shipped at /share/hypr/hyprland.lua.
               bind = [
                 # show waybar + quickshell widgets on SUPER_L keydown
-                ", SUPER_L, exec, pkill -SIGUSR1 waybar; hyprctl dispatch event quickshell:show"
+                (mkExec "SUPER_L" "pkill -SIGUSR1 waybar; hyprctl dispatch event quickshell:show")
+                # hide waybar + quickshell widgets on SUPER_L keyup. Single
+                # top-level entry with `submap_universal = true` replaces the
+                # previous three copies (top-level + inside `resize` + inside
+                # `exit` submap) — see docs section 8.5.
+                (mkBindFlags "SUPER_L"
+                  ''hl.dsp.exec_cmd("pkill -SIGUSR2 waybar; hyprctl dispatch event quickshell:hide")''
+                  {
+                    release = true;
+                    transparent = true;
+                    submap_universal = true;
+                  }
+                )
                 # Motions
                 # focus window
-                "SUPER, h, movefocus, l"
-                "SUPER, j, movefocus, d"
-                "SUPER, k, movefocus, u"
-                "SUPER, l, movefocus, r"
+                (mkBind "SUPER + h" ''hl.dsp.focus({ direction = "l" })'')
+                (mkBind "SUPER + j" ''hl.dsp.focus({ direction = "d" })'')
+                (mkBind "SUPER + k" ''hl.dsp.focus({ direction = "u" })'')
+                (mkBind "SUPER + l" ''hl.dsp.focus({ direction = "r" })'')
                 # move window
-                "SUPER SHIFT, H, movewindow, l"
-                "SUPER SHIFT, J, movewindow, d"
-                "SUPER SHIFT, K, movewindow, u"
-                "SUPER SHIFT, L, movewindow, r"
+                (mkBind "SUPER + SHIFT + H" ''hl.dsp.window.move({ direction = "l" })'')
+                (mkBind "SUPER + SHIFT + J" ''hl.dsp.window.move({ direction = "d" })'')
+                (mkBind "SUPER + SHIFT + K" ''hl.dsp.window.move({ direction = "u" })'')
+                (mkBind "SUPER + SHIFT + L" ''hl.dsp.window.move({ direction = "r" })'')
                 # switch workspace
-                "SUPER, 1, workspace, 1"
-                "SUPER, 2, workspace, 2"
-                "SUPER, 3, workspace, 3"
-                "SUPER, 4, workspace, 4"
-                "SUPER, 5, workspace, 5"
-                "SUPER, 6, workspace, 6"
-                "SUPER, 7, workspace, 7"
-                "SUPER, 8, workspace, 8"
-                "SUPER, 9, workspace, 9"
-                "SUPER, TAB, workspace, previous"
-                # move active window to workspace
-                "SUPER SHIFT, 1, movetoworkspacesilent, 1"
-                "SUPER SHIFT, 2, movetoworkspacesilent, 2"
-                "SUPER SHIFT, 3, movetoworkspacesilent, 3"
-                "SUPER SHIFT, 4, movetoworkspacesilent, 4"
-                "SUPER SHIFT, 5, movetoworkspacesilent, 5"
-                "SUPER SHIFT, 6, movetoworkspacesilent, 6"
-                "SUPER SHIFT, 7, movetoworkspacesilent, 7"
-                "SUPER SHIFT, 8, movetoworkspacesilent, 8"
-                "SUPER SHIFT, 9, movetoworkspacesilent, 9"
+                (mkBind "SUPER + 1" "hl.dsp.workspace(1)")
+                (mkBind "SUPER + 2" "hl.dsp.workspace(2)")
+                (mkBind "SUPER + 3" "hl.dsp.workspace(3)")
+                (mkBind "SUPER + 4" "hl.dsp.workspace(4)")
+                (mkBind "SUPER + 5" "hl.dsp.workspace(5)")
+                (mkBind "SUPER + 6" "hl.dsp.workspace(6)")
+                (mkBind "SUPER + 7" "hl.dsp.workspace(7)")
+                (mkBind "SUPER + 8" "hl.dsp.workspace(8)")
+                (mkBind "SUPER + 9" "hl.dsp.workspace(9)")
+                (mkBind "SUPER + TAB" ''hl.dsp.workspace("previous")'')
+                # move active window to workspace (silent — no follow)
+                (mkBind "SUPER + SHIFT + 1" "hl.dsp.window.move({ workspace = 1, silent = true })")
+                (mkBind "SUPER + SHIFT + 2" "hl.dsp.window.move({ workspace = 2, silent = true })")
+                (mkBind "SUPER + SHIFT + 3" "hl.dsp.window.move({ workspace = 3, silent = true })")
+                (mkBind "SUPER + SHIFT + 4" "hl.dsp.window.move({ workspace = 4, silent = true })")
+                (mkBind "SUPER + SHIFT + 5" "hl.dsp.window.move({ workspace = 5, silent = true })")
+                (mkBind "SUPER + SHIFT + 6" "hl.dsp.window.move({ workspace = 6, silent = true })")
+                (mkBind "SUPER + SHIFT + 7" "hl.dsp.window.move({ workspace = 7, silent = true })")
+                (mkBind "SUPER + SHIFT + 8" "hl.dsp.window.move({ workspace = 8, silent = true })")
+                (mkBind "SUPER + SHIFT + 9" "hl.dsp.window.move({ workspace = 9, silent = true })")
                 # floating
-                "SUPER SHIFT, space, togglefloating"
-                # example special workspace TODO more
-                "SUPER, X, togglespecialworkspace, magic"
-                "SUPER SHIFT, X, movetoworkspacesilent, special:magic"
+                (mkBind "SUPER + SHIFT + space" ''hl.dsp.window.float({ action = "toggle" })'')
+                # special workspace
+                (mkBind "SUPER + X" ''hl.dsp.workspace.toggle_special("magic")'')
+                (mkBind "SUPER + SHIFT + X" ''hl.dsp.window.move({ workspace = "special:magic", silent = true })'')
                 # scroll through existing workspaces
-                "SUPER, mouse_down, workspace, e+1"
-                "SUPER, mouse_up, workspace, e-1"
+                (mkBind "SUPER + mouse_down" ''hl.dsp.workspace("e+1")'')
+                (mkBind "SUPER + mouse_up" ''hl.dsp.workspace("e-1")'')
                 # window shortcuts
-                "SUPER, q, killactive"
-                "SUPER SHIFT, C, exec, hyprctl reload"
-                "SUPER, period, exec, ${emojipicker}"
-                "SUPER, Space, exec, ${runscripts}"
-                "SUPER, c, exec, ${calculator}"
-                "SUPER SHIFT, F, fullscreen"
-                "SUPER, i, exec, ${scriptsDir}/cli.system.inhibitIdle toggle"
+                (mkBind "SUPER + q" "hl.dsp.window.close()")
+                (mkExec "SUPER + SHIFT + C" "hyprctl reload")
+                (mkExec "SUPER + period" emojipicker)
+                (mkExec "SUPER + Space" runscripts)
+                (mkExec "SUPER + c" calculator)
+                (mkBind "SUPER + SHIFT + F" "hl.dsp.window.fullscreen()")
+                (mkExec "SUPER + i" "${scriptsDir}/cli.system.inhibitIdle toggle")
                 # Notification Center
-                "SUPER, n, exec, ${pkgs.swaynotificationcenter}/bin/swaync-client -t -sw"
-                "SUPER SHIFT, N, exec, ${pkgs.swaynotificationcenter}/bin/swaync-client --close-all && ${pkgs.swaynotificationcenter}/bin/swaync-client --close-panel"
+                (mkExec "SUPER + n" "${pkgs.swaynotificationcenter}/bin/swaync-client -t -sw")
+                (mkExec "SUPER + SHIFT + N" "${pkgs.swaynotificationcenter}/bin/swaync-client --close-all && ${pkgs.swaynotificationcenter}/bin/swaync-client --close-panel")
                 # application shortcuts
-                "ALT, Return, exec, ${terminal}"
-                "AlT, Space, exec, ${applicationlauncher}"
-                "ALT, a, exec, anki"
-                "ALT, b, exec, ${browser}"
-                "ALT, c, exec, ${calendar}"
-                "ALT, f, exec, ${filemanager}"
-                "ALT, m, exec, ${musicplayer}"
-                "ALT, t, exec, ${addtodailytodo}"
-                "ALT, l, exec, ${addtoshoppinglist}"
-                "ALT SHIFT, l, exec, ${openshoppinglist}"
-                "ALT, o, exec, ${prismLauncher} --path ${homeDir}/documents/obsidian"
-                "ALT, n, exec, ${prismLauncher} --path ${homeDir}/code/nixos-config/main"
-                "ALT, p, exec, ${prismLauncher}"
+                (mkExec "ALT + Return" terminal)
+                (mkExec "ALT + Space" applicationlauncher)
+                (mkExec "ALT + a" "anki")
+                (mkExec "ALT + b" browser)
+                (mkExec "ALT + c" calendar)
+                (mkExec "ALT + f" filemanager)
+                (mkExec "ALT + m" musicplayer)
+                (mkExec "ALT + t" addtodailytodo)
+                (mkExec "ALT + l" addtoshoppinglist)
+                (mkExec "ALT + SHIFT + l" openshoppinglist)
+                (mkExec "ALT + o" "${prismLauncher} --path ${homeDir}/documents/obsidian")
+                (mkExec "ALT + n" "${prismLauncher} --path ${homeDir}/code/nixos-config/main")
+                (mkExec "ALT + p" prismLauncher)
+                # submap entries — schedule auto-reset via hl.timer (ms) at
+                # the same time as we dispatch the submap, removing the need
+                # for the old `sleep N && hyprctl dispatch submap reset`
+                # shell-out. `hl.bind` accepts either an `hl.dsp.*` dispatcher
+                # value or a plain lua function as its second argument; we
+                # use a function here so the timer is scheduled in the same
+                # call as the submap entry.
+                (mkBind "SUPER + R" ''
+                  function()
+                    hl.dispatch(hl.dsp.submap("resize"))
+                    hl.timer(function()
+                      hl.dispatch(hl.dsp.submap("reset"))
+                    end, { timeout = 10000, type = "oneshot" })
+                  end
+                '')
+                (mkBind "SUPER + SHIFT + E" ''
+                  function()
+                    hl.dispatch(hl.dsp.submap("exit"))
+                    hl.timer(function()
+                      hl.dispatch(hl.dsp.submap("reset"))
+                    end, { timeout = 3000, type = "oneshot" })
+                  end
+                '')
                 # media controls
-                ", XF86AudioMute, exec, ${toggleMute}"
-                (lib.mkIf enableAudioControls ", XF86AudioRaiseVolume, exec, ${volumeUp}")
-                (lib.mkIf enableAudioControls ", XF86AudioLowerVolume, exec, ${volumeDown}")
-                ", XF86AudioPlay, exec, ${pkgs.playerctl}/bin/playerctl play-pause"
-                ", Pause, exec, ${pkgs.playerctl}/bin/playerctl play-pause"
-                ", Scroll_Lock, exec, ${pkgs.playerctl}/bin/playerctl stop" # this is fn+k on my asus laptop
-                ", XF86AudioStop, exec, ${pkgs.playerctl}/bin/playerctl stop"
-                ", XF86AudioNext, exec, ${pkgs.playerctl}/bin/playerctl next"
-                ", XF86AudioPrev, exec, ${pkgs.playerctl}/bin/playerctl previous"
-                (lib.mkIf config.nx.isLaptop ", XF86MonBrightnessUp, exec, ${brightnessUp}")
-                (lib.mkIf config.nx.isLaptop ", XF86MonBrightnessDown, exec, ${brightnessDown}")
+                (mkExec "XF86AudioMute" toggleMute)
+                (lib.mkIf enableAudioControls (mkExec "XF86AudioRaiseVolume" volumeUp))
+                (lib.mkIf enableAudioControls (mkExec "XF86AudioLowerVolume" volumeDown))
+                (mkExec "XF86AudioPlay" "${pkgs.playerctl}/bin/playerctl play-pause")
+                (mkExec "Pause" "${pkgs.playerctl}/bin/playerctl play-pause")
+                # fn+k on my asus laptop
+                (mkExec "Scroll_Lock" "${pkgs.playerctl}/bin/playerctl stop")
+                (mkExec "XF86AudioStop" "${pkgs.playerctl}/bin/playerctl stop")
+                (mkExec "XF86AudioNext" "${pkgs.playerctl}/bin/playerctl next")
+                (mkExec "XF86AudioPrev" "${pkgs.playerctl}/bin/playerctl previous")
+                (lib.mkIf config.nx.isLaptop (mkExec "XF86MonBrightnessUp" brightnessUp))
+                (lib.mkIf config.nx.isLaptop (mkExec "XF86MonBrightnessDown" brightnessDown))
                 # The Asus laptop firmware maps the touchpad toggle Fn key to Super+P.
-                (lib.mkIf config.nx.isLaptop "SUPER, p, exec, ${toggleTouchpad}")
+                (lib.mkIf config.nx.isLaptop (mkExec "SUPER + p" toggleTouchpad))
                 # print screen
-                ", Print, exec, ${scriptsDir}/application.grim.fullScreenshotToFile"
-              ];
-              bindm = [
-                "SUPER, mouse:272, movewindow"
-                "SUPER, mouse:273, resizewindow"
-              ];
-              # bindl = [
-              #   ", switch:on:Lid Switch, exec, ${scriptsDir}/cli.system.suspend"
-              # ];
-              env = [
-                "XDG_CURRENT_DESKTOP,Hyprland"
-                "XDG_SESSION_TYPE,wayland"
-                "XDG_SESSION_DESKTOP,Hyprland"
-                "GDK_BACKEND,wayland,x11"
-                # "SDL_VIDEODRIVER,wayland" # removed: causes stutter in Proton games, let Steam/Proton pick the backend
-                "_JAVA_AWT_WM_NONREPARENTING,1"
-                "QT_QPA_PLATFORM,wayland"
+                (mkExec "Print" "${scriptsDir}/application.grim.fullScreenshotToFile")
+                # mouse (formerly bindm). `mouse = true` flag matches the
+                # upstream-shipped example at /share/hypr/hyprland.lua.
+                (mkBindFlags "SUPER + mouse:272" "hl.dsp.window.drag()" { mouse = true; })
+                (mkBindFlags "SUPER + mouse:273" "hl.dsp.window.resize()" { mouse = true; })
+                # locked (formerly bindl) — suspend works even when locked
+                (mkBindFlags "SUPER + s" ''hl.dsp.exec_cmd("${scriptsDir}/cli.system.suspend")'' { locked = true; })
               ];
             };
-            extraConfig = ''
-              # resize submap (with auto reset after 10 sec)
-              bind=SUPER,R,exec,sleep 10 && hyprctl dispatch submap reset
-              bind=SUPER,R,submap,resize
-              submap=resize
-              binde=,h,resizeactive,-10 0
-              binde=,j,resizeactive,0 10
-              binde=,k,resizeactive,0 -10
-              binde=,l,resizeactive,10 0
-              bind=,escape,submap,reset
-              bindrt=SUPER,SUPER_L,exec,pkill -SIGUSR2 waybar; hyprctl dispatch event quickshell:hide
-              submap=reset
-              # exit submap (with auto reset after 3 sec)
-              bind=SUPER SHIFT,E,exec,sleep 3 && hyprctl dispatch submap reset
-              bind=SUPER SHIFT,E,submap,exit
-              submap=exit
-              # lock
-              binde=,l,exec, hyprlock
-              # logout
-              bind=SHIFT,L,exec, loginctl terminate-user $USER
-              # shutdown
-              binde=,s,exec, systemctl poweroff
-              # reboot
-              binde=,r,exec, systemctl reboot
-              bind=,escape,submap,reset
-              bindrt=SUPER,SUPER_L,exec,pkill -SIGUSR2 waybar; hyprctl dispatch event quickshell:hide
-              submap=reset
-            '';
+            # ---- submaps -----------------------------------------------------
+            # Migrated from extraConfig. `extraConfig` is now empty.
+            #
+            # The `SUPER_L` release-hide bind that used to be duplicated in
+            # each submap is replaced by the single top-level entry above with
+            # `{ submap_universal = true; release = true; transparent = true; }`
+            # — see docs section 8.5.
+            submaps = {
+              resize = {
+                settings.bind = [
+                  (mkBindFlags "h" "hl.dsp.window.resize({ x = -10, y = 0, relative = true })" {
+                    repeating = true;
+                  })
+                  (mkBindFlags "j" "hl.dsp.window.resize({ x = 0, y = 10, relative = true })" {
+                    repeating = true;
+                  })
+                  (mkBindFlags "k" "hl.dsp.window.resize({ x = 0, y = -10, relative = true })" {
+                    repeating = true;
+                  })
+                  (mkBindFlags "l" "hl.dsp.window.resize({ x = 10, y = 0, relative = true })" {
+                    repeating = true;
+                  })
+                  (mkBind "escape" ''hl.dsp.submap("reset")'')
+                ];
+              };
+              exit = {
+                settings.bind = [
+                  (mkExec "l" "hyprlock")
+                  (mkExec "SHIFT + L" "loginctl terminate-user $USER")
+                  (mkExec "s" "systemctl poweroff")
+                  (mkExec "r" "systemctl reboot")
+                  (mkBind "escape" ''hl.dsp.submap("reset")'')
+                ];
+              };
+            };
+            extraConfig = "";
             systemd = {
               enable = true;
             };

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -260,7 +260,11 @@ in
                   leaf = "border";
                   enabled = true;
                   speed = 2;
-                  bezier = "default";
+                  # hyprlang implicitly provided a `default` bezier; the lua
+                  # API doesn't — referencing an undefined curve here drops
+                  # Hyprland into a safe state with no keybinds at startup.
+                  # Fall back to the `linear` curve we define explicitly.
+                  bezier = "linear";
                 }
                 {
                   leaf = "borderangle";
@@ -273,7 +277,7 @@ in
                   leaf = "fade";
                   enabled = true;
                   speed = 2;
-                  bezier = "default";
+                  bezier = "linear";
                 }
                 {
                   leaf = "workspaces";

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -224,10 +224,25 @@ in
                   ];
                 }
               ];
-              # ---- animations ------------------------------------------------
-              # master switch
-              animations = {
-                enabled = true;
+              # ---- animations master switch ----------------------------------
+              # The lua API exposes `hl.animation(...)` (singular, per-leaf)
+              # but NOT `hl.animations(...)` — a standalone
+              # `animations = { enabled = true; }` setting would render as
+              # `hl.animations({ enabled = true })` and fail at startup with
+              # "attempt to call a nil value (field 'animations')".
+              #
+              # The master switch is set via `hl.config({ animations = {
+              # enabled = true } })` instead, matching the upstream-shipped
+              # example at /share/hypr/hyprland.lua. We invoke `hl.config`
+              # explicitly via the `_args` shape.
+              config = {
+                _args = [
+                  {
+                    animations = {
+                      enabled = true;
+                    };
+                  }
+                ];
               };
               # per-leaf animation definitions; top-level list (not nested
               # under `animations`), one `hl.animation(...)` call per entry.

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -434,28 +434,36 @@ in
                     submap_universal = true;
                   }
                 )
-                # Motions
+                # Motions — direction values use the full word form
+                # (`"left"`/`"right"`/`"up"`/`"down"`) per the upstream
+                # example at /share/hypr/hyprland.lua, not the hyprlang
+                # single-letter shorthand (`l`/`r`/`u`/`d`).
                 # focus window
-                (mkBind "SUPER + h" ''hl.dsp.focus({ direction = "l" })'')
-                (mkBind "SUPER + j" ''hl.dsp.focus({ direction = "d" })'')
-                (mkBind "SUPER + k" ''hl.dsp.focus({ direction = "u" })'')
-                (mkBind "SUPER + l" ''hl.dsp.focus({ direction = "r" })'')
+                (mkBind "SUPER + h" ''hl.dsp.focus({ direction = "left" })'')
+                (mkBind "SUPER + j" ''hl.dsp.focus({ direction = "down" })'')
+                (mkBind "SUPER + k" ''hl.dsp.focus({ direction = "up" })'')
+                (mkBind "SUPER + l" ''hl.dsp.focus({ direction = "right" })'')
                 # move window
-                (mkBind "SUPER + SHIFT + H" ''hl.dsp.window.move({ direction = "l" })'')
-                (mkBind "SUPER + SHIFT + J" ''hl.dsp.window.move({ direction = "d" })'')
-                (mkBind "SUPER + SHIFT + K" ''hl.dsp.window.move({ direction = "u" })'')
-                (mkBind "SUPER + SHIFT + L" ''hl.dsp.window.move({ direction = "r" })'')
-                # switch workspace
-                (mkBind "SUPER + 1" "hl.dsp.workspace(1)")
-                (mkBind "SUPER + 2" "hl.dsp.workspace(2)")
-                (mkBind "SUPER + 3" "hl.dsp.workspace(3)")
-                (mkBind "SUPER + 4" "hl.dsp.workspace(4)")
-                (mkBind "SUPER + 5" "hl.dsp.workspace(5)")
-                (mkBind "SUPER + 6" "hl.dsp.workspace(6)")
-                (mkBind "SUPER + 7" "hl.dsp.workspace(7)")
-                (mkBind "SUPER + 8" "hl.dsp.workspace(8)")
-                (mkBind "SUPER + 9" "hl.dsp.workspace(9)")
-                (mkBind "SUPER + TAB" ''hl.dsp.workspace("previous")'')
+                (mkBind "SUPER + SHIFT + H" ''hl.dsp.window.move({ direction = "left" })'')
+                (mkBind "SUPER + SHIFT + J" ''hl.dsp.window.move({ direction = "down" })'')
+                (mkBind "SUPER + SHIFT + K" ''hl.dsp.window.move({ direction = "up" })'')
+                (mkBind "SUPER + SHIFT + L" ''hl.dsp.window.move({ direction = "right" })'')
+                # switch workspace. `hl.dsp.workspace` is a namespace TABLE
+                # (holding `toggle_special`, `move`, `swap_monitors`,
+                # `rename`) — not a callable dispatcher. The actual
+                # workspace-switch dispatcher is `hl.dsp.focus({ workspace =
+                # N })`, per the upstream example at
+                # /share/hypr/hyprland.lua lines 277-280.
+                (mkBind "SUPER + 1" "hl.dsp.focus({ workspace = 1 })")
+                (mkBind "SUPER + 2" "hl.dsp.focus({ workspace = 2 })")
+                (mkBind "SUPER + 3" "hl.dsp.focus({ workspace = 3 })")
+                (mkBind "SUPER + 4" "hl.dsp.focus({ workspace = 4 })")
+                (mkBind "SUPER + 5" "hl.dsp.focus({ workspace = 5 })")
+                (mkBind "SUPER + 6" "hl.dsp.focus({ workspace = 6 })")
+                (mkBind "SUPER + 7" "hl.dsp.focus({ workspace = 7 })")
+                (mkBind "SUPER + 8" "hl.dsp.focus({ workspace = 8 })")
+                (mkBind "SUPER + 9" "hl.dsp.focus({ workspace = 9 })")
+                (mkBind "SUPER + TAB" ''hl.dsp.focus({ workspace = "previous" })'')
                 # move active window to workspace (silent — no follow)
                 (mkBind "SUPER + SHIFT + 1" "hl.dsp.window.move({ workspace = 1, silent = true })")
                 (mkBind "SUPER + SHIFT + 2" "hl.dsp.window.move({ workspace = 2, silent = true })")
@@ -471,9 +479,10 @@ in
                 # special workspace
                 (mkBind "SUPER + X" ''hl.dsp.workspace.toggle_special("magic")'')
                 (mkBind "SUPER + SHIFT + X" ''hl.dsp.window.move({ workspace = "special:magic", silent = true })'')
-                # scroll through existing workspaces
-                (mkBind "SUPER + mouse_down" ''hl.dsp.workspace("e+1")'')
-                (mkBind "SUPER + mouse_up" ''hl.dsp.workspace("e-1")'')
+                # scroll through existing workspaces (same dispatcher-rename
+                # as the numbered switches above).
+                (mkBind "SUPER + mouse_down" ''hl.dsp.focus({ workspace = "e+1" })'')
+                (mkBind "SUPER + mouse_up" ''hl.dsp.focus({ workspace = "e-1" })'')
                 # window shortcuts
                 (mkBind "SUPER + q" "hl.dsp.window.close()")
                 (mkExec "SUPER + SHIFT + C" "hyprctl reload")

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -196,11 +196,17 @@ in
                       # don't show update notifications each boot
                       no_update_news = true;
                     };
-                    # animations master switch (per-leaf `enabled` still set
-                    # on each entry of the top-level `animation` list below).
-                    animations = {
-                      enabled = true;
-                    };
+                    # NB: the animations master switch (`animations.enabled`)
+                    # is intentionally NOT set here. Including it in
+                    # `hl.config({...})` re-initialises the animation
+                    # manager *after* the `hl.curve(...)` / `hl.animation(...)`
+                    # calls have already run (config renders after both,
+                    # alphabetically), which clobbers each leaf's `bezier`
+                    # reference back to the engine default and visibly drops
+                    # the snappy `myBezier` curve we define above. Animations
+                    # default to enabled in Hyprland, and the per-leaf
+                    # `enabled = true` on each `hl.animation(...)` entry
+                    # below is sufficient.
                   }
                 ];
               };
@@ -275,11 +281,14 @@ in
                   leaf = "border";
                   enabled = true;
                   speed = 2;
-                  # hyprlang implicitly provided a `default` bezier; the lua
-                  # API doesn't — referencing an undefined curve here drops
-                  # Hyprland into a safe state with no keybinds at startup.
-                  # Fall back to the `linear` curve we define explicitly.
-                  bezier = "linear";
+                  # The original hyprlang config used `default` here, which
+                  # hyprlang implicitly defined as a snappy ease-out (closer
+                  # in feel to `myBezier`). The lua API has no implicit
+                  # `default` curve — referencing an undefined name drops
+                  # Hyprland into a safe state with no keybinds at startup
+                  # — so we use `myBezier` explicitly, which matches the
+                  # original perceived snappiness better than `linear`.
+                  bezier = "myBezier";
                 }
                 {
                   leaf = "borderangle";
@@ -292,7 +301,10 @@ in
                   leaf = "fade";
                   enabled = true;
                   speed = 2;
-                  bezier = "linear";
+                  # Same reasoning as `border` above — original was `default`,
+                  # which felt much snappier than `linear`. `linear` here
+                  # is what caused the sluggish floating-window fade-in.
+                  bezier = "myBezier";
                 }
                 {
                   leaf = "workspaces";
@@ -360,40 +372,31 @@ in
                 }
               ];
               # ---- startup hook ----------------------------------------------
-              # Replaces hyprlang `exec-once` and `exec`. `hl.on("hyprland.start", ...)`
-              # is the lua-idiomatic equivalent: run these commands once at
-              # session start. We fold both lists into one hook (`exec`'s
-              # per-reload semantics aren't relied on by anything here — both
-              # entries are idempotent restart-style commands).
+              # Replaces hyprlang `exec-once`. `hl.on("hyprland.start", ...)`
+              # fires once when the compositor starts and runs each
+              # registered command via `hl.exec_cmd`. (The lua API also
+              # exposes a separate `config.reloaded` event for the
+              # per-reload `exec` equivalent — we don't currently use it,
+              # so no second handler is registered.)
               #
-              # `lib.mkIf <false> { ... }` entries are stripped by the module
-              # system before they reach the renderer, so the function body
-              # only contains the actually-active commands per machine.
               # `lib.optional <bool> <x>` evaluates to `[ <x> ]` or `[]` —
               # cleaner than `lib.mkIf` here because we're building a plain
               # list in let-scope, not contributing to an option, so the
               # module system's `mkIf`-stripping pass never runs.
               on =
                 let
-                  startupCmds =
+                  startCmds =
                     lib.optional config.nx.desktop.wallpaper.enable "swaybg -i ${homeDir}/.config/wallpaper-${config.nx.desktop.wallpaper.resolution}.png --mode fill"
                     ++ [
                       "hypridle"
                     ]
                     ++ lib.optional (config.nx.isLaptop == false) "steam -silent -no-cef-sandbox"
-                    ++ [
-                      "${scriptsDir}/game.inputRemapper.defaults"
-                    ]
                     # default to 70% brightness on laptops
                     ++ lib.optional config.nx.isLaptop "${pkgs.brightnessctl}/bin/brightnessctl s 70%"
                     # default to keyboard backlight off on laptops
                     ++ lib.optional config.nx.isLaptop "${pkgs.brightnessctl}/bin/brightnessctl --device='asus::kbd_backlight' set 0"
                     ++ [
                       "${scriptsDir}/cli.hyprland.switchWorkspaceOnWindowClose"
-                      "waybar"
-                      # ex-`exec` entries (now also once-per-session):
-                      "pkill waybar && hyprctl dispatch exec waybar"
-                      "${scriptsDir}/cli.system.setHyprGaps"
                     ];
                 in
                 {
@@ -401,7 +404,7 @@ in
                     "hyprland.start"
                     (mkLuaInline ''
                       function()
-                      ${lib.concatMapStringsSep "\n" (cmd: "  hl.exec_cmd(${lib.generators.toLua { } cmd})") startupCmds}
+                      ${lib.concatMapStringsSep "\n" (cmd: "  hl.exec_cmd(${lib.generators.toLua { } cmd})") startCmds}
                       end
                     '')
                   ];
@@ -410,6 +413,22 @@ in
               # The main module contributes nothing; per-app rules merge in
               # from gaming/, programs/qutebrowser/, etc. via list-merge.
               window_rule = [ ];
+              # ---- workspace rules (lua name: workspace_rule, underscore) ----
+              # Each entry renders as one `hl.workspace_rule({...})` call,
+              # matching the upstream-shipped example at
+              # /share/hypr/hyprland.lua. Per-host overrides (e.g. wide outer
+              # margins on the ultrawide monitor in machines/navi) merge in
+              # via list-merge.
+              #
+              # Lua-native replacement for the previous shell script
+              # `cli.system.setHyprGaps`, which used `hyprctl keyword
+              # workspace ...` at session start to install these rules
+              # imperatively. That approach was incompatible with the lua
+              # parser — `hyprctl keyword` refuses to run against a
+              # non-legacy parser ("keyword can't work with non-legacy
+              # parsers. Use eval.") — so the rules now live declaratively
+              # in the config itself.
+              workspace_rule = [ ];
               # ---- binds -----------------------------------------------------
               # In lua, `bind` / `bindl` / `bindrt` / `bindm` collapse into a
               # single `hl.bind(keys, dispatcher, flags?)` call; flag tables
@@ -420,20 +439,29 @@ in
               # XF86AudioPlay"). The format matches the canonical example
               # config shipped at /share/hypr/hyprland.lua.
               bind = [
-                # show waybar + quickshell widgets on SUPER_L keydown
-                (mkExec "SUPER_L" "pkill -SIGUSR1 waybar; hyprctl dispatch event quickshell:show")
-                # hide waybar + quickshell widgets on SUPER_L keyup. Single
+                # show quickshell widgets on SUPER_L keydown. We're in lua
+                # already, so call `hl.dsp.event(...)` directly rather
+                # than shelling out via `hl.dsp.exec_cmd("hyprctl dispatch
+                # ...")` — same effect, no fork, no parser round-trip.
+                #
+                # Modifier state for SUPER_L (the left Super key itself):
+                # at keydown the modifier isn't held yet from hyprland's
+                # perspective, so the bind matches no-mod + `SUPER_L`.
+                # At keyup the modifier IS held (briefly, by release
+                # physics), so the release-firing hide bind needs the
+                # `SUPER + SUPER_L` form to match. This split mirrors the
+                # original hyprlang config (`, SUPER_L, ...` for show /
+                # `SUPER, SUPER_L, ...` for hide).
+                (mkBind "SUPER_L" ''hl.dsp.event("quickshell:show")'')
+                # hide quickshell widgets on SUPER_L keyup. Single
                 # top-level entry with `submap_universal = true` replaces the
                 # previous three copies (top-level + inside `resize` + inside
                 # `exit` submap) — see docs section 8.5.
-                (mkBindFlags "SUPER_L"
-                  ''hl.dsp.exec_cmd("pkill -SIGUSR2 waybar; hyprctl dispatch event quickshell:hide")''
-                  {
-                    release = true;
-                    transparent = true;
-                    submap_universal = true;
-                  }
-                )
+                (mkBindFlags "SUPER + SUPER_L" ''hl.dsp.event("quickshell:hide")'' {
+                  release = true;
+                  transparent = true;
+                  submap_universal = true;
+                })
                 # Motions — direction values use the full word form
                 # (`"left"`/`"right"`/`"up"`/`"down"`) per the upstream
                 # example at /share/hypr/hyprland.lua, not the hyprlang

--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -95,94 +95,114 @@ in
             # See docs/hyprland-lua-migration.md for the design.
             configType = "lua";
             settings = {
-              # ---- general ----------------------------------------------------
-              general = {
-                gaps_in = 5;
-                gaps_out = 5;
-                border_size = 3;
-                # Gradient borders use the structured table form under lua
-                # (`{ colors = { ... }, angle = 45 }`); the legacy
-                # whitespace-separated string + "45deg" suffix isn't accepted
-                # by the lua `hl.config` API — the upstream example config
-                # ships exclusively in the table form (see
-                # /share/hypr/hyprland.lua bundled with hyprland).
-                col = {
-                  active_border =
-                    let
-                      # rainbow border colors in order
-                      colors = with theme; [
-                        red
-                        orange
-                        yellow
-                        green
-                        aqua
-                        blue
-                        purple
-                      ];
-                      toRgba = color: "rgba(${builtins.substring 1 6 color}ff)";
-                    in
-                    {
-                      colors = map toRgba colors;
-                      angle = 45;
+              # ---- section settings via hl.config({...}) ---------------------
+              # The lua API only exposes a discrete set of top-level functions
+              # (`hl.bind`, `hl.monitor`, `hl.device`, `hl.curve`,
+              # `hl.animation`, `hl.window_rule`, `hl.env`, `hl.on`, etc.).
+              # "Section" settings — `general`, `input`, `decoration`,
+              # `dwindle`, `misc`, `cursor`, `debug`, `ecosystem`,
+              # `animations` (master switch), etc. — are NOT individual
+              # functions; setting them at the top level of `settings` would
+              # render as `hl.general(...)`, `hl.input(...)`, etc. and crash
+              # Hyprland with "attempt to call a nil value" at startup.
+              #
+              # All section settings must instead be passed inside a single
+              # `hl.config({...})` call. We emit that explicitly via the
+              # `_args` shape. Reference: the HM lua-config test fixture at
+              # nixpkgs/.../tests/modules/services/hyprland/lua-config.nix
+              # nests every section under `settings.config = {...}`, and the
+              # upstream-shipped example at /share/hypr/hyprland.lua does the
+              # same.
+              config = {
+                _args = [
+                  {
+                    general = {
+                      gaps_in = 5;
+                      gaps_out = 5;
+                      border_size = 3;
+                      # Gradient borders use the structured table form under
+                      # lua (`{ colors = { ... }, angle = 45 }`); the legacy
+                      # whitespace-separated string + "45deg" suffix isn't
+                      # accepted by the lua `hl.config` API — the upstream
+                      # example ships exclusively in the table form.
+                      col = {
+                        active_border =
+                          let
+                            # rainbow border colors in order
+                            colors = with theme; [
+                              red
+                              orange
+                              yellow
+                              green
+                              aqua
+                              blue
+                              purple
+                            ];
+                            toRgba = color: "rgba(${builtins.substring 1 6 color}ff)";
+                          in
+                          {
+                            colors = map toRgba colors;
+                            angle = 45;
+                          };
+                        inactive_border = "rgba(${builtins.substring 1 6 (theme.bg2)}ff)";
+                      };
+                      layout = "dwindle";
                     };
-                  inactive_border = "rgba(${builtins.substring 1 6 (theme.bg2)}ff)";
-                };
-                layout = "dwindle";
-              };
-              # ---- input -----------------------------------------------------
-              input = {
-                # Te Reo Macrons
-                kb_layout = "nz";
-                kb_variant = "mao";
-                kb_options = "lv3:rwin_switch";
-                # keyrepeat settings (lua wants ints, not strings)
-                repeat_delay = 225;
-                repeat_rate = 60;
-                follow_mouse = 2;
-                sensitivity = -0.8;
-                touchpad = {
-                  # feels right for a touchpad
-                  natural_scroll = true;
-                };
-              };
-              # ---- decoration ------------------------------------------------
-              decoration = {
-                rounding = 5;
-                blur.enabled = true;
-                shadow = {
-                  enabled = false;
-                };
-              };
-              # ---- dwindle ---------------------------------------------------
-              dwindle = {
-                # lua wants bool, not "yes"/"no"
-                preserve_split = true;
-                force_split = 2;
-              };
-              # ---- misc ------------------------------------------------------
-              misc = {
-                disable_hyprland_logo = true;
-                disable_splash_rendering = true;
-                vrr = 1;
-                # when opening another program from terminal, swallow the terminal
-                enable_swallow = false;
-                swallow_regex = "^(kitty|lf)$";
-                swallow_exception_regex = "^(wev)$";
-                # suppress start-hyprland warning when not using the watchdog wrapper
-                disable_watchdog_warning = true;
-              };
-              # ---- cursor ----------------------------------------------------
-              cursor = {
-                inactive_timeout = 5;
-              };
-              # ---- debug -----------------------------------------------------
-              debug = {
-                disable_logs = false;
-              };
-              # ---- ecosystem -------------------------------------------------
-              ecosystem = {
-                # don't show update notifications each boot
-                no_update_news = true;
+                    input = {
+                      # Te Reo Macrons
+                      kb_layout = "nz";
+                      kb_variant = "mao";
+                      kb_options = "lv3:rwin_switch";
+                      # keyrepeat settings (lua wants ints, not strings)
+                      repeat_delay = 225;
+                      repeat_rate = 60;
+                      follow_mouse = 2;
+                      sensitivity = -0.8;
+                      touchpad = {
+                        # feels right for a touchpad
+                        natural_scroll = true;
+                      };
+                    };
+                    decoration = {
+                      rounding = 5;
+                      blur.enabled = true;
+                      shadow = {
+                        enabled = false;
+                      };
+                    };
+                    dwindle = {
+                      # lua wants bool, not "yes"/"no"
+                      preserve_split = true;
+                      force_split = 2;
+                    };
+                    misc = {
+                      disable_hyprland_logo = true;
+                      disable_splash_rendering = true;
+                      vrr = 1;
+                      # when opening another program from terminal, swallow it
+                      enable_swallow = false;
+                      swallow_regex = "^(kitty|lf)$";
+                      swallow_exception_regex = "^(wev)$";
+                      # suppress start-hyprland warning when not using the watchdog wrapper
+                      disable_watchdog_warning = true;
+                    };
+                    cursor = {
+                      inactive_timeout = 5;
+                    };
+                    debug = {
+                      disable_logs = false;
+                    };
+                    ecosystem = {
+                      # don't show update notifications each boot
+                      no_update_news = true;
+                    };
+                    # animations master switch (per-leaf `enabled` still set
+                    # on each entry of the top-level `animation` list below).
+                    animations = {
+                      enabled = true;
+                    };
+                  }
+                ];
               };
               # ---- curves (bezier renamed in lua) ----------------------------
               # `curve` is in importantPrefixes so renders before `animation`.
@@ -224,26 +244,6 @@ in
                   ];
                 }
               ];
-              # ---- animations master switch ----------------------------------
-              # The lua API exposes `hl.animation(...)` (singular, per-leaf)
-              # but NOT `hl.animations(...)` — a standalone
-              # `animations = { enabled = true; }` setting would render as
-              # `hl.animations({ enabled = true })` and fail at startup with
-              # "attempt to call a nil value (field 'animations')".
-              #
-              # The master switch is set via `hl.config({ animations = {
-              # enabled = true } })` instead, matching the upstream-shipped
-              # example at /share/hypr/hyprland.lua. We invoke `hl.config`
-              # explicitly via the `_args` shape.
-              config = {
-                _args = [
-                  {
-                    animations = {
-                      enabled = true;
-                    };
-                  }
-                ];
-              };
               # per-leaf animation definitions; top-level list (not nested
               # under `animations`), one `hl.animation(...)` call per entry.
               # The curve-reference field is named `bezier` (matching the

--- a/modules/desktop/hyprland/idle.nix
+++ b/modules/desktop/hyprland/idle.nix
@@ -54,22 +54,35 @@
           enable = true;
           settings = {
             general = {
-              lock_cmd = "hyprctl dispatch exec hyprlock";
+              # `hyprctl dispatch` under the lua parser evaluates args as
+              # lua source, so legacy `exec hyprlock` fails to parse.
+              # Pass the lua-call form instead, matching the pattern in
+              # the upstream-shipped example at /share/hypr/hyprland.lua
+              # (line ~260): `hyprctl dispatch 'hl.dsp.exit()'`.
+              lock_cmd = ''hyprctl dispatch 'hl.dsp.exec_cmd("hyprlock")' '';
             };
             listener = [
               (lib.mkIf lockCfg.enable {
                 timeout = lockCfg.duration;
-                on-timeout = "hyprctl dispatch exec hyprlock";
+                on-timeout = ''hyprctl dispatch 'hl.dsp.exec_cmd("hyprlock")' '';
               })
               (lib.mkIf screenCfg.enable {
                 timeout = screenCfg.duration;
+                # KNOWN BROKEN UNDER LUA: `hyprctl dispatch dpms off|on`
+                # fails to parse under the lua dispatch wrapper. The
+                # lua-call form `hl.dsp.dpms(...)` is the likely
+                # replacement but the exact arg shape needs to be
+                # verified against hyprland source — testing live risks
+                # leaving the display in DPMS-off with no recovery path,
+                # so this is deferred to a follow-up. For now,
+                # screen-off-on-idle is silently broken.
                 on-timeout = "hyprctl dispatch dpms off";
                 on-resume = "hyprctl dispatch dpms on";
               })
               (lib.mkIf suspendCfg.enable {
                 timeout = suspendCfg.duration;
                 on-timeout = "systemctl suspend";
-                on-resume = "hyprctl dispatch exec hyprlock";
+                on-resume = ''hyprctl dispatch 'hl.dsp.exec_cmd("hyprlock")' '';
               })
             ];
           };

--- a/modules/desktop/hyprland/scripts.nix
+++ b/modules/desktop/hyprland/scripts.nix
@@ -8,33 +8,16 @@
   config = lib.mkIf (config.nx.desktop.hyprland.enable && pkgs.stdenv.isLinux) {
     home-manager.users.${config.nx.username} = {
       home.sessionPath = [ "$HOME/.local/scripts" ];
-      home.file.".local/scripts/cli.system.setHyprGaps" = {
-        executable = true;
-        text =
-          # bash
-          ''
-            #!/bin/sh
-            # Get monitor width with error handling
-            width=$(hyprctl monitors -j 2>/dev/null | jq -r '.[0].width // empty' 2>/dev/null)
-
-            # Check if we got a valid width
-            if [ -z "$width" ] || [ "$width" = "null" ]; then
-              echo "Error: Could not get monitor width" >&2
-              exit 1
-            fi
-
-            # Check if running in super-ultrawide
-            if [ "$width" -gt 5000 ]; then
-              hyprctl keyword workspace "w[t1], gapsout:5 $((width / 4))" || echo "Warning: Failed to set workspace gaps" >&2
-              hyprctl keyword workspace "s[true], gapsout:50 $((width / 4))" || echo "Warning: Failed to set workspace gaps" >&2
-            else
-              # unsetting is not possible, for now set to default
-              # https://github.com/hyprwm/Hyprland/issues/5691
-              hyprctl keyword workspace "w[t1], gapsout:5 5" || echo "Warning: Failed to set workspace gaps" >&2
-              hyprctl keyword workspace "s[true], gapsout:50 50" || echo "Warning: Failed to set workspace gaps" >&2
-            fi
-          '';
-      };
+      # NOTE: `cli.system.setHyprGaps` previously lived here and ran on
+      # session start to install workspace gap rules via `hyprctl keyword
+      # workspace ...`. Under the lua parser that command fails with
+      # "keyword can't work with non-legacy parsers. Use eval." — so the
+      # rules now live declaratively in the hyprland module instead:
+      #   - module:  modules/desktop/hyprland/default.nix (workspace_rule
+      #              extension point)
+      #   - per-host overrides (e.g. the ultrawide on navi):
+      #              machines/navi/configuration.nix
+      # See the matching comment block in default.nix near `workspace_rule`.
       home.file.".local/scripts/system.inputs.toggleTouchpad" = lib.mkIf config.nx.isLaptop {
         executable = true;
         text =
@@ -43,22 +26,28 @@
             #!/bin/sh
             export STATUS_FILE="$XDG_RUNTIME_DIR/touchpad_status"
 
+            # NOTE: `hyprctl keyword` is broken under the lua parser
+            # ("keyword can't work with non-legacy parsers. Use eval."),
+            # so the device-enable/disable lines below silently no-op.
+            # The OSD events still fire via the lua-compatible
+            # `hl.dsp.event(...)` form. Touchpad enable/disable itself is
+            # tracked as a separate follow-up.
             if ! [ -f "$STATUS_FILE" ]; then
               # disable touchpad
               hyprctl keyword 'device[asup1415:00-093a:300c-touchpad]:enabled' false > /dev/null
               touch "$STATUS_FILE"
               echo "disabled" > "$STATUS_FILE"
-              hyprctl dispatch event "quickshell:osd:touchpad:off" > /dev/null
+              hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:off")' > /dev/null
             elif [ "$(cat $STATUS_FILE)" = "enabled" ]; then
               # disable touchpad
               hyprctl keyword 'device[asup1415:00-093a:300c-touchpad]:enabled' false > /dev/null
               echo "disabled" > "$STATUS_FILE"
-              hyprctl dispatch event "quickshell:osd:touchpad:off" > /dev/null
+              hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:off")' > /dev/null
             elif [ "$(cat $STATUS_FILE)" = "disabled" ]; then
               # enable touchpad
               hyprctl keyword 'device[asup1415:00-093a:300c-touchpad]:enabled' true > /dev/null
               echo "enabled" > "$STATUS_FILE"
-              hyprctl dispatch event "quickshell:osd:touchpad:on" > /dev/null
+              hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:on")' > /dev/null
             fi
           '';
       };
@@ -75,7 +64,7 @@
             volume=$(wpctl get-volume @DEFAULT_AUDIO_SINK@ | awk '{print int($2 * 100)}')
 
             # Fire OSD event
-            hyprctl dispatch event "quickshell:osd:volume:''${volume}" > /dev/null
+            hyprctl dispatch 'hl.dsp.event("quickshell:osd:volume:'"''${volume}"'")' > /dev/null
           '';
       };
       home.file.".local/scripts/system.audio.volumeDown" = {
@@ -91,7 +80,7 @@
             volume=$(wpctl get-volume @DEFAULT_AUDIO_SINK@ | awk '{print int($2 * 100)}')
 
             # Fire OSD event
-            hyprctl dispatch event "quickshell:osd:volume:''${volume}" > /dev/null
+            hyprctl dispatch 'hl.dsp.event("quickshell:osd:volume:'"''${volume}"'")' > /dev/null
           '';
       };
       home.file.".local/scripts/system.audio.toggleMute" = {
@@ -108,10 +97,10 @@
 
             # Fire OSD event
             if echo "$mute_status" | grep -q "MUTED"; then
-              hyprctl dispatch event "quickshell:osd:volume:muted" > /dev/null
+              hyprctl dispatch 'hl.dsp.event("quickshell:osd:volume:muted")' > /dev/null
             else
               volume=$(echo "$mute_status" | awk '{print int($2 * 100)}')
-              hyprctl dispatch event "quickshell:osd:volume:''${volume}" > /dev/null
+              hyprctl dispatch 'hl.dsp.event("quickshell:osd:volume:'"''${volume}"'")' > /dev/null
             fi
           '';
       };
@@ -130,7 +119,7 @@
             brightness_percent=$(( brightness * 100 / max_brightness ))
 
             # Fire OSD event
-            hyprctl dispatch event "quickshell:osd:brightness:''${brightness_percent}" > /dev/null
+            hyprctl dispatch 'hl.dsp.event("quickshell:osd:brightness:'"''${brightness_percent}"'")' > /dev/null
           '';
       };
       home.file.".local/scripts/system.display.brightnessDown" = lib.mkIf config.nx.isLaptop {
@@ -148,7 +137,7 @@
             brightness_percent=$(( brightness * 100 / max_brightness ))
 
             # Fire OSD event
-            hyprctl dispatch event "quickshell:osd:brightness:''${brightness_percent}" > /dev/null
+            hyprctl dispatch 'hl.dsp.event("quickshell:osd:brightness:'"''${brightness_percent}"'")' > /dev/null
           '';
       };
       home.file.".local/scripts/cli.system.batteryStatus" = lib.mkIf config.nx.isLaptop {
@@ -228,7 +217,14 @@
                   if [[ "$windows_count" -eq 0 ]]; then
                     echo "$windows_count"
                     echo "Empty workspace detected"
-                    hyprctl dispatch workspace m-1 || echo "Warning: Failed to switch workspace" >&2
+                    # Under the lua parser, hyprctl dispatch evaluates its
+                    # args as lua source, so the legacy `workspace m-1`
+                    # shorthand fails to parse. We pass the dispatcher as
+                    # an explicit `hl.dsp.focus(...)` call instead, using
+                    # the "previous" workspace selector (last-focused) —
+                    # semantically equivalent to the original intent and
+                    # independent of workspace numbering / monitor layout.
+                    hyprctl dispatch 'hl.dsp.focus({ workspace = "previous" })' || echo "Warning: Failed to switch workspace" >&2
                   fi
                 fi
               fi
@@ -266,7 +262,7 @@
 
             # Start hyprlock if not already running
             if ! pgrep -x hyprlock > /dev/null; then
-              hyprctl dispatch exec hyprlock
+              hyprctl dispatch 'hl.dsp.exec_cmd("hyprlock")'
 
               # Wait for hyprlock to actually start (check for process)
               for i in {1..20}; do
@@ -316,7 +312,7 @@
 
                 systemd-inhibit --what=idle --why="Preventing idle for a task" sleep infinity &
                 echo $! > "$LOCKFILE"
-                hyprctl dispatch event quickshell:inhibit-on >/dev/null 2>&1 || true
+                hyprctl dispatch 'hl.dsp.event("quickshell:inhibit-on")' >/dev/null 2>&1 || true
             }
 
             stop_inhibit() {
@@ -332,7 +328,7 @@
                     fi
                     rm -f "$LOCKFILE"
                 fi
-                hyprctl dispatch event quickshell:inhibit-off >/dev/null 2>&1 || true
+                hyprctl dispatch 'hl.dsp.event("quickshell:inhibit-off")' >/dev/null 2>&1 || true
             }
 
             status_inhibit() {

--- a/modules/desktop/screenshot.nix
+++ b/modules/desktop/screenshot.nix
@@ -57,7 +57,12 @@ in
             };
           # shortcuts for hyprland
           hyprland.settings.bind = [
-            "SUPER SHIFT, S, exec, ${screenshotToClipboard}"
+            {
+              _args = [
+                "SUPER + SHIFT + S"
+                (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("${screenshotToClipboard}")'')
+              ];
+            }
           ];
         };
     };

--- a/modules/gaming/prismlauncher.nix
+++ b/modules/gaming/prismlauncher.nix
@@ -33,8 +33,11 @@
           wayland.windowManager.hyprland.settings =
             lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
               {
-                windowrule = [
-                  "tile on, match:class PrismLauncher"
+                window_rule = [
+                  {
+                    match.class = "PrismLauncher";
+                    tile = true;
+                  }
                 ];
               };
         };

--- a/modules/gaming/steam.nix
+++ b/modules/gaming/steam.nix
@@ -49,9 +49,12 @@
           wayland.windowManager.hyprland.settings =
             lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
               {
-                windowrule = [
+                window_rule = [
                   # fake fullscreen, good store videos
-                  "sync_fullscreen 0, match:class steam"
+                  {
+                    match.class = "steam";
+                    sync_fullscreen = false;
+                  }
                 ];
               };
         };

--- a/modules/programs/chromium.nix
+++ b/modules/programs/chromium.nix
@@ -41,9 +41,12 @@
       wayland.windowManager.hyprland.settings =
         lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
           {
-            windowrule = [
+            window_rule = [
               # sometimes chromium thinks its fine to open in a tiny window
-              "tile on, match:class Chromium-browser"
+              {
+                match.class = "Chromium-browser";
+                tile = true;
+              }
             ];
           };
     };

--- a/modules/programs/darktable.nix
+++ b/modules/programs/darktable.nix
@@ -23,11 +23,17 @@
       wayland.windowManager.hyprland.settings =
         lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
           {
-            windowrule = [
+            window_rule = [
               # darktable splash screen
-              "float on, match:title darktable starting"
+              {
+                match.title = "darktable starting";
+                float = true;
+              }
               # prevent darktable from maximising on start
-              "suppress_event fullscreen, match:class darktable"
+              {
+                match.class = "darktable";
+                suppress_event = "fullscreen";
+              }
             ];
           };
     };

--- a/modules/programs/discord.nix
+++ b/modules/programs/discord.nix
@@ -24,9 +24,12 @@
       wayland.windowManager.hyprland.settings =
         lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
           {
-            windowrule = [
+            window_rule = [
               # silently open on workspace 2
-              "workspace 2 silent, match:class discord"
+              {
+                match.class = "discord";
+                workspace = "2 silent";
+              }
             ];
           };
     };

--- a/modules/programs/home-automation.nix
+++ b/modules/programs/home-automation.nix
@@ -189,11 +189,17 @@ in
                     pagedown = "Next";
                     homeDir = config.home-manager.users.${username}.home.homeDirectory;
                     newwindow = config.nx.programs.defaultWebBrowserSettings.newWindowCmd;
+                    mkExec = keys: cmd: {
+                      _args = [
+                        keys
+                        (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("${cmd}")'')
+                      ];
+                    };
                   in
                   [
-                    "SUPER, ${pageup}, exec, ${homeDir}/.local/scripts/home.office.openBlinds"
-                    "SUPER, ${pagedown}, exec, ${homeDir}/.local/scripts/home.office.closeBlinds"
-                    "ALT, h, exec, ${newwindow} https://$HASS_DOMAIN"
+                    (mkExec "SUPER + ${pageup}" "${homeDir}/.local/scripts/home.office.openBlinds")
+                    (mkExec "SUPER + ${pagedown}" "${homeDir}/.local/scripts/home.office.closeBlinds")
+                    (mkExec "ALT + h" "${newwindow} https://$HASS_DOMAIN")
                   ];
               };
           # This script turns off the grow lights

--- a/modules/programs/libreoffice.nix
+++ b/modules/programs/libreoffice.nix
@@ -32,9 +32,12 @@ in
       wayland.windowManager.hyprland.settings =
         lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
           {
-            windowrule = [
+            window_rule = [
               # prevent libreoffice-writer from fullscreening
-              "sync_fullscreen 0, match:class libreoffice-writer"
+              {
+                match.class = "libreoffice-writer";
+                sync_fullscreen = false;
+              }
             ];
           };
     };

--- a/modules/programs/qutebrowser/default.nix
+++ b/modules/programs/qutebrowser/default.nix
@@ -477,16 +477,37 @@
           wayland.windowManager.hyprland.settings =
             lib.mkIf (config.home-manager.users.${config.nx.username}.wayland.windowManager.hyprland.enable)
               {
-                windowrule = [
+                window_rule = [
                   # floating filepickers and editors
-                  "float on, match:class qute-filepicker"
-                  "size 800 480, match:class qute-filepicker"
-                  "stay_focused on, match:class qute-filepicker"
-                  "float on, match:class qute-editor"
-                  "size 800 480, match:class qute-editor"
-                  "stay_focused on, match:class qute-editor"
+                  {
+                    match.class = "qute-filepicker";
+                    float = true;
+                  }
+                  {
+                    match.class = "qute-filepicker";
+                    size = "800 480";
+                  }
+                  {
+                    match.class = "qute-filepicker";
+                    stay_focused = true;
+                  }
+                  {
+                    match.class = "qute-editor";
+                    float = true;
+                  }
+                  {
+                    match.class = "qute-editor";
+                    size = "800 480";
+                  }
+                  {
+                    match.class = "qute-editor";
+                    stay_focused = true;
+                  }
                   # fake fullscreen, good for youtube etc
-                  "sync_fullscreen 0, match:class org.qutebrowser.qutebrowser"
+                  {
+                    match.class = "org.qutebrowser.qutebrowser";
+                    sync_fullscreen = false;
+                  }
                 ];
               };
         };

--- a/modules/programs/voice-to-text-daemon.nix
+++ b/modules/programs/voice-to-text-daemon.nix
@@ -433,8 +433,12 @@ in
 
       keybind = lib.mkOption {
         type = lib.types.str;
-        default = "SUPER, V";
-        description = "Keybind for toggle voice recording (hold to talk, release to transcribe)";
+        default = "SUPER + V";
+        description = ''
+          Keybind for toggle voice recording (hold to talk, release to
+          transcribe). Format follows Hyprland's lua-API `hl.bind` keys
+          string (mods + key joined with ` + `).
+        '';
       };
 
       notificationSound = lib.mkOption {
@@ -490,8 +494,18 @@ in
 
       # Hyprland keybinding
       wayland.windowManager.hyprland.settings.bind = [
-        "${cfg.keybind}, exec, voice-to-text toggle"
-        "${cfg.keybind} SHIFT, exec, voice-to-text cancel"
+        {
+          _args = [
+            cfg.keybind
+            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text toggle")'')
+          ];
+        }
+        {
+          _args = [
+            "${cfg.keybind} + SHIFT"
+            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text cancel")'')
+          ];
+        }
       ];
 
       # Persist configuration and cache

--- a/modules/programs/voice-to-text-daemon.nix
+++ b/modules/programs/voice-to-text-daemon.nix
@@ -492,21 +492,40 @@ in
         };
       };
 
-      # Hyprland keybinding
-      wayland.windowManager.hyprland.settings.bind = [
-        {
-          _args = [
-            cfg.keybind
-            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text toggle")'')
-          ];
-        }
-        {
-          _args = [
-            "${cfg.keybind} + SHIFT"
-            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text cancel")'')
-          ];
-        }
-      ];
+      # Hyprland keybinding.
+      #
+      # Inject SHIFT before the final key token of `cfg.keybind` for the
+      # cancel bind — `hl.bind` treats the last `+`-separated token as the
+      # key, so `"SUPER + V + SHIFT"` would bind SHIFT with mods SUPER+V
+      # (where V is not a valid mod). See voice-to-text.nix for the same
+      # treatment.
+      wayland.windowManager.hyprland.settings.bind =
+        let
+          tokens = lib.splitString " + " cfg.keybind;
+          mods = lib.init tokens;
+          key = lib.last tokens;
+          cancelKeys = lib.concatStringsSep " + " (
+            mods
+            ++ [
+              "SHIFT"
+              key
+            ]
+          );
+        in
+        [
+          {
+            _args = [
+              cfg.keybind
+              (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text toggle")'')
+            ];
+          }
+          {
+            _args = [
+              cancelKeys
+              (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text cancel")'')
+            ];
+          }
+        ];
 
       # Persist configuration and cache
       home.persistence."/persist" = {

--- a/modules/programs/voice-to-text.nix
+++ b/modules/programs/voice-to-text.nix
@@ -407,8 +407,12 @@ in
 
       keybind = lib.mkOption {
         type = lib.types.str;
-        default = "SUPER, V";
-        description = "Keybind for toggle voice recording (hold to talk, release to transcribe)";
+        default = "SUPER + V";
+        description = ''
+          Keybind for toggle voice recording (hold to talk, release to
+          transcribe). Format follows Hyprland's lua-API `hl.bind` keys
+          string (mods + key joined with ` + `).
+        '';
       };
 
       notificationSound = lib.mkOption {
@@ -440,9 +444,19 @@ in
       # Add Hyprland keybinding
       wayland.windowManager.hyprland.settings.bind = [
         # Hold to talk: press to start recording, release to transcribe
-        "${cfg.keybind}, exec, voice-to-text toggle"
+        {
+          _args = [
+            cfg.keybind
+            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text toggle")'')
+          ];
+        }
         # Cancel recording
-        "${cfg.keybind} SHIFT, exec, voice-to-text cancel"
+        {
+          _args = [
+            "${cfg.keybind} + SHIFT"
+            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text cancel")'')
+          ];
+        }
       ];
 
       # Persist configuration and model cache

--- a/modules/programs/voice-to-text.nix
+++ b/modules/programs/voice-to-text.nix
@@ -441,23 +441,44 @@ in
         pkgs.pulseaudio # for paplay notification sound
       ];
 
-      # Add Hyprland keybinding
-      wayland.windowManager.hyprland.settings.bind = [
-        # Hold to talk: press to start recording, release to transcribe
-        {
-          _args = [
-            cfg.keybind
-            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text toggle")'')
-          ];
-        }
-        # Cancel recording
-        {
-          _args = [
-            "${cfg.keybind} + SHIFT"
-            (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text cancel")'')
-          ];
-        }
-      ];
+      # Add Hyprland keybinding.
+      #
+      # The cancel-bind adds SHIFT to the user's keybind. Hyprland's lua
+      # `hl.bind` parses the last `+`-separated token of the keys string as
+      # the key and everything before it as mods — so we cannot append
+      # "+ SHIFT" after the key (`"SUPER + V + SHIFT"` would bind SHIFT as
+      # the key with mods `SUPER + V`, and V is not a valid mod). Inject
+      # SHIFT *before* the final token instead: `"SUPER + V"` →
+      # `"SUPER + SHIFT + V"`.
+      wayland.windowManager.hyprland.settings.bind =
+        let
+          tokens = lib.splitString " + " cfg.keybind;
+          mods = lib.init tokens;
+          key = lib.last tokens;
+          cancelKeys = lib.concatStringsSep " + " (
+            mods
+            ++ [
+              "SHIFT"
+              key
+            ]
+          );
+        in
+        [
+          # Hold to talk: press to start recording, release to transcribe
+          {
+            _args = [
+              cfg.keybind
+              (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text toggle")'')
+            ];
+          }
+          # Cancel recording
+          {
+            _args = [
+              cancelKeys
+              (lib.generators.mkLuaInline ''hl.dsp.exec_cmd("voice-to-text cancel")'')
+            ];
+          }
+        ];
 
       # Persist configuration and model cache
       home.persistence."/persist" = {


### PR DESCRIPTION
PR 2 of the three-PR Hyprland hyprlang → lua migration series.

Closes #1952.

## Background

- Design doc: [`docs/hyprland-lua-migration.md`](./docs/hyprland-lua-migration.md) (landed in #1950).
- PR 0 (#1949) pinned `configType = "hyprlang"` explicitly and dropped the unused `hy3` machinery. This PR flips that pin from `"hyprlang"` to `"lua"`.

## What changed

Flip `wayland.windowManager.hyprland.configType` to `"lua"` and translate every contributing module's `settings` / `extraConfig` block from string-form entries to the attrset / `_args` shape that HM's lua renderer expects. The lua renderer emits one `hl.<name>(...)` call per list element, so string-form entries no longer render as anything Hyprland's lua VM accepts — every entry must become an attrset.

**14 files** touched (matching the broad regex from design-doc section 4.18):

- `modules/desktop/hyprland/default.nix` — main module
- `machines/{navi,tui}/configuration.nix` — per-machine monitor entries
- `modules/gaming/{prismlauncher,steam}.nix` — `windowrule` → `window_rule`
- `modules/programs/{chromium,darktable,discord,libreoffice}.nix` — `windowrule` → `window_rule`
- `modules/programs/qutebrowser/default.nix` — 7 windowrules
- `modules/desktop/screenshot.nix` — bind (nested-attribute style)
- `modules/programs/home-automation.nix` — 3 binds
- `modules/programs/voice-to-text{,-daemon}.nix` — `keybind` option default changes from `"SUPER, V"` to `"SUPER + V"` (per design-doc 8.11; zero non-default overrides in the repo)

## Notable structural changes

(See design-doc sections referenced inline in the commit message for the full rationale.)

- **`bind` / `bindl` / `bindrt` / `bindm` collapse** to one `bind = [...]` list, with flag tables (`{ locked = true; }`, `{ release = true; transparent = true; }`, `{ mouse = true; }`) encoding the variant.
- **`SUPER_L` release-hide collapse** — the three copies (top-level + inside `resize` submap + inside `exit` submap) collapse into one top-level entry with `{ submap_universal = true; release = true; transparent = true; }` (section 8.5).
- **`exec-once` and `exec` fold into `hl.on("hyprland.start", …)`** — `exec-once` is not a legal lua identifier and there is no `hl.exec-once` function.
- **Submap auto-reset uses `hl.timer`** — switches from `sleep N && hyprctl dispatch submap reset` to `hl.timer(function() hl.dispatch(hl.dsp.submap("reset")) end, { timeout = N*1000, type = "oneshot" })` scheduled at submap entry, removing the shell-out (section 6.4).
- **`bezier` → `curve`** (still in `importantPrefixes` so renders before `animation`); **`animations.animation = [...]` flattens to top-level `animation = [...]`** of attrsets, with the curve-reference field named `bezier` (matching `/share/hypr/hyprland.lua` shipped with hyprland, not the wiki which says `curve`).
- **`windowrule` → `window_rule`** in every contributing file; string entries become structured attrsets with a `match = { class/title = "..." }` field.
- **Type fixes**: `repeat_delay/_rate` int (was string); `preserve_split` bool (was `"yes"`); `sync_fullscreen` bool (was `0`).
- **Gradient `col.active_border` switches to table form** `{ colors = [...]; angle = 45; }` (resolves section 8.2 — the upstream example uses the table form exclusively).
- **`extraConfig = "";`** — everything that lived there migrates to `submaps.resize` / `submaps.exit`.

## How the open questions in design-doc section 8 were resolved

The doc directed PR 2 to start with a throwaway spike to resolve the open questions. In lieu of a runtime spike, the resolutions came from reading two authoritative local sources that the spike would have ultimately referenced:

- **`/share/hypr/stubs/hl.meta.lua`** (bundled with hyprland 0.55.1) — the type stubs for every `hl.*` function. Provides `hl.bind(keys: string, dispatcher: HL.Dispatcher|function, opts?: HL.BindOptions)` and the full `HL.BindOptions` field list (`repeating`, `locked`, `release`, `non_consuming`, `transparent`, `ignore_mods`, `dont_inhibit`, `long_press`, `submap_universal`, `click`, `drag`, `description`, `desc`, `device`).
- **`/share/hypr/hyprland.lua`** (canonical example config) — uses key format `mainMod .. " + Q"` (so `"SUPER + Q"`), table form for gradients, `bezier = "..."` for animation curve refs, and `{ mouse = true }` for the mouse-bind flag despite that flag not appearing in the type stubs (so the type stubs are non-exhaustive; the example wins).

Spike findings inline in code comments where they materially affect a translation choice (gradient table form, animation `bezier` field name, `submap_universal` collapse, `hl.timer` ms units, mouse-flag).

## Verification

Per-machine builds (`nix build --no-link`, no warnings):

- ✅ `.#nixosConfigurations.navi.config.system.build.toplevel`
- ✅ `.#nixosConfigurations.tui.config.system.build.toplevel`
- ✅ `.#darwinConfigurations.m4mac.system` — **evaluation passes** (`nix eval` returns the drv path; `nix build --dry-run` plans the build cleanly). The actual `nix build` fails on this x86_64-linux host with a platform mismatch on `Brewfile.drv` (aarch64-darwin-only). Verified that **same failure reproduces on `main`** without my changes, so this is not a regression — it's a host-environment limitation (no aarch64-darwin remote builder configured), not a config issue. The structural ACs ("evaluation succeeds, no deprecation warnings") are satisfied.

Generated `~/.config/hypr/hyprland.lua` parses cleanly under `luac -p` on both navi and tui after build (verified against the lua interpreter from `nixpkgs#lua`).

Spot-check confirmations against the rendered lua:

- No `nil` / `null` literals in any generated `hl.bind(...)` (confirms `lib.mkIf false` entries are stripped before rendering).
- All seven rainbow border colours render in the `colors = { … }` table with `angle = 45`.
- `lib.mkIf config.nx.isLaptop` binds (brightness, touchpad-toggle, kbd-backlight startup) appear in `tui` lua, absent from `navi` lua.
- Startup hook `hl.on("hyprland.start", function() … end)` contains all `exec-once` + `exec` commands; the `(config.nx.isLaptop == false)` Steam autostart is correctly present on `navi` and absent on `tui`.

## **Do NOT merge yet — 24-hour soak required (per AC)**

The functional ACs ("every smoke-test bullet in design-doc section 9 step 16 behaves identically", "SUPER_L release-pulse fires in all three submap states", "rainbow border still renders") can only be verified by running `nh switch` on the user's machines and exercising the binds. Keep this PR open at least 24 hours after `nh switch` on navi + tui to surface daily-use bind regressions (obscure media keys, long-press interactions, app-specific windowrules from the contributing modules).

## Rollback plan

If anything regresses on a machine after switch, `git revert <merge-sha> && nh switch` restores the hyprlang codepath unconditionally — both renderers are still shipped side-by-side in HM at our locked rev (section 10 of the design doc).