### PR TITLE
hyprland(lua): fix dpms on/off dispatch under lua parser

### DIFF
--- a/modules/desktop/hyprland/idle.nix
+++ b/modules/desktop/hyprland/idle.nix
@@ -68,16 +68,14 @@
               })
               (lib.mkIf screenCfg.enable {
                 timeout = screenCfg.duration;
-                # KNOWN BROKEN UNDER LUA: `hyprctl dispatch dpms off|on`
-                # fails to parse under the lua dispatch wrapper. The
-                # lua-call form `hl.dsp.dpms(...)` is the likely
-                # replacement but the exact arg shape needs to be
-                # verified against hyprland source — testing live risks
-                # leaving the display in DPMS-off with no recovery path,
-                # so this is deferred to a follow-up. For now,
-                # screen-off-on-idle is silently broken.
-                on-timeout = "hyprctl dispatch dpms off";
-                on-resume = "hyprctl dispatch dpms on";
+                # Under the lua parser `hl.dsp.dpms` takes a table with
+                # an `action` field — see
+                # `src/config/lua/bindings/LuaBindingsDispatchers.cpp`
+                # (`hlDpms` → `Internal::tableToggleAction`) and
+                # `parseToggleStr` in `LuaBindingsInternal.cpp`, which
+                # accepts "on"/"off"/"enable"/"disable"/"toggle".
+                on-timeout = ''hyprctl dispatch 'hl.dsp.dpms({ action = "off" })' '';
+                on-resume = ''hyprctl dispatch 'hl.dsp.dpms({ action = "on" })' '';
               })
               (lib.mkIf suspendCfg.enable {
                 timeout = suspendCfg.duration;


### PR DESCRIPTION
## Summary

Under the lua config parser (now active on main after #1954), `hyprctl dispatch dpms off` is evaluated as `hl.dispatch(dpms off)` and fails with a lua syntax error. The two `dpms` call sites in `modules/desktop/hyprland/idle.nix` were the only "KNOWN BROKEN" entries deferred from PR #1954, because we wanted to research the exact lua call shape against hyprland source rather than test blindly (live testing during #1954 once locked the user's display in an unrecoverable DPMS-off state).

This PR replaces both lines with the lua-call form:

```nix
on-timeout = ''hyprctl dispatch 'hl.dsp.dpms({ action = "off" })' '';
on-resume  = ''hyprctl dispatch 'hl.dsp.dpms({ action = "on" })' '';
```

and removes the "KNOWN BROKEN" comment block.

## Why this is the right arg shape (sourced, not guessed)

The hyprland-0.55.1 source (`src/config/lua/bindings/LuaBindingsDispatchers.cpp`) defines `hlDpms` as:

```cpp
static int hlDpms(lua_State* L) {
    CA::eTogglableAction       action = Internal::tableToggleAction(L, 1);
    std::optional<std::string> monStr;

    if (lua_istable(L, 1))
        monStr = Internal::tableOptMonitorSelector(L, 1, "monitor", "hl.dpms");
    ...
}
```

`Internal::tableToggleAction` (in `LuaBindingsInternal.cpp`) defaults the field name to `"action"` and routes its string value through `Internal::parseToggleStr`, which accepts:

```cpp
if (str.empty() || str == "toggle") return TOGGLE_ACTION_TOGGLE;
if (str == "enable" || str == "on") return TOGGLE_ACTION_ENABLE;
if (str == "disable" || str == "off") return TOGGLE_ACTION_DISABLE;
```

So `{ action = "on" }` → `TOGGLE_ACTION_ENABLE` → `m->setDPMS(true)` for every real monitor (`Config::Actions::dpms` in `ConfigActions.cpp`), which matches the legacy hyprlang behaviour exactly. The pattern (`hl.dsp.NAME({ field = "..." })`) is the same shape this repo already uses for `hl.dsp.focus`, `hl.dsp.window.move`, etc.

The lua stub at `/share/hypr/stubs/hl.meta.lua:824` is typed only as `fun(...): HL.Dispatcher` (untyped), which is why this couldn't be derived from the stub alone in #1954.

## Verification

- `nixfmt --check modules/desktop/hyprland/idle.nix` — passes.
- `nix-instantiate --eval --strict` on both `nixosConfigurations.navi` and `nixosConfigurations.tui` `system.build.toplevel.drvPath` — both evaluate without error.
- Rendered hypridle `listener` JSON shows the exact strings hypridle will run:
  ```
  hyprctl dispatch 'hl.dsp.dpms({ action = "off" })'
  hyprctl dispatch 'hl.dsp.dpms({ action = "on" })'
  ```

### Live test plan (for the user, after `nh switch`)

Per the issue, testing live carries display-lockout risk. The safe sequence:

1. **First, verify the on-form parses, idempotently** (calling `dpms on` while the display is already on is a no-op in `Config::Actions::dpms`):
   ```
   hyprctl dispatch 'hl.dsp.dpms({ action = "on" })'
   ```
   Expected: `ok`. If you instead see a lua parse error, **stop** — revert the PR before testing the off-form.
2. Only if step 1 returns `ok`, validate the off path either by waiting for `screenTimeout.duration` to fire (default 1 h) or by temporarily binding `SUPER + SHIFT + O` to the off-form and `SUPER + SHIFT + I` to the on-form so you can recover with the on-bind (and `SUPER + SHIFT + C` reload as a fallback).

If anything goes wrong during step 2, the on-form from step 1 is your recovery — it's the same form hypridle uses for `on-resume`, so any input event will also restore the display.

Closes #1958