### PR TITLE
hyprland(lua): fix silently broken touchpad toggle (hyprctl keyword → hl.device via dispatch)

### DIFF
--- a/modules/desktop/hyprland/scripts.nix
+++ b/modules/desktop/hyprland/scripts.nix
@@ -26,26 +26,44 @@
             #!/bin/sh
             export STATUS_FILE="$XDG_RUNTIME_DIR/touchpad_status"
 
-            # NOTE: `hyprctl keyword` is broken under the lua parser
-            # ("keyword can't work with non-legacy parsers. Use eval."),
-            # so the device-enable/disable lines below silently no-op.
-            # The OSD events still fire via the lua-compatible
-            # `hl.dsp.event(...)` form. Touchpad enable/disable itself is
-            # tracked as a separate follow-up.
+            # Mutating `device[...]:enabled` at runtime under the lua
+            # parser. `hyprctl keyword` is rejected by the lua parser
+            # ("keyword can't work with non-legacy parsers. Use eval.")
+            # and `hyprctl eval` does not exist as a subcommand on
+            # hyprland 0.55.1 — so we drive the device API directly via
+            # `hyprctl dispatch '<lua>'`.
+            #
+            # `hyprctl dispatch` evaluates its argument as a lua
+            # expression and feeds the result to `hl.dispatch(...)`,
+            # whose typedef is `fun(dispatcher: HL.Dispatcher|function)`
+            # — so passing a `function() ... end` literal lets us run
+            # arbitrary lua side-effects (here: `hl.device({...})`)
+            # without needing the result to be a dispatcher value. The
+            # device API's `enabled` field is the lua-native replacement
+            # for the hyprlang `device[NAME]:enabled` keyword and is
+            # declared in the type stubs at
+            # `share/hypr/stubs/hl.meta.lua` (`HL.DeviceSpec.enabled`).
+            set_touchpad() {
+              # $1 is the lua boolean literal (`true` or `false`).
+              hyprctl dispatch \
+                "function() hl.device({ name = \"asup1415:00-093a:300c-touchpad\", enabled = $1 }) end" \
+                > /dev/null
+            }
+
             if ! [ -f "$STATUS_FILE" ]; then
               # disable touchpad
-              hyprctl keyword 'device[asup1415:00-093a:300c-touchpad]:enabled' false > /dev/null
+              set_touchpad false
               touch "$STATUS_FILE"
               echo "disabled" > "$STATUS_FILE"
               hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:off")' > /dev/null
             elif [ "$(cat $STATUS_FILE)" = "enabled" ]; then
               # disable touchpad
-              hyprctl keyword 'device[asup1415:00-093a:300c-touchpad]:enabled' false > /dev/null
+              set_touchpad false
               echo "disabled" > "$STATUS_FILE"
               hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:off")' > /dev/null
             elif [ "$(cat $STATUS_FILE)" = "disabled" ]; then
               # enable touchpad
-              hyprctl keyword 'device[asup1415:00-093a:300c-touchpad]:enabled' true > /dev/null
+              set_touchpad true
               echo "enabled" > "$STATUS_FILE"
               hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:on")' > /dev/null
             fi


### PR DESCRIPTION
Closes #1959.

## Problem

After PR #1954 migrated hyprland to the lua parser, `hyprctl keyword 'device[...]:enabled' <bool>` is rejected by the lua VM (`keyword can't work with non-legacy parsers. Use eval.`) but `hyprctl` still exits 0 — so all three call sites in the `system.inputs.toggleTouchpad` script silently no-op. The OSD fires and `$XDG_RUNTIME_DIR/touchpad_status` updates, but the touchpad's actual enable state never changes on the device.

This is the same failure class PR #1954 already fixed for `cli.system.setHyprGaps` (which moved to declarative `workspace_rule`s); only the laptop machine (`tui`) is affected because the script is gated on `nx.isLaptop`.

## Mechanism research (per issue body §"Suggested next steps")

| Candidate | Verdict |
|---|---|
| `hyprctl eval '...'` | Not a subcommand on hyprland 0.55.1 (`hyprctl --help` lists no `eval`). |
| Shell fires `hl.dsp.event("touchpad:toggle")`, lua-side `hl.on("touchpad:toggle", ...)` | `hl.on` only accepts the closed enum `HL.EventName` — `config.reloaded`, `hyprland.start`, `window.*`, `workspace.*`, etc. Custom event names aren't supported. (See `share/hypr/stubs/hl.meta.lua:5`.) |
| `hyprctl dispatch '<lua-function-literal>'` | ✅ Works. `hl.dispatch`'s typedef is `fun(dispatcher: HL.Dispatcher\|function): any` — so passing a `function() ... end` literal lets us run arbitrary side-effecting lua. `HL.DeviceSpec.enabled` (`share/hypr/stubs/hl.meta.lua:493`) is the lua-native equivalent of the hyprlang `device[NAME]:enabled` keyword. |

The third approach is the smallest change: only `scripts.nix` is touched, no addition to the hyprland lua config (and therefore no risk to AC #6 "no regression to other lua-dispatch call sites"). A `set_touchpad` shell helper packages the dispatcher call once and is called with `true`/`false` from each of the three branches.

The "NOTE" comment block at the top of the toggleTouchpad block is replaced with a comment that documents the chosen mechanism and links to the relevant stub fields.

## Verification

- `nix build .#nixosConfigurations.tui.config.system.build.toplevel` — succeeds.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — succeeds (AC #5: non-laptop host still builds).
- Rendered script extracted from the tui derivation and run through `sh -n` — parses cleanly.
- The non-laptop `navi` configuration does not install the script file at all (`home.file ? "..." → false`) — `lib.mkIf config.nx.isLaptop` gate preserved (AC #5).
- Other call sites in `scripts.nix` and elsewhere that use the lua-form `hyprctl dispatch 'hl.dsp.event(...)'` / `'hl.dsp.focus(...)'` are untouched (AC #6).

ACs #1–#4 (functional touchpad-toggle behaviour, OSD sync, status-file sync across a 5-press sequence) require live verification on `tui` post-merge — they cannot be exercised from the build sandbox.

## Out of scope

Per the spawn prompt and #1961, the workspace-switch-on-window-close script and other event-driven scripts are explicitly not touched here.