### PR TITLE
prism review: unblock stale interrupted agent + fix in-progress round number

### DIFF
--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -606,6 +606,22 @@ func StartMonitorProcess(opts MonitorOpts, prismBinary string) error {
 // completed) review group for parentSession, or "" when none exists.
 // It is used to detect duplicate `prism review` invocations for the same
 // parent session.
+//
+// A group member counts as terminal here when EITHER:
+//
+//   - its state is in {finished, error, deleted} — aligned with
+//     db.terminalStates so a "deleted" sibling does not block the guard; OR
+//   - its ended_at is non-NULL — the row has been closed by `prism cleanup`,
+//     `prism reset`, or any other lifecycle path that calls SetEnded, even
+//     if the state string is still "interrupted" or "active" (#1962
+//     primary fix: closes the dead-sidecar gap where cleanup runs but the
+//     state flip to "deleted" never happens because the sidecar is gone).
+//
+// An "interrupted" row whose ended_at is still NULL is intentionally NOT
+// terminal here: the sidecar is alive and the user may still redirect the
+// agent via `prism prompt`, eventually reaching finished/error (#1495).
+// Only once cleanup (or any other SetEnded path) closes the row does the
+// ended_at arm trip and the guard release.
 func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) {
 	members, err := d.GroupMembersForParent(parentSession)
 	if err != nil {
@@ -623,7 +639,7 @@ func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) 
 			continue
 		}
 		gid := *m.GroupID
-		if !isTerminalState(m.State) {
+		if !isTerminalForGuard(m) {
 			groupStates[gid] = true
 		} else if _, exists := groupStates[gid]; !exists {
 			groupStates[gid] = false
@@ -636,6 +652,32 @@ func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) 
 		}
 	}
 	return "", nil
+}
+
+// isTerminalForGuard reports whether a group member should be treated as
+// terminal for the purpose of the `prism review` in-progress guard
+// (ActiveReviewGroupForParent). See the comment on ActiveReviewGroupForParent
+// for the full rationale. The two arms are intentionally OR-ed:
+//
+//  1. state-based: {finished, error, deleted}
+//  2. ended_at-based: ended_at IS NOT NULL
+//
+// Arm 2 is the "ended_at wins" check from #1962: any row whose session has
+// been closed by `prism cleanup` (which calls SetEnded) is terminal here
+// regardless of what the state string says, because the sidecar that would
+// have updated the state to "deleted" is already gone. This is what makes
+// the user's escape hatch — `prism cleanup --yes --session <agent>` —
+// actually release the in-progress guard, even when the cleanup happened
+// against a dead-sidecar row that still reads state="interrupted".
+func isTerminalForGuard(m db.Status) bool {
+	if m.EndedAt != nil {
+		return true
+	}
+	switch m.State {
+	case "finished", "error", "deleted":
+		return true
+	}
+	return false
 }
 
 // currentCycleProducedVerdicts reports whether the current group's

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -456,6 +456,199 @@ func TestActiveReviewGroupForParent_InProgressRound(t *testing.T) {
 	}
 }
 
+// TestActiveReviewGroupForParent_InterruptedWithEndedAtIsTerminal is the
+// primary regression test for #1962 Bug A.
+//
+// Reproducer shape: a review group has one member in state "interrupted"
+// whose sidecar has already exited (ended_at is non-NULL, simulating what
+// `prism cleanup --yes --session <agent>` does via SetEnded). Before #1962
+// this row was treated as non-terminal forever, permanently blocking the
+// next `prism review` invocation. After the fix, ActiveReviewGroupForParent
+// must treat the ended_at-non-NULL row as terminal regardless of state
+// string and return "" (no active group).
+func TestActiveReviewGroupForParent_InterruptedWithEndedAtIsTerminal(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@interrupted-cleaned"
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Round 3 review-goal is "interrupted" with ended_at set (sidecar
+	// already exited; cleanup ran but did not flip state to "deleted"
+	// because the sidecar was already gone).
+	interruptedSess := parent + "~review-3-review-goal"
+	if err := d.UpsertStatus(interruptedSess, "nixos-config", "/wt", "interrupted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus interrupted: %v", err)
+	}
+	if err := d.SetGroupID(interruptedSess, groupID); err != nil {
+		t.Fatalf("SetGroupID interrupted: %v", err)
+	}
+	if err := d.SetEnded(interruptedSess); err != nil {
+		t.Fatalf("SetEnded interrupted: %v", err)
+	}
+
+	// Sibling agents finished cleanly.
+	for _, agent := range []string{"review-code", "review-security", "review-qa", "review-context"} {
+		sess := parent + "~review-3-" + agent
+		if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %s: %v", agent, err)
+		}
+		if err := d.SetGroupID(sess, groupID); err != nil {
+			t.Fatalf("SetGroupID %s: %v", agent, err)
+		}
+	}
+
+	gid, err := review.ActiveReviewGroupForParent(d, parent)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent: %v", err)
+	}
+	if gid != "" {
+		t.Errorf("ActiveReviewGroupForParent = %q, want \"\" (interrupted member with ended_at must be terminal; #1962 Bug A)", gid)
+	}
+}
+
+// TestActiveReviewGroupForParent_InterruptedWithLiveSidecarStillBlocks is the
+// edge-case test for #1962 AC #4: when the in-progress guard fires for a
+// genuinely active round (a live sidecar with a not-yet-terminal agent), the
+// existing refusal behaviour is preserved unchanged.
+//
+// "Genuinely active" here means an interrupted row whose ended_at is still
+// NULL — the sidecar is alive and the user may still redirect the agent via
+// `prism prompt` (#1495). This row must NOT be treated as terminal.
+func TestActiveReviewGroupForParent_InterruptedWithLiveSidecarStillBlocks(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@interrupted-live"
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// review-goal is interrupted but sidecar is still alive (ended_at NULL).
+	interruptedSess := parent + "~review-1-review-goal"
+	if err := d.UpsertStatus(interruptedSess, "nixos-config", "/wt", "interrupted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus interrupted: %v", err)
+	}
+	if err := d.SetGroupID(interruptedSess, groupID); err != nil {
+		t.Fatalf("SetGroupID interrupted: %v", err)
+	}
+	// Note: deliberately NOT calling SetEnded — the sidecar is alive.
+
+	gid, err := review.ActiveReviewGroupForParent(d, parent)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent: %v", err)
+	}
+	if gid != groupID {
+		t.Errorf("ActiveReviewGroupForParent = %q, want %q (live-sidecar interrupted must still block; #1962 AC #4)", gid, groupID)
+	}
+}
+
+// TestActiveReviewGroupForParent_DeletedIsTerminal verifies that a
+// state="deleted" member is treated as terminal by the in-progress guard.
+// This aligns with db.terminalStates and closes the second arm of the
+// divergence noted in groups.go: a deleted row should never block a new
+// review round.
+func TestActiveReviewGroupForParent_DeletedIsTerminal(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@deleted-member"
+
+	groupID, err := d.RegisterGroup(parent)
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	deletedSess := parent + "~review-1-review-goal"
+	if err := d.UpsertStatus(deletedSess, "nixos-config", "/wt", "deleted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus deleted: %v", err)
+	}
+	if err := d.SetGroupID(deletedSess, groupID); err != nil {
+		t.Fatalf("SetGroupID deleted: %v", err)
+	}
+
+	gid, err := review.ActiveReviewGroupForParent(d, parent)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent: %v", err)
+	}
+	if gid != "" {
+		t.Errorf("ActiveReviewGroupForParent = %q, want \"\" (deleted member must be terminal)", gid)
+	}
+}
+
+// TestRunAsync_InProgressGuardReportsCorrectRound is the regression test for
+// #1962 Bug B: the in-progress-guard error message must report the round of
+// the actually-stuck group, not the lowest-numbered round across all groups
+// for this parent.
+//
+// Reproducer shape: three prior rounds for the same parent, only round 3
+// has a non-terminal (live-sidecar interrupted) member. The guard must fire
+// with "round 3" in the message, not "round 1".
+func TestRunAsync_InProgressGuardReportsCorrectRound(t *testing.T) {
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	parent := "nixos-config@multi-round"
+
+	// Rounds 1 and 2 — every member terminal (finished).
+	for _, round := range []int{1, 2} {
+		gid, gErr := d.RegisterGroupWithPR(parent, "42", round)
+		if gErr != nil {
+			t.Fatalf("RegisterGroupWithPR round %d: %v", round, gErr)
+		}
+		for _, agent := range []string{"review-goal", "review-code"} {
+			sess := fmt.Sprintf("%s~review-%d-%s", parent, round, agent)
+			if err := d.UpsertStatus(sess, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+				t.Fatalf("UpsertStatus: %v", err)
+			}
+			if err := d.SetGroupID(sess, gid); err != nil {
+				t.Fatalf("SetGroupID: %v", err)
+			}
+		}
+	}
+
+	// Round 3 — review-goal is interrupted with a live sidecar (ended_at
+	// NULL), which blocks the guard. This is the "genuinely stuck" group.
+	round3ID, err := d.RegisterGroupWithPR(parent, "42", 3)
+	if err != nil {
+		t.Fatalf("RegisterGroupWithPR round 3: %v", err)
+	}
+	stuckSess := parent + "~review-3-review-goal"
+	if err := d.UpsertStatus(stuckSess, "nixos-config", "/wt", "interrupted", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus stuck: %v", err)
+	}
+	if err := d.SetGroupID(stuckSess, round3ID); err != nil {
+		t.Fatalf("SetGroupID stuck: %v", err)
+	}
+
+	opts := review.Opts{
+		ParentSession: parent,
+		WorkerSession: parent,
+		Worktree:      t.TempDir(),
+		DBPath:        dbPath,
+		Agents:        []review.Agent{{Name: "review-goal"}},
+		PRNumber:      "42",
+	}
+	_, err = review.RunAsync(opts, "")
+	if err == nil {
+		t.Fatalf("RunAsync: expected in-progress-guard error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "round 3 is already in progress") {
+		t.Errorf("in-progress guard error = %q, want substring \"round 3 is already in progress\" (#1962 Bug B)", msg)
+	}
+	if !strings.Contains(msg, round3ID) {
+		t.Errorf("in-progress guard error = %q, want substring %q (the stuck group's ID)", msg, round3ID)
+	}
+	if strings.Contains(msg, "round 1 is already in progress") {
+		t.Errorf("in-progress guard error = %q, must NOT mention round 1 (round 1 is terminal)", msg)
+	}
+}
+
 // ── buildMonitorResults ───────────────────────────────────────────────────────
 
 // TestBuildMonitorResults_MissingSession verifies that a session not in

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -387,9 +387,20 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		// Non-fatal: log and proceed (better to allow duplicate than block falsely).
 		proglog.Warnf("[prism review] warning: could not check for active review group: %v\n", activeErr)
 	} else if activeGroupID != "" {
-		// Determine the round number for a useful error message.
-		members, _ := d.GroupMembersForParent(opts.ParentSession)
-		activeRound := ReviewRoundForGroup(members)
+		// Determine the round number for a useful error message. Filter
+		// members to just the active group's rows before extracting the
+		// round — without this filter, ReviewRoundForGroup returns the
+		// first round it encounters across ALL groups for this parent,
+		// which is almost always round 1 even when the stuck group is
+		// round N>1 (#1962 Bug B).
+		allMembers, _ := d.GroupMembersForParent(opts.ParentSession)
+		activeMembers := make([]db.Status, 0, len(allMembers))
+		for _, m := range allMembers {
+			if m.GroupID != nil && *m.GroupID == activeGroupID {
+				activeMembers = append(activeMembers, m)
+			}
+		}
+		activeRound := ReviewRoundForGroup(activeMembers)
 		if activeRound > 0 {
 			return nil, fmt.Errorf("prism review: round %d is already in progress for this PR (group %s).\n"+
 				"Wait for it to complete or cancel the sessions with `prism cleanup`.",


### PR DESCRIPTION
Closes #1962.

## Summary

Two bugs in the `prism review` in-progress guard that, together, can permanently block subsequent review rounds for a PR after a prior round leaves an `interrupted` member behind with a dead sidecar.

### Bug A (primary) — `prism cleanup` doesn't release the guard for dead-sidecar interrupted rows

The user's documented escape hatch `prism cleanup --yes --session <agent>` calls `SetEnded` (which sets `ended_at`) but does **not** flip state from `interrupted` to `deleted` when the agent's sidecar has already exited — the state-flip lives in the dead sidecar's shutdown path. `ActiveReviewGroupForParent`'s terminal check used `review.isTerminalState` ({finished, error}) which intentionally excluded `interrupted` for the live-redirection case (#1495) — but the same check also misses cleaned-up dead-sidecar rows whose `ended_at` is set.

**Fix** (option 2 + the `ended_at` defensive check from the issue body): introduce `isTerminalForGuard`, used only by `ActiveReviewGroupForParent`, that treats a member as terminal when EITHER:

1. its state is in `{finished, error, deleted}` (aligned with `db.terminalStates`), OR
2. its `ended_at` is non-NULL.

Arm 2 is the primary fix: any row closed by `SetEnded` counts as terminal regardless of the state string, so cleanup releases the guard even when the dead-sidecar state-flip never happens.

The live-sidecar interrupted case (#1495) is preserved: an `interrupted` row whose `ended_at` is still NULL still blocks the guard, so the user can redirect the agent via `prism prompt` without false-completing the round. `review.isTerminalState` (the `pollAgents` per-agent progress tracker) is unchanged for the same reason.

### Bug B (secondary, cosmetic) — wrong round number in the in-progress-guard error

The error message reported "round 1 is already in progress" when the actually-stuck group was round 3 (see issue body for the live reproducer from PR #1954). `ReviewRoundForGroup` was being called with members from **all** groups for the parent and returned whichever round it encountered first.

**Fix**: filter members to just `activeGroupID`'s rows before calling `ReviewRoundForGroup`, so the reported round matches the group ID in the error message.

## Regression tests added

In `internal/review/monitor_test.go`:

- `TestActiveReviewGroupForParent_InterruptedWithEndedAtIsTerminal` — primary AC for Bug A: an `interrupted`+`ended_at` member must be terminal (no active group).
- `TestActiveReviewGroupForParent_InterruptedWithLiveSidecarStillBlocks` — edge-case AC #4: `interrupted` with `ended_at` NULL still blocks the guard.
- `TestActiveReviewGroupForParent_DeletedIsTerminal` — aligns with `db.terminalStates`; a `deleted` member must not block.
- `TestRunAsync_InProgressGuardReportsCorrectRound` — Bug B: three rounds, only round 3 stuck, error message must name round 3, not round 1.

Existing `ReviewGroupsList` tests confirm the `prism reviews list` roll-up (unchanged terminal-state definition) is unaffected (AC #6).

## Acceptance criteria coverage

- [x] **AC #1**: After `prism cleanup --yes --session <agent>` on a dead-sidecar agent, the row no longer blocks subsequent `prism review` (the `ended_at` arm of `isTerminalForGuard` trips on the row `SetEnded` left behind).
- [x] **AC #2**: `prism review` on a PR with a prior round whose sole non-terminal member is an `interrupted` agent with non-NULL `ended_at` succeeds rather than refusing.
- [x] **AC #3**: The in-progress-guard "round N" matches the group named in the same error (test asserts both the round and the group ID).
- [x] **AC #4**: Live-sidecar interrupted (no `ended_at`) still triggers the existing refusal — explicit test.
- [x] **AC #5**: Cleanup contract is unchanged (no `cleanup.go` edits); live-sidecar cleanup retains the existing teardown via `SetEnded`.
- [x] **AC #6**: `prism reviews list` roll-up uses `db.terminalStates`, which is unchanged; existing tests pass.

## Pre-PR checks

- `go build ./...` ✅
- `go test ./...` ✅ (all packages green)
- `go test -race ./internal/review/... ./internal/db/...` ✅
- `go vet ./...` ✅
- `nix build .#prism` ✅

CI will additionally run `go-tests` and `nix-build-prism-checked` per the prism gate.

Refs #1962.