### PR TITLE
prism: refuse to start a session without git identity (#1960)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -445,6 +445,11 @@ func TestValidateSandboxExecArgs_OK(t *testing.T) {
 	m := container.New(container.Config{
 		SessionName:   "repo@feat",
 		AllocatedPort: 14010,
+		// Required since #1960: writeGitconfig refuses to start a session
+		// without [user] in the gitconfig (otherwise git falls back to
+		// `<sandbox-user>@<sandbox-host>` inside the sandbox).
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	})
 	t.Cleanup(func() {
 		// PrepareSandboxExec writes the profile to a temp file; remove it
@@ -469,6 +474,9 @@ func TestValidateSandboxExecArgs_MissingProfile(t *testing.T) {
 	m := container.New(container.Config{
 		SessionName:   "repo@gone",
 		AllocatedPort: 14011,
+		// Required since #1960 — see TestValidateSandboxExecArgs_OK.
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	})
 	args, err := m.PrepareSandboxExec()
 	if err != nil {

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -534,13 +534,19 @@ func (m *Manager) writeSshConfig(mode isolationMode) error {
 // the sandbox, where $HOME depends on the isolation mode (see isolationMode).
 //
 // Sections included:
-//   - [user] — only when GitUserName and GitUserEmail are both non-empty;
-//     includes signingKey when the signing public key can be resolved.
+//   - [user] — always; name and email come from cfg.GitUserName /
+//     cfg.GitUserEmail. Includes signingKey when the signing public key can
+//     be resolved.
 //   - [commit] / [gpg] — only when the signing keys are available.
 //   - [push] — autoSetupRemote = true (always).
 //   - [init] — defaultBranch = main (always).
 //
-// Missing identity → [user] section omitted, warning logged (AC-14).
+// Missing identity → return error, refuse to write the gitconfig (issue
+// #1960). The previous behaviour of "warn and skip [user]" caused git inside
+// the sandbox to fall back to OS-level identity guessing
+// (`<sandbox-user>@<sandbox-host>`), which GitHub then aggregated into noisy
+// `Co-authored-by:` trailers on squash merge.
+//
 // Missing signing keys → signing sections omitted, warning logged (AC-13).
 //
 // The mode argument controls the paths embedded in the generated file:
@@ -603,24 +609,33 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 	sandboxSigningKeyPub := filepath.Join(sandboxSshDir, "signing-key.pub")
 	sandboxAllowedSigners := filepath.Join(sandboxSshDir, "allowed_signers")
 
-	// [user] section — only when identity is present.
-	if m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
-		sb.WriteString("[user]\n")
-		sb.WriteString("    name = " + m.cfg.GitUserName + "\n")
-		sb.WriteString("    email = " + m.cfg.GitUserEmail + "\n")
-		if hasSigning {
-			sb.WriteString("    signingKey = " + sandboxSigningKeyPub + "\n")
-		}
-	} else {
-		log.Printf("container: git identity (name=%q, email=%q) missing; omitting [user] section from gitconfig",
-			m.cfg.GitUserName, m.cfg.GitUserEmail)
+	// [user] section — required. Missing identity is a hard error (issue
+	// #1960): without a configured [user] section, git falls back to
+	// OS-level identity guessing inside the sandbox (e.g. `worker@prism`,
+	// `bot@local`), and any commit produced by the session is authored as
+	// that synthetic identity. GitHub then aggregates the synthetic
+	// identity into a `Co-authored-by:` trailer when the PR is squash
+	// merged. Refusing to write the gitconfig forces the operator to fix
+	// the upstream config (nix → prism-tui.nix extractor → config.json) at
+	// session-start time rather than discovering the noise post-merge.
+	if m.cfg.GitUserName == "" || m.cfg.GitUserEmail == "" {
+		return fmt.Errorf(
+			"container: git identity missing (name=%q, email=%q): refusing to start session without [user] in gitconfig — "+
+				"set git_user_name and git_user_email in ~/.config/prism/config.json (Nix users: ensure programs.git.includes[].contents.user.name and .email are set; "+
+				"prism-tui.nix extracts these into config.json at switch time)",
+			m.cfg.GitUserName, m.cfg.GitUserEmail,
+		)
+	}
+	sb.WriteString("[user]\n")
+	sb.WriteString("    name = " + m.cfg.GitUserName + "\n")
+	sb.WriteString("    email = " + m.cfg.GitUserEmail + "\n")
+	if hasSigning {
+		sb.WriteString("    signingKey = " + sandboxSigningKeyPub + "\n")
 	}
 
-	// [commit] and [gpg] sections — only when signing keys are available AND
-	// identity is present. Without identity the [user] section is omitted, which
-	// means signingKey is never set; writing gpgsign=true in that case would
-	// cause every git commit to fail.
-	if hasSigning && m.cfg.GitUserName != "" && m.cfg.GitUserEmail != "" {
+	// [commit] and [gpg] sections — only when signing keys are available.
+	// (Identity is now guaranteed present by the check above.)
+	if hasSigning {
 		// Read the signing public key content to build the allowed_signers file.
 		// Only write [gpg "ssh"] allowedSignersFile when the file was actually
 		// produced — if it can't be written, podman must not be given a

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -875,3 +875,165 @@ func TestHarnessConfigFilePath_MatchesManagerMethod(t *testing.T) {
 // Config.AgentEnvVars (e.g. GIT_EDITOR) are emitted as --env KEY=VALUE in the
 // podman run arg list, while KUBECONFIG and AWS_CONFIG_FILE are suppressed
 // because those files are bind-mounted at their canonical default paths.
+// ── issue #1960: git identity must be hard-required ─────────────────────────
+//
+// writeGitconfig must refuse to write a gitconfig without [user] in every
+// isolation mode. The previous behaviour (warn and skip [user]) caused git
+// inside the sandbox to fall back to `<sandbox-user>@<sandbox-host>` (e.g.
+// `worker <bot@local>`); GitHub then aggregated that synthetic identity into
+// a `Co-authored-by:` trailer on squash merge. See issue #1960 for the full
+// inventory of historical noisy trailers.
+
+// gitconfigIdentityModes is the per-mode matrix exercised by the regression
+// tests below. Each entry names the mode constant used by writeGitconfig and
+// a label used in error messages. Podman is intentionally NOT covered here —
+// the podman path is no longer reachable in the spawn lifecycle, but the same
+// writeGitconfig codepath gates it, so the bwrap/sandbox-exec coverage below
+// proves the invariant for all three modes.
+var gitconfigIdentityModes = []struct {
+	name string
+	mode isolationMode
+}{
+	{"bwrap", isolationBwrap},
+	{"sandbox-exec", isolationSandboxExec},
+}
+
+// TestWriteGitconfig_AllModes_UserSectionRequired asserts the AC: the staged
+// gitconfig produced by writeGitconfig contains a [user] section with the
+// configured name and email for every isolation mode.
+func TestWriteGitconfig_AllModes_UserSectionRequired(t *testing.T) {
+	for _, tc := range gitconfigIdentityModes {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeHome := t.TempDir()
+			t.Setenv("HOME", fakeHome)
+
+			const wantName = "prismatic-koi"
+			const wantEmail = "ben@tinfoilforest.nz"
+
+			m := New(Config{
+				SessionName:   "repo@feat",
+				AllocatedPort: 14000,
+				GitUserName:   wantName,
+				GitUserEmail:  wantEmail,
+			})
+			if err := m.writeGitconfig(tc.mode); err != nil {
+				t.Fatalf("writeGitconfig(%s): %v", tc.name, err)
+			}
+			t.Cleanup(func() {
+				_ = os.Remove(m.gitconfigFilePath())
+				_ = os.Remove(m.allowedSignersFilePath())
+			})
+
+			data, err := os.ReadFile(m.gitconfigFilePath())
+			if err != nil {
+				t.Fatalf("read gitconfig: %v", err)
+			}
+			content := string(data)
+
+			// [user] header must be present.
+			if !strings.Contains(content, "[user]\n") {
+				t.Errorf("mode=%s: gitconfig is missing the [user] header; content:\n%s",
+					tc.name, content)
+			}
+			// name and email lines must be present with the configured values.
+			wantNameLine := "name = " + wantName
+			if !strings.Contains(content, wantNameLine) {
+				t.Errorf("mode=%s: gitconfig is missing %q; content:\n%s",
+					tc.name, wantNameLine, content)
+			}
+			wantEmailLine := "email = " + wantEmail
+			if !strings.Contains(content, wantEmailLine) {
+				t.Errorf("mode=%s: gitconfig is missing %q; content:\n%s",
+					tc.name, wantEmailLine, content)
+			}
+		})
+	}
+}
+
+// TestWriteGitconfig_AllModes_EmptyIdentityRefused asserts the AC: missing
+// identity is a hard error, not a silent omission. The combinations covered
+// are (name="", email=""), (name="x", email=""), and (name="", email="x") —
+// any empty field is sufficient to refuse.
+func TestWriteGitconfig_AllModes_EmptyIdentityRefused(t *testing.T) {
+	cases := []struct {
+		label string
+		name  string
+		email string
+	}{
+		{"both-empty", "", ""},
+		{"name-empty", "", "ben@tinfoilforest.nz"},
+		{"email-empty", "prismatic-koi", ""},
+	}
+	for _, mode := range gitconfigIdentityModes {
+		for _, c := range cases {
+			t.Run(mode.name+"/"+c.label, func(t *testing.T) {
+				fakeHome := t.TempDir()
+				t.Setenv("HOME", fakeHome)
+
+				m := New(Config{
+					SessionName:   "repo@feat",
+					AllocatedPort: 14000,
+					GitUserName:   c.name,
+					GitUserEmail:  c.email,
+				})
+				err := m.writeGitconfig(mode.mode)
+				if err == nil {
+					t.Fatalf("mode=%s name=%q email=%q: writeGitconfig returned nil, want error",
+						mode.name, c.name, c.email)
+				}
+				// Error must name the problem clearly so the operator can
+				// fix it. The message threads through to the spawn error
+				// path, so it is what the user actually sees.
+				msg := err.Error()
+				for _, want := range []string{"git identity missing", "[user]"} {
+					if !strings.Contains(msg, want) {
+						t.Errorf("mode=%s name=%q email=%q: error %q must mention %q",
+							mode.name, c.name, c.email, msg, want)
+					}
+				}
+
+				// The gitconfig file must NOT have been written. The
+				// previous behaviour wrote a [user]-less gitconfig and
+				// returned nil, which is the exact regression we want to
+				// catch.
+				if _, statErr := os.Stat(m.gitconfigFilePath()); statErr == nil {
+					t.Errorf("mode=%s name=%q email=%q: gitconfig at %s should not exist after refusal",
+						mode.name, c.name, c.email, m.gitconfigFilePath())
+					_ = os.Remove(m.gitconfigFilePath())
+				}
+			})
+		}
+	}
+}
+
+// TestPrepareSandboxExecHome_EmptyIdentityAborts asserts that the failure
+// from writeGitconfig propagates up through PrepareSandboxExecHome (the
+// sandbox-exec staging entry point) so the session does not start. The
+// previous behaviour logged the error and continued, which is what allowed
+// the bug to surface only post-merge.
+func TestPrepareSandboxExecHome_EmptyIdentityAborts(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	// PrepareSandboxExecHome requires the various host dirs that newFakeHome
+	// creates for the broader sandbox-exec test suite. Re-create the minimal
+	// subset here so the test stands on its own.
+	for _, d := range []string{".ssh", ".config/pi", ".cache/nix"} {
+		if err := os.MkdirAll(filepath.Join(fakeHome, d), 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	m := New(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "empty-identity-test",
+		// Explicitly leave GitUserName and GitUserEmail unset to exercise
+		// the refusal path.
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err == nil {
+		t.Fatalf("PrepareSandboxExecHome returned stagingHome=%q nil error, want error", stagingHome)
+	}
+	if !strings.Contains(err.Error(), "git identity missing") {
+		t.Errorf("PrepareSandboxExecHome error %q must mention 'git identity missing'", err.Error())
+	}
+}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -340,8 +340,14 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// Use the existing writeGitconfig helper with a synthetic isolationMode
 	// that uses the staging HOME as $HOME. We write the gitconfig to the
 	// staging path directly.
+	//
+	// A failure here is fatal — return the error so the session does not
+	// start with a missing or broken gitconfig. Previously we logged and
+	// continued, which is what let issue #1960 (missing [user] section →
+	// synthetic in-sandbox identity → noisy Co-authored-by trailer) sneak
+	// through unnoticed.
 	if err := m.writeGitconfigToDir(stagingHome); err != nil {
-		log.Printf("container: sandbox-exec: write staging .gitconfig: %v", err)
+		return "", fmt.Errorf("container: sandbox-exec: write staging .gitconfig: %w", err)
 	}
 
 	// ── .nix-profile symlink ──────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -15,7 +15,20 @@ import (
 // newSandboxExecManager creates a Manager and injects a sandboxExecIsolator
 // so tests can drive BuildArgs/PrepareSandboxExec end-to-end without a real
 // macOS host.
+//
+// Default git identity is auto-populated when the caller leaves
+// GitUserName / GitUserEmail empty so the per-mode `writeGitconfig` hard
+// error from issue #1960 (refuse to start without [user]) does not
+// retroactively break every pre-existing sandbox-exec test that does not
+// itself care about git identity. Tests that exercise the empty-identity
+// path explicitly set these fields back to "".
 func newSandboxExecManager(cfg Config) *Manager {
+	if cfg.GitUserName == "" {
+		cfg.GitUserName = "test-user"
+	}
+	if cfg.GitUserEmail == "" {
+		cfg.GitUserEmail = "test@example.com"
+	}
 	m := New(cfg)
 	m.isolator = newSandboxExecIsolator(m.name)
 	return m

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
@@ -99,6 +99,13 @@ func newProfileManager(t *testing.T) *container.Manager {
 		SessionName: "integ-sandbox-exec-profile-test",
 		InstanceID:  instanceID,
 		Worktree:    t.TempDir(),
+		// Required since #1960: writeGitconfig refuses to start a
+		// session without [user] in the gitconfig. The integration
+		// suite does not care about identity, so we inject a sentinel
+		// matching the default used by newSandboxExecManager in the
+		// container package's own tests.
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	}
 	return container.New(cfg)
 }
@@ -145,6 +152,9 @@ func newProfileManagerWithBareRoot(t *testing.T) *container.Manager {
 		InstanceID:  instanceID,
 		Worktree:    t.TempDir(),
 		BareRoot:    bareRoot,
+		// Required since #1960 — see newProfileManager.
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	}
 	return container.New(cfg)
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go
@@ -61,6 +61,10 @@ func newPIOAuthPersistenceManager(t *testing.T) *container.Manager {
 		Worktree:    t.TempDir(),
 		Harness:     "pi",
 		BareRoot:    t.TempDir(), // needed for the BareRoot-ancestor allow block
+		// Required since #1960 — see newProfileManager
+		// (sandbox_exec_helpers_darwin_test.go).
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	}
 	return container.New(cfg)
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_darwin_test.go
@@ -45,6 +45,12 @@ func newPIProfileManager(t *testing.T, sockPath string) *container.Manager {
 		InstanceID:      instanceID,
 		Worktree:        t.TempDir(),
 		HostAPISockPath: sockPath,
+		// Required since #1960: writeGitconfig refuses to start a
+		// session without [user] in the gitconfig. See
+		// newProfileManager (sandbox_exec_helpers_darwin_test.go) for
+		// the full rationale.
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	}
 	return container.New(cfg)
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_oauth_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_oauth_darwin_test.go
@@ -52,6 +52,10 @@ func newPIOAuthProfileManager(t *testing.T) *container.Manager {
 		InstanceID:  instanceID,
 		Worktree:    t.TempDir(),
 		Harness:     "pi",
+		// Required since #1960 — see newProfileManager
+		// (sandbox_exec_helpers_darwin_test.go).
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
 	}
 	return container.New(cfg)
 }


### PR DESCRIPTION
## Summary

Closes #1960.

`container.Manager.writeGitconfig` silently omitted the `[user]` section from the in-sandbox `~/.gitconfig` when either `cfg.GitUserName` or `cfg.GitUserEmail` was empty, logging only a warning. Inside the sandbox, git then fell back to OS-level identity guessing — `<sandbox-user>@<sandbox-host>` — producing synthetic authors like `worker <bot@local>`, `worker <worker@prism>`, and `Prism Agent <agent@prism.local>`. When such a commit was squash-merged via GitHub, the synthetic identity was auto-aggregated into a noisy `Co-authored-by:` trailer on `main`. Most recent example: PR #1955 (branch commit `3cafafe7`).

## Changes

Two changes close the loophole:

1. **`writeGitconfig` now returns an error** when either `GitUserName` or `GitUserEmail` is empty, instead of warning and continuing. The error message names the missing fields and tells the operator exactly which config keys to set:
   > `container: git identity missing (name="", email=""): refusing to start session without [user] in gitconfig — set git_user_name and git_user_email in ~/.config/prism/config.json (Nix users: ensure programs.git.includes[].contents.user.name and .email are set; prism-tui.nix extracts these into config.json at switch time)`

   This propagates up through the per-mode `Prepare` dispatchers (bwrap, sandbox-exec) so `prism spawn` refuses to start with a clear failure rather than producing tainted commits silently.

2. **`PrepareSandboxExecHome` no longer swallows the `writeGitconfigToDir` error** with `log.Printf` — it now returns the error. Without this, the sandbox-exec staging path would have continued past a failed gitconfig write and a session would still have started, which was the very failure mode the `writeGitconfig` change is meant to prevent.

## Regression coverage

New tests in `internal/container/container_test.go`:

- **`TestWriteGitconfig_AllModes_UserSectionRequired`** — for each isolation mode (bwrap, sandbox-exec), asserts that the staged gitconfig contains a `[user]` section with the configured name and email lines. Satisfies the per-mode AC.
- **`TestWriteGitconfig_AllModes_EmptyIdentityRefused`** — for every combination of empty name / empty email / both empty, asserts that `writeGitconfig` returns an error mentioning `"git identity missing"` and `"[user]"`, **and** that no gitconfig file was written to disk. The file-not-written assertion is the precise regression: the previous bug was a writable `[user]`-less gitconfig.
- **`TestPrepareSandboxExecHome_EmptyIdentityAborts`** — asserts that the failure propagates up through the sandbox-exec staging entry point so the session does not start.

## Test fixture updates

- `newSandboxExecManager` auto-populates a default test identity when the caller leaves `GitUserName` / `GitUserEmail` empty. This keeps the large existing sandbox-exec test surface (which doesn't care about identity) passing without per-test edits, while still allowing the new empty-identity tests to set the fields back to `""`.
- Two `cmd/agent_run_test.go` tests now set `GitUserName` / `GitUserEmail` explicitly because they call `PrepareSandboxExec`, which now requires identity end-to-end.

## Quality gates

- `go build ./...` — clean
- `go test ./...` — all pass (including the new tests)
- `go test -race ./internal/container/` — clean
- `go vet ./...` — clean
- `nix build .#prism` — clean
- `nix build .#prism { runChecks = true; }` (homeless-shelter sandbox) — clean

## Acceptance criteria mapping

- [x] [security] Empty identity → `prism spawn` refuses with a clear error. Covered by `TestWriteGitconfig_AllModes_EmptyIdentityRefused` × `TestPrepareSandboxExecHome_EmptyIdentityAborts`.
- [x] [edge-case] Regression test asserts the staged in-sandbox `~/.gitconfig` contains `[user]` with the configured name + email in each isolation mode. Covered by `TestWriteGitconfig_AllModes_UserSectionRequired`.
- [x] [functional] bwrap and sandbox-exec coverage. (Darwin live-host AC items can only be verified post-merge with a real `prism spawn` on the user's Linux NixOS host; the Darwin path is covered by the unit tests for `isolationSandboxExec` that exercise the same `writeGitconfig` codepath.)
- [x] [functional] No new PR after this lands can produce a `Co-authored-by:` trailer for the listed synthetic identities — the session refuses to start in that condition.
