### PR TITLE
battery-notifier: fix razer charge_* sysfs perms via udev rule

### DIFF
--- a/modules/services/battery-notifier.nix
+++ b/modules/services/battery-notifier.nix
@@ -27,6 +27,46 @@ let
   daemonConfigFile = pkgs.writeText "battery-notifier-config.json" daemonConfigJSON;
 
   anyDeviceEnabled = enabledDevices != { };
+
+  anyRazerDevice = lib.any (d: d.enable && d.kind == "razer") (lib.attrValues cfg.devices);
+
+  # openrazer's shipped udev rule (99-razer.rules) sets GROUP:=openrazer on
+  # the usb|input|hid device nodes, but the razermouse kernel module creates
+  # the per-attribute files (charge_level, charge_status) inside the device's
+  # sysfs directory as root:root 0440. Those files are what battery-notifier
+  # reads — and because the user (in the openrazer group) is not the owner
+  # and the group is root, every read returns EACCES.
+  #
+  # This wrapper runs from a udev RUN+= when an idVendor==1532 hid device
+  # appears and walks the sysfs directory chgrp/chmod'ing any battery-related
+  # attribute files that exist. Using a wrapper rather than inlining the
+  # commands into RUN+= avoids the well-known fragility of shell escaping
+  # and %p expansion inside udev rule strings (see issue #1972).
+  #
+  # The script is defensive: it tolerates the attributes being absent (not
+  # every razer device exposes a battery) and tolerates udev firing the rule
+  # before the kernel module has created the sysfs files (a short retry loop
+  # handles the race).
+  razerFixPermsScript = pkgs.writeShellScript "razer-fix-charge-perms" ''
+    # $DEVPATH is exported by udev, e.g. /devices/pci0000:00/.../0003:1532:00B7.0007
+    sysfs="/sys$DEVPATH"
+    # Try a few times in case the kernel module hasn't created the
+    # attribute files yet when udev fires this rule.
+    for _ in 1 2 3 4 5; do
+      if [ -e "$sysfs/charge_level" ] || [ -e "$sysfs/charge_status" ]; then
+        for f in "$sysfs"/charge_level "$sysfs"/charge_status; do
+          [ -e "$f" ] || continue
+          ${pkgs.coreutils}/bin/chgrp openrazer "$f" || true
+          ${pkgs.coreutils}/bin/chmod g+r "$f"     || true
+        done
+        exit 0
+      fi
+      ${pkgs.coreutils}/bin/sleep 0.2
+    done
+    # No battery attributes appeared — not an error (most razer devices
+    # don't have a battery).
+    exit 0
+  '';
 in
 {
   options.nx.services.batteryNotifier = {
@@ -97,12 +137,18 @@ in
     # /sys/bus/hid/devices/*1532*/ which the daemon reads directly —
     # no Polychromatic-CLI subprocess. openrazer's own batteryNotifier
     # is left disabled because we own that responsibility now.
-    hardware.openrazer =
-      lib.mkIf (lib.any (d: d.enable && d.kind == "razer") (lib.attrValues cfg.devices))
-        {
-          enable = true;
-          batteryNotifier.enable = false;
-        };
+    hardware.openrazer = lib.mkIf anyRazerDevice {
+      enable = true;
+      batteryNotifier.enable = false;
+    };
+
+    # Fix sysfs perms on razer battery attribute files. See the comment on
+    # `razerFixPermsScript` above for the root-cause explanation. Gated on
+    # the same condition as `hardware.openrazer.enable` so hosts with no
+    # razer device declared get no extra udev rule.
+    services.udev.extraRules = lib.mkIf anyRazerDevice ''
+      ACTION=="add", SUBSYSTEM=="hid", ATTRS{idVendor}=="1532", RUN+="${razerFixPermsScript}"
+    '';
 
     home-manager.users.${config.nx.username} = lib.mkIf anyDeviceEnabled {
       # polychromatic is intentionally NOT installed — the Go daemon


### PR DESCRIPTION
Closes #1972.

## Summary

openrazer's shipped udev rule (`/etc/udev/rules.d/99-razer.rules`,
`SUBSYSTEM=="usb|input|hid", GROUP:="openrazer"`) sets the device
node's group to `openrazer`, but does **not** propagate that group to
the per-attribute files (`charge_level`, `charge_status`) that the
`razermouse` kernel module creates inside the device's sysfs directory.
Those files come out `-r--r----- root:root`, so `battery-notifier`
(running as `ben`, who is in the `openrazer` group) gets EACCES on
every read and the mouse-battery notification path is fully
non-functional on `navi`.

This PR implements candidate 1 from the issue body — a custom udev
rule co-located with the existing `hardware.openrazer.enable` block
in `modules/services/battery-notifier.nix` and gated on the same
any-razer-device condition.

## Implementation notes

- The gate condition (previously inlined into `hardware.openrazer = lib.mkIf …`)
  is extracted into a single `anyRazerDevice` let-binding so the two
  consumers (`hardware.openrazer` and `services.udev.extraRules`) provably
  reference the same predicate. AC: "fix is gated on the same condition
  that enables the `hardware.openrazer` block".
- The actual chgrp/chmod work runs from a `pkgs.writeShellScript`
  wrapper rather than inline in `RUN+="…"`. The issue body explicitly
  flagged shell escaping inside `RUN+=` as fragile and recommended this
  fallback; the wrapper uses `$DEVPATH` (exported by udev) which is more
  reliable than `%p` expansion through a shell quoting layer.
- The script is defensive in two ways:
  1. `[ -e "$f" ] || continue` — most razer devices don't have a
     battery, so the attribute files won't exist; that's not an error.
  2. A 5×0.2s retry loop handles the race where udev fires the rule
     before the kernel module has created the attribute files.
- The shell script ignores `chgrp` / `chmod` failures (`|| true`) so a
  transient failure doesn't cause udev to log the worker as failing —
  the next device-add (or `udevadm trigger`) will retry.

## Verification

**Static (run in this worktree):**

- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — OK
- `nix build .#nixosConfigurations.tui.config.system.build.toplevel` — OK
- `nixfmt modules/services/battery-notifier.nix` — clean
- `shellcheck` on the generated wrapper — clean
- `udevadm verify --resolve-names=never .../99-local.rules` — `Success: 1, Fail: 0`

**Gating, verified by construction:**

```
$ nix eval --impure --raw --expr '
    let
      flake = builtins.getFlake (toString ./.);
      base  = flake.nixosConfigurations.navi;
      no-razer = base.extendModules {
        modules = [{
          nx.services.batteryNotifier.devices.mouse.enable =
            flake.inputs.nixpkgs.lib.mkForce false;
        }];
      };
      flat = builtins.replaceStrings ["\n"] [" "]
               no-razer.config.services.udev.extraRules;
    in
      if no-razer.config.hardware.openrazer.enable
      then "FAIL: openrazer still enabled"
      else if (builtins.match ".*1532.*" flat) != null
      then "FAIL: razer rule still present"
      else "PASS"
  '
PASS
```

i.e. with the only razer device disabled, both `hardware.openrazer.enable`
and the `1532` udev rule disappear from the toplevel config. AC #4
satisfied.

**Live verification (post-`nh switch` on `navi`, for the human):**

The AC mentions `udevadm test /sys/bus/hid/devices/0003:1532:00B7.0007 2>&1 | head`
as the safer pre-replug verification. That requires the live `/sys`
tree on `navi` and isn't runnable in the worker's sandboxed worktree,
so it stays as a post-switch step:

1. `nh switch` on `navi`.
2. `udevadm test /sys/bus/hid/devices/0003:1532:00B7.0007 2>&1 | head -40`
   — expect to see the new `RUN+="/nix/store/…-razer-fix-charge-perms"`
   entry resolved.
3. Either re-plug the mouse, or
   `echo 0003:1532:00B7.0007 | sudo tee /sys/bus/hid/drivers/razermouse/unbind`
   followed by `… > /sys/bus/hid/drivers/razermouse/bind`.
4. `ls -la /sys/bus/hid/devices/0003:1532:00B7.0007/charge_level` —
   expect `-r--r----- root openrazer`.
5. `systemctl --user restart battery-notifier` then
   `journalctl --user-unit battery-notifier -b` — expect no
   `razer_read_failed` warnings and a `Present: true` razer sample
   within ~2 minutes.

## Out of scope

The issue body also flagged two daemon-side oddities (double-warning
at startup, no subsequent ticks logged in the journal). Both are
explicitly out of scope for this PR per the issue's "Notes for the
worker" section — they will be filed separately if still relevant
after this fix lands and the daemon starts producing healthy samples.
