### PR TITLE
hyprland(scripts): document cli.system.batteryStatus caller

### DIFF
--- a/modules/desktop/hyprland/scripts.nix
+++ b/modules/desktop/hyprland/scripts.nix
@@ -158,6 +158,15 @@
             hyprctl dispatch 'hl.dsp.event("quickshell:osd:brightness:'"''${brightness_percent}"'")' > /dev/null
           '';
       };
+      # Live caller: modules/desktop/hyprland/hyprlock.nix renders the battery
+      # icon + percentage on the lockscreen via a `cmd[update:5000]` label in
+      # the laptop-only block, polling this script every 5 seconds.
+      #
+      # Intentionally kept (not orphaned): the survey in closed issue #1961
+      # flagged this script as potentially unused after battery-notifier was
+      # rewritten as a Go daemon in #1955, but the hyprlock label above is a
+      # live dependency. See issue #1980 for the reachability check and
+      # decision to retain.
       home.file.".local/scripts/cli.system.batteryStatus" = lib.mkIf config.nx.isLaptop {
         executable = true;
         text =


### PR DESCRIPTION
Documentation-only follow-up to closed issue #1961, which deferred a side-quest
on whether `cli.system.batteryStatus` was orphaned after battery-notifier was
rewritten as a Go daemon in #1955.

## Reachability check

```
$ rg -nF "batteryStatus" -t nix -t sh -t lua -t qml -t js -t ts
modules/desktop/hyprland/scripts.nix:161:      home.file.".local/scripts/cli.system.batteryStatus" = lib.mkIf config.nx.isLaptop {
modules/desktop/hyprland/hyprlock.nix:72:              text = "cmd[update:5000] ${homeDir}/.local/scripts/cli.system.batteryStatus";
```

The script has exactly one live caller: the `cmd[update:5000]` label in the
laptop-only block of `modules/desktop/hyprland/hyprlock.nix`, which polls the
script every 5s to render the battery icon + percentage on the lockscreen.
**Not orphaned. Kept.**

## Change

Added a comment block immediately above the `home.file."...batteryStatus"`
entry in `scripts.nix` naming the live caller and explaining the script is
intentionally retained. References #1961 and #1980 so a future `rg` on the
script name surfaces the trail in-tree.

The script body and its `executable` / `text` fields are unchanged
byte-for-byte (see diff — only the 9-line comment block is new).

## Verification

- `nix flake check --no-build` passes.
- `git diff` shows only the comment block addition.

Closes #1980