### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779507042,
-        "narHash": "sha256-7wOwi8B6D0BYsieZCnHZZj2sNUzgJhLoIVSfkwB7lxQ=",
+        "lastModified": 1779592288,
+        "narHash": "sha256-pVZwRFVFdHS3D3G07MiZQcSPENnv1xlYCJtfabkqd3Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509ed3c603349a9d43de9e2ae6613baea6bd5b34",
+        "rev": "23703a32ef3d7803a2f1bb9909a3f46fc5185e37",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1779511298,
-        "narHash": "sha256-tHnSKnseojhalOjU0Ne9RxmYN+LblGuqfONGr2+vOOc=",
+        "lastModified": 1779600993,
+        "narHash": "sha256-Uu7EhMH+U3io7OPcK/saiflnFJyOI/j/21css7ZwYOQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e58e40ad6fa436cdf59ad01d24562821f2e7baed",
+        "rev": "e333c8669aa55464d84bafc3988d32d067ec0a92",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779357205,
-        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/26353190055

## Closure diff: navi

```
chafa: 1.18.1 → 1.18.2
firefox: 151.0 → 151.0.1, 12.3 KiB
firefox-unwrapped: 151.0 → 151.0.1, 95.6 KiB
kitty: 0.46.2 → 0.47.0, 2.2 MiB
libdwarf: 2.2.0 → 2.3.1
libodfgen: 0.1.7 → 0.1.8, -181.6 KiB
nixos-system-navi: 26.05.20260521.f83fc3c → 26.05.20260523.2991645
source: 480.8 KiB
stylua: 2.4.1 → 2.5.2, 110.2 KiB
zathura: 2026.02.09 → 2026.05.20, 522.0 KiB
zathura-with-plugins: 2026.02.09 → 2026.05.20
```

## Closure diff: tui

```
OVMF: 202602 → ∅, -8.0 MiB
OVMF-xen: ∅ → 202602, 4.0 MiB
chafa: 1.18.1 → 1.18.2
firefox: 151.0 → 151.0.1, 12.3 KiB
firefox-unwrapped: 151.0 → 151.0.1, 95.6 KiB
kitty: 0.46.2 → 0.47.0, 2.2 MiB
libdwarf: 2.2.0 → 2.3.1
libodfgen: 0.1.7 → 0.1.8, -181.6 KiB
nixos-system-tui: 26.05.20260521.f83fc3c → 26.05.20260523.2991645
source: 480.8 KiB
stylua: 2.4.1 → 2.5.2, 110.2 KiB
zathura: 2026.02.09 → 2026.05.20, 522.0 KiB
zathura-with-plugins: 2026.02.09 → 2026.05.20
```