### PR TITLE
anthropic-oauth: separate moved system text from first user block (#1983)

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/transforms.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/transforms.test.ts
@@ -1,0 +1,261 @@
+// Regression tests for transformBody — specifically the
+// "Relocate non-core system entries to user messages" block.
+// Run with: node --test transforms.test.ts  (Node 20+, zero new deps)
+//
+// Covers the acceptance criteria from GitHub issue #1983:
+//   - [functional] array-content first user message: relocated system text is
+//     separated from the original first text block by exactly "\n\n" when the
+//     resulting blocks are read in order.
+//   - [functional] string-content first user message: existing
+//     `prefix + "\n\n" + original` behaviour is preserved unchanged.
+//   - [edge-case] multiple non-core system entries are joined to each other by
+//     "\n\n" AND separated from the original user content by "\n\n".
+//   - [edge-case] when no non-core system entries need relocating, the first
+//     user message is not mutated.
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { transformBody } from "./transforms.ts"
+
+const SYSTEM_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude."
+
+type ParsedBody = {
+  system?: Array<{ type?: string; text?: string }>
+  messages?: Array<{
+    role?: string
+    content?: string | Array<{ type?: string; text?: string }>
+  }>
+}
+
+// Helper: parse the JSON string returned by transformBody back into an object
+// for structural assertions.
+function parseResult(body: ReturnType<typeof transformBody>): ParsedBody {
+  assert.equal(
+    typeof body,
+    "string",
+    "transformBody should return a JSON string for a JSON input",
+  )
+  return JSON.parse(body as string) as ParsedBody
+}
+
+// Helper: concatenate the text of all text blocks in a content array in order.
+function joinTextBlocks(
+  content: string | Array<{ type?: string; text?: string }> | undefined,
+): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("")
+}
+
+// ---------------------------------------------------------------------------
+// [functional] array-content first user message — the regression case.
+// ---------------------------------------------------------------------------
+describe("transformBody — relocate non-core system entries (array content)", () => {
+  it("separates the moved system text from the first user text block by \\n\\n", () => {
+    const input = JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      system: [
+        { type: "text", text: SYSTEM_IDENTITY },
+        {
+          type: "text",
+          text: "Current working directory: /home/ben/code/nixos-config/main",
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+        },
+      ],
+    })
+
+    const result = parseResult(transformBody(input))
+
+    // Only the billing header and identity should remain in system[].
+    assert.ok(Array.isArray(result.system))
+    const remainingTexts = (result.system ?? []).map((e) => e.text ?? "")
+    assert.ok(
+      remainingTexts.some((t) => t.startsWith("x-anthropic-billing-header")),
+      "billing header should remain in system[]",
+    )
+    assert.ok(
+      remainingTexts.some((t) => t === SYSTEM_IDENTITY),
+      "identity prefix should remain in system[]",
+    )
+    assert.ok(
+      !remainingTexts.some((t) => t.includes("nixos-config/main")),
+      "non-core system entry should be moved out of system[]",
+    )
+
+    // The first user message should still have array content.
+    const firstUser = result.messages?.[0]
+    assert.ok(firstUser, "first user message present")
+    assert.ok(
+      Array.isArray(firstUser.content),
+      "first user content stays an array",
+    )
+
+    // Concatenation of text blocks must NOT glue "main" directly onto "hi".
+    const joined = joinTextBlocks(firstUser.content)
+    assert.ok(
+      !joined.includes("mainhi"),
+      `text blocks must not glue together; got: ${JSON.stringify(joined)}`,
+    )
+    assert.ok(
+      joined.includes("nixos-config/main\n\nhi"),
+      `moved system text must be separated from user text by \\n\\n; got: ${JSON.stringify(joined)}`,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [functional] string-content first user message — existing behaviour preserved.
+// ---------------------------------------------------------------------------
+describe("transformBody — relocate non-core system entries (string content)", () => {
+  it("preserves prefix + \\n\\n + original for string content", () => {
+    const input = JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      system: [
+        { type: "text", text: SYSTEM_IDENTITY },
+        {
+          type: "text",
+          text: "Current working directory: /home/ben/code/nixos-config/main",
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: "hi",
+        },
+      ],
+    })
+
+    const result = parseResult(transformBody(input))
+
+    const firstUser = result.messages?.[0]
+    assert.ok(firstUser, "first user message present")
+    assert.equal(
+      typeof firstUser.content,
+      "string",
+      "string content stays a string",
+    )
+    assert.equal(
+      firstUser.content,
+      "Current working directory: /home/ben/code/nixos-config/main\n\nhi",
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [edge-case] multiple non-core system entries joined by \n\n to each other
+// AND separated from the original user content by \n\n.
+// ---------------------------------------------------------------------------
+describe("transformBody — multiple non-core system entries", () => {
+  it("joins moved entries to each other and separates them from user content (array)", () => {
+    const input = JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      system: [
+        { type: "text", text: SYSTEM_IDENTITY },
+        { type: "text", text: "FIRST_NON_CORE" },
+        { type: "text", text: "SECOND_NON_CORE" },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "USER_TEXT" }],
+        },
+      ],
+    })
+
+    const result = parseResult(transformBody(input))
+    const firstUser = result.messages?.[0]
+    assert.ok(firstUser, "first user message present")
+    assert.ok(Array.isArray(firstUser.content))
+
+    const joined = joinTextBlocks(firstUser.content)
+    assert.ok(
+      joined.includes("FIRST_NON_CORE\n\nSECOND_NON_CORE"),
+      `moved entries should be joined by \\n\\n; got: ${JSON.stringify(joined)}`,
+    )
+    assert.ok(
+      joined.includes("SECOND_NON_CORE\n\nUSER_TEXT"),
+      `last moved entry should be separated from user text by \\n\\n; got: ${JSON.stringify(joined)}`,
+    )
+  })
+
+  it("joins moved entries to each other and separates them from user content (string)", () => {
+    const input = JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      system: [
+        { type: "text", text: SYSTEM_IDENTITY },
+        { type: "text", text: "FIRST_NON_CORE" },
+        { type: "text", text: "SECOND_NON_CORE" },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: "USER_TEXT",
+        },
+      ],
+    })
+
+    const result = parseResult(transformBody(input))
+    const firstUser = result.messages?.[0]
+    assert.ok(firstUser, "first user message present")
+    assert.equal(typeof firstUser.content, "string")
+    assert.equal(
+      firstUser.content,
+      "FIRST_NON_CORE\n\nSECOND_NON_CORE\n\nUSER_TEXT",
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [edge-case] no non-core system entries → first user message is not mutated.
+// ---------------------------------------------------------------------------
+describe("transformBody — no non-core system entries", () => {
+  it("does not mutate the first user message when movedTexts is empty (array)", () => {
+    const originalContent = [{ type: "text", text: "USER_TEXT" }]
+    const input = JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      system: [{ type: "text", text: SYSTEM_IDENTITY }],
+      messages: [
+        {
+          role: "user",
+          content: originalContent,
+        },
+      ],
+    })
+
+    const result = parseResult(transformBody(input))
+    const firstUser = result.messages?.[0]
+    assert.ok(firstUser, "first user message present")
+    assert.deepEqual(
+      firstUser.content,
+      originalContent,
+      "first user content should be unchanged when no entries are moved",
+    )
+  })
+
+  it("does not mutate the first user message when movedTexts is empty (string)", () => {
+    const input = JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      system: [{ type: "text", text: SYSTEM_IDENTITY }],
+      messages: [
+        {
+          role: "user",
+          content: "USER_TEXT",
+        },
+      ],
+    })
+
+    const result = parseResult(transformBody(input))
+    const firstUser = result.messages?.[0]
+    assert.ok(firstUser, "first user message present")
+    assert.equal(firstUser.content, "USER_TEXT")
+  })
+})

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/transforms.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/transforms.ts
@@ -209,7 +209,11 @@ export function transformBody(
         if (typeof firstUser.content === "string") {
           firstUser.content = prefix + "\n\n" + firstUser.content
         } else if (Array.isArray(firstUser.content)) {
-          firstUser.content.unshift({ type: "text", text: prefix })
+          // Append "\n\n" to mirror the string-content branch — otherwise
+          // the moved system text glues directly onto the first user text
+          // block when adjacent text blocks are presented to the model
+          // (e.g. "...nixos-config/main" + "hi" → "mainhi"). See #1983.
+          firstUser.content.unshift({ type: "text", text: prefix + "\n\n" })
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes a token-stream artefact in the `anthropic-oauth` PI extension where the tail of the system prompt was glued directly onto the user's first message — producing visible mangling like `/home/ben/code/nixos-config/mainhi` when the user typed `hi`.

## Root cause

`modules/programs/prism/pi/extensions/anthropic-oauth/transforms.ts`, in the *Relocate non-core system entries to user messages* block, had two branches:

- The string-content branch correctly inserted `"\n\n"` between the moved system prefix and the original user content.
- The array-content branch (which fires for Claude Code, since its first user message uses content blocks) did `firstUser.content.unshift({ type: "text", text: prefix })` with no trailing separator. Adjacent text blocks are presented contiguously to the model, so the moved system text butted directly against the user's first text block.

## Fix

One-liner: append `"\n\n"` to `prefix` before the `unshift`, mirroring the string branch.

## Regression test

New file: `modules/programs/prism/pi/extensions/anthropic-oauth/transforms.test.ts` (uses `node --test` / `node:test` / `node:assert`, same conventions as `stream.test.ts` and `auth.test.ts`). Covers all four ACs:

- [functional] array-content first user message: relocated system text is separated from the original first text block by exactly `\n\n` (asserts on the in-order concatenation of text blocks; explicitly forbids `mainhi`).
- [functional] string-content first user message: existing `prefix + "\n\n" + original` behaviour preserved unchanged.
- [edge-case] multiple non-core entries: joined to each other by `\n\n` (existing `movedTexts.join("\n\n")` behaviour) **and** separated from the original user content by `\n\n`. Covered for both string and array content.
- [edge-case] no non-core entries (`movedTexts.length === 0`): first user message is not mutated. Covered for both string and array content.

I verified the regression test by temporarily reverting the fix — the array-content test fails with the exact `mainhi` string from the issue (`text blocks must not glue together; got: "Current working directory: /home/ben/code/nixos-config/mainhi"`), then passes again with the fix in place.

## Test run

```
$ cd modules/programs/prism/pi/extensions/anthropic-oauth/
$ node --test transforms.test.ts stream.test.ts auth.test.ts credentials.test.ts
ℹ tests 47
ℹ pass 47
ℹ fail 0
```

Closes #1983