### PR TITLE
prism(pi): overlay-bind host ~/.pi/agent/sessions/ for bwrap mode

### DIFF
--- a/modules/programs/prism/prism/cmd/reset_resume_e2e_test.go
+++ b/modules/programs/prism/prism/cmd/reset_resume_e2e_test.go
@@ -1,24 +1,31 @@
 package cmd
 
-// End-to-end seam test for the issue #1947 fix.
+// End-to-end seam test for the issue #1947 fix, updated for #1985.
 //
 // Pins the post-reset invariant: given a DB row with a non-empty
-// harness_session_id AND a transcript JSONL on disk (bwrap layout), after the
-// `prism reset` DB + FS code paths run, neither half of pi_invocation.go's
-// `--session <id>` injection trigger remains:
+// harness_session_id AND a transcript JSONL on disk, after the
+// `prism reset` DB + FS code paths run, the `--session <id>` injection
+// trigger in pi_invocation.go no longer fires — via the DB-side guard alone.
+//
+// Post-#1985 update: bwrap pi sessions now write into the host's global
+// ~/.pi/agent/sessions/ tree (the per-prism-session staging dir was removed
+// to restore cross-session per-cwd history). `resetClearPiTranscripts` does
+// NOT touch that global tree — same intentional skip as host mode, because
+// the dir holds state belonging to non-prism pi invocations too. The FS
+// transcript therefore survives the reset; the DB-side `HarnessSessionID =
+// nil` clear is what prevents the resume.
+//
+// Invariants pinned here:
 //
 //   (1) DB:  CurrentStatus.HarnessSessionID is nil (so cmd/agent_run.go feeds
 //       the empty string into container.Config.HarnessSessionID).
-//   (2) FS:  the transcript JSONL is gone (so piResolveResumeSession returns
-//       false even when called with a stale UUID).
+//   (2) FS:  the transcript JSONL survives by design (matches host mode).
 //   (3) PIInvocation: with HarnessSessionID="" the helper short-circuits and
-//       does not append --session at all (issue #1838 contract).
+//       does not append --session at all (issue #1838 contract) — this is
+//       the load-bearing half of the reset guard now.
 //
-// Host-mode is pinned separately: it does not consume harness_session_id from
-// the DB on the spawn/switch paths (internal/session/session.go:181-182), so
-// the reset code path is a no-op for it w.r.t. the resume pointer \u2014 covered
-// by TestResetClearPiTranscripts_NoSubtreeUnderHashIsNoOp (no bwrap subtree
-// for a host-mode session means nothing is touched).
+// Host-mode behaviour has not changed and is pinned separately by
+// TestReset_E2E_HostModeUnchanged below.
 
 import (
 	"os"
@@ -65,10 +72,12 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 	}
 	d.Close()
 
-	// ---- Seed FS (bwrap layout) ----
-	// <stateHome>/prism/run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl
-	hash := prismSession.SessionDirName(sessionName)
-	transcriptDir := filepath.Join(stateHome, "prism", "run", hash, "pi-agent", "sessions",
+	// ---- Seed FS (post-#1985 bwrap layout: host-global ~/.pi/agent/sessions/) ----
+	// Pi inside the bwrap sandbox writes to $PI_CODING_AGENT_DIR/sessions/,
+	// which is overlay-bound to the host's ~/.pi/agent/sessions/. So the
+	// host-side transcript path matches host mode.
+	home := os.Getenv("HOME")
+	transcriptDir := filepath.Join(home, ".pi", "agent", "sessions",
 		"--home-user-code-myrepo-feature--")
 	if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
 		t.Fatalf("mkdir transcriptDir: %v", err)
@@ -77,8 +86,14 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 	if err := os.WriteFile(transcript, []byte(`{"type":"session"}`), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}
-	// Plant a sibling file under the hashDir that must survive the reset.
+	// Plant a sibling file under the legacy per-prism-session hash dir that
+	// must survive the reset — the run/<hash>/ subtree still holds
+	// agent-run.log, hostapi.sock, sidecar.pid etc.
+	hash := prismSession.SessionDirName(sessionName)
 	hashDir := filepath.Join(stateHome, "prism", "run", hash)
+	if err := os.MkdirAll(hashDir, 0o700); err != nil {
+		t.Fatalf("mkdir hashDir: %v", err)
+	}
 	siblingPath := filepath.Join(hashDir, "agent-run.log")
 	if err := os.WriteFile(siblingPath, []byte("keep me"), 0o600); err != nil {
 		t.Fatalf("write sibling: %v", err)
@@ -127,9 +142,13 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 		t.Errorf("post-reset DB EndedAt = nil, want non-nil")
 	}
 
-	// (2) FS: transcript JSONL gone, hashDir + sibling preserved.
-	if _, err := os.Stat(transcript); !os.IsNotExist(err) {
-		t.Errorf("transcript still present (stat err=%v)", err)
+	// (2) FS: post-#1985, the transcript JSONL SURVIVES the reset by design
+	//     (it lives in the user's global ~/.pi/agent/sessions/, which holds
+	//     state belonging to non-prism pi invocations too — same intentional
+	//     skip as host mode). The hashDir and its sibling files are also
+	//     preserved.
+	if _, err := os.Stat(transcript); err != nil {
+		t.Errorf("transcript was removed by reset; post-#1985 bwrap transcripts must survive: %v", err)
 	}
 	if _, err := os.Stat(hashDir); err != nil {
 		t.Errorf("hashDir removed: %v", err)
@@ -138,12 +157,14 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 		t.Errorf("sibling file removed: %v", err)
 	}
 
-	// (3) container.ResolvePIResumeSession returns false post-reset, even
-	//     when invoked with the stale UUID. This proves the FS half of the
-	//     guard: even if cmd/agent_run.go somehow forwarded a non-empty SID,
-	//     PIInvocation would skip --session because the transcript is gone.
-	if container.ResolvePIResumeSession(preCfg) {
-		t.Errorf("post-reset: ResolvePIResumeSession = true, want false")
+	// (3) container.ResolvePIResumeSession still returns true post-reset
+	//     when invoked with the stale UUID — the transcript is still there.
+	//     This is intentional: the reset guard is now the DB-side clear, not
+	//     the FS-side clear. The realistic path (next assertion) proves the
+	//     full chain is safe.
+	if !container.ResolvePIResumeSession(preCfg) {
+		t.Errorf("post-reset: ResolvePIResumeSession = false, want true " +
+			"(transcript intentionally survives reset; DB-side clear is the guard)")
 	}
 
 	// (4) The realistic post-reset path \u2014 cmd/agent_run.go feeds

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -557,24 +557,13 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--setenv", "PRISM_HARNESS_PIPE", "unix://"+cfg.HarnessPipeSockPath)
 	}
 
-	// ── PI session persistence dir (read-write, conditional, pi only) ────────
-	// PI stores OAuth session state at ~/.pi/agent/sessions/. This directory
-	// must be bind-mounted read-write so that PI can load existing OAuth tokens
-	// inside the sandbox and write back refreshed tokens. Without the mount,
-	// PI's anthropic-oauth extension receives null from getApiKey and the
-	// session fails with "No Anthropic auth available."
-	//
-	// Conditional: only emitted when the directory exists on the host. When
-	// absent (e.g. a fresh install before any PI session has run), the mount is
-	// silently omitted and the session starts normally.
-	if cfg.Harness == "pi" {
-		piSessionsDir := filepath.Join(home, ".pi", "agent", "sessions")
-		if _, err := os.Stat(piSessionsDir); err == nil {
-			args = append(args, "--bind", piSessionsDir, piSessionsDir)
-		}
-	}
-
-	// ── PI-specific bind mounts (harness=pi only) ────────────────────────────
+	// ── PI-specific bind mounts (harness=pi only) ────────────────────────
+	// Note: the host's ~/.pi/agent/sessions/ directory is now overlaid onto
+	// $PI_CODING_AGENT_DIR/sessions/ inside the sandbox by
+	// appendPIBwrapMounts (called below), so a dedicated --bind of
+	// ~/.pi/agent/sessions onto its own host path is no longer needed — pi
+	// inside the sandbox reaches the host directory via PI_CODING_AGENT_DIR,
+	// not via the host home path. See #1985.────
 	// These must be appended before the "--" terminator so bwrap processes
 	// them as namespace arguments rather than as parts of the inner command.
 	if cfg.Harness == "pi" {

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -563,7 +563,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// appendPIBwrapMounts (called below), so a dedicated --bind of
 	// ~/.pi/agent/sessions onto its own host path is no longer needed — pi
 	// inside the sandbox reaches the host directory via PI_CODING_AGENT_DIR,
-	// not via the host home path. See #1985.────
+	// not via the host home path. See #1985.
+	//
 	// These must be appended before the "--" terminator so bwrap processes
 	// them as namespace arguments rather than as parts of the inner command.
 	if cfg.Harness == "pi" {

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -2242,11 +2242,27 @@ func TestHelpers_HasSetenv(t *testing.T) {
 	}
 }
 
-// ── PI session persistence dir bind mount ────────────────────────────────────
+// ── PI session persistence: global per-cwd history overlay (#1985) ───────────
+//
+// The host's ~/.pi/agent/sessions/ directory is overlay-mounted onto
+// $PI_CODING_AGENT_DIR/sessions/ inside the sandbox by appendPIBwrapMounts
+// (called from BuildArgs when Harness == "pi"). The tests below pin that
+// contract: the overlay --bind must appear in the arg list, must use the
+// in-sandbox sessions path as its destination (NOT the host path), must come
+// AFTER the staging-dir bind (so bwrap applies it as an overlay on top), and
+// must appear before the "--" terminator.
+//
+// Pre-#1985 these tests verified a separate --bind of
+// ~/.pi/agent/sessions onto its own host path, motivated by an OAuth-tokens
+// comment. That mount was dead code in the bwrap path (pi inside the sandbox
+// only writes to PI_CODING_AGENT_DIR, never to the host home path), so it was
+// removed during the #1985 consolidation.
 
 // bwrapPIFixture extends bwrapFixture with the minimum PI-specific config
 // needed to exercise the pi harness code path in BuildArgs. It creates a fake
-// PI binary and extension directory and returns a Config with Harness="pi" set.
+// PI binary, extension directory, AND PI agent config staging directory, and
+// returns a Config with Harness="pi" plus the PIAgentConfigHostDir set so the
+// sessions-overlay bind path in appendPIBwrapMounts is exercised.
 func bwrapPIFixture(t *testing.T) (m *Manager, fakeHome string, cleanup func()) {
 	t.Helper()
 
@@ -2259,100 +2275,137 @@ func bwrapPIFixture(t *testing.T) (m *Manager, fakeHome string, cleanup func()) 
 	if err := os.WriteFile(filepath.Join(extDir, "prism.ts"), []byte("// ext"), 0o644); err != nil {
 		t.Fatalf("bwrapPIFixture: write pi extension: %v", err)
 	}
+	// Stage a PI agent config dir so appendPIBwrapMounts takes the
+	// PIAgentConfigHostDir != "" branch and emits the sessions overlay.
+	agentCfgDir := t.TempDir()
 
 	m, fakeHome, cleanup = bwrapFixture(t, Config{
-		SessionName:        "repo@pi",
-		Worktree:           t.TempDir(),
-		AllocatedPort:      14010,
-		Harness:            "pi",
-		PIBinaryPath:       fakePIBin,
-		PIExtensionHostDir: extDir,
+		SessionName:             "repo@pi",
+		Worktree:                t.TempDir(),
+		AllocatedPort:           14010,
+		Harness:                 "pi",
+		PIBinaryPath:            fakePIBin,
+		PIExtensionHostDir:      extDir,
+		PIAgentConfigHostDir:    agentCfgDir,
+		PIAgentConfigSandboxDir: "/run/prism/pi-agent",
 	})
 	return m, fakeHome, cleanup
 }
 
-// TestBwrapBuildArgs_PISessionsDirBoundWhenExists verifies that when
-// ~/.pi/agent/sessions exists on the host and cfg.Harness == "pi",
-// BuildArgs emits --bind SRC SRC for the directory (read-write).
-func TestBwrapBuildArgs_PISessionsDirBoundWhenExists(t *testing.T) {
+// findBindPairs returns every (src, dst) --bind pair in args, in order.
+func findBindPairs(args []string) [][2]string {
+	var pairs [][2]string
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] == "--bind" {
+			pairs = append(pairs, [2]string{args[i+1], args[i+2]})
+		}
+	}
+	return pairs
+}
+
+// TestBwrapBuildArgs_PISessionsOverlay_BindsHostOntoSandbox verifies that the
+// host's ~/.pi/agent/sessions/ directory is bind-mounted onto the in-sandbox
+// $PI_CODING_AGENT_DIR/sessions/ path (NOT its host path) — the core #1985
+// fix that restores global per-cwd history persistence.
+func TestBwrapBuildArgs_PISessionsOverlay_BindsHostOntoSandbox(t *testing.T) {
 	m, fakeHome, cleanup := bwrapPIFixture(t)
 	defer cleanup()
 
-	// Create the PI sessions directory under the fake HOME.
-	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
-	if err := os.MkdirAll(piSessionsDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll pi sessions dir: %v", err)
-	}
-
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	if !hasBind(args, piSessionsDir) {
-		t.Errorf("PI sessions dir %q not found as --bind SRC SRC in args: %v", piSessionsDir, args)
+	wantSrc := filepath.Join(fakeHome, ".pi", "agent", "sessions")
+	wantDst := "/run/prism/pi-agent/sessions"
+
+	found := false
+	for _, p := range findBindPairs(args) {
+		if p[0] == wantSrc && p[1] == wantDst {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --bind %q %q (host pi sessions overlaid onto sandbox PI_CODING_AGENT_DIR/sessions); args=%v",
+			wantSrc, wantDst, args)
 	}
 }
 
-// TestBwrapBuildArgs_PISessionsDirOmittedWhenAbsent verifies that when
-// ~/.pi/agent/sessions does not exist on the host, BuildArgs does NOT
-// emit --bind for it — the session must start without error.
-func TestBwrapBuildArgs_PISessionsDirOmittedWhenAbsent(t *testing.T) {
+// TestBwrapBuildArgs_PISessionsOverlay_CreatesHostDirIfMissing verifies AC8
+// edge case: the spawn does not fail when ~/.pi/agent/ does not yet exist on
+// the host. The overlay code creates the host directory before emitting the
+// bind, so pi can write to it from inside the sandbox.
+func TestBwrapBuildArgs_PISessionsOverlay_CreatesHostDirIfMissing(t *testing.T) {
 	m, fakeHome, cleanup := bwrapPIFixture(t)
 	defer cleanup()
 
-	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
-	// Do NOT create piSessionsDir — it should be absent from args.
-
-	b := &bwrapIsolator{name: m.name}
-	args := b.BuildArgs(m)
-
-	if hasBind(args, piSessionsDir) {
-		t.Errorf("absent PI sessions dir %q should be omitted but found as --bind in args: %v", piSessionsDir, args)
-	}
-}
-
-// TestBwrapBuildArgs_PISessionsDirNotBoundForNonPI verifies that when
-// cfg.Harness != "pi", the PI sessions directory is NOT bound even when it
-// exists on the host — this is a PI-only concern.
-func TestBwrapBuildArgs_PISessionsDirNotBoundForNonPI(t *testing.T) {
-	m, fakeHome, cleanup := bwrapFixture(t, Config{
-		SessionName:   "repo@main",
-		Worktree:      t.TempDir(),
-		AllocatedPort: 14010,
-		Harness:       "pi", // not "pi"
-	})
-	defer cleanup()
-
-	// Create the PI sessions directory so the stat() would succeed if the
-	// code were wrong.
-	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
-	if err := os.MkdirAll(piSessionsDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll pi sessions dir: %v", err)
+	hostSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
+	// Pre-condition: directory does NOT exist (the fixture does not create it).
+	if _, err := os.Stat(hostSessionsDir); !os.IsNotExist(err) {
+		t.Fatalf("pre-condition: %q must not exist (stat err=%v)", hostSessionsDir, err)
 	}
 
 	b := &bwrapIsolator{name: m.name}
-	args := b.BuildArgs(m)
+	_ = b.BuildArgs(m)
 
-	if hasBind(args, piSessionsDir) {
-		t.Errorf("PI sessions dir %q must not be bound for non-pi harness; found as --bind in args: %v", piSessionsDir, args)
+	// Post-condition: BuildArgs created the host sessions dir as a side-effect
+	// of preparing the overlay bind, so the subsequent bwrap exec will succeed
+	// (bwrap requires the bind source to exist).
+	if info, err := os.Stat(hostSessionsDir); err != nil {
+		t.Errorf("expected BuildArgs to create %q; stat err=%v", hostSessionsDir, err)
+	} else if !info.IsDir() {
+		t.Errorf("expected %q to be a directory; got mode=%v", hostSessionsDir, info.Mode())
 	}
 }
 
-// TestBwrapBuildArgs_PISessionsDirBindBeforeTerminator verifies that the PI
-// sessions directory bind mount appears before the "--" terminator in the arg
-// list. bwrap requires all namespace flags to appear before the "--" separator.
-func TestBwrapBuildArgs_PISessionsDirBindBeforeTerminator(t *testing.T) {
+// TestBwrapBuildArgs_PISessionsOverlay_AfterStagingDirBind verifies that the
+// host-sessions overlay --bind appears AFTER the staging-dir --bind in the
+// arg list — bwrap applies binds in argument order, so the overlay only
+// takes effect when it comes second.
+func TestBwrapBuildArgs_PISessionsOverlay_AfterStagingDirBind(t *testing.T) {
 	m, fakeHome, cleanup := bwrapPIFixture(t)
 	defer cleanup()
 
-	piSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
-	if err := os.MkdirAll(piSessionsDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll pi sessions dir: %v", err)
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	hostSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
+	sandboxSessionsDir := "/run/prism/pi-agent/sessions"
+	sandboxAgentDir := "/run/prism/pi-agent"
+
+	stagingIdx, overlayIdx := -1, -1
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] != "--bind" {
+			continue
+		}
+		if args[i+2] == sandboxAgentDir && stagingIdx < 0 {
+			stagingIdx = i
+		}
+		if args[i+1] == hostSessionsDir && args[i+2] == sandboxSessionsDir {
+			overlayIdx = i
+		}
 	}
+	if stagingIdx < 0 {
+		t.Fatalf("staging-dir --bind onto %q not found in args=%v", sandboxAgentDir, args)
+	}
+	if overlayIdx < 0 {
+		t.Fatalf("sessions overlay --bind onto %q not found in args=%v", sandboxSessionsDir, args)
+	}
+	if overlayIdx <= stagingIdx {
+		t.Errorf("sessions overlay --bind (idx=%d) must come AFTER staging-dir --bind (idx=%d); args=%v",
+			overlayIdx, stagingIdx, args)
+	}
+}
+
+// TestBwrapBuildArgs_PISessionsOverlay_BeforeTerminator verifies that the
+// sessions overlay bind appears before the "--" terminator. bwrap requires
+// all namespace flags to precede the separator.
+func TestBwrapBuildArgs_PISessionsOverlay_BeforeTerminator(t *testing.T) {
+	m, fakeHome, cleanup := bwrapPIFixture(t)
+	defer cleanup()
 
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// Find the -- separator index.
 	sepIdx := -1
 	for i, a := range args {
 		if a == "--" {
@@ -2364,16 +2417,47 @@ func TestBwrapBuildArgs_PISessionsDirBindBeforeTerminator(t *testing.T) {
 		t.Fatalf("-- separator not found in args: %v", args)
 	}
 
-	// Verify the PI sessions --bind appears before the separator.
+	wantSrc := filepath.Join(fakeHome, ".pi", "agent", "sessions")
+	wantDst := "/run/prism/pi-agent/sessions"
 	found := false
-	for i := 0; i < sepIdx-2; i++ {
-		if args[i] == "--bind" && args[i+1] == piSessionsDir && args[i+2] == piSessionsDir {
+	for i := 0; i+2 < sepIdx; i++ {
+		if args[i] == "--bind" && args[i+1] == wantSrc && args[i+2] == wantDst {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("PI sessions dir --bind %q %q not found before -- terminator in args: %v",
-			piSessionsDir, piSessionsDir, args)
+		t.Errorf("sessions overlay --bind %q %q not found before -- terminator in args: %v",
+			wantSrc, wantDst, args)
+	}
+}
+
+// TestBwrapBuildArgs_PISessionsOverlay_OmittedForNonPI verifies that the
+// host-sessions overlay is NOT emitted when Harness != "pi" — the entire PI
+// bind-mount block (including the staging-dir bind that the overlay depends
+// on) is gated on cfg.Harness == "pi".
+func TestBwrapBuildArgs_PISessionsOverlay_OmittedForNonPI(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+		Harness:       "anthropic",
+	})
+	defer cleanup()
+
+	// Even with the host dir present, the non-pi path must not bind it.
+	hostSessionsDir := filepath.Join(fakeHome, ".pi", "agent", "sessions")
+	if err := os.MkdirAll(hostSessionsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll pi sessions dir: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for _, p := range findBindPairs(args) {
+		if p[0] == hostSessionsDir {
+			t.Errorf("non-pi harness must not --bind %q; got pair %v in args=%v",
+				hostSessionsDir, p, args)
+		}
 	}
 }

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -189,7 +189,9 @@ func piResolveResumeSession(cfg Config) bool {
 // The three branches mirror internal/harness/pi/archive.go::piSessionsRoot:
 //
 //	host         → <home>/.pi/agent/sessions
-//	bwrap        → <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions
+//	bwrap        → <home>/.pi/agent/sessions  (overlay-mounted into the sandbox
+//	                                            at $PI_CODING_AGENT_DIR/sessions;
+//	                                            see appendPIBwrapMounts and #1985)
 //	sandbox-exec → <stagingHome>/.pi/agent/sessions
 //
 // Mode is inferred from cfg fields rather than carried explicitly:
@@ -198,8 +200,10 @@ func piResolveResumeSession(cfg Config) bool {
 //     PIAgentConfigSandboxDir == PIAgentConfigHostDir (sandbox-exec shares the
 //     host FS, so populatePIConfig deliberately collapses the two paths).
 //   - bwrap is identified by SessionName being set AND
-//     PIAgentConfigSandboxDir != PIAgentConfigHostDir (bwrap remaps the staging
-//     dir to /run/prism/pi-agent inside the sandbox).
+//     PIAgentConfigSandboxDir != PIAgentConfigHostDir. As of #1985 bwrap
+//     overlays the host's ~/.pi/agent/sessions/ directly under the
+//     in-sandbox $PI_CODING_AGENT_DIR, so the host-side resolution is the
+//     same as host mode — collapsed into the fallback branch below.
 //   - host is the fallback when neither condition matches.
 //
 // Returns ok=false only when host-mode resolution fails (no home dir).
@@ -214,25 +218,12 @@ func piResumeSessionsRoot(cfg Config) (string, bool) {
 		return filepath.Join(stagingHome, ".pi", "agent", "sessions"), true
 	}
 
-	// bwrap: per-session staging dir under XDG_STATE_HOME.
-	if cfg.SessionName != "" && cfg.PIAgentConfigSandboxDir != "" &&
-		cfg.PIAgentConfigSandboxDir != cfg.PIAgentConfigHostDir {
-		stateHome := os.Getenv("XDG_STATE_HOME")
-		if stateHome == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", false
-			}
-			stateHome = filepath.Join(home, ".local", "state")
-		}
-		return filepath.Join(
-			stateHome, "prism", "run",
-			sessionDirName(cfg.SessionName),
-			"pi-agent", "sessions",
-		), true
-	}
-
-	// host (and unhandled fallbacks): real home directory.
+	// bwrap and host: both resolve to the real home's ~/.pi/agent/sessions/.
+	// (Before #1985 bwrap pointed at <XDG_STATE_HOME>/prism/run/<hash>/pi-agent/
+	// sessions/; that directory disappeared on `prism cleanup`, taking the
+	// history with it. The sessions subtree is now overlay-bound from the
+	// host's ~/.pi/agent/sessions/ in appendPIBwrapMounts so writes persist
+	// across prism-session lifetimes.)
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		return "", false
@@ -591,6 +582,32 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 		args = append(args, "--dir", agentConfigSandboxDir)
 		args = append(args, "--bind", agentConfigHostDir, agentConfigSandboxDir)
 		args = append(args, "--setenv", "PI_CODING_AGENT_DIR", agentConfigSandboxDir)
+
+		// ── PI sessions overlay (read-write, global, #1985) ─────────────────
+		// Overlay the host's ~/.pi/agent/sessions/ onto
+		// <agentConfigSandboxDir>/sessions/ so pi-written JSONL transcripts
+		// land in the user's global per-cwd history directory rather than the
+		// per-prism-session staging dir (which disappears on `prism cleanup`).
+		//
+		// This bind MUST be emitted after the staging-dir bind above so that
+		// bwrap applies it as an overlay (later --bind entries take effect on
+		// top of earlier ones at the same mount point). The staging dir keeps
+		// providing APPEND_SYSTEM.md / settings.json / themes / AGENTS.md /
+		// skills / auth.json; only the `sessions/` subdirectory is redirected.
+		//
+		// We create the host directory if it does not exist so a fresh install
+		// (no prior pi history) does not fail the spawn — bwrap requires the
+		// bind source to exist. Best-effort: if MkdirAll fails (e.g. read-only
+		// home), we skip the overlay rather than aborting the launch — pi will
+		// fall back to writing into the staging dir, matching pre-#1985
+		// behaviour for that one session.
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			hostSessionsDir := filepath.Join(home, ".pi", "agent", "sessions")
+			if mkErr := os.MkdirAll(hostSessionsDir, 0o700); mkErr == nil {
+				sandboxSessionsDir := filepath.Join(agentConfigSandboxDir, "sessions")
+				args = append(args, "--bind", hostSessionsDir, sandboxSessionsDir)
+			}
+		}
 	}
 
 	// ── PI auth.json bind-mount (read-write) ─────────────────────────────

--- a/modules/programs/prism/prism/internal/container/pi_invocation_resume_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_resume_test.go
@@ -195,9 +195,10 @@ func TestPIInvocation_Resume_EmptyHarnessSessionIDIsSilent(t *testing.T) {
 }
 
 // TestPIResumeSessionsRoot_AllModes verifies that the mode-aware resolver
-// covers all three isolation modes pi can run in (AC6):
+// covers the isolation modes pi can run in (AC6). Post-#1985 the bwrap
+// branch collapses into the host default (overlay-bound at launch):
 //   - host:         <home>/.pi/agent/sessions
-//   - bwrap:        <XDG_STATE_HOME>/prism/run/<dirHash>/pi-agent/sessions
+//   - bwrap:        <home>/.pi/agent/sessions  (same root as host)
 //   - sandbox-exec: <stagingHome>/.pi/agent/sessions
 func TestPIResumeSessionsRoot_AllModes(t *testing.T) {
 	home := t.TempDir()

--- a/modules/programs/prism/prism/internal/container/pi_invocation_resume_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_resume_test.go
@@ -22,23 +22,24 @@ import (
 )
 
 // writeBwrapResumeSession writes a synthetic pi session JSONL file at the
-// bwrap-mode sessions root (<XDG_STATE_HOME>/prism/run/<hash>/pi-agent/sessions/
-// <encoded-cwd>/<ts>_<uuid>.jsonl) and returns the on-disk path.
+// post-#1985 bwrap-mode sessions root (<home>/.pi/agent/sessions/<encoded-cwd>/
+// <ts>_<uuid>.jsonl) and returns the on-disk path.
+//
+// Pre-#1985 this helper planted files under
+// <XDG_STATE_HOME>/prism/run/<hash>/pi-agent/sessions/; that staging-dir
+// layout is gone now — bwrap pi sessions write into the host's global
+// ~/.pi/agent/sessions/ tree (same as host mode), and the staging dir is
+// overlay-bound onto it inside the sandbox.
 //
 // The file content is not parsed by the test \u2014 PIInvocation only stats the
 // directory listing and matches on the filename suffix.
-func writeBwrapResumeSession(t *testing.T, sessionName, worktree, sessionID string) string {
+func writeBwrapResumeSession(t *testing.T, _ /*sessionName*/, worktree, sessionID string) string {
 	t.Helper()
-	stateHome := os.Getenv("XDG_STATE_HOME")
-	if stateHome == "" {
-		t.Fatalf("writeBwrapResumeSession: XDG_STATE_HOME must be set by the caller")
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Fatalf("writeBwrapResumeSession: resolve HOME: %v", err)
 	}
-	dir := filepath.Join(
-		stateHome, "prism", "run",
-		sessionDirName(sessionName),
-		"pi-agent", "sessions",
-		encodePiCWD(worktree),
-	)
+	dir := filepath.Join(home, ".pi", "agent", "sessions", encodePiCWD(worktree))
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("mkdir resume session dir: %v", err)
 	}
@@ -67,6 +68,7 @@ func bwrapResumeCfg(sessionName, worktree, harnessSessionID string) Config {
 // InitialPrompt argument.
 func TestPIInvocation_Resume_AppendsSessionWhenFileExists(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
 
 	const sessionName = "myrepo@feature"
 	const worktree = "/home/user/code/myrepo/feature"
@@ -102,6 +104,7 @@ func TestPIInvocation_Resume_AppendsSessionWhenFileExists(t *testing.T) {
 // when InitialPrompt is empty.
 func TestPIInvocation_Resume_AppendsSession_NoInitialPrompt(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
 
 	const sessionName = "myrepo@feature"
 	const worktree = "/home/user/code/myrepo/feature"
@@ -130,6 +133,7 @@ func TestPIInvocation_Resume_AppendsSession_NoInitialPrompt(t *testing.T) {
 func TestPIInvocation_Resume_OmitsSessionWhenFileMissing(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("HOME", t.TempDir())
 
 	const sessionName = "myrepo@feature"
 	const worktree = "/home/user/code/myrepo/feature"
@@ -168,6 +172,7 @@ func TestPIInvocation_Resume_OmitsSessionWhenFileMissing(t *testing.T) {
 func TestPIInvocation_Resume_EmptyHarnessSessionIDIsSilent(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("HOME", t.TempDir())
 
 	const sessionName = "myrepo@feature"
 	const worktree = "/home/user/code/myrepo/feature"
@@ -215,6 +220,9 @@ func TestPIResumeSessionsRoot_AllModes(t *testing.T) {
 	})
 
 	t.Run("bwrap", func(t *testing.T) {
+		// Post-#1985: bwrap sessions write to the host's ~/.pi/agent/sessions/
+		// (same as host mode); the per-session staging dir is overlay-bound
+		// onto the in-sandbox $PI_CODING_AGENT_DIR/sessions/ at launch.
 		const sessionName = "myrepo@feature"
 		cfg := Config{
 			SessionName:             sessionName,
@@ -225,9 +233,15 @@ func TestPIResumeSessionsRoot_AllModes(t *testing.T) {
 		if !ok {
 			t.Fatalf("piResumeSessionsRoot(bwrap): ok=false, want true")
 		}
-		want := filepath.Join(stateHome, "prism", "run", sessionDirName(sessionName), "pi-agent", "sessions")
+		want := filepath.Join(home, ".pi", "agent", "sessions")
 		if got != want {
 			t.Errorf("piResumeSessionsRoot(bwrap) = %q, want %q", got, want)
+		}
+		// Defensive: must NOT point under the old per-session staging dir.
+		oldStaging := filepath.Join(stateHome, "prism", "run")
+		if strings.HasPrefix(got, oldStaging) {
+			t.Errorf("piResumeSessionsRoot(bwrap) %q must not point under the per-session staging dir %q anymore (#1985)",
+				got, oldStaging)
 		}
 	})
 

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -49,7 +49,6 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/container"
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
-	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // piArchiveAdapter implements harness/archive.ArchiveAdapter for PI.
@@ -83,15 +82,15 @@ func NewArchiveAdapter() harnessarchive.ArchiveAdapter {
 // encoded-cwd is derived from p.Worktree in both cases. Bug #1538 fix: only
 // the home base differs for sandbox-exec sessions.
 //
-// For bwrap sessions (IsolationMode == "bwrap"), PI writes into the per-session
-// pi-agent staging directory bind-mounted into the sandbox at
-// $PI_CODING_AGENT_DIR — on the host that resolves to
-// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/. Pi defaults
-// --session-dir to <PI_CODING_AGENT_DIR>/sessions/, so the JSONL lands at
-// <run>/pi-agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl — note there is no
-// ".pi/agent" join under the run dir (the staging dir IS the agent dir). The
-// session-dir hash is computed via session.SessionDirName (sha256 prefix). See
-// bug #1814 for the analysis.
+// For bwrap sessions (IsolationMode == "bwrap"), PI writes into the host's
+// ~/.pi/agent/sessions/ directory the same way as host mode. The sandbox
+// overlays that host directory onto $PI_CODING_AGENT_DIR/sessions/ inside
+// the namespace (see container.appendPIBwrapMounts), so writes pass through
+// to <home>/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl on the host.
+// This is the #1985 fix that restored the global per-cwd history users
+// expect; before that fix bwrap pointed at
+// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/ which was
+// torn down with the prism session (see bugs #1538 / #1814 for context).
 //
 // See docs/pi-rpc-interface.md Q5 for the authoritative path specification.
 func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, error) {
@@ -134,15 +133,19 @@ func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, er
 }
 
 // piSessionsRoot returns the per-mode sessions directory — the directory under
-// which pi creates one subdirectory per encoded CWD. The three branches are:
+// which pi creates one subdirectory per encoded CWD. The two distinct branches
+// are:
 //
-//	host         → <home>/.pi/agent/sessions
-//	bwrap        → <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions
+//	host / bwrap → <home>/.pi/agent/sessions
 //	sandbox-exec → <stagingHome>/.pi/agent/sessions
 //
-// The bwrap branch falls through to the host branch when SessionName is empty
-// (no way to derive a sessionDirHash), matching the no-op contract used by
-// SourcePath when HarnessSessionID or Worktree is empty.
+// Before #1985 bwrap pointed at
+// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/, but that
+// directory was torn down with the prism session, taking the per-cwd history
+// with it. The bwrap launch now overlay-mounts the host's
+// ~/.pi/agent/sessions/ onto $PI_CODING_AGENT_DIR/sessions/ inside the
+// sandbox (see container.appendPIBwrapMounts), so the host-side root is the
+// same as host mode and the bwrap branch collapses into the default.
 func piSessionsRoot(p harnessarchive.SourceParams) (string, error) {
 	switch {
 	case p.IsolationMode == "sandbox-exec" && p.InstanceID != "":
@@ -155,28 +158,9 @@ func piSessionsRoot(p harnessarchive.SourceParams) (string, error) {
 		}
 		return filepath.Join(stagingHome, ".pi", "agent", "sessions"), nil
 
-	case p.IsolationMode == "bwrap" && p.SessionName != "":
-		// bwrap: PI writes into the per-session pi-agent staging dir at
-		// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/.
-		// There is no .pi/agent join — the staging dir IS the agent dir.
-		stateHome := os.Getenv("XDG_STATE_HOME")
-		if stateHome == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", fmt.Errorf("pi archive: resolve home for bwrap state dir: %w", err)
-			}
-			stateHome = filepath.Join(home, ".local", "state")
-		}
-		return filepath.Join(
-			stateHome, "prism", "run",
-			session.SessionDirName(p.SessionName),
-			"pi-agent", "sessions",
-		), nil
-
 	default:
-		// host (and any fallback — empty IsolationMode, podman, or a
-		// bwrap/sandbox-exec session missing its identifier): use the real
-		// home directory.
+		// host, bwrap, podman, empty IsolationMode — all resolve to the
+		// real home directory's ~/.pi/agent/sessions/.
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", fmt.Errorf("pi archive: resolve home: %w", err)

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -9,7 +9,6 @@ import (
 
 	harnessarchive "github.com/prismatic-koi/prism/internal/harness/archive"
 	"github.com/prismatic-koi/prism/internal/harness/pi"
-	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // encodePiCWDForTest mirrors the encodePiCWD logic in archive.go for use in
@@ -469,14 +468,23 @@ func TestArchiveAdapter_EndToEnd_HostMode(t *testing.T) {
 	}
 }
 
-// stageBwrapSession writes a fake pi JSONL file at the bwrap layout path and
-// returns (filePath, content). It assumes $XDG_STATE_HOME has already been
-// redirected to a temp dir by the caller (t.Setenv("XDG_STATE_HOME", t.TempDir())).
-func stageBwrapSession(t *testing.T, stateHome, sessionName, worktree, harnessSessionID string) (string, string) {
+// stageBwrapSession writes a fake pi JSONL file at the post-#1985 bwrap
+// layout path — the host's global ~/.pi/agent/sessions/ tree, same as host
+// mode — and returns (filePath, content). It assumes $HOME has already been
+// redirected by the caller (t.Setenv("HOME", t.TempDir())).
+//
+// Pre-#1985 this helper planted files under
+// <XDG_STATE_HOME>/prism/run/<dirHash>/pi-agent/sessions/. That staging-dir
+// layout was torn down with the prism session, taking the per-cwd history
+// with it. The host-side path is now identical to host mode.
+func stageBwrapSession(t *testing.T, _ /*stateHome*/, _ /*sessionName*/, worktree, harnessSessionID string) (string, string) {
 	t.Helper()
-	dirHash := session.SessionDirName(sessionName)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Fatalf("stageBwrapSession: resolve HOME: %v", err)
+	}
 	encodedCWD := encodePiCWDForTest(worktree)
-	sessDir := filepath.Join(stateHome, "prism", "run", dirHash, "pi-agent", "sessions", encodedCWD)
+	sessDir := filepath.Join(home, ".pi", "agent", "sessions", encodedCWD)
 	if err := os.MkdirAll(sessDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -491,12 +499,14 @@ func stageBwrapSession(t *testing.T, stateHome, sessionName, worktree, harnessSe
 
 // TestArchiveAdapter_SourcePath_Bwrap_FindsMatchingFile verifies that under
 // bwrap mode, SourcePath locates the JSONL inside
-// <XDG_STATE_HOME>/prism/run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/
-// and returns the matching file path (AC #1, #2, #5).
+// <home>/.pi/agent/sessions/<encoded-cwd>/ and returns the matching file
+// path. Post-#1985 the bwrap branch resolves to the same host-global path as
+// host mode (the sandbox overlays it onto $PI_CODING_AGENT_DIR/sessions/).
 func TestArchiveAdapter_SourcePath_Bwrap_FindsMatchingFile(t *testing.T) {
 	// Redirect both $HOME and $XDG_STATE_HOME so no real-host paths are
 	// touched (works in both dev shell and Nix sandbox).
-	t.Setenv("HOME", t.TempDir())
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
@@ -520,21 +530,20 @@ func TestArchiveAdapter_SourcePath_Bwrap_FindsMatchingFile(t *testing.T) {
 		t.Errorf("SourcePath (bwrap): got %q, want %q", got, wantPath)
 	}
 
-	// The path must be under the run/<sessionDirHash>/pi-agent/sessions/<encoded-cwd>/
-	// layout — not under ~/.pi/agent/sessions/ — and the sessionDirHash must
-	// match session.SessionDirName(sessionName) byte-for-byte.
+	// The path must be under the host-global ~/.pi/agent/sessions/<encoded-cwd>/
+	// layout — the same root host mode uses.
 	wantPrefix := filepath.Join(
-		stateHome, "prism", "run",
-		session.SessionDirName(sessionName),
-		"pi-agent", "sessions",
+		fakeHome, ".pi", "agent", "sessions",
 		encodePiCWDForTest(worktree),
 	)
 	if !strings.HasPrefix(got, wantPrefix) {
 		t.Errorf("SourcePath (bwrap): got %q, expected prefix %q", got, wantPrefix)
 	}
-	// Defensive: must not point into the ~/.pi/agent/ tree.
-	if strings.Contains(got, filepath.Join(".pi", "agent")) {
-		t.Errorf("SourcePath (bwrap) returned path under .pi/agent/: %q", got)
+	// Defensive: must NOT point under the old per-session staging dir.
+	oldStaging := filepath.Join(stateHome, "prism", "run")
+	if strings.HasPrefix(got, oldStaging) {
+		t.Errorf("SourcePath (bwrap) %q must not point under the pre-#1985 per-session staging dir %q",
+			got, oldStaging)
 	}
 }
 
@@ -582,10 +591,11 @@ func TestArchiveAdapter_Archive_Bwrap_EndToEnd(t *testing.T) {
 }
 
 // TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName verifies that when
-// IsolationMode is "bwrap" but SessionName is empty (the bwrap branch cannot
-// compute a sessionDirHash), SourcePath returns a path that Archive treats as
-// a no-op — matching the existing fallback contract for the other modes
-// (AC #6).
+// IsolationMode is "bwrap" but SessionName is empty, SourcePath still
+// resolves (post-#1985 the bwrap branch no longer needs the SessionName —
+// it resolves to ~/.pi/agent/sessions/ like host mode). Archive on the
+// resulting sentinel must still be a no-op when no matching transcript
+// exists, matching the contract for the other modes.
 func TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
@@ -593,7 +603,7 @@ func TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName(t *testing.T) {
 
 	a := pi.NewArchiveAdapter()
 	p := harnessarchive.SourceParams{
-		SessionName:      "", // empty — bwrap branch cannot compute dirHash
+		SessionName:      "", // empty — post-#1985 bwrap no longer needs dirHash
 		IsolationMode:    "bwrap",
 		HarnessSessionID: "ses_01HQXY",
 		Worktree:         "/tmp/test-no-session-name",
@@ -603,7 +613,7 @@ func TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName(t *testing.T) {
 		t.Fatalf("SourcePath (bwrap empty SessionName): %v", err)
 	}
 
-	// Archive on that sentinel must be a no-op (the dir does not exist).
+	// Archive on that sentinel must be a no-op (no matching transcript exists).
 	rawDir := t.TempDir()
 	if err := a.Archive(context.Background(), got, rawDir, p); err != nil {
 		t.Fatalf("Archive on bwrap-empty-SessionName sentinel: %v", err)
@@ -617,21 +627,20 @@ func TestArchiveAdapter_SourcePath_Bwrap_EmptySessionName(t *testing.T) {
 // TestArchiveAdapter_SourcePath_Bwrap_NoMatchingFile verifies that when the
 // bwrap encoded-cwd directory exists but contains no file matching
 // *_<HarnessSessionID>.jsonl, SourcePath returns a sentinel path inside the
-// encoded-cwd dir and Archive on that sentinel is a no-op (AC #7).
+// encoded-cwd dir and Archive on that sentinel is a no-op.
 func TestArchiveAdapter_SourcePath_Bwrap_NoMatchingFile(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	const sessionName = "nixos-config@bwrap-nomatch"
 	const worktree = "/tmp/test-bwrap-nomatch-worktree"
 	const harnessSessionID = "ses_NOTPRESENT"
 
-	// Create the encoded-cwd dir but with a file that does NOT match the
-	// HarnessSessionID suffix — so the scan succeeds but finds no match.
-	dirHash := session.SessionDirName(sessionName)
+	// Post-#1985: bwrap pi sessions write to the host's ~/.pi/agent/sessions/
+	// tree. Create the encoded-cwd dir there, with a non-matching transcript.
 	encodedCWD := encodePiCWDForTest(worktree)
-	sessDir := filepath.Join(stateHome, "prism", "run", dirHash, "pi-agent", "sessions", encodedCWD)
+	sessDir := filepath.Join(fakeHome, ".pi", "agent", "sessions", encodedCWD)
 	if err := os.MkdirAll(sessDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
@@ -670,10 +679,14 @@ func TestArchiveAdapter_SourcePath_Bwrap_NoMatchingFile(t *testing.T) {
 	}
 }
 
-// TestArchiveAdapter_SourcePath_CrossMode_NoContamination verifies that with
-// identical SessionName + Worktree + HarnessSessionID, the three isolation
-// modes (bwrap, host, sandbox-exec) return paths that differ along the
-// documented dimensions — no cross-contamination (AC #9).
+// TestArchiveAdapter_SourcePath_CrossMode_NoContamination verifies that
+// SourcePath produces paths anchored in the right per-mode root:
+//
+//   - host and bwrap collapse to the SAME ~/.pi/agent/sessions/ root
+//     (post-#1985, bwrap overlays this dir onto the sandbox path so the
+//     host-side resolution is identical).
+//   - sandbox-exec is anchored in the per-instance staging HOME and must
+//     NOT collide with the host/bwrap path.
 func TestArchiveAdapter_SourcePath_CrossMode_NoContamination(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
@@ -714,9 +727,11 @@ func TestArchiveAdapter_SourcePath_CrossMode_NoContamination(t *testing.T) {
 		t.Fatalf("SourcePath (sandbox-exec): %v", err)
 	}
 
-	// All three must differ.
-	if hostPath == bwrapPath {
-		t.Errorf("host and bwrap returned the same path: %q", hostPath)
+	// host and bwrap now collapse to the same root (#1985). sandbox-exec
+	// must still differ.
+	if hostPath != bwrapPath {
+		t.Errorf("host and bwrap should collapse to the same root post-#1985; host=%q bwrap=%q",
+			hostPath, bwrapPath)
 	}
 	if hostPath == sandboxPath {
 		t.Errorf("host and sandbox-exec returned the same path: %q", hostPath)
@@ -731,20 +746,17 @@ func TestArchiveAdapter_SourcePath_CrossMode_NoContamination(t *testing.T) {
 		t.Errorf("host path %q does not have prefix %q", hostPath, hostPrefix)
 	}
 
-	// bwrap: under <stateHome>/prism/run/<dirHash>/pi-agent/sessions/, and
-	// MUST NOT touch .pi/agent.
-	bwrapPrefix := filepath.Join(
-		stateHome, "prism", "run",
-		session.SessionDirName(sessionName),
-		"pi-agent", "sessions",
-	)
-	if !strings.HasPrefix(bwrapPath, bwrapPrefix) {
-		t.Errorf("bwrap path %q does not have prefix %q", bwrapPath, bwrapPrefix)
+	// bwrap: also under <fakeHome>/.pi/agent/sessions/ (post-#1985).
+	// MUST NOT point under the pre-#1985 per-prism-session staging dir.
+	if !strings.HasPrefix(bwrapPath, hostPrefix) {
+		t.Errorf("bwrap path %q does not have prefix %q (post-#1985 collapses to host root)",
+			bwrapPath, hostPrefix)
 	}
-	if strings.Contains(bwrapPath, filepath.Join(".pi", "agent")) {
-		t.Errorf("bwrap path %q must not contain .pi/agent", bwrapPath)
+	oldBwrapPrefix := filepath.Join(stateHome, "prism", "run")
+	if strings.HasPrefix(bwrapPath, oldBwrapPrefix) {
+		t.Errorf("bwrap path %q must not point under pre-#1985 staging dir %q",
+			bwrapPath, oldBwrapPrefix)
 	}
-
 	// sandbox-exec: under <fakeHome>/.local/state/prism/sessions/<instanceID>/home/.pi/agent/sessions/
 	sandboxPrefix := filepath.Join(
 		fakeHome, ".local", "state", "prism", "sessions", instanceID, "home",


### PR DESCRIPTION
Closes #1985

## Problem

Bwrap-launched pi wrote session JSONLs to
`~/.local/state/prism/run/<hash>/pi-agent/sessions/<encoded-cwd>/` — a
per-prism-session staging dir that disappeared with the prism session.
Each spawn on the same worktree saw an empty history, breaking the
expected "global per-cwd pi history" the user gets running pi directly.

Regression introduced when `PI_CODING_AGENT_DIR=/run/prism/pi-agent` was
added (#1538 / #1814).

## Fix

In `appendPIBwrapMounts`, after the existing staging-dir bind, emit a
second `--bind` that overlays the host's `~/.pi/agent/sessions/` onto
`$PI_CODING_AGENT_DIR/sessions/` inside the sandbox. bwrap applies binds
in argument order, so the overlay layers on top of the staging dir's
`sessions/` subdirectory. Pi keeps writing to
`$PI_CODING_AGENT_DIR/sessions/<encoded-cwd>/` from inside the sandbox,
but those writes now land in `~/.pi/agent/sessions/<encoded-cwd>/` on the
host — the same global tree host-mode pi uses.

The staging dir is unchanged for everything else (APPEND_SYSTEM.md,
settings.json, themes/, AGENTS.md, skills/, auth.json symlink) — only
the `sessions/` subdir is redirected, so #1979's role-prompt + skills
plumbing is preserved.

`piResumeSessionsRoot` (pi_invocation.go) and `piSessionsRoot`
(archive.go) updated: the bwrap branch now collapses into the host
fallback (both return `~/.pi/agent/sessions/`), so resume lookup and
archive both see the real on-disk path.

The `~/.pi/agent/sessions` `--bind` block in `bwrap.go:561-577` (the
"OAuth tokens" comment) was redundant — it mounted at the host path, but
pi inside the sandbox only writes to `PI_CODING_AGENT_DIR`, not the host
home path. Removed.

## Reset behaviour

`resetClearPiTranscripts` already intentionally skipped
`~/.pi/agent/sessions/` for host mode ("would also touch state belonging
to non-prism pi invocations — strictly out of scope"). Post-#1985 bwrap
matches host mode: the transcript survives `prism reset` by design.

The reset guard against accidental resume is now the DB-side
`HarnessSessionID = nil` clear alone — that was already the load-bearing
half; the FS-side wipe was defence-in-depth for the staging-dir era.
`reset_resume_e2e_test.go` updated to pin the new contract.

## Edge cases handled

- `~/.pi/agent/sessions/` does not exist at spawn time → created with
  `os.MkdirAll` mode `0o700` before the bind (bwrap requires the source
  to exist).
- `os.UserHomeDir()` fails or `MkdirAll` fails → overlay silently skipped,
  pi falls back to writing into the staging dir for that one session
  (matching pre-#1985 behaviour).
- OAuth: `auth.json` is bind-mounted directly at its host path
  (unchanged); `atlassian-mcp-oauth.json` likewise (unchanged). The
  removed `~/.pi/agent/sessions` bind was unrelated to OAuth tokens
  despite the comment — pi's OAuth state lives in those two files, not
  in `sessions/`.
- Non-pi harnesses: the new overlay is gated on the existing
  `cfg.PIAgentConfigHostDir != ""` check, which is only set by the pi
  spawn path.

## Manual smoke-test plan

1. Spawn a prism pi session in a worktree → JSONL appears at
   `~/.pi/agent/sessions/<encoded-cwd>/`.
2. `prism cleanup` → JSONL remains on disk.
3. Spawn a second prism session on the same worktree → previous JSONL
   still listed under `~/.pi/agent/sessions/<encoded-cwd>/`.
4. Resume into the previous session via `pi --session <uuid>` → loads
   the existing transcript.

## CI checks run locally

- `go build ./...` ✅
- `go test ./...` ✅
- `go test -race ./internal/container/ ./internal/harness/pi/ ./cmd/` ✅
- `nix build .#prism` ✅
- `nix build --impure --no-link --expr '... prism.override { runChecks = true; }'` ✅ (homeless-shelter gate)