### PR TITLE
Add grill-me skill to prism pi

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -82,6 +82,7 @@
         cp -r ${./skills/acceptance-criteria}/* $out/acceptance-criteria/
         cp -r ${./skills/retro}/* $out/retro/
         cp -r ${./skills/atlassian}/* $out/atlassian/
+        cp -r ${./skills/grill-me}/* $out/grill-me/
       '';
 
       # Vendored pi extensions directory — built as a single derivation so it

--- a/modules/programs/prism/skills/grill-me/SKILL.md
+++ b/modules/programs/prism/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
This change adds a new "grill-me" skill to the prism module, designed to help users stress-test plans and designs through rigorous questioning. The skill is now included in the pi derivation to allow for its deployment and use within the environment.