### PR TITLE
prism: raise default isolator concurrency cap from 20 to 50

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -25,8 +25,6 @@
       prism = {
         profile.default = "anthropic";
         agent.isolation.default = "bwrap";
-
-        bwrapConcurrencyCap = 50;
       };
       anki.enable = false; # build broken as of 2025-08-30
       calibre.enable = true;

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -113,22 +113,22 @@ in
 
     nx.programs.prism.bwrapConcurrencyCap = lib.mkOption {
       type = lib.types.int;
-      default = 20;
+      default = 50;
       description = ''
         Maximum number of concurrent bwrap sessions (agent_status rows with
         ended_at IS NULL AND isolation_mode = 'bwrap') before new bwrap spawns
-        are refused. 0 means uncapped. Default of 20 is conservative enough for
+        are refused. 0 means uncapped. Default of 50 is conservative enough for
         any machine without an explicit per-machine override.
       '';
     };
 
     nx.programs.prism.sandboxExecConcurrencyCap = lib.mkOption {
       type = lib.types.int;
-      default = 20;
+      default = 50;
       description = ''
         Maximum number of concurrent sandbox-exec sessions (agent_status rows
         with ended_at IS NULL AND isolation_mode = 'sandbox-exec') before new
-        sandbox-exec spawns are refused. 0 means uncapped. Default of 20
+        sandbox-exec spawns are refused. 0 means uncapped. Default of 50
         mirrors bwrapConcurrencyCap. Darwin-only isolation mode; this option
         is rendered into config.json on all machines but only used on Darwin.
       '';

--- a/modules/programs/prism/prism/docs/invariants/session-lifecycle.md
+++ b/modules/programs/prism/prism/docs/invariants/session-lifecycle.md
@@ -21,7 +21,7 @@ to all of them. The valid isolation modes referenced below are `bwrap`,
 - Two concurrent `prism spawn` calls for the same session name in the same prism process serialise through an in-process lock; the second caller sees the live row and exits non-zero with `"is already alive ... concurrent spawn rejected"`.
 - `prism spawn --branch <name>` without `--reuse` fails when an active session already exists on that branch; with `--reuse` it returns the existing session's name, port, and agent and exits 0.
 - `prism spawn --wait` blocks until the spawned session's first turn reaches `finished`, `error`, `interrupted`, or `deleted`, with a default timeout of `10m`.
-- `prism spawn` enforces a per-isolator concurrency cap for `bwrap` and `sandbox-exec` (compiled-in default `20` each; configurable via `bwrap_concurrency_cap` / `sandbox_exec_concurrency_cap` in `~/.config/prism/config.json`) and refuses to start a new session over the cap unless `--ignore-concurrency-cap` is passed; `host` mode is uncapped.
+- `prism spawn` enforces a per-isolator concurrency cap for `bwrap` and `sandbox-exec` (compiled-in default `50` each; configurable via `bwrap_concurrency_cap` / `sandbox_exec_concurrency_cap` in `~/.config/prism/config.json`) and refuses to start a new session over the cap unless `--ignore-concurrency-cap` is passed; `host` mode is uncapped.
 - Spawning onto `main` in a bare+worktree repo (where `<repo>/main/` already exists as a worktree) fails with a git error rather than creating a second worktree on the same branch.
 - The default isolation mode for a new session is the machine-level `default_isolation_mode` from `~/.config/prism/config.json` (default `host`), optionally overridden per-path by `project_isolation_overrides`.
 

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -108,14 +108,14 @@ type Config struct {
 	// BwrapConcurrencyCap is the maximum number of active bwrap sessions
 	// (agent_status rows with ended_at IS NULL AND isolation_mode = 'bwrap')
 	// before new bwrap spawns are refused. Zero means uncapped (not "cap of
-	// zero"). The default of 20 is conservative enough for any machine without
+	// zero"). The default of 50 is conservative enough for any machine without
 	// an explicit per-machine override.
 	BwrapConcurrencyCap int `json:"bwrap_concurrency_cap"`
 
 	// SandboxExecConcurrencyCap is the maximum number of active sandbox-exec
 	// sessions (agent_status rows with ended_at IS NULL AND
 	// isolation_mode = 'sandbox-exec') before new sandbox-exec spawns are
-	// refused. Zero means uncapped (not "cap of zero"). The default of 20
+	// refused. Zero means uncapped (not "cap of zero"). The default of 50
 	// mirrors BwrapConcurrencyCap. Can be overridden per-machine via the Nix
 	// sandboxExecConcurrencyCap option (written to config.json). Darwin only.
 	SandboxExecConcurrencyCap int `json:"sandbox_exec_concurrency_cap"`
@@ -181,18 +181,18 @@ type parsedConfig struct {
 }
 
 // DefaultBwrapConcurrencyCap is the compiled-in default maximum number of
-// concurrent bwrap sessions. A value of 20 is conservative enough for any
+// concurrent bwrap sessions. A value of 50 is conservative enough for any
 // machine without an explicit override. The cap can be raised per-machine
 // via the Nix bwrapConcurrencyCap option (written to config.json).
 // Zero means uncapped.
-const DefaultBwrapConcurrencyCap = 20
+const DefaultBwrapConcurrencyCap = 50
 
 // DefaultSandboxExecConcurrencyCap is the compiled-in default maximum number
 // of concurrent sandbox-exec sessions. Mirrors DefaultBwrapConcurrencyCap —
-// 20 is conservative enough for any Darwin machine without an explicit
+// 50 is conservative enough for any Darwin machine without an explicit
 // override. The cap can be raised per-machine via the Nix
 // sandboxExecConcurrencyCap option (written to config.json). Zero means uncapped.
-const DefaultSandboxExecConcurrencyCap = 20
+const DefaultSandboxExecConcurrencyCap = 50
 
 // defaults returns the compiled-in fallback Config (gruvbox-dark palette,
 // standard paths). These values are used whenever no config file is found.


### PR DESCRIPTION
Raises the compiled-in default for both `bwrap_concurrency_cap` and `sandbox_exec_concurrency_cap` from 20 to 50.

## What changes

- `DefaultBwrapConcurrencyCap` and `DefaultSandboxExecConcurrencyCap` in `internal/config/config.go`: 20 → 50 (plus doc-comment updates on both constants and the corresponding `Config` fields).
- `docs/invariants/session-lifecycle.md`: the `prism spawn` cap line now reads `compiled-in default \`50\` each`.

## What does not change

- The override path is untouched — an explicit `bwrap_concurrency_cap` / `sandbox_exec_concurrency_cap` in `~/.config/prism/config.json` continues to win over the compiled-in default.
- The cap-check call site, the `CapStatus` error wording / exit code, and the `--ignore-concurrency-cap` flag are untouched.
- `host` mode remains uncapped (`Cap.Limit == 0`).

## Why

The previous default felt constricting on capable machines — on Darwin (sandbox-exec) the user was hitting the cap with normal coordinator-driven workloads, and navi (Linux) was already overriding the bwrap cap upward via `~/.config/prism/config.json`.

This is a tactical raise of a crude proxy. The deeper question — "what should this cap actually measure?" — is parked separately under #1991 and is **not** addressed here.

## Tests

No existing test pinned the literal `20` for these constants (the only similarly-named test constant is `DefaultConcurrencyCap = 6` in `internal/container/concurrency.go`, which is the podman cap and is unrelated). Nothing to update.

Local pre-PR self-check:

```
cd modules/programs/prism/prism/
go build ./...   # clean
go test ./...   # all packages pass
```

And from the repo root:

```
nix build .#prism   # succeeds
```

CI will run the homeless-shelter gate (`go-tests` + `nix-build-prism-checked`).

Closes #1990