### PR TITLE
fix(prism/pi-skills): mkdir $out/grill-me before cp

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -73,7 +73,7 @@
       # the persisted ~/.pi/agent/skills/ directory that would dangle after
       # nix-collect-garbage removes the store paths they pointed to.
       skillsDir = pkgs.runCommand "pi-skills" { } ''
-        mkdir -p $out/prism $out/aws $out/acceptance-criteria $out/retro $out/atlassian
+        mkdir -p $out/prism $out/aws $out/acceptance-criteria $out/retro $out/atlassian $out/grill-me
         cp -r ${./skills/prism}/* $out/prism/
         ${lib.optionalString pkgs.stdenv.isLinux ''
           cp -r ${./skills/playwright-cli} $out/playwright-cli


### PR DESCRIPTION
## Summary

One-line fix for the Darwin-only build break on `main` introduced by #1989.

`modules/programs/prism/pi.nix` builds the `pi-skills` derivation; the `mkdir -p` line was missing `$out/grill-me`, so `cp -r ${./skills/grill-me}/* $out/grill-me/` failed under BSD `cp` on Darwin (GNU `cp` on Linux tolerated it).

## Change

```diff
-        mkdir -p $out/prism $out/aws $out/acceptance-criteria $out/retro $out/atlassian
+        mkdir -p $out/prism $out/aws $out/acceptance-criteria $out/retro $out/atlassian $out/grill-me
```

## Verification

- `nix build .#prism` — ✅
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — ✅
- Inspected resulting `pi-skills` store path: contains all six explicit skill dirs (`acceptance-criteria atlassian aws grill-me prism retro`) plus the Linux-only `playwright-cli`. No regression for the other five.
- Darwin build path will be verified by CI (no Darwin host available on this worker).

Closes #1994