### PR TITLE
hyprland: replace toggleTouchpad shell script with inline lua closure

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -36,7 +36,6 @@ in
             runscripts = "${scriptsDir}/application.scripts.launcher";
             calculator = "${scriptsDir}/application.rofi.calculator";
             applicationlauncher = "${scriptsDir}/application.launcher";
-            toggleTouchpad = "${scriptsDir}/system.inputs.toggleTouchpad";
             volumeUp = "${scriptsDir}/system.audio.volumeUp";
             volumeDown = "${scriptsDir}/system.audio.volumeDown";
             toggleMute = "${scriptsDir}/system.audio.toggleMute";
@@ -625,7 +624,31 @@ in
                 (lib.mkIf config.nx.isLaptop (mkExec "XF86MonBrightnessUp" brightnessUp))
                 (lib.mkIf config.nx.isLaptop (mkExec "XF86MonBrightnessDown" brightnessDown))
                 # The Asus laptop firmware maps the touchpad toggle Fn key to Super+P.
-                (lib.mkIf config.nx.isLaptop (mkExec "SUPER + p" toggleTouchpad))
+                # Inline lua closure (formerly the
+                # `system.inputs.toggleTouchpad` shell script in scripts.nix).
+                # The lua API is write-only for per-device `enabled`
+                # (`hl.device` is declared `fun(spec): nil`, and no
+                # `get_device` exists on `HL.API`), so the toggle has to
+                # track its own intended state. Holding that state in a
+                # closure inside the same lua VM as the device config means
+                # it resets in lockstep with `hyprctl reload` — fixing the
+                # desync the old shell script had where its status file in
+                # `$XDG_RUNTIME_DIR` outlived the device's config-default
+                # reset. Same IIFE-with-private-state pattern used by the
+                # submap auto-reset binds above.
+                (lib.mkIf config.nx.isLaptop (
+                  mkBind "SUPER + p" ''
+                    (function()
+                      local enabled = true
+                      local name = "asup1415:00-093a:300c-touchpad"
+                      return function()
+                        enabled = not enabled
+                        hl.device({ name = name, enabled = enabled })
+                        hl.dsp.event("quickshell:osd:touchpad:" .. (enabled and "on" or "off"))
+                      end
+                    end)()
+                  ''
+                ))
                 # print screen
                 (mkExec "Print" "${scriptsDir}/application.grim.fullScreenshotToFile")
                 # mouse (formerly bindm). `mouse = true` flag matches the

--- a/modules/desktop/hyprland/scripts.nix
+++ b/modules/desktop/hyprland/scripts.nix
@@ -18,57 +18,16 @@
       #   - per-host overrides (e.g. the ultrawide on navi):
       #              machines/navi/configuration.nix
       # See the matching comment block in default.nix near `workspace_rule`.
-      home.file.".local/scripts/system.inputs.toggleTouchpad" = lib.mkIf config.nx.isLaptop {
-        executable = true;
-        text =
-          # bash
-          ''
-            #!/bin/sh
-            export STATUS_FILE="$XDG_RUNTIME_DIR/touchpad_status"
-
-            # Mutating `device[...]:enabled` at runtime under the lua
-            # parser. `hyprctl keyword` is rejected by the lua parser
-            # ("keyword can't work with non-legacy parsers. Use eval.")
-            # and `hyprctl eval` does not exist as a subcommand on
-            # hyprland 0.55.1 — so we drive the device API directly via
-            # `hyprctl dispatch '<lua>'`.
-            #
-            # `hyprctl dispatch` evaluates its argument as a lua
-            # expression and feeds the result to `hl.dispatch(...)`,
-            # whose typedef is `fun(dispatcher: HL.Dispatcher|function)`
-            # — so passing a `function() ... end` literal lets us run
-            # arbitrary lua side-effects (here: `hl.device({...})`)
-            # without needing the result to be a dispatcher value. The
-            # device API's `enabled` field is the lua-native replacement
-            # for the hyprlang `device[NAME]:enabled` keyword and is
-            # declared in the type stubs at
-            # `share/hypr/stubs/hl.meta.lua` (`HL.DeviceSpec.enabled`).
-            set_touchpad() {
-              # $1 is the lua boolean literal (`true` or `false`).
-              hyprctl dispatch \
-                "function() hl.device({ name = \"asup1415:00-093a:300c-touchpad\", enabled = $1 }) end" \
-                > /dev/null
-            }
-
-            if ! [ -f "$STATUS_FILE" ]; then
-              # disable touchpad
-              set_touchpad false
-              touch "$STATUS_FILE"
-              echo "disabled" > "$STATUS_FILE"
-              hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:off")' > /dev/null
-            elif [ "$(cat $STATUS_FILE)" = "enabled" ]; then
-              # disable touchpad
-              set_touchpad false
-              echo "disabled" > "$STATUS_FILE"
-              hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:off")' > /dev/null
-            elif [ "$(cat $STATUS_FILE)" = "disabled" ]; then
-              # enable touchpad
-              set_touchpad true
-              echo "enabled" > "$STATUS_FILE"
-              hyprctl dispatch 'hl.dsp.event("quickshell:osd:touchpad:on")' > /dev/null
-            fi
-          '';
-      };
+      # NOTE: `system.inputs.toggleTouchpad` previously lived here — a
+      # shell script bound to SUPER + p that toggled the laptop touchpad
+      # via `hyprctl dispatch` and tracked its intended state in
+      # `$XDG_RUNTIME_DIR/touchpad_status`. The status file outlived
+      # `hyprctl reload` while the device's runtime `enabled` flag did not,
+      # so the two desynced after every reload. The whole thing now lives
+      # as an inline lua closure inside the hyprland config; the closure's
+      # local `enabled` resets in lockstep with the device's config-default
+      # state. See the `SUPER + p` bind in
+      # `modules/desktop/hyprland/default.nix`. (issue #2000)
       home.file.".local/scripts/system.audio.volumeUp" = {
         executable = true;
         text =


### PR DESCRIPTION
Drops the `~/.local/scripts/system.inputs.toggleTouchpad` shell script and replaces it with an inline lua closure bound directly on `SUPER + p` inside the hyprland lua config.

## Why

- The lua API is write-only for per-device `enabled` (`hl.device` is declared `fun(spec): nil` and there is no `get_device` on `HL.API`), so the toggle has to track its own intended state.
- The old script tracked that state in `$XDG_RUNTIME_DIR/touchpad_status`, but the file outlived `hyprctl reload` while the device's runtime `enabled` flag did not — every reload desynced the two and the next press flipped the wrong way.
- Holding the state in a lua closure inside the same VM as the device config means it resets in lockstep with `hyprctl reload`, so the desync disappears.

## Notes

- The device-name string `asup1415:00-093a:300c-touchpad` and the OSD event names `quickshell:osd:touchpad:on` / `quickshell:osd:touchpad:off` are reused unchanged — quickshell subscribes to those exact names.
- Same IIFE-with-private-state pattern as the submap auto-reset binds already in the file.
- Gated on `config.nx.isLaptop` as before; absent from non-laptop hosts' generated hyprland config (verified via `nix eval` on `tui` vs `navi`).
- A `# NOTE:` breadcrumb is left in `scripts.nix` where the old script block lived, matching the style of existing removal notes for `cli.system.setHyprGaps` and `cli.hyprland.switchWorkspaceOnWindowClose`.

## Pre-PR self-check

- `nixfmt .` — no diff.
- `nix build .#nixosConfigurations.tui.config.system.build.toplevel` — succeeds.
- Rendered `hyprland.lua` on `tui` contains:
  ```lua
  hl.bind("SUPER + p", ((function()
    local enabled = true
    local name = "asup1415:00-093a:300c-touchpad"
    return function()
      enabled = not enabled
      hl.device({ name = name, enabled = enabled })
      hl.dsp.event("quickshell:osd:touchpad:" .. (enabled and "on" or "off"))
    end
  end)()
  ))
  ```
- Rendered `hyprland.lua` on `navi` (non-laptop) contains no `SUPER + p` binding.

Closes #2000