### PR TITLE
colour-scheme: add edge (sainnhe) and switch navi to it

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -18,7 +18,7 @@
     externalAudio.enable = true; # using external dac
     deviceLocation = "office";
     desktop = {
-      theme = "everforest";
+      theme = "edge";
       wallpaper.variant = "enso-6colour";
     };
     programs = {

--- a/modules/colour-scheme/default.nix
+++ b/modules/colour-scheme/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./schema.nix
     ./catppuccin-latte.nix
+    ./edge.nix
     ./everforest.nix
     ./github-light.nix
     ./gruvbox.nix
@@ -18,6 +19,7 @@
       default = "everforest";
       type = lib.types.enum [
         "catppuccin-latte"
+        "edge"
         "everforest"
         "github-light"
         "gruvbox-dark"

--- a/modules/colour-scheme/edge.nix
+++ b/modules/colour-scheme/edge.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  theme = lib.mkIf (config.nx.desktop.theme == "edge") {
+    name = "edge";
+    type = "dark";
+    foreground = "#c5cdd9";
+    primary = "#a0c980";
+    secondary = "#6cb6eb";
+    red = "#ec7279";
+    orange = "#deb974";
+    yellow = "#deb974";
+    green = "#a0c980";
+    aqua = "#5dbbc1";
+    blue = "#6cb6eb";
+    purple = "#d38aea";
+    grey0 = "#535c6a";
+    grey1 = "#758094";
+    grey2 = "#828a98";
+    statusline1 = "#a0c980";
+    statusline2 = "#c5cdd9";
+    statusline3 = "#ec7279";
+    bg_dim = "#24262a";
+    bg0 = "#2c2e34";
+    bg1 = "#33353f";
+    bg2 = "#363944";
+    bg3 = "#3b3e48";
+    bg4 = "#414550";
+    bg5 = "#414550";
+    bg_visual = "#493c53";
+    bg_red = "#55393d";
+    bg_green = "#394634";
+    bg_blue = "#354157";
+    bg_yellow = "#4e432f";
+  };
+}


### PR DESCRIPTION
Adds a new colour scheme module for [Edge](https://github.com/sainnhe/edge), by the same author as everforest, and switches the `navi` machine over to it.

## Changes

- **`modules/colour-scheme/edge.nix`** (new) — follows `everforest.nix`'s structure, populating every field in `modules/colour-scheme/schema.nix`. Palette values are pulled from sainnhe's upstream `autoload/edge.vim` `get_palette()` function, **default style, dark variant**.
- **`modules/colour-scheme/default.nix`** — imports `./edge.nix` and adds `"edge"` to the `nx.desktop.theme` enum (both alphabetical).
- **`machines/navi/configuration.nix`** — `theme = "everforest";` → `theme = "edge";`.

## Palette mapping notes

Edge's upstream palette doesn't include an `orange` channel or a `bg5`. Following the precedent set by `onedark.nix`:

- `orange` falls back to `yellow` (`#deb974`), the warmest accent in the upstream palette.
- `bg5` mirrors `bg4`.
- `bg_visual` uses upstream `bg_purple` (`#493c53`), the closest analogue to everforest's tinted selection background.

`statusline1/2/3` mirror the everforest pattern: primary green, foreground, error red.

## Verification

```
$ nix eval .#nixosConfigurations.navi.config.theme.name
"edge"
```

`nix build .#nixosConfigurations.navi.config.system.build.toplevel --dry-run` succeeds. Other machines (`tui`, `m4mac`) still evaluate to their explicit `"onedark"` themes — the default change is inert for them.

All touched files formatted with `nixfmt`.