### PR TITLE
neovim: add edge theme plugin

### DIFF
--- a/modules/programs/prism/neovim/plugins/default.nix
+++ b/modules/programs/prism/neovim/plugins/default.nix
@@ -19,6 +19,7 @@
     ./oil.nix
     ./telescope.nix
     ./theme-catpuccin.nix
+    ./theme-edge.nix
     ./theme-everforest.nix
     ./theme-github-light.nix
     ./theme-gruvbox.nix

--- a/modules/programs/prism/neovim/plugins/theme-edge.nix
+++ b/modules/programs/prism/neovim/plugins/theme-edge.nix
@@ -1,0 +1,77 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  theme = config.theme;
+in
+{
+  home-manager.users.${config.nx.username}.programs.neovim.plugins =
+    lib.mkIf (config.theme.name == "edge")
+      [
+        {
+          plugin = pkgs.vimPlugins.edge;
+          type = "lua";
+          config =
+            # lua
+            ''
+              vim.g.edge_style = "default"
+              vim.g.edge_better_performance = 1
+              vim.o.background = "${theme.type}"
+
+              -- edge is a vimscript colour scheme without a lua setup() API,
+              -- so highlight overrides are applied via vim.api.nvim_set_hl after
+              -- the scheme loads. Wrap them in a ColorScheme autocmd so they
+              -- re-apply on reload (upstream-recommended pattern).
+              local edge_obsidian_highlights = vim.api.nvim_create_augroup(
+                "EdgeObsidianHighlights",
+                { clear = true }
+              )
+              vim.api.nvim_create_autocmd("ColorScheme", {
+                group = edge_obsidian_highlights,
+                pattern = "edge",
+                callback = function()
+                  vim.api.nvim_set_hl(0, "ObsidianTodo", {
+                    fg = "${theme.purple}",
+                    bold = true,
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianDone", {
+                    fg = "${theme.green}",
+                    bold = true,
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianRightArrow", {
+                    fg = "${theme.purple}",
+                    bold = true,
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianTilde", {
+                    fg = "${theme.orange}",
+                    bold = true,
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianRefText", {
+                    fg = "${theme.blue}",
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianExtLinkIcon", {
+                    fg = "${theme.blue}",
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianTag", {
+                    fg = "${theme.blue}",
+                    italic = true,
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianBullet", {
+                    fg = "${theme.grey0}",
+                    bold = true,
+                  })
+                  vim.api.nvim_set_hl(0, "ObsidianHighlightText", {
+                    fg = "${theme.bg0}",
+                    bg = "${theme.primary}",
+                  })
+                end,
+              })
+
+              vim.cmd("colorscheme edge")
+            '';
+        }
+      ];
+}


### PR DESCRIPTION
Adds the neovim half of the Edge colour scheme integration, completing the work begun in #2003 (which landed `modules/colour-scheme/edge.nix` and switched navi to `nx.desktop.theme = "edge"`).

The palette module was in place but no corresponding entry under `modules/programs/prism/neovim/plugins/` existed, so neovim was falling back to its default scheme on navi.

## Changes

- New module `modules/programs/prism/neovim/plugins/theme-edge.nix`, gated on `config.theme.name == "edge"` and modelled on `theme-onedark.nix`.
- Uses `pkgs.vimPlugins.edge` (sainnhe/edge upstream) — no manual `fetchFromGitHub`.
- Sets `vim.g.edge_style = "default"` (matches the `default` variant the palette module was built against) and `vim.g.edge_better_performance = 1` per upstream recommendation.
- Sets `vim.o.background` from `config.theme.type` (`dark`).
- Edge is a **vimscript** colour scheme without a lua `setup()` API, so Obsidian highlight overrides are applied via `vim.api.nvim_set_hl` wrapped in a `ColorScheme` autocmd (so they survive a reload). The highlight set mirrors `theme-onedark.nix`: ObsidianTodo / Done / RightArrow / Tilde / RefText / ExtLinkIcon / Tag / Bullet / HighlightText.
- Every colour value is pulled from `config.theme.*` — no hardcoded hex.
- Imported from `modules/programs/prism/neovim/plugins/default.nix` in alphabetical position between `theme-catpuccin.nix` and `theme-everforest.nix`.

## Verification

- `nixfmt .` clean.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel --dry-run` evaluated successfully.
- On machines whose `config.theme.name != "edge"` the `lib.mkIf` guard ensures no edge plugin entry is emitted.

Does not touch prism Go source, so the homeless-shelter CI jobs aren't gated on this PR.