### PR TITLE
Update orange color in edge scheme

### DIFF
--- a/modules/colour-scheme/edge.nix
+++ b/modules/colour-scheme/edge.nix
@@ -12,7 +12,7 @@
     primary = "#a0c980";
     secondary = "#6cb6eb";
     red = "#ec7279";
-    orange = "#deb974";
+    orange = "#e59676";
     yellow = "#deb974";
     green = "#a0c980";
     aqua = "#5dbbc1";


### PR DESCRIPTION
Adjusted the orange hex code in the edge color scheme to improve visual contrast. This change ensures the color better aligns with the intended palette definition.