### PR TITLE
qutebrowser: clear-history task — VACUUM, daily cadence, skip while running

### DIFF
--- a/modules/programs/qutebrowser/clear-history-task.nix
+++ b/modules/programs/qutebrowser/clear-history-task.nix
@@ -31,13 +31,27 @@ in
               clear-qutebrowser-history = pkgs.writeShellScript "clear-qutebrowser-history" ''
                 #!/bin/bash
 
+                # Skip if qutebrowser is currently running — avoid lock
+                # contention against its own DB connection. The next daily
+                # run will catch up.
+                if ${pkgs.procps}/bin/pgrep -x qutebrowser > /dev/null; then
+                  exit 0
+                fi
+
                 # Path to your SQLite database
                 DB_PATH="${homeDir}/.local/share/qutebrowser/history.sqlite"
 
-                # Delete entries older than 7 days
+                # Nothing to do if the DB does not exist yet (fresh install).
+                if [ ! -f "$DB_PATH" ]; then
+                  exit 0
+                fi
+
+                # Delete entries older than 7 days, then VACUUM to reclaim
+                # the freed pages so the file actually shrinks.
                 ${pkgs.sqlite}/bin/sqlite3 "$DB_PATH" <<EOF
                 DELETE FROM History WHERE atime < CAST(strftime('%s', 'now', '-7 days') AS INTEGER);
                 DELETE FROM CompletionHistory WHERE last_atime < CAST(strftime('%s', 'now', '-7 days') AS INTEGER);
+                VACUUM;
                 EOF
               '';
             in
@@ -56,10 +70,10 @@ in
             };
           systemd.user.timers.qutebrowser-clear-history-timer = {
             Unit = {
-              Description = "Run clear qutebrowser history task every 1 hour";
+              Description = "Run clear qutebrowser history task daily";
             };
             Timer = {
-              OnCalendar = "hourly";
+              OnCalendar = "daily";
               Persistent = true;
               Unit = "clear-qutebrowser-history.service";
             };


### PR DESCRIPTION
Closes #2002

Three fixes to `modules/programs/qutebrowser/clear-history-task.nix`:

### 1. `VACUUM;` after the `DELETE`s
SQLite does not reclaim space on `DELETE` — deleted rows leave free pages in the file but the file does not shrink. Added `VACUUM;` to the same heredoc as the two `DELETE`s so the on-disk file actually shrinks after a prune.

### 2. Daily, not hourly
With a 7-day retention window, running the prune 168 times per week is overkill. Switched `OnCalendar = "hourly"` → `"daily"`. `Persistent = true` is retained so a missed run (laptop asleep at the scheduled time) catches up on next wake. Updated the timer `Unit.Description` ("every 1 hour" → "daily") to match.

### 3. Skip while qutebrowser is running
Added a guard at the top of the script:
```bash
if ${pkgs.procps}/bin/pgrep -x qutebrowser > /dev/null; then
  exit 0
fi
```
This avoids the lock-contention class of issue entirely — when qutebrowser is open it has its own connection to the DB and a long-held write lock from the prune can stall its writes. The next daily run picks up the work. `pgrep` is invoked via the absolute Nix store path (`pkgs.procps` is the nixpkgs package that provides it) rather than relying on `PATH`.

### Bonus: no-DB edge case
Added an existence check on `$DB_PATH` so a fresh qutebrowser install with no history file yet exits 0 cleanly instead of letting `sqlite3` error out.

## Verification

- `nixfmt .` — no diff produced.
- `nix build .#nixosConfigurations.navi.config.system.build.toplevel` — succeeds.
- Inspected the realised script (`navi` toplevel): the `pgrep` guard, DB existence check, `VACUUM;`, and absolute store paths for both `pgrep` and `sqlite3` are all present.
- Ran the realised script on this host (qutebrowser not running, no `history.sqlite` present): exits 0 cleanly, does not touch the DB.
- `nix eval` of the timer confirms `OnCalendar = "daily"; Persistent = true;` and the updated description.