### PR TITLE
review: require parseable verdict on every member for cycle counting (#1995)

### DIFF
--- a/modules/programs/prism/prism/internal/review/loop_limit_test.go
+++ b/modules/programs/prism/prism/internal/review/loop_limit_test.go
@@ -7,9 +7,9 @@ package review_test
 // Invariants under test:
 //
 //   1. CompletedReviewCyclesForParent counts only groups that (a) are fully
-//      terminal AND (b) produced at least one finished member with a non-empty
-//      assistant message and no startup_error. Pure-infrastructure failures do
-//      not count.
+//      terminal AND (b) every member finished with a parseable `<verdict>`
+//      tag (#1995). Pure-infrastructure failures and rounds where any agent
+//      terminated without a parseable verdict do not count.
 //
 //   2. The LOOP-LIMIT footer is appended to the review-complete delivery body
 //      when the current cycle is itself verdict-producing AND the cumulative
@@ -60,12 +60,15 @@ func TestBuildLoopLimitFooter_HandlesEmptyPRNumber(t *testing.T) {
 
 // ── currentCycleProducedVerdicts ────────────────────────────────────────────
 
+// TestCurrentCycleProducedVerdicts_PositiveCase pins the happy-path single
+// member case: a finished member with a parseable `<verdict>FAIL</verdict>`
+// counts as verdict-producing.
 func TestCurrentCycleProducedVerdicts_PositiveCase(t *testing.T) {
 	groupData := map[string]db.GroupMemberResult{
 		"a~review-1-review-goal": {State: "finished", LastMessage: `{"text":"<verdict>FAIL</verdict>"}`},
 	}
 	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
-		t.Error("a finished member with a non-empty assistant message should count as verdict-producing")
+		t.Error("a finished member with a parseable <verdict> tag should count as verdict-producing")
 	}
 }
 
@@ -88,13 +91,117 @@ func TestCurrentCycleProducedVerdicts_FinishedButEmptyMessageIsNotVerdictProduci
 	}
 }
 
-func TestCurrentCycleProducedVerdicts_MixedIsVerdictProducing(t *testing.T) {
+// TestCurrentCycleProducedVerdicts_MixedNoStartIsNotVerdictProducing replaces
+// the pre-#1995 lenient-contract assertion. Under the tightened contract a
+// group only counts as verdict-producing when EVERY member emitted a
+// parseable `<verdict>` tag; one no-start sibling alongside one PASS is no
+// longer sufficient.
+func TestCurrentCycleProducedVerdicts_MixedNoStartIsNotVerdictProducing(t *testing.T) {
 	groupData := map[string]db.GroupMemberResult{
 		"a~review-1-review-goal": {State: "error", StartupError: "container failed to bind port"},
 		"a~review-1-review-code": {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
 	}
+	if review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("a mixed group (one no-start + one PASS) must NOT count as verdict-producing under the #1995 contract")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_AllPassesIsVerdictProducing is the
+// regression guard for the happy path (AC #1995): a round where every
+// member emits a parseable `<verdict>PASS</verdict>` still counts.
+func TestCurrentCycleProducedVerdicts_AllPassesIsVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal":     {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-code":     {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-security": {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-qa":       {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-context":  {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+	}
 	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
-		t.Error("a mixed group with at least one finished verdict must count as verdict-producing")
+		t.Error("an all-PASS round must continue to count as verdict-producing")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_FourPassOneFailIsVerdictProducing is the
+// second regression guard (AC #1995): a round with 4 PASS + 1 parseable
+// FAIL is still verdict-producing — the FAIL is surfaced as a normal
+// review failure, not a no-verdict re-run signal.
+func TestCurrentCycleProducedVerdicts_FourPassOneFailIsVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal":     {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-code":     {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-security": {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-qa":       {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-context":  {State: "finished", LastMessage: `{"text":"<verdict>FAIL</verdict>"}`},
+	}
+	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("4-PASS + 1-FAIL round must still count as verdict-producing")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_NoVerdictTagIsNotVerdictProducing covers
+// AC #1995 case (a): finished + non-empty LastMessage + no parseable verdict
+// tag — NOT verdict-producing. This is the #1993 root-cause shape (model
+// truncated mid-analysis without emitting `<verdict>`).
+func TestCurrentCycleProducedVerdicts_NoVerdictTagIsNotVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "finished", LastMessage: `{"text":"AC6: host mode is uncapped \u2014 the diff doesn't introduce a cap for host. ACHIEVED."}`},
+	}
+	if review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("finished + non-empty LastMessage + no <verdict> tag must NOT count as verdict-producing (#1995)")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_ParseablePassIsVerdictProducing covers
+// AC #1995 case (b): finished + non-empty LastMessage + parseable
+// `<verdict>PASS</verdict>` — verdict-producing.
+func TestCurrentCycleProducedVerdicts_ParseablePassIsVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "finished", LastMessage: `{"text":"All ACs verified.\n<verdict>PASS</verdict>"}`},
+	}
+	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("finished + parseable <verdict>PASS</verdict> must count as verdict-producing (#1995)")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_ParseableFailIsVerdictProducing covers
+// AC #1995 case (c): finished + non-empty LastMessage + parseable
+// `<verdict>FAIL</verdict>` — verdict-producing.
+func TestCurrentCycleProducedVerdicts_ParseableFailIsVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-goal": {State: "finished", LastMessage: `{"text":"Found a blocker.\n<verdict>FAIL</verdict>"}`},
+	}
+	if !review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("finished + parseable <verdict>FAIL</verdict> must count as verdict-producing (#1995)")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_PartialNoVerdictIsNotVerdictProducing
+// covers AC #1995 edge-case 6: a round where 3 agents produce parseable
+// verdicts and 2 terminate without parseable verdicts does NOT count as
+// verdict-producing. This is exactly the PR #1992 / #1993 shape.
+func TestCurrentCycleProducedVerdicts_PartialNoVerdictIsNotVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{
+		"a~review-1-review-security": {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-qa":       {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-context":  {State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+		"a~review-1-review-goal":     {State: "finished", LastMessage: `{"text":"AC6 ACHIEVED."}`}, // no <verdict>
+		"a~review-1-review-code":     {State: "finished", LastMessage: ""},                          // empty
+	}
+	if review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("3 parseable + 2 no-verdict round must NOT count as verdict-producing (the #1993 shape)")
+	}
+}
+
+// TestCurrentCycleProducedVerdicts_EmptyGroupIsNotVerdictProducing pins the
+// defensive case: an empty groupData (no members at all) must not be
+// treated as verdict-producing — otherwise the "every member emitted a
+// verdict" vacuous-truth would tick the cycle counter for a zero-agent
+// round.
+func TestCurrentCycleProducedVerdicts_EmptyGroupIsNotVerdictProducing(t *testing.T) {
+	groupData := map[string]db.GroupMemberResult{}
+	if review.CurrentCycleProducedVerdictsForTest(groupData) {
+		t.Error("an empty groupData must not count as verdict-producing")
 	}
 }
 
@@ -158,18 +265,18 @@ func TestBashSubstringFalseMatch_DoesNotIncrementCycles(t *testing.T) {
 }
 
 // TestCompletedReviewCyclesForParent_CountsVerdictProducingGroups verifies
-// the happy path: two prior groups, both fully terminal, both produced
-// verdicts → count = 2.
+// the happy path: two prior groups, both fully terminal, every member
+// produced a parseable `<verdict>` tag → count = 2.
 func TestCompletedReviewCyclesForParent_CountsVerdictProducingGroups(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@two-cycles"
 
-	// Round 1: two agents, both finished, both produced assistant messages.
+	// Round 1: two agents, both finished, both emitted parseable verdicts.
 	g1 := registerGroupAndSeedMembers(t, d, parent, 1,
 		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 		memberSpec{role: "review-code", state: "finished", text: `<verdict>PASS</verdict>`},
 	)
-	// Round 2: same agents, both finished, both produced assistant messages.
+	// Round 2: same agents, both finished, both emitted parseable verdicts.
 	g2 := registerGroupAndSeedMembers(t, d, parent, 2,
 		memberSpec{role: "review-goal", state: "finished", text: `<verdict>PASS</verdict>`},
 		memberSpec{role: "review-code", state: "finished", text: `<verdict>FAIL</verdict>`},
@@ -184,13 +291,45 @@ func TestCompletedReviewCyclesForParent_CountsVerdictProducingGroups(t *testing.
 	}
 }
 
+// TestCompletedReviewCyclesForParent_ExcludesNoVerdictGroups is the
+// historical-cycle twin of
+// TestCurrentCycleProducedVerdicts_PartialNoVerdictIsNotVerdictProducing
+// (#1995). A prior round where even one member terminated without a
+// parseable `<verdict>` tag must NOT count toward the cycle total — the
+// monitor will instead deliver the ran-but-no-parseable-verdict prompt and
+// expect the worker to re-run.
+func TestCompletedReviewCyclesForParent_ExcludesNoVerdictGroups(t *testing.T) {
+	d := openTestDB(t)
+	parent := "nixos-config@no-verdict"
+
+	// Round 1: real verdict-producing cycle, every member emits a verdict.
+	registerGroupAndSeedMembers(t, d, parent, 1,
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
+		memberSpec{role: "review-code", state: "finished", text: `<verdict>PASS</verdict>`},
+	)
+	// Round 2: review-goal terminated mid-analysis without a verdict tag
+	// (the #1993 shape) — must not count toward the total.
+	registerGroupAndSeedMembers(t, d, parent, 2,
+		memberSpec{role: "review-goal", state: "finished", text: "AC6: host mode is uncapped. ACHIEVED."},
+		memberSpec{role: "review-code", state: "finished", text: `<verdict>PASS</verdict>`},
+	)
+
+	n, err := review.CompletedReviewCyclesForParent(d, parent, "")
+	if err != nil {
+		t.Fatalf("CompletedReviewCyclesForParent: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count = %d, want 1 (round 2 had a no-verdict member and must not count)", n)
+	}
+}
+
 // TestCompletedReviewCyclesForParent_ExcludesAllNoStartGroups verifies the
 // AC: an "all agents failed to start" cycle does not count as a real cycle.
 func TestCompletedReviewCyclesForParent_ExcludesAllNoStartGroups(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@no-start"
 
-	// Round 1: real verdict-producing cycle.
+	// Round 1: real verdict-producing cycle (every member emits a verdict).
 	registerGroupAndSeedMembers(t, d, parent, 1,
 		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
@@ -217,7 +356,7 @@ func TestCompletedReviewCyclesForParent_ExcludesActiveGroups(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@in-flight"
 
-	// Round 1: terminated.
+	// Round 1: terminated with a parseable verdict.
 	registerGroupAndSeedMembers(t, d, parent, 1,
 		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
@@ -243,10 +382,10 @@ func TestCompletedReviewCyclesForParent_ExcludeGroupID(t *testing.T) {
 	parent := "nixos-config@exclude-test"
 
 	g1 := registerGroupAndSeedMembers(t, d, parent, 1,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
 	g2 := registerGroupAndSeedMembers(t, d, parent, 2,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
 
 	// Without exclude: 2.
@@ -295,14 +434,16 @@ func TestMonitorFunc_AppendsFooterOnThirdNonConvergedCycle(t *testing.T) {
 	d := openTestDB(t)
 	parent := "nixos-config@spam-repro"
 
-	// Seed two prior verdict-producing cycles on this parent.
+	// Seed two prior verdict-producing cycles on this parent. Each member
+	// emits a parseable `<verdict>` tag so the #1995 "every member must
+	// emit a verdict" predicate counts both rounds.
 	registerGroupAndSeedMembers(t, d, parent, 1,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
-		memberSpec{role: "review-code", state: "finished", text: "PASS output"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
+		memberSpec{role: "review-code", state: "finished", text: `<verdict>PASS</verdict>`},
 	)
 	registerGroupAndSeedMembers(t, d, parent, 2,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
-		memberSpec{role: "review-code", state: "finished", text: "PASS output"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
+		memberSpec{role: "review-code", state: "finished", text: `<verdict>PASS</verdict>`},
 	)
 
 	// Round 3 is the in-flight cycle the monitor is delivering for.
@@ -331,10 +472,10 @@ func TestMonitorFunc_NoFooterOnConvergedThirdCycle(t *testing.T) {
 	parent := "nixos-config@converged-third"
 
 	registerGroupAndSeedMembers(t, d, parent, 1,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
 	registerGroupAndSeedMembers(t, d, parent, 2,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
 
 	// Round 3: passes. We assert the footer is NOT appended.
@@ -354,10 +495,10 @@ func TestMonitorFunc_NoFooterOnInfrastructureFailureCycle(t *testing.T) {
 	parent := "nixos-config@infra-third"
 
 	registerGroupAndSeedMembers(t, d, parent, 1,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
 	registerGroupAndSeedMembers(t, d, parent, 2,
-		memberSpec{role: "review-goal", state: "finished", text: "FAIL output"},
+		memberSpec{role: "review-goal", state: "finished", text: `<verdict>FAIL</verdict>`},
 	)
 
 	// Round 3: all agents failed to start.
@@ -429,7 +570,7 @@ func seedStartupErrorEvent(t *testing.T, d *db.DB, sessionName, reason string) {
 func mockMonitorRound3(t *testing.T, d *db.DB, parent, prNumber string) string {
 	t.Helper()
 	gid := registerGroupAndSeedMembers(t, d, parent, 3,
-		memberSpec{role: "review-goal", state: "finished", text: "Goal FAIL details"},
+		memberSpec{role: "review-goal", state: "finished", text: "Goal FAIL details\n<verdict>FAIL</verdict>"},
 		memberSpec{role: "review-code", state: "finished", text: "<verdict>PASS</verdict>"},
 	)
 	return assembleDeliveryBody(t, d, parent, prNumber, 3, gid, false /* allPassed */, false /* infra */)

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -794,12 +794,17 @@ func buildLoopLimitFooter(cycles int, prNumber string) string {
 //
 //   1. Every member of the group is in a terminal state (so the group is no
 //      longer running), AND
-//   2. At least one member finished with a non-empty assistant message AND no
-//      startup_error event — i.e. the group produced real per-agent verdicts.
+//   2. Every member finished with a parseable `<verdict>PASS</verdict>` /
+//      `<verdict>FAIL</verdict>` tag — i.e. the group produced a full set
+//      of real per-agent verdicts (#1995). The per-member check is shared
+//      with the in-flight predicate via memberProducedParseableVerdict so
+//      the two callsites cannot drift.
 //
 // This is the single source of truth for cycle counting in the LOOP-LIMIT
 // firing logic. Pure-infrastructure failures (every member never bound its
-// port) are excluded by condition 2 — mirroring the documented contract in
+// port) AND ran-but-no-parseable-verdict rounds (any member terminated in
+// `finished` state without emitting a `<verdict>` tag — the #1993 shape)
+// are both excluded by condition 2 — mirroring the documented contract in
 // `modules/programs/prism/skills/prism/SKILL.md`:
 //
 //   "Count re-run cycles from the first round that had a full set of agent

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -164,9 +164,12 @@ func MonitorFunc(opts MonitorOpts) error {
 
 	// LOOP-LIMIT footer (#1512). Append the footer to the prompt body when
 	//   (a) the cycle has not converged (¬allPassed),
-	//   (b) THIS cycle is itself a verdict-producing cycle (otherwise the
-	//       "infrastructure failure" branch in buildDeliveryMessage already
-	//       tells the worker to re-run — it is not yet at the limit), AND
+	//   (b) THIS cycle is itself a verdict-producing cycle — i.e. every
+	//       member emitted a parseable `<verdict>` tag (#1995). When the
+	//       cycle is NOT verdict-producing, the relevant branch in
+	//       buildDeliveryMessage ("infrastructure failure" or
+	//       "ran but produced no parseable verdict") already tells the
+	//       worker to re-run — it is not yet at the limit, AND
 	//   (c) the total count of verdict-producing cycles for this parent
 	//       (including this one) is ≥ REVIEW_CYCLE_THRESHOLD.
 	//
@@ -408,15 +411,41 @@ func buildDeliveryMessage(prNumber string, round int, formattedResults string, a
 		}
 	}
 
-	if allPassed {
+	// Count ran-but-no-parseable-verdict failures (#1995): agents that
+	// terminated in `finished` state with no startup_error, but whose
+	// LastMessage either is empty or does not contain a parseable
+	// `<verdict>PASS</verdict>` / `<verdict>FAIL</verdict>` tag. These are
+	// distinct from no-start failures (the agent did run — the output is
+	// just unparseable) AND from FAIL verdicts (no code-quality signal was
+	// produced). The worker should re-run, not escalate, not treat as FAIL.
+	var noVerdictSessions []string
+	for _, sess := range agentSessions {
+		mr, ok := groupData[sess]
+		if !ok {
+			continue
+		}
+		if mr.StartupError != "" {
+			continue // already counted as no-start
+		}
+		if mr.State != "finished" {
+			continue // a non-finished state is surfaced via the unexpected-state branch in buildMonitorResults
+		}
+		if memberProducedParseableVerdict(mr) {
+			continue
+		}
+		noVerdictSessions = append(noVerdictSessions, sess)
+	}
+
+	switch {
+	case allPassed:
 		sb.WriteString("**All 5 review agents passed.** You may proceed with announcing completion.\n\n")
-	} else if len(noStartSessions) > 0 && len(noStartSessions) == len(agentSessions) {
+	case len(noStartSessions) > 0 && len(noStartSessions) == len(agentSessions):
 		// Every agent failed to start — pure infrastructure failure with no
 		// code-quality signal at all.
 		sb.WriteString("**All review agents failed to start (infrastructure failure).** ")
 		sb.WriteString("This is NOT a code-quality verdict — no agents ran. ")
 		sb.WriteString("Re-run `prism review` to retry; do not treat this as FAIL.\n\n")
-	} else if len(noStartSessions) > 0 {
+	case len(noStartSessions) > 0:
 		// Mixed: some agents returned FAIL/PASS verdicts; others failed to start.
 		// Surface both signals so the coordinator knows to both fix code issues
 		// AND re-run for the agents that never ran.
@@ -424,7 +453,16 @@ func buildDeliveryMessage(prNumber string, round int, formattedResults string, a
 		sb.WriteString("Fix any blocking issues from the agents that ran, then re-run `prism review` ")
 		sb.WriteString("to cover the agents that failed to start (infrastructure failure). ")
 		sb.WriteString("Do not treat no-start errors as code-quality verdicts.\n\n")
-	} else {
+	case len(noVerdictSessions) > 0:
+		// One or more agents ran to `finished` but produced no parseable
+		// `<verdict>` tag (#1995). The signal is incomplete — not a
+		// code-quality FAIL — so the worker should re-run rather than
+		// treat this as a normal failed review.
+		sb.WriteString("**One or more review agents ran but produced no parseable verdict.** ")
+		sb.WriteString("This is NOT a code-quality FAIL — the agents reached `finished` state without emitting a `<verdict>PASS</verdict>` / `<verdict>FAIL</verdict>` tag (e.g. truncated mid-analysis or ended on a tool-only turn). ")
+		sb.WriteString("Re-run `prism review` to retry; this round does NOT count toward the 3-cycle limit. ")
+		sb.WriteString("If any other agent surfaced blocking issues, address those before re-running.\n\n")
+	default:
 		sb.WriteString("**One or more review agents failed.** Fix the blocking issues and re-run `prism review`.\n\n")
 	}
 
@@ -680,19 +718,43 @@ func isTerminalForGuard(m db.Status) bool {
 	return false
 }
 
-// currentCycleProducedVerdicts reports whether the current group's
-// GroupResults contain at least one finished member with a non-empty
-// LastMessage and no startup_error — the same condition
-// CompletedReviewCyclesForParent applies to historical groups. Used by the
-// monitor to decide whether the in-flight cycle counts toward the LOOP-LIMIT
-// threshold.
+// currentCycleProducedVerdicts reports whether *every* member of the current
+// group produced a parseable `<verdict>` tag. Used by the monitor to decide
+// whether the in-flight cycle counts toward the LOOP-LIMIT threshold.
+//
+// Contract (#1995): a cycle is verdict-producing iff there is at least one
+// member AND every member is finished with a non-empty assistant message that
+// AssessPassed classifies as either VerdictPass or VerdictFail. If any member
+// is in a non-finished state, missing a LastMessage, had a startup_error, or
+// terminated without emitting a parseable `<verdict>` tag, the cycle is NOT
+// counted — the worker is expected to re-run.
+//
+// This is the same predicate `CompletedReviewCyclesForParent` applies to
+// historical groups; the two share the contract.
 func currentCycleProducedVerdicts(groupData map[string]db.GroupMemberResult) bool {
+	if len(groupData) == 0 {
+		return false
+	}
 	for _, mr := range groupData {
-		if mr.State == "finished" && mr.LastMessage != "" && mr.StartupError == "" {
-			return true
+		if !memberProducedParseableVerdict(mr) {
+			return false
 		}
 	}
-	return false
+	return true
+}
+
+// memberProducedParseableVerdict reports whether a single group member's
+// terminal state contains a parseable `<verdict>PASS</verdict>` or
+// `<verdict>FAIL</verdict>` marker. Shared by both the in-flight predicate
+// (currentCycleProducedVerdicts) and the historical predicate inside
+// CompletedReviewCyclesForParent so the contract is defined exactly once.
+func memberProducedParseableVerdict(mr db.GroupMemberResult) bool {
+	if mr.State != "finished" || mr.LastMessage == "" || mr.StartupError != "" {
+		return false
+	}
+	text := ExtractAssistantText(mr.LastMessage)
+	_, kind := AssessPassed(text)
+	return kind != VerdictNone
 }
 
 // REVIEW_CYCLE_THRESHOLD is the number of completed verdict-producing review
@@ -783,13 +845,20 @@ func CompletedReviewCyclesForParent(d *db.DB, parentSession, excludeGroupID stri
 			continue
 		}
 
-		// Condition 2: at least one member produced a verdict-shaped result.
-		// We use GroupResults to read the last assistant message and any
-		// startup_error — a member with non-empty LastMessage AND empty
-		// StartupError (and state == "finished") is treated as "produced a
-		// verdict". Even if the verdict body lacks an explicit PASS/FAIL
-		// marker (which AssessPassed would classify as VerdictNone), the
-		// agent still ran and produced output — that is a real cycle.
+		// Condition 2: every member produced a parseable `<verdict>` tag.
+		// We use GroupResults to read each member's last assistant message,
+		// startup_error, and state, and require AssessPassed to return
+		// VerdictPass or VerdictFail for every member (#1995). A group where
+		// any member terminated without a parseable verdict — empty
+		// LastMessage, startup_error, or mid-analysis truncation — is NOT
+		// counted: the worker is expected to re-run.
+		//
+		// Rationale: the lenient predicate ("at least one finished member
+		// with non-empty LastMessage") tripped the LOOP-LIMIT at cycle 3 in
+		// PR #1992 even though only 3 of 5 agents had actually emitted
+		// verdicts; the other two finished with no parseable `<verdict>` tag.
+		// See `docs/diagnoses/review-agent-no-verdict-1993.md` for the full
+		// trace; #1995 tightened both predicates to share this contract.
 		groupData, gErr := d.GroupResults(gid)
 		if gErr != nil {
 			// Be defensive: a bad row should not silently underreport cycle
@@ -799,10 +868,13 @@ func CompletedReviewCyclesForParent(d *db.DB, parentSession, excludeGroupID stri
 			proglog.Warnf("[prism review] warning: GroupResults(%s) failed during cycle counting: %v\n", gid, gErr)
 			continue
 		}
-		producedVerdict := false
+		if len(groupData) == 0 {
+			continue
+		}
+		producedVerdict := true
 		for _, mr := range groupData {
-			if mr.State == "finished" && mr.LastMessage != "" && mr.StartupError == "" {
-				producedVerdict = true
+			if !memberProducedParseableVerdict(mr) {
+				producedVerdict = false
 				break
 			}
 		}

--- a/modules/programs/prism/prism/internal/review/monitor_test.go
+++ b/modules/programs/prism/prism/internal/review/monitor_test.go
@@ -1267,3 +1267,64 @@ func TestBuildDeliveryMessage_PureCodeFail(t *testing.T) {
 		t.Errorf("pure code fail: header should NOT mention 'infrastructure failure': %q", msg)
 	}
 }
+
+// TestBuildDeliveryMessage_RanButNoParseableVerdict pins the #1995 framing:
+// when at least one agent reached `finished` state but emitted no parseable
+// `<verdict>` tag, the delivery message must surface a dedicated branch
+// that is distinct from both the "all-no-start" and "mixed no-start"
+// branches. The text must (a) make clear this is NOT a code-quality FAIL
+// and (b) tell the worker to re-run.
+func TestBuildDeliveryMessage_RanButNoParseableVerdict(t *testing.T) {
+	sessGoal := "nixos-config@parent~review-1-review-goal"
+	sessCode := "nixos-config@parent~review-1-review-code"
+	sessSec := "nixos-config@parent~review-1-review-security"
+	groupData := map[string]db.GroupMemberResult{
+		// review-goal: finished without a parseable verdict (mid-analysis
+		// truncation — the #1993 root-cause shape).
+		sessGoal: {SessionName: sessGoal, State: "finished", LastMessage: `{"text":"AC6 ACHIEVED."}`},
+		// review-code: finished with empty LastMessage (tool-only final
+		// turn — the other #1993 sub-case).
+		sessCode: {SessionName: sessCode, State: "finished", LastMessage: ""},
+		// review-security: ran fine and emitted a verdict.
+		sessSec: {SessionName: sessSec, State: "finished", LastMessage: `{"text":"<verdict>PASS</verdict>"}`},
+	}
+	msg := review.BuildDeliveryMessageForTest("42", 1, "results text", false, groupData, []string{sessGoal, sessCode, sessSec})
+
+	if !findSubstring(msg, "no parseable verdict") {
+		t.Errorf("ran-but-no-parseable-verdict: header should mention 'no parseable verdict': %q", msg)
+	}
+	if !findSubstring(msg, "NOT a code-quality FAIL") {
+		t.Errorf("ran-but-no-parseable-verdict: header should clarify this is NOT a code-quality FAIL: %q", msg)
+	}
+	if !findSubstring(msg, "Re-run") && !findSubstring(msg, "re-run") {
+		t.Errorf("ran-but-no-parseable-verdict: header should instruct re-run: %q", msg)
+	}
+	if !findSubstring(msg, "does NOT count toward the 3-cycle limit") {
+		t.Errorf("ran-but-no-parseable-verdict: header should clarify this round does not count toward the 3-cycle limit: %q", msg)
+	}
+	// Must NOT use the no-start or mixed-no-start framings.
+	if findSubstring(msg, "infrastructure failure") {
+		t.Errorf("ran-but-no-parseable-verdict: header must NOT mention 'infrastructure failure' (the agents did run): %q", msg)
+	}
+	if findSubstring(msg, "failed to start") {
+		t.Errorf("ran-but-no-parseable-verdict: header must NOT mention 'failed to start' (the agents did start): %q", msg)
+	}
+}
+
+// TestBuildDeliveryMessage_NoStartTakesPrecedenceOverNoVerdict pins the
+// ordering: when a round mixes no-start errors AND ran-but-no-verdict
+// agents, the existing mixed-no-start framing wins. Re-running addresses
+// both, and the no-start framing already covers the infrastructure half
+// of the signal.
+func TestBuildDeliveryMessage_NoStartTakesPrecedenceOverNoVerdict(t *testing.T) {
+	sessGoal := "nixos-config@parent~review-1-review-goal"
+	sessCode := "nixos-config@parent~review-1-review-code"
+	groupData := map[string]db.GroupMemberResult{
+		sessGoal: {SessionName: sessGoal, State: "error", StartupError: "health check timed out"},
+		sessCode: {SessionName: sessCode, State: "finished", LastMessage: `{"text":"AC6 ACHIEVED."}`},
+	}
+	msg := review.BuildDeliveryMessageForTest("42", 1, "results text", false, groupData, []string{sessGoal, sessCode})
+	if !findSubstring(msg, "failed to start") {
+		t.Errorf("mixed no-start + no-verdict: existing mixed-no-start framing should win: %q", msg)
+	}
+}

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -271,10 +271,32 @@ catches drift in one fetch, before any agent spawns.
 **Cycle-counter contract.** Gate failures (behind-main refusal, fetch failure,
 missing `origin/main`, rebase conflict abort) **do not increment** the
 review-cycle counter. They are the same category as "round already in
-progress" / pure-infrastructure failures: no agents spawned, no verdicts
-produced. A worker that hits the gate three times in a row and then runs
-three real reviews still has all three real cycles available before the
-LOOP-LIMIT footer fires.
+progress" / pure-infrastructure failures / ran-but-no-parseable-verdict
+rounds (#1995): no full set of parseable verdicts was produced, so the
+round does not count. A worker that hits the gate three times in a row
+and then runs three real reviews still has all three real cycles
+available before the LOOP-LIMIT footer fires.
+
+Rounds that **do not count** toward the 3-cycle limit:
+
+- **Pre-flight gate refusals** — behind-main, fetch failure, missing
+  `origin/main`, rebase conflict abort. No agents spawned.
+- **Round-already-in-progress refusals** — a prior review is still
+  active for the same parent. No agents spawned.
+- **Pure-infrastructure failures** — every agent failed to start
+  (container never bound its port). Header mentions "infrastructure
+  failure".
+- **Ran-but-no-parseable-verdict rounds** (#1995) — one or more agents
+  reached `finished` state without emitting a parseable
+  `<verdict>PASS</verdict>` / `<verdict>FAIL</verdict>` tag (e.g.
+  truncated mid-analysis or ended on a tool-only turn). Header says
+  **"One or more review agents ran but produced no parseable verdict"**
+  and explicitly tells the worker to re-run. This is NOT a code-quality
+  FAIL — re-run, do not escalate.
+
+In each of these cases the correct action is to re-run `prism review`
+(after fixing any orthogonal blocking issues another agent surfaced),
+not to escalate.
 
 **Design notes:**
 
@@ -305,6 +327,26 @@ Signs of a no-start error in the per-agent findings:
 - `**Verdict:** ERROR`
 - Output contains `ERROR: agent failed to start (no-start):`
 - The delivery message header mentions "infrastructure failure" and instructs you to re-run
+
+### Handling ran-but-no-parseable-verdict in review-complete prompts
+
+When a review-complete prompt says **"One or more review agents ran but
+produced no parseable verdict"** (#1995), treat it the same way you treat a
+no-start error: re-run `prism review <pr>` rather than escalate. The agents
+did run — the problem is that one or more of them terminated in `finished`
+state without emitting a parseable `<verdict>PASS</verdict>` /
+`<verdict>FAIL</verdict>` tag (e.g. truncated mid-analysis, ended on a
+tool-only turn). This is **not** a code-quality FAIL and the round **does
+not count** toward the 3-cycle limit.
+
+Signs of a ran-but-no-parseable-verdict round:
+- The per-agent output for at least one agent contains
+  `ERROR: no verdict found in agent output` or `ERROR: no output produced`
+- The delivery message header explicitly says the agent(s) ran but produced
+  no parseable verdict and instructs you to re-run
+
+If any other agent in the same round surfaced genuine blocking issues, fix
+those before re-running.
 
 If no review-complete prompt arrives within 30 minutes, check progress with:
 


### PR DESCRIPTION
Tighten the `prism review` cycle-counter so it no longer fires LOOP-LIMIT
on rounds where one or more agents reached `finished` state without
emitting a parseable `<verdict>` tag.

## What changed

### Predicate change (functional AC #1)
`currentCycleProducedVerdicts` and the historical-cycle twin inside
`CompletedReviewCyclesForParent` both now require **every** member to
have:

- `state == "finished"`,
- non-empty `LastMessage`,
- empty `StartupError`, AND
- `AssessPassed(ExtractAssistantText(LastMessage))` returning
  `VerdictPass` or `VerdictFail` (i.e. a parseable `<verdict>...</verdict>` tag).

The shared check lives in a new `memberProducedParseableVerdict` helper
so the two callsites cannot drift. The design comment at the historical
predicate (which previously endorsed the lenient contract) is updated
accordingly.

### Delivery-message branch (functional AC #2)
`buildDeliveryMessage` grows a fourth branch — distinct from
`all-no-start`, `mixed no-start`, and `pure code FAIL` — for the
"ran-but-no-parseable-verdict" shape. The wording makes clear:

- this is **not** a code-quality FAIL,
- the agents **did** run (so it is not an infrastructure failure either),
- the worker should re-run, and
- the round **does not** count toward the 3-cycle limit.

The new branch is selected when at least one member is `finished` with
no `StartupError` but is missing a parseable verdict. `noStartSessions`
takes precedence so a mixed no-start + no-verdict round still surfaces
the existing mixed-no-start framing (a single test pins that ordering).

### Skill-doc update (functional AC #3)
`modules/programs/prism/skills/prism/SKILL.md` now lists
ran-but-no-parseable-verdict alongside the existing categories that do
not count toward the 3-cycle limit, and adds a "Handling
ran-but-no-parseable-verdict in review-complete prompts" subsection
that mirrors the existing no-start subsection.

### Tests
- `TestCurrentCycleProducedVerdicts_MixedIsVerdictProducing` (which
  asserted the lenient contract) is flipped to
  `..._MixedNoStartIsNotVerdictProducing`.
- Historical-cycle test seed data updated to use parseable `<verdict>`
  tags instead of bare `"FAIL"` / `"PASS output"` strings.
- New unit tests cover:
  - AC #6 (a)/(b)/(c): finished + no verdict tag / + `<verdict>PASS</verdict>` / + `<verdict>FAIL</verdict>`
  - AC #4 regression guard: 5-PASS round still counts
  - AC #5 regression guard: 4-PASS + 1-FAIL round still counts
  - The #1993 shape: 3-PASS + 2-no-verdict does **not** count
  - Empty groupData defensive case
  - `CompletedReviewCyclesForParent_ExcludesNoVerdictGroups`
  - `TestBuildDeliveryMessage_RanButNoParseableVerdict`
  - `TestBuildDeliveryMessage_NoStartTakesPrecedenceOverNoVerdict`

## Verification

```
$ go build ./...         # OK
$ go test ./...          # OK (all packages)
$ nix build .#prism      # OK
```

The homeless-shelter / `go-tests` signals are exercised by CI.

## Out of scope (per issue body)

- Why the model stops without emitting `<verdict>` (prompt design).
- Restructuring `review-goal` / `review-code` prompts.
- Surfacing `stopReason="length"` as a distinct sidecar signal.

Closes #1995
Refs #1993