### PR TITLE
playwright-cli: enable on Darwin via playwright-driver.browsers-chromium

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -217,15 +217,13 @@
       nx.programs.prism.piExtensionDir = "${prismExtensionDir}";
 
       home-manager.users.${config.nx.username} = {
-        home.packages =
-          with pkgs;
-          [
-            pi-coding-agent
-            fd
-            tsx # for testing pi extensions
-            mitmproxy # for testing
-          ]
-          ++ lib.optional pkgs.stdenv.isLinux playwright-cli;
+        home.packages = with pkgs; [
+          pi-coding-agent
+          fd
+          tsx # for testing pi extensions
+          mitmproxy # for testing
+          playwright-cli
+        ];
 
         programs.zsh.shellAliases = {
           pi =

--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -75,9 +75,7 @@
       skillsDir = pkgs.runCommand "pi-skills" { } ''
         mkdir -p $out/prism $out/aws $out/acceptance-criteria $out/retro $out/atlassian $out/grill-me
         cp -r ${./skills/prism}/* $out/prism/
-        ${lib.optionalString pkgs.stdenv.isLinux ''
-          cp -r ${./skills/playwright-cli} $out/playwright-cli
-        ''}
+        cp -r ${./skills/playwright-cli} $out/playwright-cli
         cp ${awsSkillFile} $out/aws/SKILL.md
         cp -r ${./skills/acceptance-criteria}/* $out/acceptance-criteria/
         cp -r ${./skills/retro}/* $out/retro/

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -94,9 +94,12 @@ rec {
           prev.direnv;
 
       # packages not yet in nixpkgs; use local definitions
-      # playwright-cli depends on chromium which is Linux-only
-      playwright-cli =
-        if final.stdenv.isLinux then final.callPackage ../pkgs/playwright-cli.nix { } else null;
+      # playwright-cli is cross-platform: on Linux it uses pkgs.chromium
+      # (the user's daily-driver browser, closure already paid for); on
+      # Darwin it uses pkgs.playwright-driver.browsers-chromium (the
+      # playwright-pinned "Google Chrome for Testing" build, identity-
+      # isolated from the user's Chrome.app).
+      playwright-cli = final.callPackage ../pkgs/playwright-cli.nix { };
 
       prism = final.callPackage ../pkgs/prism.nix { };
 

--- a/pkgs/playwright-cli.nix
+++ b/pkgs/playwright-cli.nix
@@ -1,11 +1,53 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   makeWrapper,
+  writeShellScript,
   chromium,
+  playwright-driver,
 }:
 
+let
+  isDarwin = stdenv.hostPlatform.isDarwin;
+
+  # On Darwin we cannot hard-code the chromium executable path because the
+  # playwright-driver browsers derivation embeds a chromium revision string
+  # (e.g. `chromium-1200`), an architecture-dependent dir name
+  # (`chrome-mac-arm64` vs `chrome-mac`), and a binary name that upstream
+  # Google have renamed before (currently "Google Chrome for Testing"). A
+  # runtime glob resolves the binary from the stable browsers-root path,
+  # which makes the wrapper resilient to all three moving parts.
+  browsersPath = "${playwright-driver.browsers-chromium}";
+
+  # Shell launcher that resolves the chromium executable at exec time and
+  # exec's it. PLAYWRIGHT_MCP_EXECUTABLE_PATH on Darwin points at this
+  # launcher so the resolution happens lazily, not at build time.
+  darwinChromiumLauncher = writeShellScript "playwright-cli-browser-launcher" ''
+    set -eu
+    browsers_path=${lib.escapeShellArg browsersPath}
+    # The browsers derivation contains:
+    #   <browsers_path>/chromium-<rev>/chrome-mac{,-arm64}/<App>.app/Contents/MacOS/<binary>
+    # All three of <rev>, the arch dir, and the binary name have shifted
+    # upstream before; resolve them by glob and take the first match.
+    exe=""
+    for candidate in "$browsers_path"/chromium-*/chrome-mac*/*.app/Contents/MacOS/*; do
+      if [ -x "$candidate" ]; then
+        exe="$candidate"
+        break
+      fi
+    done
+    if [ -z "$exe" ]; then
+      echo "playwright-cli: could not locate chromium binary under $browsers_path" >&2
+      exit 1
+    fi
+    exec "$exe" "$@"
+  '';
+
+  chromiumExecutablePath =
+    if isDarwin then "${darwinChromiumLauncher}" else "${chromium}/bin/chromium";
+in
 buildNpmPackage rec {
   pname = "playwright-cli";
   version = "0.1.13";
@@ -25,9 +67,9 @@ buildNpmPackage rec {
 
   postFixup = ''
     wrapProgram $out/bin/playwright-cli \
-      --set-default PLAYWRIGHT_MCP_EXECUTABLE_PATH ${chromium}/bin/chromium \
+      --set-default PLAYWRIGHT_MCP_EXECUTABLE_PATH ${chromiumExecutablePath} \
       --set-default PLAYWRIGHT_MCP_BROWSER chromium \
-      --set-default PLAYWRIGHT_MCP_HEADLESS true
+      --set-default PLAYWRIGHT_MCP_HEADLESS false
   '';
 
   meta = {


### PR DESCRIPTION
Enables `playwright-cli` on Darwin by using `pkgs.playwright-driver.browsers-chromium` (the playwright-pinned "Google Chrome for Testing" build) instead of `pkgs.chromium` (which is Linux-only in nixpkgs). Linux keeps using `pkgs.chromium` — the user's daily-driver browser, closure already paid for.

## Changes

- **`pkgs/playwright-cli.nix`**
  - Adds `playwright-driver` and `writeShellScript` as inputs.
  - On Darwin: `PLAYWRIGHT_MCP_EXECUTABLE_PATH` points at a small shell launcher that resolves the chromium binary at exec time via a glob: `<browsers>/chromium-*/chrome-mac*/*.app/Contents/MacOS/*`. This insulates the wrapper from upstream changes to the chromium revision string, the `chrome-mac` vs `chrome-mac-arm64` arch dir, and the binary name (currently "Google Chrome for Testing", previously just "Chromium").
  - On Linux: `PLAYWRIGHT_MCP_EXECUTABLE_PATH` stays as `${chromium}/bin/chromium` (unchanged behaviour).
  - Launcher exits non-zero with a clear `playwright-cli: could not locate chromium binary under <path>` error if no candidate matches.
  - Temporarily flips `PLAYWRIGHT_MCP_HEADLESS` from `true` to `false` on both platforms so the operator can eyeball chromium actually opening during validation. A follow-up will flip this back.

- **`overlays/default.nix`**
  - Removes the `isLinux` gate around `playwright-cli`. Comment updated to explain the new cross-platform shape.

- **`modules/programs/prism/pi.nix`**
  - `playwright-cli` is now an unconditional entry in `home.packages` (the `lib.optional pkgs.stdenv.isLinux playwright-cli` is gone).

## Verification

Built locally on `aarch64-darwin`:

```
$ nix-build -E '...pkgs.playwright-cli' --no-out-link
/nix/store/sj3rf4fhi085i325r1azi68qrllv48db-playwright-cli-0.1.13
```

Wrapper contents (Darwin):

```
export PLAYWRIGHT_MCP_EXECUTABLE_PATH=${PLAYWRIGHT_MCP_EXECUTABLE_PATH-'/nix/store/.../playwright-cli-browser-launcher'}
export PLAYWRIGHT_MCP_BROWSER=${PLAYWRIGHT_MCP_BROWSER-'chromium'}
export PLAYWRIGHT_MCP_HEADLESS=${PLAYWRIGHT_MCP_HEADLESS-'false'}
```

Glob resolves to:

```
/nix/store/dk73wd5gbnd7xnxfgjfnl6zyzrk3dc4y-playwright-browsers/chromium-1217/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing
```

`playwright-cli --help` runs and prints usage without raising a missing-browser error.

Mutated-launcher negative test (pointing `browsers_path` at a nonexistent dir):

```
playwright-cli: could not locate chromium binary under /tmp/nonexistent-xyz
exit=1
```

Closure check (Darwin):

```
$ nix-store -qR <out> | grep -E 'chromium|chrome' | grep -v playwright-browsers
(empty)
```

No reference to `/Applications/`, `pkgs.chromium`, or `pkgs.google-chrome` in the Darwin closure.

`nix flake check --no-build --all-systems` passes for both `aarch64-darwin` and `x86_64-linux`.

Closes #2014
