### PR TITLE
fix(prism): allow empty prompt for tmux Prefix+a keybind spawns

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -378,19 +378,24 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	if overrideSource, _ := cmd.Flags().GetString("prompt-source"); overrideSource != "" {
 		promptSource = overrideSource
 	}
+	attachFlag, _ := cmd.Flags().GetBool("attach")
+	// headless when invoked from a shell/agent rather than the tmux keybinding.
+	// The keybinding sets PRISM_SPAWN_PATH; --attach overrides to force a switch.
+	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""
 	// Reject an empty prompt at the operator boundary (issue #1891). When the
 	// hidden --prompt-source flag is set we are running as the child of the
 	// host-API /spawn handler, which has already validated that req.Prompt is
 	// non-empty (layer 3); skipping the check there keeps the proxy's own
 	// 400 surface as the source of truth for that path.
-	if promptText == "" && promptSource != "proxy-spawn" {
+	//
+	// Keybind carve-out (issue #2012): the tmux Prefix+a keybind invokes
+	// `prism spawn --attach` with no --prompt because the operator types the
+	// initial prompt to the live agent after the popup attaches. The keybind
+	// sets PRISM_SPAWN_PATH (the `fromKeybind` discriminator), so an empty
+	// prompt on that path is legitimate and must be allowed through.
+	if promptText == "" && promptSource != "proxy-spawn" && !fromKeybind {
 		return emptyPromptError(cmd, "prism spawn")
 	}
-
-	attachFlag, _ := cmd.Flags().GetBool("attach")
-	// headless when invoked from a shell/agent rather than the tmux keybinding.
-	// The keybinding sets PRISM_SPAWN_PATH; --attach overrides to force a switch.
-	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""
 	cfg := config.Load()
 
 	// Resolve the effective isolation mode. This validates --isolation
@@ -652,6 +657,13 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// harness-specific string literals appear in the session package.
 	// harnessFlag was already validated above, so the error is unreachable.
 	h, _ := harness.New(harnessFlag, "", nil, "", "")
+	// Keybind carve-out (issue #2012): when the spawn was initiated by the
+	// tmux Prefix+a keybind and no prompt was supplied, opt out of the layer-4
+	// empty-prompt guard in SpawnSession. The operator types the initial
+	// prompt to the live agent after the popup attaches. Any other combination
+	// (non-keybind, or keybind with an explicit --prompt) keeps the original
+	// #1891 guard active.
+	allowEmptyPrompt := fromKeybind && promptText == ""
 	spawnOpts := session.SpawnOpts{
 		SessionName:      sessionName,
 		Repo:             deriveRepo(worktreePath),
@@ -667,6 +679,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		RuntimeEnvVars:   h.RuntimeEnv(),
 		HarnessName:      harnessFlag,
 		ModelsByRole:     modelsByRole,
+		AllowEmptyPrompt: allowEmptyPrompt,
 		// ForceFresh=true: spawn always wants a new instance. If a session
 		// with the same name already exists it is a stale zombie and should
 		// be killed.

--- a/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
@@ -1,0 +1,137 @@
+package cmd
+
+// Tests for the keybind carve-out of the layer-1+2 empty-prompt guard
+// (issue #2012). The tmux Prefix+a keybind invokes `prism spawn --attach`
+// with no --prompt — the operator types the initial prompt to the live
+// agent after the popup attaches. The keybind discriminator is the
+// PRISM_SPAWN_PATH environment variable; when that is set and no prompt
+// was supplied, runSpawn must skip the empty-prompt rejection so the
+// popup does not flash-close with an unreadable error.
+//
+// Without PRISM_SPAWN_PATH set, the existing emptyPromptError must still
+// fire — protecting the shell-invocation path and proving the relaxation
+// is gated on the discriminator only.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildSpawnCmdForEmptyPromptTest mirrors buildAbtestCmd but keeps the test
+// helper local to this file so it does not couple to abtest-only fixtures.
+func buildSpawnCmdForEmptyPromptTest(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().StringArray("abtest", nil, "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "pi", "")
+	cmd.Flags().StringArray("model-override", nil, "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("prompt-source", "", "")
+	addPromptFlags(cmd)
+	return cmd
+}
+
+// TestRunSpawn_KeybindCarveOut_EmptyPromptAccepted verifies that runSpawn
+// with PRISM_SPAWN_PATH set and no prompt does NOT return emptyPromptError.
+//
+// Because the test environment has no real git repo at PRISM_SPAWN_PATH and
+// no live tmux server is available, runSpawn will still fail downstream of
+// the layer-1+2 guard — typically on resolveBareRoot ("not inside a git
+// repo") or another pre-flight check. The assertion is therefore negative:
+// the error must NOT contain the empty-prompt message. That is sufficient
+// evidence that the layer-1+2 guard let the call through, which is the
+// exact behaviour the issue #2012 fix promises.
+func TestRunSpawn_KeybindCarveOut_EmptyPromptAccepted(t *testing.T) {
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	// No --prompt / --prompt-file flags set — promptText resolves to "".
+
+	t.Setenv("PRISM_HOST_API", "")
+	// PRISM_SPAWN_PATH is the keybind discriminator. Set it to a non-git
+	// temp dir so resolveBareRoot returns "not inside a git repo" without
+	// hitting the live tmux pane path (#1180 isolation pattern).
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_BARE_ROOT", "")
+	withNoopTmux(t)
+
+	err := runSpawn(cmd, nil)
+	if err == nil {
+		// runSpawn must fail later (no git repo), but it must not error
+		// on the empty-prompt guard. A nil error here would mean the
+		// test environment accidentally bootstrapped a session — fail loudly.
+		t.Fatal("runSpawn returned nil — expected a downstream failure (no git repo) past the empty-prompt guard")
+	}
+	if strings.Contains(err.Error(), "a prompt is required") ||
+		strings.Contains(err.Error(), "empty string — supply a non-empty prompt") ||
+		strings.Contains(err.Error(), "empty stdin — supply a non-empty prompt") ||
+		strings.Contains(err.Error(), "file is empty — supply a non-empty prompt") {
+		t.Errorf("runSpawn returned empty-prompt error despite PRISM_SPAWN_PATH being set: %v", err)
+	}
+}
+
+// TestRunSpawn_NoKeybind_EmptyPromptStillRejected verifies that runSpawn
+// with PRISM_SPAWN_PATH unset (i.e. invoked from a normal shell) and no
+// prompt still returns the existing emptyPromptError shape. This guards
+// the existing layer-1+2 behaviour for the non-keybind path.
+func TestRunSpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	// No --prompt flags set.
+
+	t.Setenv("PRISM_HOST_API", "")
+	// IMPORTANT: PRISM_SPAWN_PATH explicitly unset (not just empty in the
+	// caller's environment — t.Setenv guarantees the env var is "" for
+	// the duration of the test, which os.Getenv treats identically to
+	// unset for the fromKeybind check).
+	t.Setenv("PRISM_SPAWN_PATH", "")
+	t.Setenv("PRISM_BARE_ROOT", "")
+	withNoopTmux(t)
+
+	err := runSpawn(cmd, nil)
+	if err == nil {
+		t.Fatal("runSpawn with empty prompt and no PRISM_SPAWN_PATH: expected non-nil error, got nil")
+	}
+	// The default branch of emptyPromptError fires when no prompt flag was
+	// set at all: "a prompt is required — supply --prompt <text>, --prompt -
+	// (stdin), or --prompt-file <path>".
+	if !strings.Contains(err.Error(), "a prompt is required") {
+		t.Errorf("error %q does not contain 'a prompt is required'", err.Error())
+	}
+}
+
+// TestRunSpawn_KeybindCarveOut_DoesNotSwallowSuppliedPrompt verifies the
+// AC edge-case: when PRISM_SPAWN_PATH is set AND a non-empty --prompt is
+// also supplied, the carve-out does not swallow the prompt. We assert this
+// by checking the error is NOT an empty-prompt error (proving the guard
+// is bypassed cleanly without erasing the prompt the caller supplied).
+//
+// The downstream failure here is the same as the empty-prompt-accepted
+// test: "not inside a git repo" from resolveBareRoot. We only care that
+// the layer-1+2 guard does not misclassify a supplied prompt as empty.
+func TestRunSpawn_KeybindCarveOut_DoesNotSwallowSuppliedPrompt(t *testing.T) {
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	_ = cmd.Flags().Set("prompt", "hello from the keybind path")
+
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_BARE_ROOT", "")
+	withNoopTmux(t)
+
+	err := runSpawn(cmd, nil)
+	if err == nil {
+		t.Fatal("runSpawn returned nil — expected a downstream failure (no git repo)")
+	}
+	if strings.Contains(err.Error(), "a prompt is required") ||
+		strings.Contains(err.Error(), "empty string — supply a non-empty prompt") {
+		t.Errorf("runSpawn misclassified a supplied prompt as empty: %v", err)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -225,6 +225,15 @@ type SpawnOpts struct {
 	// instead of a "session created" success line followed by an idle
 	// session that will never make progress (see #1051 widening comment).
 	ReadinessTimeout time.Duration
+
+	// AllowEmptyPrompt opts the caller out of the layer-4 empty-prompt guard
+	// for LayoutFull / LayoutAgentOnly (issue #2012). The tmux Prefix+a
+	// keybind invokes `prism spawn --attach` with no --prompt so the operator
+	// can type the initial prompt to the live agent after the popup attaches;
+	// `cmd/spawn.go` sets this field when `PRISM_SPAWN_PATH` is present and
+	// no prompt was supplied. All other callers should leave this false so
+	// the original "agent pane needs a prompt" guard (#1891) keeps firing.
+	AllowEmptyPrompt bool
 }
 
 // SpawnSession creates a single prism session end-to-end: seeds the
@@ -264,7 +273,11 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// LayoutScratchpad are not agent panes — they are plain shells/dashboards
 	// — and legitimately have no prompt, so they must continue to accept
 	// an empty opts.Prompt.
-	if opts.Prompt == "" && (opts.Layout == LayoutFull || opts.Layout == LayoutAgentOnly) {
+	//
+	// opts.AllowEmptyPrompt opts the caller out of this guard — used by the
+	// keybind carve-out (issue #2012) where the operator types the initial
+	// prompt to the live agent after the popup attaches.
+	if opts.Prompt == "" && !opts.AllowEmptyPrompt && (opts.Layout == LayoutFull || opts.Layout == LayoutAgentOnly) {
 		return fmt.Errorf("spawn session: Prompt is required for layout %d (LayoutFull or LayoutAgentOnly) — an agent pane cannot start without a prompt", opts.Layout)
 	}
 

--- a/modules/programs/prism/prism/internal/session/spawn_allow_empty_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_allow_empty_prompt_test.go
@@ -1,0 +1,92 @@
+package session
+
+// Tests for the keybind carve-out of the layer-4 empty-prompt guard
+// (issue #2012). The layer-4 guard at the top of SpawnSession refuses
+// LayoutFull / LayoutAgentOnly when opts.Prompt is empty (#1891). The
+// tmux Prefix+a keybind needs to spawn a full-layout session with no
+// initial prompt because the operator types it to the live agent after
+// the popup attaches. The new opts.AllowEmptyPrompt field opts the
+// caller out of the layer-4 guard; cmd/spawn.go sets it when
+// PRISM_SPAWN_PATH is present and no prompt was supplied.
+//
+// These tests are package-internal (`package session`, not session_test)
+// so they can use spyTmuxBin / openSpawnTestDB from spawn_test.go — the
+// same pattern as TestSpawnSession_NoPrompt_LayoutAgentOnly_Rejected.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSpawnSession_AllowEmptyPrompt_LayoutFull_Accepted verifies that
+// SpawnSession with Layout=LayoutFull, empty Prompt, AND AllowEmptyPrompt=true
+// passes the layer-4 guard. We do not assert the full spawn succeeds — that
+// would require a real tmux server and sidecar binary — only that the
+// rejection at the layer-4 guard does NOT fire.
+//
+// A successful pass means the error (if any) does not contain the
+// "Prompt is required" message, OR the call returns nil. Both outcomes
+// confirm the relaxation worked; either way, the layer-4 reject does not
+// match what we observe.
+func TestSpawnSession_AllowEmptyPrompt_LayoutFull_Accepted(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@allow-empty-full"
+	opts := SpawnOpts{
+		SessionName: sessionName,
+		Repo:        "myrepo",
+		Worktree:    "/worktrees/myrepo-allow-empty-full",
+		AgentRole:   "worker",
+		// Prompt deliberately empty.
+		Layout:           LayoutFull,
+		IsolationMode:    "host",
+		HarnessName:      "pi",
+		AllowEmptyPrompt: true,
+	}
+
+	err := SpawnSession(d, opts)
+	if err != nil && strings.Contains(err.Error(), "Prompt is required") {
+		t.Fatalf("SpawnSession with AllowEmptyPrompt=true still returned the layer-4 'Prompt is required' rejection: %v", err)
+	}
+}
+
+// TestSpawnSession_AllowEmptyPrompt_LayoutFull_OptInRequired is the
+// matching negative test: the same call without AllowEmptyPrompt set is
+// still rejected by the layer-4 guard. Together with the positive test
+// above this proves the carve-out is gated on the opt-in and does not
+// silently weaken the existing #1891 guard for any caller that forgot
+// to set it.
+func TestSpawnSession_AllowEmptyPrompt_LayoutFull_OptInRequired(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@allow-empty-full-default"
+	opts := SpawnOpts{
+		SessionName:   sessionName,
+		Repo:          "myrepo",
+		Worktree:      "/worktrees/myrepo-allow-empty-full-default",
+		AgentRole:     "worker",
+		Layout:        LayoutFull,
+		IsolationMode: "host",
+		HarnessName:   "pi",
+		// AllowEmptyPrompt deliberately omitted (defaults to false).
+	}
+
+	err := SpawnSession(d, opts)
+	if err == nil {
+		t.Fatal("SpawnSession (empty Prompt, LayoutFull, AllowEmptyPrompt=false): got nil, want layer-4 rejection per issue #1891")
+	}
+	if !strings.Contains(err.Error(), "Prompt is required") {
+		t.Errorf("error %q does not mention 'Prompt is required'", err.Error())
+	}
+	// Nothing should have been written to the DB: refusal must happen
+	// before any side-effects (same invariant as the #1891 layer-4 test).
+	if st, _ := d.CurrentStatus(sessionName); st != nil {
+		t.Errorf("agent_status row created despite empty-prompt rejection: %+v", st)
+	}
+}

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -253,7 +253,16 @@ in
               # (#{pane_current_path} is expanded by tmux for -d). The popup
               # pane then reports that same path via pane_current_path, so
               # prism's CurrentPanePath() fallback works without PRISM_SPAWN_PATH.
+              #
+              # PRISM_SPAWN_PATH is also set explicitly so the spawn command
+              # can discriminate keybind-initiated spawns from shell/agent
+              # callers. The empty-prompt guard (issue #1891) is relaxed for
+              # the keybind path — the operator types the initial prompt to
+              # the live agent after the popup attaches, so requiring
+              # --prompt at invocation time would flash-close the popup with
+              # an unreadable error (issue #2012).
               bind a display-popup -E -d "#{pane_current_path}" -w 60% -h 20% -b single \
+                -e "PRISM_SPAWN_PATH=#{pane_current_path}" \
                 "${prism} spawn --attach"
 
               # agent scrolling keybinds — active when the pane is a prism agent


### PR DESCRIPTION
The tmux **Prefix+a** keybind invokes `prism spawn --attach` with no
`--prompt` because the operator types the initial prompt to the live
agent after the popup attaches. PR #1891 / #1893 added an empty-prompt
operator-boundary guard to `cmd/spawn.go` that now rejects this with a
1-second flash of `a prompt is required` inside the `display-popup -E`
popup — the popup closes before the user can read the error.

## Fix (Option A from #2012)

1. **`modules/programs/prism/tmux.nix`** — set
   `PRISM_SPAWN_PATH=#{pane_current_path}` in the Prefix+a popup
   environment so the keybind path is discriminable from shell/agent
   callers. The existing `fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""`
   line in `runSpawn` already implies this was the design.
2. **`modules/programs/prism/prism/cmd/spawn.go`** — relax the layer-1+2
   empty-prompt check so that when `fromKeybind` is true, an empty prompt
   is allowed through. The check continues to fire for non-keybind,
   non-proxy-spawn callers exactly as today.
3. **`modules/programs/prism/prism/internal/session/spawn.go`** — add
   `SpawnOpts.AllowEmptyPrompt` and skip the layer-4 "Prompt is
   required for layout %d" reject when set. `runSpawn` passes `true`
   when `fromKeybind && promptText == ""`.

Layer 3 (`internal/sidecar/host_api.go` `/spawn` handler) is
intentionally **not** relaxed — that handler serves non-prism HTTP
callers and the keybind never reaches it.

## Tests

- `cmd/spawn_empty_prompt_test.go` — three new tests covering:
  - `PRISM_SPAWN_PATH` set + empty prompt passes the layer-1+2 guard
  - `PRISM_SPAWN_PATH` unset + empty prompt still returns `emptyPromptError`
  - the carve-out does not swallow a supplied `--prompt` when
    `PRISM_SPAWN_PATH` is also set
- `internal/session/spawn_allow_empty_prompt_test.go` — two new tests
  covering the layer-4 relaxation: `LayoutFull` + empty `Prompt` +
  `AllowEmptyPrompt=true` succeeds; the same call without the opt-in
  still rejects with "Prompt is required".

## Quality gates

- `go test ./...` from `modules/programs/prism/prism/` — `./cmd`,
  `./internal/session` and all other non-host-dependent packages pass.
  Pre-existing `fork failed: Operation not permitted` failures in
  `./cmd`, `./internal/tmux`, `./internal/container` and
  `./internal/integration` reproduce on `main` without my changes —
  they are sandbox-environment limitations on the worker host that CI's
  Linux sandbox does not hit.
- `nix build .#prism` from the repo root: ✅
- `nixfmt .` on `tmux.nix`: ✅

Closes #2012
