### PR TITLE
prism: per-session mute flag suppressing outbound coordinator notifications

### DIFF
--- a/modules/programs/prism/prism/cmd/escalate.go
+++ b/modules/programs/prism/prism/cmd/escalate.go
@@ -195,6 +195,21 @@ func runEscalateForSession(database *db.DB, fromSession, explicitTo, promptText 
 		return nil
 	}
 
+	// Muted guard: when the calling session is muted, suppress the outbound
+	// coordinator escalation notification. The state transition and the
+	// session.escalated agent_events row are still written above so the
+	// dashboard reflects reality; only the bus delivery is skipped. This
+	// mirrors the notifyCoordinator suppression in internal/sidecar/notify.go
+	// for the finish-notification path — outbound to the coordinator is the
+	// suppression boundary, DB writes are unaffected. (#2013)
+	if selfStatus.Muted {
+		fmt.Fprintf(os.Stderr,
+			"prism escalate: session %q is muted; coordinator notification suppressed (state still transitioned to escalated, bus event still written).\n",
+			fromSession,
+		)
+		return nil
+	}
+
 	// Deliver via prism prompt machinery. We write the bus_messages row as
 	// "delivered" only on success; the sidecar's prompt path already does this
 	// for the audit trail, so we delegate by invoking the same code path that

--- a/modules/programs/prism/prism/cmd/list_sessions.go
+++ b/modules/programs/prism/prism/cmd/list_sessions.go
@@ -153,6 +153,7 @@ func renderSessionTable(ss []db.Status, groupParents map[string]string, abtestPa
 		harness string
 		title   string
 		abtest  bool // true when this session is part of an --abtest pair
+		muted   bool // true when the session's notifications are muted
 	}
 
 	var rows []row
@@ -166,7 +167,7 @@ func renderSessionTable(ss []db.Status, groupParents map[string]string, abtestPa
 			port = fmt.Sprintf("%d", *s.HarnessPort)
 		}
 		isAbtest := abtestPairs != nil && abtestPairs[s.SessionName] != ""
-		rows = append(rows, row{name: s.SessionName, state: s.State, port: port, harness: displayHarness(s.Harness), title: title, abtest: isAbtest})
+		rows = append(rows, row{name: s.SessionName, state: s.State, port: port, harness: displayHarness(s.Harness), title: title, abtest: isAbtest, muted: s.Muted})
 	}
 
 	// Sort rows using the same parent-attribution logic as the dashboard's
@@ -278,10 +279,17 @@ func renderSessionTable(ss []db.Status, groupParents map[string]string, abtestPa
 			nameStyle = styleName
 		}
 
-		// Build the display name: append ↔ indicator for abtest-paired sessions.
+		// Build the display name: append ↔ indicator for abtest-paired sessions
+		// and a (muted) suffix when notifications from this session are
+		// suppressed. The suffix is a plain marker (no colour) so it survives
+		// pipe-through-tee and other dumb-renderer callers; the prominent
+		// status-bar indicator lives in `prism sessions session-status`.
 		displayName := r.name
 		if r.abtest {
-			displayName = r.name + " ↔"
+			displayName = displayName + " ↔"
+		}
+		if r.muted {
+			displayName = displayName + " (muted)"
 		}
 
 		fmt.Printf("%s  %s  %s  %s  %s\n",

--- a/modules/programs/prism/prism/cmd/list_sessions_muted_test.go
+++ b/modules/programs/prism/prism/cmd/list_sessions_muted_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+// Tests for the muted-aware surface of `prism sessions list` (#2013):
+//
+//   - The (muted) marker appears on muted rows in the human-readable table.
+//   - The `muted` field appears in the --json output of every session object.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestListSessions_MutedRowHasMarker asserts the AC: every muted session
+// shows a `(muted)` marker in the human-readable table; unmuted rows do not.
+func TestListSessions_MutedRowHasMarker(t *testing.T) {
+	d := openStatsTestDB(t)
+
+	const mutedSession = "nixos-config@muted-row"
+	const plainSession = "nixos-config@plain-row"
+
+	for _, s := range []string{mutedSession, plainSession} {
+		if err := d.UpsertStatus(s, "nixos-config", "/tmp/w", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", s, err)
+		}
+	}
+	if _, err := d.SetMuted(mutedSession, true); err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+
+	listSessionsCmd.Flags().Set("all", "true")        //nolint:errcheck
+	defer listSessionsCmd.Flags().Set("all", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := listSessionsCmd.RunE(listSessionsCmd, nil); err != nil {
+			t.Errorf("list-sessions: %v", err)
+		}
+	})
+
+	// Find the line for the muted session. Match by session name to avoid
+	// false-negatives from terminal escape sequences wrapped around the name.
+	var mutedLine, plainLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, mutedSession) {
+			mutedLine = line
+		}
+		if strings.Contains(line, plainSession) {
+			plainLine = line
+		}
+	}
+	if mutedLine == "" {
+		t.Fatalf("muted session %q not found in output:\n%s", mutedSession, out)
+	}
+	if plainLine == "" {
+		t.Fatalf("plain session %q not found in output:\n%s", plainSession, out)
+	}
+	if !strings.Contains(mutedLine, "(muted)") {
+		t.Errorf("muted row missing (muted) marker:\n%s", mutedLine)
+	}
+	if strings.Contains(plainLine, "(muted)") {
+		t.Errorf("unmuted row has (muted) marker:\n%s", plainLine)
+	}
+}
+
+// TestListSessions_JSON_IncludesMutedField asserts the AC: every session
+// object in the --json output exposes a `muted` field. We don't assert on
+// the exact casing of other fields (the broader Status struct uses
+// PascalCase field names \u2014 see types.go) because the only field with an
+// explicit json tag is `muted`, and that's the field this AC requires.
+func TestListSessions_JSON_IncludesMutedField(t *testing.T) {
+	d := openStatsTestDB(t)
+
+	const mutedSession = "nixos-config@json-muted"
+	const plainSession = "nixos-config@json-plain"
+
+	for _, s := range []string{mutedSession, plainSession} {
+		if err := d.UpsertStatus(s, "nixos-config", "/tmp/w", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", s, err)
+		}
+	}
+	if _, err := d.SetMuted(mutedSession, true); err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+
+	listSessionsCmd.Flags().Set("all", "true")         //nolint:errcheck
+	listSessionsCmd.Flags().Set("json", "true")        //nolint:errcheck
+	defer func() {
+		listSessionsCmd.Flags().Set("all", "false")  //nolint:errcheck
+		listSessionsCmd.Flags().Set("json", "false") //nolint:errcheck
+	}()
+
+	out := captureStdout(t, func() {
+		if err := listSessionsCmd.RunE(listSessionsCmd, nil); err != nil {
+			t.Errorf("list-sessions --json: %v", err)
+		}
+	})
+
+	var doc struct {
+		Sessions []map[string]json.RawMessage `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &doc); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\nout: %s", err, out)
+	}
+	if len(doc.Sessions) == 0 {
+		t.Fatalf("expected at least one session in JSON output:\n%s", out)
+	}
+
+	var (
+		foundMuted bool
+		foundPlain bool
+	)
+	for _, s := range doc.Sessions {
+		nameRaw, ok := s["SessionName"]
+		if !ok {
+			t.Fatalf("session object missing SessionName key: %v", s)
+		}
+		var name string
+		if err := json.Unmarshal(nameRaw, &name); err != nil {
+			t.Fatalf("unmarshal SessionName: %v", err)
+		}
+		mutedRaw, ok := s["muted"]
+		if !ok {
+			t.Errorf("session %q missing `muted` field; keys=%v", name, mapKeys(s))
+			continue
+		}
+		var muted bool
+		if err := json.Unmarshal(mutedRaw, &muted); err != nil {
+			t.Errorf("session %q has non-bool muted: %v", name, err)
+			continue
+		}
+		switch name {
+		case mutedSession:
+			foundMuted = true
+			if !muted {
+				t.Errorf("session %q: muted=false in JSON, want true", name)
+			}
+		case plainSession:
+			foundPlain = true
+			if muted {
+				t.Errorf("session %q: muted=true in JSON, want false", name)
+			}
+		}
+	}
+	if !foundMuted {
+		t.Errorf("muted session %q not found in JSON output", mutedSession)
+	}
+	if !foundPlain {
+		t.Errorf("plain session %q not found in JSON output", plainSession)
+	}
+}
+
+func mapKeys(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/modules/programs/prism/prism/cmd/mute.go
+++ b/modules/programs/prism/prism/cmd/mute.go
@@ -1,0 +1,149 @@
+package cmd
+
+// prism mute — toggle or set the muted flag on a session.
+//
+// This command is intentionally hidden from --help, cobra completion, and any
+// agent-facing documentation. It is an operator escape hatch for the human at
+// the keyboard, not a tool for AI coordinators to discover. See issue #2013
+// for the design rationale.
+//
+// Surface:
+//
+//	prism mute             # toggle current pane's session (reads PRISM_SESSION_NAME)
+//	prism mute <session>   # toggle the named session
+//	prism mute --on <s>    # idempotently set <s> muted=true
+//	prism mute --off <s>   # idempotently set <s> muted=false
+//
+// Semantics:
+//
+//   - The muted flag is an orthogonal boolean on agent_status; agent lifecycle
+//     (active / waiting / idle / escalated / etc.) keeps moving normally.
+//   - Persistence survives sidecar restart.
+//   - No auto-unmute. A muted session that hits finished stays muted; the
+//     terminal `has finished` notification is suppressed too. Missed
+//     notifications are dropped, not queued for replay on unmute.
+//   - Suppression scope is outbound coordinator notifications only
+//     (session.finished AND session.escalated). DB writes are unaffected;
+//     inbound delivery to the muted session is unaffected.
+//   - Muting a coordinator is permitted and persists, but has no observable
+//     effect on notification flow (coordinators do not notify themselves).
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// muteCmd is the (hidden) `prism mute` command. Hidden=true keeps it out of
+// `--help` and cobra's completion output; the help text below is still
+// reachable via `prism help mute` for the operator who knows the command
+// exists.
+var muteCmd = &cobra.Command{
+	Use:    "mute [session]",
+	Short:  "Toggle or set the muted flag on a session (operator escape hatch)",
+	Hidden: true,
+	Long: `Toggle or set the muted flag on a session.
+
+With no positional argument, toggles the session named in PRISM_SESSION_NAME
+(set automatically inside a prism pane). With a positional argument, toggles
+the named session regardless of the calling pane's PRISM_SESSION_NAME.
+
+While muted, the session's outbound coordinator notifications are suppressed
+(both 'has finished' and the escalation bus notification). DB writes,
+lifecycle state transitions, and inbound delivery to the session are all
+unaffected. The flag is persistent and survives sidecar restart; it is never
+auto-cleared, including on session termination.
+
+--on and --off set the flag idempotently. They are mutually exclusive.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runMute,
+}
+
+func init() {
+	muteCmd.Flags().Bool("on", false, "Idempotently set muted=true (cannot combine with --off)")
+	muteCmd.Flags().Bool("off", false, "Idempotently set muted=false (cannot combine with --on)")
+	muteCmd.MarkFlagsMutuallyExclusive("on", "off")
+	rootCmd.AddCommand(muteCmd)
+}
+
+// runMute resolves the target session and applies the requested mute state.
+//
+// Target resolution:
+//   - One positional argument: use it verbatim.
+//   - No positional argument: read PRISM_SESSION_NAME; error if unset.
+//
+// Mode resolution:
+//   - --on: set muted=true; no stdout output if already muted.
+//   - --off: set muted=false; no stdout output if already unmuted.
+//   - Neither: toggle; print "muted: <name>" or "unmuted: <name>".
+//
+// A non-existent target session is a hard error (exit non-zero) and never
+// inserts a row \u2014 the muted flag belongs to a real lifecycle row, not a
+// phantom one created on first reference.
+func runMute(cmd *cobra.Command, args []string) error {
+	on, _ := cmd.Flags().GetBool("on")
+	off, _ := cmd.Flags().GetBool("off")
+
+	var target string
+	switch len(args) {
+	case 0:
+		target = os.Getenv("PRISM_SESSION_NAME")
+		if target == "" {
+			return errors.New(
+				"prism mute: no current session — pass a session name or run from a prism pane",
+			)
+		}
+	case 1:
+		target = args[0]
+	}
+
+	database, err := openDB()
+	if err != nil {
+		return fmt.Errorf("prism mute: open db: %w", err)
+	}
+	defer database.Close()
+
+	current, ok, err := database.IsMuted(target)
+	if err != nil {
+		return fmt.Errorf("prism mute: read mute state for %q: %w", target, err)
+	}
+	if !ok {
+		return fmt.Errorf("prism mute: session %q not found", target)
+	}
+
+	switch {
+	case on:
+		if current {
+			// Already in desired state — idempotent no-op, no output.
+			return nil
+		}
+		if _, err := database.SetMuted(target, true); err != nil {
+			return fmt.Errorf("prism mute: set muted: %w", err)
+		}
+		fmt.Printf("muted: %s\n", target)
+		return nil
+	case off:
+		if !current {
+			return nil
+		}
+		if _, err := database.SetMuted(target, false); err != nil {
+			return fmt.Errorf("prism mute: clear muted: %w", err)
+		}
+		fmt.Printf("unmuted: %s\n", target)
+		return nil
+	default:
+		// Toggle.
+		next := !current
+		if _, err := database.SetMuted(target, next); err != nil {
+			return fmt.Errorf("prism mute: toggle muted: %w", err)
+		}
+		if next {
+			fmt.Printf("muted: %s\n", target)
+		} else {
+			fmt.Printf("unmuted: %s\n", target)
+		}
+		return nil
+	}
+}

--- a/modules/programs/prism/prism/cmd/mute_test.go
+++ b/modules/programs/prism/prism/cmd/mute_test.go
@@ -1,0 +1,285 @@
+package cmd
+
+// Tests for `prism mute` (#2013).
+//
+// The command is intentionally hidden; these tests exercise the RunE surface
+// directly without going through `prism --help`. The discoverability AC is
+// asserted separately in TestMuteCmd_IsHidden.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// resetMuteFlags clears the on/off flags between sub-tests so flag state from
+// one case does not bleed into the next. cobra.Command flags are package-level
+// singletons, so explicit reset is required.
+func resetMuteFlags(t *testing.T) {
+	t.Helper()
+	_ = muteCmd.Flags().Set("on", "false")
+	_ = muteCmd.Flags().Set("off", "false")
+}
+
+// runMuteHelper invokes runMute against a freshly-constructed cobra command
+// tree so the mutual-exclusion validation in cobra.MarkFlagsMutuallyExclusive
+// actually fires. It mirrors how the real binary parses argv.
+func runMuteHelper(t *testing.T, argv ...string) (string, error) {
+	t.Helper()
+	resetMuteFlags(t)
+
+	// Build a throwaway parent so cobra Execute() walks the flag set the
+	// same way as the real CLI. We can't use rootCmd directly because it
+	// registers many side-effecting commands; spinning up a tiny clone is
+	// cheaper and keeps the test focused.
+	parent := &cobra.Command{Use: "prism"}
+	// Reuse the configured muteCmd so its flag registrations (mutually
+	// exclusive group, hidden bit, etc.) are exercised verbatim.
+	parent.AddCommand(muteCmd)
+	parent.SetArgs(append([]string{"mute"}, argv...))
+
+	out := captureStdout(t, func() {
+		_ = parent.Execute() // capture error via ExecuteC below
+	})
+	// Re-run via ExecuteC to retrieve the error directly. cobra's Execute
+	// already printed any usage; ExecuteC short-circuits validation we have
+	// already proved above and returns the error from RunE.
+	parent.SetArgs(append([]string{"mute"}, argv...))
+	resetMuteFlags(t)
+	parent.SetOut(nil)
+	parent.SetErr(nil)
+	_, err := parent.ExecuteC()
+	return out, err
+}
+
+// TestMute_NoArgs_TogglesCurrentSession asserts that running `prism mute`
+// in a pane with PRISM_SESSION_NAME=foo toggles foo's muted flag and prints
+// the expected stdout line.
+func TestMute_NoArgs_TogglesCurrentSession(t *testing.T) {
+	d := openStatsTestDB(t)
+
+	const session = "prism-test@mute-noargs"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	t.Setenv("PRISM_SESSION_NAME", session)
+	resetMuteFlags(t)
+
+	out := captureStdout(t, func() {
+		if err := runMute(muteCmd, nil); err != nil {
+			t.Fatalf("runMute: %v", err)
+		}
+	})
+	if want := "muted: " + session; !strings.Contains(out, want) {
+		t.Errorf("expected stdout to contain %q, got %q", want, out)
+	}
+
+	muted, ok, err := d.IsMuted(session)
+	if err != nil || !ok {
+		t.Fatalf("IsMuted: %v ok=%v", err, ok)
+	}
+	if !muted {
+		t.Errorf("expected session muted after first toggle")
+	}
+
+	// Second toggle flips it back.
+	out2 := captureStdout(t, func() {
+		if err := runMute(muteCmd, nil); err != nil {
+			t.Fatalf("runMute (second): %v", err)
+		}
+	})
+	if want := "unmuted: " + session; !strings.Contains(out2, want) {
+		t.Errorf("expected stdout to contain %q, got %q", want, out2)
+	}
+	muted2, _, _ := d.IsMuted(session)
+	if muted2 {
+		t.Errorf("expected session unmuted after second toggle")
+	}
+}
+
+// TestMute_PositionalTargetsNamedSession asserts that `prism mute bar`
+// toggles bar's muted flag even when the calling pane's PRISM_SESSION_NAME is
+// set to a different session.
+func TestMute_PositionalTargetsNamedSession(t *testing.T) {
+	d := openStatsTestDB(t)
+	const target = "prism-test@positional-target"
+	const caller = "prism-test@positional-caller"
+	for _, s := range []string{target, caller} {
+		if err := d.UpsertStatus(s, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", s, err)
+		}
+	}
+	t.Setenv("PRISM_SESSION_NAME", caller)
+	resetMuteFlags(t)
+
+	captureStdout(t, func() {
+		if err := runMute(muteCmd, []string{target}); err != nil {
+			t.Fatalf("runMute: %v", err)
+		}
+	})
+
+	mutedTarget, _, _ := d.IsMuted(target)
+	if !mutedTarget {
+		t.Errorf("positional target was not muted")
+	}
+	mutedCaller, _, _ := d.IsMuted(caller)
+	if mutedCaller {
+		t.Errorf("caller session should not have been touched by positional invocation")
+	}
+}
+
+// TestMute_OnIsIdempotent asserts the AC: `prism mute --on foo` twice is a
+// no-op on the second call and emits no stdout. The exit code is 0 either way.
+func TestMute_OnIsIdempotent(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "prism-test@idempotent-on"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	resetMuteFlags(t)
+	_ = muteCmd.Flags().Set("on", "true")
+
+	out1 := captureStdout(t, func() {
+		if err := runMute(muteCmd, []string{session}); err != nil {
+			t.Fatalf("runMute --on (first): %v", err)
+		}
+	})
+	if !strings.Contains(out1, "muted: "+session) {
+		t.Errorf("first --on must print muted line, got %q", out1)
+	}
+
+	// Second --on: no stdout, exit 0.
+	resetMuteFlags(t)
+	_ = muteCmd.Flags().Set("on", "true")
+	out2 := captureStdout(t, func() {
+		if err := runMute(muteCmd, []string{session}); err != nil {
+			t.Fatalf("runMute --on (second): %v", err)
+		}
+	})
+	if strings.TrimSpace(out2) != "" {
+		t.Errorf("second --on must be silent, got %q", out2)
+	}
+	muted, _, _ := d.IsMuted(session)
+	if !muted {
+		t.Errorf("session should remain muted after second --on")
+	}
+}
+
+// TestMute_OffIsIdempotent mirrors the --on idempotence AC for --off.
+func TestMute_OffIsIdempotent(t *testing.T) {
+	d := openStatsTestDB(t)
+	const session = "prism-test@idempotent-off"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	// Pre-mute the session so --off has work to do.
+	if _, err := d.SetMuted(session, true); err != nil {
+		t.Fatalf("seed SetMuted: %v", err)
+	}
+
+	resetMuteFlags(t)
+	_ = muteCmd.Flags().Set("off", "true")
+	out1 := captureStdout(t, func() {
+		if err := runMute(muteCmd, []string{session}); err != nil {
+			t.Fatalf("runMute --off (first): %v", err)
+		}
+	})
+	if !strings.Contains(out1, "unmuted: "+session) {
+		t.Errorf("first --off must print unmuted line, got %q", out1)
+	}
+
+	resetMuteFlags(t)
+	_ = muteCmd.Flags().Set("off", "true")
+	out2 := captureStdout(t, func() {
+		if err := runMute(muteCmd, []string{session}); err != nil {
+			t.Fatalf("runMute --off (second): %v", err)
+		}
+	})
+	if strings.TrimSpace(out2) != "" {
+		t.Errorf("second --off must be silent, got %q", out2)
+	}
+}
+
+// TestMute_OnOff_MutuallyExclusive asserts the AC: `prism mute --on --off`
+// exits non-zero with a cobra-enforced mutual-exclusion error.
+func TestMute_OnOff_MutuallyExclusive(t *testing.T) {
+	// Use a fresh sub-tree so cobra's mutual-exclusion check actually runs.
+	parent := &cobra.Command{Use: "prism"}
+	parent.AddCommand(muteCmd)
+	parent.SetArgs([]string{"mute", "--on", "--off", "irrelevant"})
+	resetMuteFlags(t)
+	// Silence stderr/usage prints so the test output stays clean.
+	parent.SetErr(devNullWriter{})
+	parent.SetOut(devNullWriter{})
+
+	_, err := parent.ExecuteC()
+	resetMuteFlags(t)
+	if err == nil {
+		t.Fatal("expected error for --on --off, got nil")
+	}
+	// cobra phrases this as "if any flags in the group [on off] are set none
+	// of the others can be". Accept either the human phrasing or the cobra
+	// canonical wording so the test does not break on a cobra upgrade.
+	msg := err.Error()
+	if !strings.Contains(msg, "mutually exclusive") && !strings.Contains(msg, "[on off]") {
+		t.Errorf("error must signal mutual exclusion, got %q", err)
+	}
+}
+
+// TestMute_NoArgs_MissingEnv_Errors asserts the AC: `prism mute` with no args
+// and PRISM_SESSION_NAME unset exits non-zero with a clear error.
+func TestMute_NoArgs_MissingEnv_Errors(t *testing.T) {
+	openStatsTestDB(t) // wires up testDBPath even though we'll error before opening
+	t.Setenv("PRISM_SESSION_NAME", "")
+	resetMuteFlags(t)
+
+	err := runMute(muteCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for no-args + missing PRISM_SESSION_NAME, got nil")
+	}
+	if !strings.Contains(err.Error(), "no current session") {
+		t.Errorf("error must mention 'no current session', got %q", err)
+	}
+}
+
+// TestMute_UnknownSession_Errors asserts the AC: `prism mute does-not-exist`
+// exits non-zero with a clear "session not found" error AND does not insert a
+// new agent_status row for the missing session.
+func TestMute_UnknownSession_Errors(t *testing.T) {
+	d := openStatsTestDB(t)
+	resetMuteFlags(t)
+
+	err := runMute(muteCmd, []string{"does-not-exist"})
+	if err == nil {
+		t.Fatal("expected error for unknown session, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error must mention 'not found', got %q", err)
+	}
+
+	// Confirm no phantom row was inserted.
+	st, lookupErr := d.CurrentStatus("does-not-exist")
+	if lookupErr != nil {
+		t.Fatalf("CurrentStatus: %v", lookupErr)
+	}
+	if st != nil {
+		t.Errorf("phantom row inserted for missing session: %+v", st)
+	}
+}
+
+// TestMuteCmd_IsHidden asserts the discoverability AC: the cobra command
+// carries Hidden=true so it does not appear in `--help` or completion output.
+func TestMuteCmd_IsHidden(t *testing.T) {
+	if !muteCmd.Hidden {
+		t.Error("muteCmd.Hidden must be true so prism mute does not appear in --help or completion")
+	}
+}
+
+// devNullWriter discards writes so tests do not pollute stderr/stdout.
+type devNullWriter struct{}
+
+func (devNullWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/modules/programs/prism/prism/cmd/sessions.go
+++ b/modules/programs/prism/prism/cmd/sessions.go
@@ -11,6 +11,7 @@ package cmd
 //	prism sessions status --tmux-format  tmux colour-formatted output
 //	prism sessions status --waiting   only the waiting count
 //	prism sessions status --json      JSON object keyed by state
+//	prism sessions session-status --tmux-format  per-session tmux status segment
 //
 // Hidden backward-compat aliases:
 //
@@ -20,6 +21,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/tmuxstatus"
 )
 
 var sessionsCmd = &cobra.Command{
@@ -62,6 +65,22 @@ JSON object keyed by state with integer counts.
 	RunE: runStatus,
 }
 
+// sessionsSessionStatusCmd renders a per-session tmux status segment. Today
+// it only encodes the muted flag; the surface is designed to grow with
+// additional per-session indicators without changing the tmux-side wiring.
+var sessionsSessionStatusCmd = &cobra.Command{
+	Use:   "session-status [session]",
+	Short: "Emit a per-session tmux status segment",
+	Long: `Emit a per-session tmux status-right segment for the session named in
+PRISM_SESSION_NAME (or the positional argument when given).
+
+With --tmux-format, the output uses tmux #[bg=...,fg=...] colour escapes.
+With no targetable session, the output is empty and exit code is 0 — the
+graceful-degradation contract matching FormatWaiting.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runSessionStatus,
+}
+
 func init() {
 	sessionsListCmd.Flags().BoolP("all", "A", false, "List ALL sessions across all repos, including other repos' workers.\nBy default the listing already includes other repos' coordinators — only their workers are hidden.")
 	sessionsListCmd.Flags().Bool("json", false, "Emit structured JSON (array of session objects) to stdout instead of the human-readable table")
@@ -70,9 +89,68 @@ func init() {
 	sessionsStatusCmd.Flags().Bool("tmux-format", false, "Emit tmux #[fg=...] colour-formatted output")
 	sessionsStatusCmd.Flags().Bool("json", false, "Emit a JSON object keyed by state with integer counts (mutually exclusive with --tmux-format)")
 
+	sessionsSessionStatusCmd.Flags().Bool("tmux-format", false, "Emit tmux #[bg=...,fg=...] colour-formatted output (the only currently-supported format)")
+
 	sessionsCmd.AddCommand(sessionsListCmd)
 	sessionsCmd.AddCommand(sessionsStatusCmd)
+	sessionsCmd.AddCommand(sessionsSessionStatusCmd)
 	rootCmd.AddCommand(sessionsCmd)
+}
+
+// runSessionStatus is the RunE for `prism sessions session-status`.
+//
+// Resolution order for the target session:
+//   1. Positional argument when given.
+//   2. PRISM_SESSION_NAME environment variable.
+//   3. Empty — emit "" and exit 0 (graceful-degradation contract).
+//
+// A DB-lookup failure (DB closed, session not in DB) also degrades to empty
+// stdout, never to an error. The status bar must never display an error.
+func runSessionStatus(cmd *cobra.Command, args []string) error {
+	var target string
+	switch len(args) {
+	case 1:
+		target = args[0]
+	case 0:
+		target = os.Getenv("PRISM_SESSION_NAME")
+	}
+	if target == "" {
+		return nil
+	}
+
+	d, err := openDB()
+	if err != nil {
+		return nil
+	}
+	defer d.Close()
+
+	st, err := d.CurrentStatus(target)
+	if err != nil || st == nil {
+		return nil
+	}
+
+	seg := tmuxstatus.FormatSessionStatus(
+		tmuxstatus.SessionStatus{Name: target, Muted: st.Muted},
+		sessionStatusColors(),
+	)
+	if seg != "" {
+		fmt.Print(seg)
+	}
+	return nil
+}
+
+// sessionStatusColors returns the palette slice used by FormatSessionStatus.
+// Wrapped so the formatter in internal/tmuxstatus stays free of the
+// cmd-package theme globals.
+func sessionStatusColors() tmuxstatus.Colors {
+	return tmuxstatus.Colors{
+		Yellow:  ColorYellow,
+		Purple:  ColorPurple,
+		Green:   ColorGreen,
+		Red:     ColorRed,
+		Primary: ColorPrimary,
+		Bg0:     ColorBg0,
+	}
 }
 
 // sessionJSONRow is the snake_case JSON schema for a single sessions row.

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -29,7 +29,7 @@ const (
 	// It must be bumped whenever a new migrateVNtoVN+1 function is added.
 	// A meta-test in db_test.go asserts that this constant equals the count of
 	// migration functions, so forgetting to bump it will fail CI.
-	currentSchemaVersion = 33
+	currentSchemaVersion = 34
 )
 
 // DB wraps a SQLite connection.
@@ -111,7 +111,8 @@ CREATE TABLE IF NOT EXISTS agent_status (
   harness           TEXT NOT NULL DEFAULT 'pi',
   harness_session_id TEXT,
   harness_port      INTEGER,
-  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL
+  group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+  muted             INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS bus_messages (
@@ -629,6 +630,9 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV32ToV33(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV33ToV34(conn, &version); err != nil {
+		return err
+	}
 	if version > currentSchemaVersion {
 		return fmt.Errorf(
 			"db schema version %d is newer than this prism binary (max %d); "+
@@ -676,6 +680,35 @@ func runMigrations(conn *sql.DB) error {
 // The partial WHERE (harness_port IS NOT NULL AND ended_at IS NULL) excludes
 // both NULL/released ports and ended sessions, so that ended sessions' ports
 // can be reclaimed by new sessions without triggering a constraint error.
+// migrateV33ToV34 adds the `muted` column to agent_status (issue #2013).
+// The column is `INTEGER NOT NULL DEFAULT 0` so existing rows are
+// initialised as unmuted (false). The ALTER TABLE is guarded by a
+// pragma_table_info check so the migration is idempotent on fresh databases
+// where the declarative schema block above already includes the column.
+func migrateV33ToV34(conn *sql.DB, version *int) error {
+	if *version >= 34 {
+		return nil
+	}
+	var exists int
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('agent_status') WHERE name = 'muted'`,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("db: migration v33\u2192v34: check muted column: %w", err)
+	}
+	if exists == 0 {
+		if _, err := conn.Exec(
+			`ALTER TABLE agent_status ADD COLUMN muted INTEGER NOT NULL DEFAULT 0`,
+		); err != nil {
+			return fmt.Errorf("db: migration v33\u2192v34: add muted: %w", err)
+		}
+	}
+	if _, err := conn.Exec(`UPDATE schema_version SET version = 34`); err != nil {
+		return fmt.Errorf("db: migration v33\u2192v34: %w", err)
+	}
+	*version = 34
+	return nil
+}
+
 func migrateV32ToV33(conn *sql.DB, version *int) error {
 	if *version >= 33 {
 		return nil

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -50,8 +50,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version: got %d, want 34", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1232,8 +1232,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1307,8 +1307,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1859,8 +1859,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1925,8 +1925,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1995,8 +1995,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -2090,8 +2090,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -2183,8 +2183,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2727,8 +2727,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2816,8 +2816,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4666,8 +4666,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// Check each row.
@@ -5094,8 +5094,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5369,8 +5369,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5590,8 +5590,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// sessions table must exist.
@@ -5744,8 +5744,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 }
 
@@ -6298,8 +6298,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6356,8 +6356,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6658,8 +6658,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6720,8 +6720,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6879,8 +6879,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6933,8 +6933,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	var startedAt int64
@@ -7087,8 +7087,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -7160,8 +7160,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7296,8 +7296,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7350,8 +7350,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	// spawn_outcome must still exist.
@@ -7465,8 +7465,8 @@ func TestMigration_V23ToV24_CrashRecovery(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&finalVer); err != nil {
 		t.Fatalf("read schema_version after recovery: %v", err)
 	}
-	if finalVer != 33 {
-		t.Errorf("schema_version after recovery: got %d, want 33", finalVer)
+	if finalVer != 34 {
+		t.Errorf("schema_version after recovery: got %d, want 34", finalVer)
 	}
 
 	// Sessions data must be preserved (the two rows seeded by seedV23DB).
@@ -8194,8 +8194,8 @@ func TestMigration_V10ToV11_DropsLegacyOpencodeColumns(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// opencode_sid and opencode_port must be gone from agent_status.
@@ -8278,8 +8278,8 @@ func TestMigration_V10ToV11_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	// Columns must remain dropped.
@@ -8448,8 +8448,8 @@ func TestMigration_V11ToV12_CreatesIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// Index must exist after migration.
@@ -8521,8 +8521,8 @@ func TestMigration_V11ToV12_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	var idxName string
@@ -8622,8 +8622,8 @@ func TestMigration_V16ToV17_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// The pre-existing sessions row must be unchanged.
@@ -8658,8 +8658,8 @@ func TestMigration_V16ToV17_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 }
 
@@ -8750,8 +8750,8 @@ func TestMigration_V18ToV19_CreatesPendingMerges(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	var tname string
@@ -8897,8 +8897,8 @@ func TestMigration_V19ToV20_AddsStatusSessionIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	var iname string
@@ -9066,8 +9066,8 @@ func TestMigration_V24ToV25_CreatesSpawnInputs(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	var tname string
@@ -9268,8 +9268,8 @@ func TestMigration_V25ToV26_DropsHostModeAndBackfillsPodman(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// host_mode column must be gone.
@@ -9367,8 +9367,8 @@ func TestMigration_V25ToV26_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 
 	var hmCount int
@@ -9488,8 +9488,8 @@ func TestMigration_V26ToV27_CreatesHarnessFrames(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	var tname string
@@ -9658,8 +9658,8 @@ func TestMigration_V27ToV28_BodyRuns_AddsAbtestPairID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// abtest_pair_id must exist on spawn_inputs.
@@ -9702,8 +9702,8 @@ func TestMigration_V27ToV28_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// The column must still be present — exactly one (not duplicated by a
@@ -9831,8 +9831,8 @@ func TestMigration_V28ToV29_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	var startedAt int64
@@ -9865,8 +9865,8 @@ func TestMigration_V28ToV29_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 }
 
@@ -9963,8 +9963,8 @@ func TestMigration_V29ToV30_BodyRuns_AddsParentSession(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	var n int
@@ -10003,8 +10003,8 @@ func TestMigration_V29ToV30_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	// Exactly one parent_session column — not duplicated by re-ADD.
@@ -10134,8 +10134,8 @@ func TestMigration_V30ToV31_AddsPRNumberAndRound(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after migration: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after migration: got %d, want 34", version)
 	}
 
 	for _, col := range []string{"pr_number", "round"} {

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -45,7 +45,7 @@ func TestOpen_CreatesSchema(t *testing.T) {
 		}
 	}
 
-	// Verify schema_version=33 (all migrations applied on Open).
+	// Verify schema_version=34 (all migrations applied on Open).
 	var version int
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -422,7 +422,7 @@ WHERE a.session_name = ?`
 // to a session_groups row with parent_session = parentSession.
 func (d *DB) GroupMembersForParent(parentSession string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
 	return d.queryStatuses(q, parentSession)
@@ -434,7 +434,7 @@ WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)
 // cleaned up.
 func (d *DB) GroupMembersForGroup(groupID string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE group_id = ?
 ORDER BY session_name ASC`
@@ -524,7 +524,7 @@ func (d *DB) ReviewGroupsList(limit int) ([]ReviewGroupSummary, error) {
 	placeholders := strings.Repeat("?,", len(groupIDs))
 	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
 	memberQ := `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE group_id IN (` + placeholders + `)
 ORDER BY group_id ASC, session_name ASC`

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 33 {
-		t.Errorf("schema_version after fresh open = %d, want 33", ver)
+	if ver != 34 {
+		t.Errorf("schema_version after fresh open = %d, want 34", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 33 {
-		t.Errorf("schema_version after second open = %d, want 33", ver)
+	if ver != 34 {
+		t.Errorf("schema_version after second open = %d, want 34", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/db/muted_test.go
+++ b/modules/programs/prism/prism/internal/db/muted_test.go
@@ -1,0 +1,196 @@
+package db
+
+// DB-layer tests for the muted flag on agent_status (#2013). These exercise
+// the SetMuted / IsMuted helpers and the persistence-across-Open contract
+// asserted by the issue ACs:
+//
+//   - "Setting a session to muted, restarting the sidecar, and reading
+//     db.Status for that session returns Muted: true."
+//   - "prism cleanup --session <name> removes the session row including its
+//     muted flag; a subsequent prism mute <name> for that now-gone session
+//     returns a clear 'session not found' error."
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// openMutedTestDB opens a fresh DB under t.TempDir() and registers cleanup.
+func openMutedTestDB(t *testing.T) (*DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "muted.db")
+	d, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d, path
+}
+
+// TestStatus_MutedDefaultsFalse asserts new rows default to unmuted.
+func TestStatus_MutedDefaultsFalse(t *testing.T) {
+	d, _ := openMutedTestDB(t)
+
+	const session = "prism-test@muted-default"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	st, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus returned nil")
+	}
+	if st.Muted {
+		t.Errorf("new row default Muted = true, want false")
+	}
+}
+
+// TestStatus_SetMutedRoundtrip asserts SetMuted persists and CurrentStatus
+// reads back the same value. Both the true and false transitions are tested.
+func TestStatus_SetMutedRoundtrip(t *testing.T) {
+	d, _ := openMutedTestDB(t)
+	const session = "prism-test@muted-roundtrip"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	ok, err := d.SetMuted(session, true)
+	if err != nil || !ok {
+		t.Fatalf("SetMuted(true): ok=%v err=%v", ok, err)
+	}
+	st, _ := d.CurrentStatus(session)
+	if !st.Muted {
+		t.Error("Muted false after SetMuted(true)")
+	}
+
+	ok, err = d.SetMuted(session, false)
+	if err != nil || !ok {
+		t.Fatalf("SetMuted(false): ok=%v err=%v", ok, err)
+	}
+	st, _ = d.CurrentStatus(session)
+	if st.Muted {
+		t.Error("Muted true after SetMuted(false)")
+	}
+}
+
+// TestStatus_MutedPersistsAcrossReopen asserts the AC: muted=true survives a
+// db.Close + db.Open cycle (the on-disk persistence contract that mirrors a
+// sidecar restart).
+func TestStatus_MutedPersistsAcrossReopen(t *testing.T) {
+	d, path := openMutedTestDB(t)
+	const session = "prism-test@muted-persist"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if _, err := d.SetMuted(session, true); err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+	d.Close()
+
+	// Re-open the same on-disk file.
+	d2, err := Open(path)
+	if err != nil {
+		t.Fatalf("re-Open: %v", err)
+	}
+	defer d2.Close()
+
+	st, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus after reopen: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus after reopen returned nil")
+	}
+	if !st.Muted {
+		t.Errorf("Muted not persisted across reopen; got Muted=false, want true")
+	}
+}
+
+// TestStatus_SetMutedMissingRowReturnsFalse asserts that SetMuted on a
+// non-existent row returns (false, nil) and does NOT insert a phantom row.
+func TestStatus_SetMutedMissingRowReturnsFalse(t *testing.T) {
+	d, _ := openMutedTestDB(t)
+
+	ok, err := d.SetMuted("does-not-exist", true)
+	if err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+	if ok {
+		t.Error("SetMuted on missing row returned ok=true, want false")
+	}
+
+	st, _ := d.CurrentStatus("does-not-exist")
+	if st != nil {
+		t.Errorf("phantom row inserted: %+v", st)
+	}
+}
+
+// TestStatus_IsMutedTreatsEndedSessionAsMissing asserts the AC behaviour
+// after `prism cleanup --session <name>`: the agent_status row carries
+// ended_at, IsMuted returns (false, false, nil), and the CLI maps that to
+// a "session not found" error.
+//
+// We simulate cleanup by calling SetEnded (the same method cleanup invokes
+// under the hood) rather than running the full cleanup command, which would
+// pull in tmux / git / archive paths irrelevant to the DB-layer contract.
+func TestStatus_IsMutedTreatsEndedSessionAsMissing(t *testing.T) {
+	d, _ := openMutedTestDB(t)
+	const session = "prism-test@muted-ended"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	// Mute first, then end \u2014 this also covers the "muted flag is preserved
+	// in the row but the CLI cannot see it" forensic case.
+	if _, err := d.SetMuted(session, true); err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+	if err := d.SetEnded(session); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	muted, ok, err := d.IsMuted(session)
+	if err != nil {
+		t.Fatalf("IsMuted: %v", err)
+	}
+	if ok {
+		t.Error("IsMuted on ended session returned ok=true; want false (treated as not-found)")
+	}
+	if muted {
+		t.Error("IsMuted on ended session returned muted=true; want false")
+	}
+
+	// And SetMuted on an ended session is also a no-op (rows affected = 0).
+	updated, err := d.SetMuted(session, false)
+	if err != nil {
+		t.Fatalf("SetMuted on ended: %v", err)
+	}
+	// SetMuted does not filter on ended_at by design \u2014 it updates whatever row
+	// matches. We accept the post-state observation: if SetMuted updated, the
+	// row's muted column is now 0; if not, the prior value persists. Either
+	// way IsMuted continues to treat the ended row as missing.
+	_ = updated
+
+	muted2, ok2, err := d.IsMuted(session)
+	if err != nil {
+		t.Fatalf("IsMuted (post): %v", err)
+	}
+	if ok2 || muted2 {
+		t.Errorf("IsMuted after re-set on ended session: ok=%v muted=%v; want false,false", ok2, muted2)
+	}
+
+	// Direct CurrentStatus must still surface the row \u2014 the dashboard / audit
+	// path needs to see ended sessions. Confirm ended_at is set.
+	st, _ := d.CurrentStatus(session)
+	if st == nil {
+		t.Fatal("CurrentStatus returned nil for ended row; want non-nil")
+	}
+	if st.EndedAt == nil {
+		t.Error("ended row has nil EndedAt; SetEnded should have stamped it")
+	} else if st.EndedAt.After(time.Now().Add(1 * time.Second)) {
+		t.Errorf("ended row EndedAt %v is in the future", st.EndedAt)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -506,6 +506,60 @@ func (d *DB) ClearAllResumePointers() (int64, error) {
 	return n, nil
 }
 
+// SetMuted sets the muted flag for sessionName to muted (true = 1, false = 0).
+//
+// Returns (false, nil) when no agent_status row exists for sessionName so
+// callers (the `prism mute` CLI) can report a clear "session not found"
+// error without inserting a phantom row. Returns (true, nil) when the row
+// exists and the column was updated.
+//
+// The boolean does not indicate whether the value actually changed — calling
+// SetMuted twice with the same value is a no-op-on-state but still returns
+// (true, nil) so the CLI's idempotence path can be observed by the caller.
+func (d *DB) SetMuted(sessionName string, muted bool) (bool, error) {
+	val := 0
+	if muted {
+		val = 1
+	}
+	res, err := d.conn.Exec(
+		`UPDATE agent_status SET muted = ? WHERE session_name = ?`,
+		val, sessionName,
+	)
+	if err != nil {
+		return false, fmt.Errorf("db: set muted: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("db: set muted rows affected: %w", err)
+	}
+	return n > 0, nil
+}
+
+// IsMuted reports whether the session is currently muted. Returns
+// (false, false, nil) when no row exists or the row exists but the session
+// has already been ended (ended_at IS NOT NULL) — in both cases the mute
+// CLI treats the session as "not found" and refuses to toggle.
+//
+// Restricting the lookup to live (ended_at IS NULL) rows matches the AC for
+// `prism cleanup --session <name>` followed by `prism mute <name>`: after
+// cleanup, the row carries ended_at, so mute reports "session not found".
+// The flag column itself is not erased — it persists alongside ended_at for
+// audit — but the operator-facing surface treats the session as gone.
+func (d *DB) IsMuted(sessionName string) (bool, bool, error) {
+	var m int64
+	err := d.conn.QueryRow(
+		`SELECT muted FROM agent_status WHERE session_name = ? AND ended_at IS NULL`,
+		sessionName,
+	).Scan(&m)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("db: is muted: %w", err)
+	}
+	return m != 0, true, nil
+}
+
 // ClearEnded clears the ended_at timestamp for sessionName, making the session
 // visible again to AllActiveStatus and the dashboard (which both filter
 // WHERE ended_at IS NULL). Called when a session resumes from a terminal state
@@ -893,7 +947,7 @@ func (d *DB) HarnessSessionIDForInstance(instanceID string) (string, error) {
 // CurrentStatus returns the agent_status row for sessionName, or nil if not found.
 func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE session_name = ?`
 	row := d.conn.QueryRow(q, sessionName)
@@ -910,7 +964,7 @@ WHERE session_name = ?`
 // AllActiveStatus returns all agent_status rows where ended_at IS NULL.
 func (d *DB) AllActiveStatus() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
@@ -941,7 +995,7 @@ func (d *DB) ActiveSessionCountForMode(mode string) (int, error) {
 // helpers; callable for any IsolationMode value.
 func (d *DB) ActiveSessionsForMode(mode string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL AND isolation_mode = ?`
 	return d.queryStatuses(q, mode)
@@ -950,7 +1004,7 @@ WHERE ended_at IS NULL AND isolation_mode = ?`
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
@@ -973,7 +1027,7 @@ WHERE ended_at IS NULL AND repo = ?`
 // coordinators. Other-repo workers are hidden as noise.
 func (d *DB) AllActiveStatusForRepoAndOtherCoordinators(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL
   AND (
@@ -994,7 +1048,7 @@ WHERE ended_at IS NULL
 // exists. This is the natural-key dedupe check used by prism spawn --reuse.
 func (d *DB) ActiveStatusForRepoBranch(repo, branch string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ? AND worktree = ?
 LIMIT 1`
@@ -1020,7 +1074,7 @@ func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
 	// percent signs in session names are matched exactly, not as wildcards.
 	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE session_name LIKE ? ESCAPE '\'`
 	return d.queryStatuses(q, escaped+"%")
@@ -1054,7 +1108,7 @@ func (d *DB) WaitingCount() (int, error) {
 // strict per-coordinator targeting is required.
 func (d *DB) ActivePISessionsForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL AND harness = 'pi' AND repo = ? AND state IN ('active', 'idle', 'waiting')`
 	return d.queryStatuses(q, repo)
@@ -1065,7 +1119,7 @@ WHERE ended_at IS NULL AND harness = 'pi' AND repo = ? AND state IN ('active', '
 // by the /apply-profile and /register-provider host-API endpoints (P3.LIVE, #1214).
 func (d *DB) AllActivePISessions() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE ended_at IS NULL AND harness = 'pi' AND state IN ('active', 'idle', 'waiting')`
 	return d.queryStatuses(q)
@@ -1083,7 +1137,7 @@ WHERE ended_at IS NULL AND harness = 'pi' AND state IN ('active', 'idle', 'waiti
 // or more means the worker must specify --to explicitly.
 func (d *DB) CoordinatorCandidatesForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE repo = ? AND ended_at IS NULL
   AND (root_agent_name = 'coordinator' OR (root_agent_name IS NULL AND session_name = ? || '@main'))
@@ -1098,7 +1152,7 @@ ORDER BY last_seen DESC`
 // returned and a duplicate is silently tolerated.
 func (d *DB) CoordinatorForRepo(repo string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
 FROM agent_status
 WHERE repo = ? AND root_agent_name = 'coordinator' AND ended_at IS NULL
 ORDER BY last_seen DESC
@@ -1172,11 +1226,12 @@ func scanStatus(s scanner) (*Status, error) {
 	var harnessPort sql.NullInt64
 	var isolationMode sql.NullString
 	var groupID sql.NullString
+	var muted int64
 	err := s.Scan(
 		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
 		&st.Title, &st.AgentName, &st.ModelID,
 		&st.RootAgentName, &st.RootModelID, &isolationMode, &instanceID, &lastSeen, &endedAt,
-		&harness, &harnessSessionID, &harnessPort, &groupID,
+		&harness, &harnessSessionID, &harnessPort, &groupID, &muted,
 	)
 	if err != nil {
 		return nil, err
@@ -1210,6 +1265,7 @@ func scanStatus(s scanner) (*Status, error) {
 		hp := int(harnessPort.Int64)
 		st.HarnessPort = &hp
 	}
+	st.Muted = muted != 0
 	return &st, nil
 }
 

--- a/modules/programs/prism/prism/internal/db/types.go
+++ b/modules/programs/prism/prism/internal/db/types.go
@@ -40,6 +40,14 @@ type Status struct {
 	// when this session is not part of a group. Populated by SpawnSession
 	// when opts.GroupID is non-empty (see #849 §3.1 and #859).
 	GroupID *string
+	// Muted, when true, suppresses outbound coordinator notifications
+	// emitted from this session (session.finished and session.escalated).
+	// DB writes (agent_status.state, last_seen, ended_at, agent_events rows)
+	// continue to fire as normal, and inbound delivery to this session is
+	// also unaffected. Toggled explicitly by the operator; never auto-cleared
+	// (a muted session that hits finished stays muted, and the missed
+	// notification is dropped, not queued).
+	Muted bool `json:"muted"`
 }
 
 // BusMessage represents a row in the bus_messages table.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1424,8 +1424,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 33 {
-		t.Errorf("schema_version after second open: got %d, want 33", version)
+	if version != 34 {
+		t.Errorf("schema_version after second open: got %d, want 34", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -230,6 +230,18 @@ func (s *Sidecar) notifyCoordinator() {
 		return
 	}
 
+	// Muted guard: the operator has explicitly silenced this session's
+	// outbound coordinator notifications via `prism mute`. The flag is
+	// orthogonal to the agent state machine: lifecycle transitions and DB
+	// writes continue normally; only the bus-notification to the coordinator
+	// is suppressed. Missed notifications are dropped, not queued — if the
+	// session is unmuted after a finish, the coordinator does not receive a
+	// retroactive ping.
+	if selfStatusErr == nil && selfStatus != nil && selfStatus.Muted {
+		s.logger().Printf("sidecar: notifyCoordinator: suppressed (cause=muted)")
+		return
+	}
+
 	// DB-backed coordinator lookup: find the active coordinator for this repo.
 	coordStatus, err := s.cfg.DB.CoordinatorForRepo(s.cfg.Repo)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/sidecar/notify_muted_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_muted_test.go
@@ -1,0 +1,222 @@
+// Tests for the muted-session notification-suppression path (#2013).
+//
+// The mute check in notifyCoordinator is additive next to the existing
+// escalated / review-agent / investigate-agent / coordinator-session
+// suppression guards. These tests verify that:
+//
+//   (a) a muted worker does not emit notifyCoordinator on session.finished;
+//   (b) a muted worker does not emit on session.escalated (the escalate cmd
+//       path is covered by a cmd-package test, but the in-sidecar guard is
+//       proven here by exercising notifyCoordinator while StateEscalated is
+//       set \u2014 the existing escalated-guard takes precedence, which is fine);
+//   (c) unmuting restores notification on the next session.finished;
+//   (d) the existing escalated / review-agent / coordinator-session
+//       suppression guards still fire when the muted flag is unset.
+//
+// Isolation contract: every test uses sidecartest.NewIsolated and the
+// "prism-test@" session-name prefix per AGENTS.md.
+package sidecar
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// newMutedTestSidecar builds a fully isolated test bus with a coordinator
+// (root_agent_name='coordinator'), a worker session row, and a Sidecar
+// pointed at the worker. The returned tracker records every invocation of
+// the notifyCoordinatorDeliverFn seam so the test can assert the post-state
+// "did delivery happen?" question without depending on bus_messages row
+// counting (which is its own concern, covered by notify_test.go).
+func newMutedTestSidecar(t *testing.T, workerSession, coordSession, repo string) (*Sidecar, *sidecartest.Bus, *deliveryTracker) {
+	t.Helper()
+	bus := sidecartest.NewIsolated(t, coordSession)
+	seedTestCoordinator(t, bus.DB, coordSession)
+	seedTestWorker(t, bus.DB, workerSession, repo)
+
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: workerSession,
+		Repo:        repo,
+		Worktree:    "/tmp/test-worker-" + workerSession,
+		DB:          bus.DB,
+		Clock:       clk,
+		HTTPClient:  bus.HTTPServer.Client(),
+		Harness:     newSSEHarness(),
+		AgentRole:   "worker",
+	}
+	s := New(cfg)
+
+	tr := &deliveryTracker{}
+	s.notifyCoordinatorDeliverFn = func(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any, source string, deliverAs string) error {
+		tr.calls = append(tr.calls, deliveryCall{to: sessionName, text: text})
+		return nil
+	}
+	return s, bus, tr
+}
+
+type deliveryCall struct {
+	to   string
+	text string
+}
+
+type deliveryTracker struct{ calls []deliveryCall }
+
+func (t *deliveryTracker) Count() int { return len(t.calls) }
+
+// TestNotifyCoordinator_MutedSuppresses asserts AC (a): a worker whose
+// agent_status.muted = 1 does not invoke the coordinator delivery path on
+// session.finished. The escalate / review-agent / coordinator guards must
+// not be load-bearing here \u2014 the worker is a plain worker in a non-escalated
+// state, the only reason to suppress is the muted flag.
+func TestNotifyCoordinator_MutedSuppresses(t *testing.T) {
+	workerSession := "prism-test@worker-muted-suppress"
+	coordSession := "prism-test@coordinator-muted-suppress"
+	repo := "prism-test"
+
+	s, bus, tr := newMutedTestSidecar(t, workerSession, coordSession, repo)
+
+	if _, err := bus.DB.SetMuted(workerSession, true); err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+
+	s.notifyCoordinator()
+
+	if got := tr.Count(); got != 0 {
+		t.Errorf("muted worker delivered %d coordinator notification(s); want 0", got)
+	}
+}
+
+// TestNotifyCoordinator_MutedSuppresses_EscalatedStillSuppressed asserts
+// AC (b)-equivalent: when a muted worker is also in StateEscalated, the
+// existing escalated guard short-circuits first \u2014 the test does not need
+// the mute guard to be the reason. The point of this test is to prove that
+// flipping the muted flag does not break the escalated suppression.
+func TestNotifyCoordinator_MutedAndEscalatedBothSuppressed(t *testing.T) {
+	workerSession := "prism-test@worker-muted-esc"
+	coordSession := "prism-test@coordinator-muted-esc"
+	repo := "prism-test"
+
+	s, bus, tr := newMutedTestSidecar(t, workerSession, coordSession, repo)
+
+	// Transition the worker to escalated AND set muted.
+	if err := bus.DB.UpsertStatus(workerSession, repo, "/tmp/test-worker-"+workerSession, "escalated", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus escalated: %v", err)
+	}
+	if _, err := bus.DB.SetMuted(workerSession, true); err != nil {
+		t.Fatalf("SetMuted: %v", err)
+	}
+
+	s.notifyCoordinator()
+
+	if got := tr.Count(); got != 0 {
+		t.Errorf("muted+escalated worker delivered %d coordinator notification(s); want 0", got)
+	}
+}
+
+// TestNotifyCoordinator_UnmuteRestoresNotification asserts AC (c): a muted
+// worker that is then unmuted DOES notify on the next session.finished
+// transition. The same Sidecar instance is reused across mute → unmute →
+// notify to prove there is no in-process caching of the muted flag.
+func TestNotifyCoordinator_UnmuteRestoresNotification(t *testing.T) {
+	workerSession := "prism-test@worker-unmute-restores"
+	coordSession := "prism-test@coordinator-unmute-restores"
+	repo := "prism-test"
+
+	s, bus, tr := newMutedTestSidecar(t, workerSession, coordSession, repo)
+
+	// Mute, notify, expect zero deliveries.
+	if _, err := bus.DB.SetMuted(workerSession, true); err != nil {
+		t.Fatalf("SetMuted true: %v", err)
+	}
+	s.notifyCoordinator()
+	if got := tr.Count(); got != 0 {
+		t.Fatalf("muted notify delivered %d; want 0", got)
+	}
+
+	// Unmute, notify, expect exactly one delivery to the coordinator.
+	if _, err := bus.DB.SetMuted(workerSession, false); err != nil {
+		t.Fatalf("SetMuted false: %v", err)
+	}
+	s.notifyCoordinator()
+	if got := tr.Count(); got != 1 {
+		t.Fatalf("after unmute, delivered %d coordinator notification(s); want 1", got)
+	}
+	if tr.calls[0].to != coordSession {
+		t.Errorf("post-unmute delivery target = %q, want %q", tr.calls[0].to, coordSession)
+	}
+}
+
+// TestNotifyCoordinator_ExistingGuardsStillFireWhenUnmuted asserts AC (d):
+// with muted=false (the default), the existing escalated and
+// review-agent suppression guards continue to behave exactly as today \u2014
+// adding the mute check did not regress them.
+func TestNotifyCoordinator_ExistingGuardsStillFireWhenUnmuted(t *testing.T) {
+	repo := "prism-test"
+	coordSession := "prism-test@coordinator-guards"
+
+	t.Run("escalated_guard_still_fires", func(t *testing.T) {
+		workerSession := "prism-test@worker-guards-escalated"
+		s, bus, tr := newMutedTestSidecar(t, workerSession, coordSession, repo)
+		// Drive the worker into escalated WITHOUT muting it.
+		if err := bus.DB.UpsertStatus(workerSession, repo, "/tmp/w", "escalated", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus: %v", err)
+		}
+		s.notifyCoordinator()
+		if got := tr.Count(); got != 0 {
+			t.Errorf("escalated guard regressed: %d deliveries; want 0", got)
+		}
+	})
+
+	t.Run("review_agent_guard_still_fires", func(t *testing.T) {
+		// Review-agent sessions follow the name convention "<parent>~review-<N>-<role>".
+		workerSession := "prism-test@worker-guards~review-1-review-goal"
+		s, bus, tr := newMutedTestSidecar(t, workerSession, coordSession, repo)
+		// Plain finished state, no muted flag.
+		_ = bus
+		s.notifyCoordinator()
+		if got := tr.Count(); got != 0 {
+			t.Errorf("review-agent guard regressed: %d deliveries; want 0", got)
+		}
+	})
+}
+
+// TestNotifyCoordinator_MutedFinishThenUnmute_NoRetroactivePing asserts the
+// edge-case AC: if a session enters `finished` while muted and is later
+// unmuted, the coordinator does NOT retroactively receive the suppressed
+// finish notification \u2014 missed notifications are dropped, not queued.
+//
+// We exercise this by calling notifyCoordinator while muted, then unmuting,
+// and confirming the delivery seam was not invoked at unmute time. The
+// production code has no replay queue, so this test is really a guard that
+// nobody added one as a "convenience" later.
+func TestNotifyCoordinator_MutedFinishThenUnmute_NoRetroactivePing(t *testing.T) {
+	workerSession := "prism-test@worker-muted-noreplay"
+	coordSession := "prism-test@coordinator-muted-noreplay"
+	repo := "prism-test"
+
+	s, bus, tr := newMutedTestSidecar(t, workerSession, coordSession, repo)
+
+	if _, err := bus.DB.SetMuted(workerSession, true); err != nil {
+		t.Fatalf("SetMuted true: %v", err)
+	}
+	s.notifyCoordinator() // suppressed
+	if got := tr.Count(); got != 0 {
+		t.Fatalf("muted notify delivered %d; want 0", got)
+	}
+
+	// Unmute. There is no separate "process pending notifications" call;
+	// the missed notification must stay dropped.
+	if _, err := bus.DB.SetMuted(workerSession, false); err != nil {
+		t.Fatalf("SetMuted false: %v", err)
+	}
+
+	// The seam must remain at zero invocations \u2014 nothing fires until a
+	// fresh session.finished event arrives (which would call
+	// notifyCoordinator again).
+	if got := tr.Count(); got != 0 {
+		t.Errorf("after unmute (no new finish event), delivered %d; want 0 (no replay)", got)
+	}
+}

--- a/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus.go
+++ b/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus.go
@@ -48,6 +48,50 @@ type Colors struct {
 	Green   string // finished count
 	Red     string // error count
 	Primary string // trailing "| " separator
+	// Bg0 is the background-base colour, used as the foreground of inverted
+	// indicators (e.g. the MUTED token paints palette.Purple as background
+	// and palette.bg0 as foreground for prominent reverse-video contrast).
+	Bg0 string
+}
+
+// SessionStatus is the per-session status segment input for FormatSessionStatus.
+//
+// Only fields the formatter actively renders need be set. Name is included
+// for forward-compat (the renderer currently does not embed it; the tmux
+// status-left already shows the session name) but kept on the struct so a
+// future change can read it without touching callers.
+type SessionStatus struct {
+	Name  string
+	Muted bool
+}
+
+// FormatSessionStatus renders the per-session tmux status-right segment.
+//
+// Contract (matches the FormatWaiting graceful-degradation pattern):
+//
+//   - If s.Name is empty AND nothing else needs to render, return "" so the
+//     segment disappears from the status bar entirely.
+//   - When s.Muted is true, emit a prominent inverted-purple MUTED token
+//     using the bg=<Purple>,fg=<Bg0> reverse-video pattern. No emoji.
+//   - When s.Muted is false, the segment renders empty so an unmuted pane
+//     does not waste status-bar real estate on a "not muted" indicator.
+//
+// The current rendering set is intentionally narrow: today the only
+// per-session state the human operator wants surfaced is the muted flag.
+// Other future per-session indicators can be threaded through this same
+// formatter without changing the tmux-side wiring.
+func FormatSessionStatus(s SessionStatus, col Colors) string {
+	if s.Name == "" && !s.Muted {
+		return ""
+	}
+	if !s.Muted {
+		return ""
+	}
+	// Inverted purple block. The leading "#[default]" resets any inherited
+	// foreground/background so the bg paint is exact, the body sets bg+fg,
+	// and the trailing "#[default]" restores the status-right defaults so
+	// downstream segments are not affected by the leak-through.
+	return fmt.Sprintf("#[default]#[bg=%s,fg=%s,bold] MUTED #[default] ", col.Purple, col.Bg0)
 }
 
 // FormatWaiting renders the --waiting --tmux-format segment: a single

--- a/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus_test.go
+++ b/modules/programs/prism/prism/internal/tmuxstatus/tmuxstatus_test.go
@@ -15,6 +15,52 @@ func testColors() Colors {
 		Green:   "#green",
 		Red:     "#red",
 		Primary: "#primary",
+		Bg0:     "#bg0",
+	}
+}
+
+// TestFormatSessionStatus_MutedRendersInvertedPurple asserts the AC: a muted
+// session's status segment includes a prominent inverted-purple MUTED token
+// (bg=palette.Purple, fg=palette.bg0) with no emoji.
+func TestFormatSessionStatus_MutedRendersInvertedPurple(t *testing.T) {
+	got := FormatSessionStatus(SessionStatus{Name: "repo@branch", Muted: true}, testColors())
+
+	for _, want := range []string{
+		"MUTED",
+		"bg=#purple",
+		"fg=#bg0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("muted session output must contain %q:\n  full: %q", want, got)
+		}
+	}
+	// AC: no emoji. The MUTED indicator is plain-text + inverted colour.
+	// A simple proof-of-concept guard: reject the common emoji codepoint range
+	// used by status-bar bells / mute glyphs (U+1F500–U+1F5FF, U+1F300–U+1F3FF,
+	// U+1F400–U+1F4FF). We just ensure no rune above the BMP makes it through.
+	for _, r := range got {
+		if r > 0xFFFF {
+			t.Errorf("MUTED indicator must not contain emoji-range codepoints, got rune U+%X in %q", r, got)
+			break
+		}
+	}
+}
+
+// TestFormatSessionStatus_UnmutedIsEmpty asserts the AC: unmuted sessions
+// render the empty string so the status bar does not waste real estate on a
+// "not muted" indicator.
+func TestFormatSessionStatus_UnmutedIsEmpty(t *testing.T) {
+	if got := FormatSessionStatus(SessionStatus{Name: "repo@branch", Muted: false}, testColors()); got != "" {
+		t.Errorf("unmuted session must render empty, got %q", got)
+	}
+}
+
+// TestFormatSessionStatus_EmptyNameIsEmpty asserts the graceful-degradation
+// contract: when no session is in play the segment vanishes. This matches
+// FormatWaiting's zero-waiting → empty pattern.
+func TestFormatSessionStatus_EmptyNameIsEmpty(t *testing.T) {
+	if got := FormatSessionStatus(SessionStatus{}, testColors()); got != "" {
+		t.Errorf("empty SessionStatus must render empty, got %q", got)
 	}
 }
 

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -149,11 +149,13 @@ in
               set -g status-left-length 30
               set -g status-left " [#{session_name}] "
               # set -g status-right "#{?window_bigger,[#{window_offset_x}#,#{window_offset_y}] ,}#{=21:pane_title} "
-              # status-right composition: prism segment first, then the
-              # hostname. The prism segment emits an empty string when its
-              # daemon is down or has nothing waiting, so the visible bar
-              # collapses cleanly to just `#h ` in the steady state.
-              set -g status-right "#(${prism} sessions status --waiting --tmux-format)#h "
+              # status-right composition: aggregate waiting count first, then
+              # the per-session status segment for the pane's session (currently
+              # the mute indicator). Each helper emits "" in the empty case so
+              # the visible bar collapses cleanly when nothing needs surfacing.
+              # PRISM_SESSION_NAME is set on prism panes and read by the
+              # session-status helper to know which session to render.
+              set -g status-right "#(${prism} sessions status --waiting --tmux-format)#(PRISM_SESSION_NAME=#{session_name} ${prism} sessions session-status --tmux-format)"
               set -g status-style 'bg=${bg1} fg=${secondary}'
               set -g message-style 'bg=${primary} fg=${bg1}'
               set -g mode-style 'bg=${bg3} fg=${foreground}'
@@ -216,6 +218,16 @@ in
               bind-key q display-popup -E -w 60% -h 40% -b single "${prism} cleanup"
               # restart prism (prefix+R)
               bind-key R run-shell '${prism} restart'
+              # toggle session mute (prefix+m). Operator escape hatch (see #2013):
+              # silences this session's outbound coordinator notifications until
+              # toggled off. The tmux session name doubles as the prism session
+              # name on prism-managed panes. The display-message fallback covers
+              # plain shell / dashboard panes (where the tmux session name does
+              # not correspond to a prism session) so a stray Prefix+m there
+              # does not crash tmux or surface a stack trace.
+              bind-key m if-shell '[ -n "#{session_name}" ]' \
+                'run-shell -b "${prism} mute #{session_name} || ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\""' \
+                'display-message "prism mute: no current session"'
               # easy config reload
               bind-key r source-file ~/.config/tmux/tmux.conf \; display-message "tmux.conf reloaded"
 


### PR DESCRIPTION
Adds an undocumented, persistent, explicit-toggle-only mute flag on each
session that suppresses outbound coordinator notifications from that
session while the flag is set. Designed for the human operator who takes
the keys on a worker for an extended back-and-forth — every harness turn
emits 'has finished' to the coordinator otherwise.

## DB layer

- `agent_status.muted INTEGER NOT NULL DEFAULT 0` (v33→v34 migration)
- `db.Status` carries `Muted bool` with `json:"muted"` tag
- `db.SetMuted` / `db.IsMuted` helpers
- `IsMuted` treats `ended_at IS NOT NULL` rows as not-found so post-cleanup `prism mute <name>` surfaces a clear session-not-found error

## Suppression

Additive next to the existing escalated / review-agent / investigate-agent / coordinator-session guards in `notifyCoordinator`:

- `internal/sidecar/notify.go`: skip coordinator delivery when muted
- `cmd/escalate.go`: skip the outbound coordinator escalation prompt when the calling session is muted (DB state transition and `session.escalated` bus event still fire)

## CLI

- `prism mute [<session>] [--on | --off]` — `Hidden=true`; not in `--help` or completion. No-args toggles `PRISM_SESSION_NAME`. `--on`/`--off` idempotent and mutually exclusive (cobra-enforced).

## Tmux

- Prefix+m toggles the current pane's session mute; `display-message` fallback for non-prism panes
- `status-right` replaces `#h` with a new `prism sessions session-status --tmux-format` segment that renders an inverted-purple `MUTED` token (`bg=palette.Purple`, `fg=palette.bg0`) when the session is muted; empty otherwise

## Discoverability

`prism mute` appears only in the implementation, tests, the tmux keybind comment, and the issue. Hidden from cobra; absent from skill files, agent prompts, and coordinator-facing docs.

## Tests

- `internal/db/muted_test.go` — `SetMuted`/`IsMuted`/persistence-across-reopen and the ended-session-treated-as-missing AC
- `internal/sidecar/notify_muted_test.go` — muted `notifyCoordinator` suppression, unmute-restores, no-replay-on-unmute, existing-guards not regressed
- `internal/tmuxstatus/tmuxstatus_test.go` — inverted-purple `MUTED` token, unmuted-renders-empty, empty-name-renders-empty
- `cmd/mute_test.go` — no-args toggle, positional toggle, `--on`/`--off` idempotence, `--on --off` mutual exclusion, missing-env error, unknown-session error, `Hidden=true`
- `cmd/list_sessions_muted_test.go` — `(muted)` marker in table, `muted` field in `--json` output

## Build verification

- `go build ./...` clean
- `go test ./internal/db/ ./internal/tmuxstatus/ ./internal/sidecar/` all pass
- `nix build .#prism` passes
- `nix build --impure ... packages.aarch64-darwin.prism.override { runChecks = true; }` passes (the homeless-shelter sandbox build that the `nix-build-prism-checked` CI job runs)

## Pre-existing test failures (unchanged)

`./cmd/` has ~30 pre-existing `fork failed: Operation not permitted` failures (`TestRestoreSession_*`, `TestPersistentModel*`, `TestCleanupYes_*`, `TestPopupModel*`, `TestEnsureDashSession*`, `TestEventTmuxSessionEnd_*`, `TestSwitchPath_*`) that reproduce on `main` (c97a793a) without these changes. This is the same class the #2016 worker called out — sandbox-environment limitations on the worker host that CI's Linux sandbox does not hit. Broadening `skipIfSandboxPTY()` to detect the prism worker container fingerprint is a separate change, not in scope here.

Closes #2013
