### PR TITLE
prism escalate: unambiguous OK signal + sender-side idempotency guard (#2018)

### DIFF
--- a/modules/programs/prism/prism/cmd/escalate.go
+++ b/modules/programs/prism/prism/cmd/escalate.go
@@ -28,6 +28,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -132,9 +134,16 @@ func runEscalate(cmd *cobra.Command, args []string) error {
 	// host-side prism CLI and DB are not directly accessible. Proxy to the
 	// host sidecar's /escalate endpoint, which shells back to `prism escalate`
 	// on the host with PRISM_HOST_API unset. The host-side invocation will
-	// produce the success line; we surface its body/error to the caller.
+	// produce the success line; the proxy forwards its stdout/stderr to the
+	// caller's streams so the OK signal reaches the container's bash tool.
+	// (Without this re-emit, the container caller would see no output on
+	// success — the exact symptom issue #2018 set out to eliminate.)
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		if err := proxyEscalate(apiURL, explicitTo, promptText); err != nil {
+		dedupArg := ""
+		if cmd.Flags().Changed("dedup-window") {
+			dedupArg = dedupWindow.String()
+		}
+		if err := proxyEscalate(apiURL, explicitTo, promptText, jsonOut, dedupArg); err != nil {
 			return escalateReportError(cmd, err)
 		}
 		return nil
@@ -660,13 +669,50 @@ func discoverLastReviewVerdicts(database *db.DB, fromSession string) []string {
 
 // proxyEscalate forwards the escalate request to the host sidecar. The
 // sidecar handler shells out to `prism escalate` on the host, where the
-// direct DB path runs.
-func proxyEscalate(apiURL, explicitTo, promptText string) error {
+// direct DB path runs. The host-side child's stdout and stderr are returned
+// in the response body and re-emitted on the local streams here so the
+// container caller sees the success/replay line (and — in --json mode — the
+// JSON envelope on stdout). Without this round-trip, the container path
+// would be silent on success, reproducing the symptom issue #2018 set out
+// to eliminate.
+func proxyEscalate(apiURL, explicitTo, promptText string, jsonOut bool, dedupWindow string) error {
+	return proxyEscalateWithWriters(apiURL, explicitTo, promptText, jsonOut, dedupWindow, os.Stdout, os.Stderr)
+}
+
+// escalateProxyResponse is the host-API /escalate response shape. stdout and
+// stderr are the captured byte streams of the host-side `prism escalate`
+// subprocess; the container-side caller writes them verbatim to its own
+// stdout/stderr so the byte content is identical to a host invocation
+// (modulo trailing whitespace). On failure error is non-empty; the streams
+// are still populated so partial-success progress lines survive.
+type escalateProxyResponse struct {
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+	Error  string `json:"error,omitempty"`
+}
+
+// proxyEscalateWithWriters is the testable form of proxyEscalate: stdout and
+// stderr destinations are injectable so unit tests can capture forwarded
+// output without redirecting os.Stdout / os.Stderr.
+//
+// We do NOT route through proxyToHostAPI here because that helper short-
+// circuits the body on any HTTP >= 400, swallowing the stdout/stderr fields
+// the handler attaches to error responses. We need both streams forwarded
+// unconditionally so the caller sees partial output and the underlying
+// cause even when the host child failed. This is parity with
+// proxyCleanupToHostAPIWithWriters (issue #1527).
+func proxyEscalateWithWriters(apiURL, explicitTo, promptText string, jsonOut bool, dedupWindow string, stdout, stderr io.Writer) error {
 	body := map[string]any{
 		"prompt": promptText,
 	}
 	if explicitTo != "" {
 		body["to"] = explicitTo
+	}
+	if jsonOut {
+		body["json"] = true
+	}
+	if strings.TrimSpace(dedupWindow) != "" {
+		body["dedup_window"] = dedupWindow
 	}
 	// Pass our session name so the host can identify the calling session
 	// without the CWD walk (the host-side process spawned by the sidecar
@@ -674,7 +720,64 @@ func proxyEscalate(apiURL, explicitTo, promptText string) error {
 	if envSession := os.Getenv("PRISM_SESSION_NAME"); envSession != "" {
 		body["from"] = envSession
 	}
-	return proxyToHostAPI(apiURL, "/escalate", body, nil)
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("proxyEscalate: marshal request body: %w", err)
+	}
+
+	client, reqURL, err := newEscalateHostAPIClient(apiURL)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("proxyEscalate: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("host-API /escalate: read response: %w", readErr)
+	}
+
+	var parsed escalateProxyResponse
+	if len(respBody) > 0 {
+		if unmarshalErr := json.Unmarshal(respBody, &parsed); unmarshalErr != nil {
+			return fmt.Errorf("host-API /escalate: unmarshal response: %w (body=%s)", unmarshalErr, strings.TrimSpace(string(respBody)))
+		}
+	}
+	// Forward the host-side streams unconditionally — even on error.
+	if parsed.Stdout != "" {
+		_, _ = io.WriteString(stdout, parsed.Stdout)
+	}
+	if parsed.Stderr != "" {
+		_, _ = io.WriteString(stderr, parsed.Stderr)
+	}
+	if resp.StatusCode >= 400 {
+		if parsed.Error != "" {
+			return fmt.Errorf("host-API /escalate: %s", parsed.Error)
+		}
+		return fmt.Errorf("host-API /escalate: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// newEscalateHostAPIClient resolves an http.Client and request URL for the
+// /escalate endpoint, supporting both the unix:// and http:// PRISM_HOST_API
+// shapes used elsewhere in this package (parity with proxyToHostAPI).
+func newEscalateHostAPIClient(apiURL string) (*http.Client, string, error) {
+	if strings.HasPrefix(apiURL, "http://") {
+		return newTCPHostAPIClient(), apiURL + "/escalate", nil
+	}
+	sockPath, parseErr := parseUnixSocketURL(apiURL)
+	if parseErr != nil {
+		return nil, "", fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+	}
+	return newHostAPIClient(sockPath), "http://prism-hostapi/escalate", nil
 }
 
 // runCmdInDir runs name with args in dir and returns stdout. A non-zero exit

--- a/modules/programs/prism/prism/cmd/escalate.go
+++ b/modules/programs/prism/prism/cmd/escalate.go
@@ -63,7 +63,39 @@ Discovery rules:
     marker in the calling session's own log. The worker stays paused.
 
 Any incoming turn_start (from prism prompt, a human typing into tmux, or any
-other source) clears the escalated state and resumes the worker normally.`,
+other source) clears the escalated state and resumes the worker normally.
+
+Output:
+
+  On success the command prints exactly one line to stdout, mirrored to
+  stderr so bash-tool captures that combine the streams always surface the
+  signal:
+
+    prism escalate: OK delivered to <target> (delivery_id=<uuid>)
+
+  The "OK" token is the first whitespace-delimited word after "escalate:"
+  so callers can grep for it as the unambiguous success signal.
+
+  With --json, stdout instead carries a single JSON object:
+
+    {"delivered_to": "<target>", "delivery_id": "<uuid>", "replayed": false}
+
+  In --json mode the human-readable line is NOT emitted on stdout (mutual
+  exclusion). It may still be mirrored to stderr for log capture. On error,
+  --json emits {"error": "<message>"} to stderr and exits non-zero.
+
+Sender-side idempotency:
+
+  Running prism escalate a second time within 5 minutes with the same
+  (calling session, target, prompt text) triple as a previously-delivered
+  escalation is a no-op: no new bus_messages row, no new agent_events rows,
+  no re-delivery, no state-transition write. The replay invocation exits 0
+  with stdout:
+
+    prism escalate: OK already delivered to <target> (delivery_id=<prior>, age=<duration>)
+
+  The success line is the verification of delivery — do NOT re-run to
+  confirm the first call landed.`,
 	Args: cobra.NoArgs,
 	RunE: runEscalate,
 }
@@ -71,28 +103,46 @@ other source) clears the escalated state and resumes the worker normally.`,
 func init() {
 	addPromptFlags(escalateCmd)
 	escalateCmd.Flags().String("to", "", `Explicit coordinator session to receive the escalation. Required when auto-discovery finds multiple coordinator candidates in the same repo. Optional otherwise.`)
+	escalateCmd.Flags().Bool("json", false, `Emit a single JSON object to stdout instead of the human-readable success line. Shape: {"delivered_to":"<target>","delivery_id":"<uuid>","replayed":<bool>}. Errors emit {"error":"<msg>"} to stderr.`)
+	escalateCmd.Flags().Duration("dedup-window", 5*time.Minute, "Override the sender-side dedup window for replay detection. Hidden — for tests and operator override only.")
+	_ = escalateCmd.Flags().MarkHidden("dedup-window")
 	rootCmd.AddCommand(escalateCmd)
 }
+
+// escalateDefaultDedupWindow is the default sender-side dedup window for
+// `prism escalate`. A second invocation with byte-identical (from, target,
+// prompt_text) within this window short-circuits as a replay. See #2018.
+const escalateDefaultDedupWindow = 5 * time.Minute
 
 func runEscalate(cmd *cobra.Command, args []string) error {
 	promptText, err := requirePromptInput(cmd)
 	if err != nil {
-		return err
+		return escalateReportError(cmd, err)
 	}
 
 	explicitTo, _ := cmd.Flags().GetString("to")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	dedupWindow, _ := cmd.Flags().GetDuration("dedup-window")
+	if dedupWindow <= 0 {
+		dedupWindow = escalateDefaultDedupWindow
+	}
+	opts := escalateOptions{jsonOut: jsonOut, dedupWindow: dedupWindow}
 
 	// Container path: when running inside an isolated worker container, the
 	// host-side prism CLI and DB are not directly accessible. Proxy to the
 	// host sidecar's /escalate endpoint, which shells back to `prism escalate`
-	// on the host with PRISM_HOST_API unset.
+	// on the host with PRISM_HOST_API unset. The host-side invocation will
+	// produce the success line; we surface its body/error to the caller.
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyEscalate(apiURL, explicitTo, promptText)
+		if err := proxyEscalate(apiURL, explicitTo, promptText); err != nil {
+			return escalateReportError(cmd, err)
+		}
+		return nil
 	}
 
 	database, err := openDB()
 	if err != nil {
-		return fmt.Errorf("open db: %w", err)
+		return escalateReportError(cmd, fmt.Errorf("open db: %w", err))
 	}
 	defer database.Close()
 
@@ -100,22 +150,82 @@ func runEscalate(cmd *cobra.Command, args []string) error {
 	cwd, _ := os.Getwd()
 	if envSession := os.Getenv("PRISM_SESSION_NAME"); envSession != "" {
 		// Tests and the host-API proxy may set PRISM_SESSION_NAME directly.
-		return runEscalateForSession(database, envSession, explicitTo, promptText)
+		if err := runEscalateForSessionOpts(database, envSession, explicitTo, promptText, opts); err != nil {
+			return escalateReportError(cmd, err)
+		}
+		return nil
 	}
 	fromSession := deriveSessionNameFromCWD(cwd)
 	if fromSession == "" {
-		return fmt.Errorf(
-			"prism escalate: could not derive calling session from CWD %q\n" +
+		return escalateReportError(cmd, fmt.Errorf(
+			"prism escalate: could not derive calling session from CWD %q\n"+
 				"hint: run from inside a prism worktree, or set PRISM_SESSION_NAME",
 			cwd,
-		)
+		))
 	}
-	return runEscalateForSession(database, fromSession, explicitTo, promptText)
+	if err := runEscalateForSessionOpts(database, fromSession, explicitTo, promptText, opts); err != nil {
+		return escalateReportError(cmd, err)
+	}
+	return nil
 }
+
+// escalateOptions carries the per-invocation switches that are not part of
+// the core (database, fromSession, explicitTo, promptText) tuple.
+type escalateOptions struct {
+	jsonOut     bool
+	dedupWindow time.Duration
+}
+
+// escalateReportError formats and emits an error for `prism escalate`.
+// In --json mode it writes {"error":"<msg>"} to stderr; in human mode it
+// returns the error so the cobra/main wrapper prints it. In both cases the
+// returned error drives a non-zero exit code.
+func escalateReportError(cmd *cobra.Command, err error) error {
+	if err == nil {
+		return nil
+	}
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	if !jsonOut {
+		return err
+	}
+	payload := map[string]string{"error": err.Error()}
+	if b, mErr := json.Marshal(payload); mErr == nil {
+		fmt.Fprintln(os.Stderr, string(b))
+	} else {
+		fmt.Fprintf(os.Stderr, "{\"error\":%q}\n", err.Error())
+	}
+	// Returning a non-nil error still drives os.Exit(1) from main, but the
+	// human formatter in main also prints err to stderr. Suppress that by
+	// wrapping with a quiet-exit type so main only emits the JSON we wrote.
+	return &quietExitErr{inner: err}
+}
+
+// quietExitErr suppresses main's default "fmt.Fprintln(os.Stderr, err)"
+// rendering for --json error paths: main checks for the exitCoder interface
+// and uses its ExitCode but only prints err.Error() when Error() is non-empty.
+// We override Error() to return an empty string so nothing is written; the
+// JSON error envelope has already been printed.
+type quietExitErr struct{ inner error }
+
+func (q *quietExitErr) Error() string { return "" }
+func (q *quietExitErr) ExitCode() int { return 1 }
+func (q *quietExitErr) Unwrap() error { return q.inner }
 
 // runEscalateForSession is the testable core of runEscalate, parameterised on
 // the calling session name so unit tests can drive it without the CWD walk.
+// This is the public, backwards-compatible signature used by existing tests;
+// new callers should use runEscalateForSessionOpts to thread --json and
+// --dedup-window through.
 func runEscalateForSession(database *db.DB, fromSession, explicitTo, promptText string) error {
+	return runEscalateForSessionOpts(database, fromSession, explicitTo, promptText, escalateOptions{dedupWindow: escalateDefaultDedupWindow})
+}
+
+// runEscalateForSessionOpts is the full testable core, including the
+// --json and --dedup-window switches that runEscalate threads from cobra.
+func runEscalateForSessionOpts(database *db.DB, fromSession, explicitTo, promptText string, opts escalateOptions) error {
+	if opts.dedupWindow <= 0 {
+		opts.dedupWindow = escalateDefaultDedupWindow
+	}
 	selfStatus, err := database.CurrentStatus(fromSession)
 	if err != nil {
 		return fmt.Errorf("prism escalate: read self status: %w", err)
@@ -167,6 +277,27 @@ func runEscalateForSession(database *db.DB, fromSession, explicitTo, promptText 
 		OccurredAt: time.Now().UTC().Format(time.RFC3339),
 	}
 
+	// Sender-side idempotency guard (issue #2018): if this is a byte-equal
+	// re-run of a recent escalation we already delivered to the same target,
+	// short-circuit before any state transition, agent_events write, or
+	// bus_messages row. The session must currently be in `escalated` state
+	// for the dedup path — if it has since transitioned out (e.g. an
+	// incoming turn_start unstuck the worker), the second invocation is a
+	// genuine re-escalation and proceeds normally.
+	if target != nil && selfStatus.State == string(agent.StateEscalated) {
+		prior, perr := database.FindRecentEquivalentBusMessage(fromSession, target.SessionName, promptText, opts.dedupWindow)
+		if perr == nil && prior != nil {
+			emitEscalateReplay(opts, target.SessionName, prior)
+			return nil
+		}
+		if perr != nil {
+			// Surface the lookup error to stderr but do not fail the call —
+			// fall through to the normal path. A stale or unreadable bus
+			// row should not prevent a genuine escalation.
+			fmt.Fprintf(os.Stderr, "prism escalate: dedup lookup failed: %v (proceeding with fresh delivery)\n", perr)
+		}
+	}
+
 	// Transition the calling session to escalated. This must happen even when
 	// no coordinator was found (per the discovery rules), so do it before any
 	// delivery attempt that might fail.
@@ -214,16 +345,88 @@ func runEscalateForSession(database *db.DB, fromSession, explicitTo, promptText 
 	// "delivered" only on success; the sidecar's prompt path already does this
 	// for the audit trail, so we delegate by invoking the same code path that
 	// `prism prompt` uses.
-	if err := deliverEscalationPrompt(database, fromSession, target, promptText); err != nil {
+	deliveryID, err := deliverEscalationPrompt(database, fromSession, target, promptText)
+	if err != nil {
 		// Delivery failed but state is already escalated. Surface the error
 		// so the worker knows; the bus event was already written so the
 		// coordinator may still see the escalation through the bus.
 		return fmt.Errorf("prism escalate: deliver prompt to %s: %w", target.SessionName, err)
 	}
 
-	fmt.Printf("prism escalate: delivered to %s; session %s now in 'escalated' state\n", target.SessionName, fromSession)
+	emitEscalateSuccess(opts, target.SessionName, deliveryID)
 	_ = targetInstanceID // surfaced via bus payload; not used directly here
 	return nil
+}
+
+// emitEscalateSuccess writes the success signal for a fresh delivery.
+// In human mode the same line goes to stdout AND stderr so a bash tool that
+// captures either stream surfaces the OK signal. In --json mode stdout gets
+// a single JSON object; the human line is mirrored to stderr only.
+func emitEscalateSuccess(opts escalateOptions, target, deliveryID string) {
+	human := fmt.Sprintf("prism escalate: OK delivered to %s (delivery_id=%s)", target, deliveryID)
+	if opts.jsonOut {
+		obj := map[string]any{
+			"delivered_to": target,
+			"delivery_id":  deliveryID,
+			"replayed":     false,
+		}
+		if b, err := json.Marshal(obj); err == nil {
+			fmt.Fprintln(os.Stdout, string(b))
+		} else {
+			fmt.Fprintf(os.Stdout, "{\"delivered_to\":%q,\"delivery_id\":%q,\"replayed\":false}\n", target, deliveryID)
+		}
+		fmt.Fprintln(os.Stderr, human)
+		return
+	}
+	fmt.Fprintln(os.Stdout, human)
+	fmt.Fprintln(os.Stderr, human)
+}
+
+// emitEscalateReplay writes the success signal for a deduped replay. The
+// duration is formatted from time.Since(prior.SentAt) in the shortest
+// human-readable unit (s/m/h).
+func emitEscalateReplay(opts escalateOptions, target string, prior *db.BusMessage) {
+	age := time.Since(prior.SentAt)
+	ageStr := formatEscalateAge(age)
+	human := fmt.Sprintf("prism escalate: OK already delivered to %s (delivery_id=%s, age=%s)", target, prior.ID, ageStr)
+	if opts.jsonOut {
+		ageSec := int64(age.Round(time.Second).Seconds())
+		if ageSec < 0 {
+			ageSec = 0
+		}
+		obj := map[string]any{
+			"delivered_to": target,
+			"delivery_id":  prior.ID,
+			"replayed":     true,
+			"age_seconds":  ageSec,
+		}
+		if b, err := json.Marshal(obj); err == nil {
+			fmt.Fprintln(os.Stdout, string(b))
+		} else {
+			fmt.Fprintf(os.Stdout, "{\"delivered_to\":%q,\"delivery_id\":%q,\"replayed\":true,\"age_seconds\":%d}\n", target, prior.ID, ageSec)
+		}
+		fmt.Fprintln(os.Stderr, human)
+		return
+	}
+	fmt.Fprintln(os.Stdout, human)
+	fmt.Fprintln(os.Stderr, human)
+}
+
+// formatEscalateAge renders a duration as the shortest of "<N>s", "<N>m",
+// or "<N>h". Sub-second durations clamp to "0s". This matches the format
+// described in the acceptance criteria of issue #2018.
+func formatEscalateAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int64(d.Round(time.Second).Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int64(d.Round(time.Minute).Minutes()))
+	default:
+		return fmt.Sprintf("%dh", int64(d.Round(time.Hour).Hours()))
+	}
 }
 
 // resolveEscalationTarget applies the discovery rules from the issue:
@@ -336,8 +539,10 @@ func writeSessionEscalatedEvent(database *db.DB, fromSession string, selfStatus 
 // sessions, host-API socket for socket-pipe (PI) sessions.
 //
 // The audit row in bus_messages is written with delivered_at set on success.
-// from_session is the calling worker session.
-func deliverEscalationPrompt(database *db.DB, fromSession string, target *db.Status, promptText string) error {
+// from_session is the calling worker session. The returned string is the
+// bus_messages.id (a UUID) that the caller surfaces as the delivery_id in
+// the success line.
+func deliverEscalationPrompt(database *db.DB, fromSession string, target *db.Status, promptText string) (string, error) {
 	msg := db.BusMessage{
 		ID:           uuid.New().String(),
 		FromSession:  fromSession,
@@ -362,7 +567,7 @@ func deliverEscalationPrompt(database *db.DB, fromSession string, target *db.Sta
 			if writeErr := database.WriteBusMessageFailed(msg); writeErr != nil {
 				fmt.Fprintf(os.Stderr, "prism escalate: write failed audit: %v\n", writeErr)
 			}
-			return err
+			return "", err
 		}
 	} else {
 		// Pre-migration row with no harness column. Fall back to HTTP delivery.
@@ -370,14 +575,14 @@ func deliverEscalationPrompt(database *db.DB, fromSession string, target *db.Sta
 			if writeErr := database.WriteBusMessageFailed(msg); writeErr != nil {
 				fmt.Fprintf(os.Stderr, "prism escalate: write failed audit: %v\n", writeErr)
 			}
-			return err
+			return "", err
 		}
 	}
 
 	if err := database.WriteBusMessageDelivered(msg); err != nil {
 		fmt.Fprintf(os.Stderr, "prism escalate: write delivered audit: %v\n", err)
 	}
-	return nil
+	return msg.ID, nil
 }
 
 // deliverEscalationToTarget delivers the escalation to the target session.

--- a/modules/programs/prism/prism/cmd/escalate_idempotency_test.go
+++ b/modules/programs/prism/prism/cmd/escalate_idempotency_test.go
@@ -1,0 +1,554 @@
+package cmd
+
+// Tests for `prism escalate` Part B (unambiguous success signal) and Part C
+// (sender-side idempotency guard). See issue #2018.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// captureStdoutStderr redirects os.Stdout and os.Stderr to pipes for the
+// duration of fn, draining both concurrently so writes larger than the
+// kernel pipe buffer cannot deadlock. See
+// modules/programs/prism/prism/docs/stdout-capture-testing.md.
+func captureStdoutStderr(t *testing.T, fn func()) (stdout string, stderr string) {
+	t.Helper()
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe (stdout): %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe (stderr): %v", err)
+	}
+	oldOut := os.Stdout
+	oldErr := os.Stderr
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	var outBuf, errBuf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&outBuf, rOut)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&errBuf, rErr)
+	}()
+
+	fn()
+
+	wOut.Close()
+	wErr.Close()
+	wg.Wait()
+	os.Stdout = oldOut
+	os.Stderr = oldErr
+	return outBuf.String(), errBuf.String()
+}
+
+// busRowCount returns the number of bus_messages rows for the given pair.
+func busRowCount(t *testing.T, d *db.DB, fromSession, toSession string) int {
+	t.Helper()
+	var n int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM bus_messages WHERE from_session = ? AND to_session = ?",
+		fromSession, toSession,
+	).Scan(&n); err != nil {
+		t.Fatalf("count bus_messages: %v", err)
+	}
+	return n
+}
+
+// eventCount returns the number of agent_events rows for (session, type).
+func eventCount(t *testing.T, d *db.DB, sessionName, evType string) int {
+	t.Helper()
+	var n int
+	if err := d.QueryRow(
+		"SELECT COUNT(*) FROM agent_events WHERE session_name = ? AND type = ?",
+		sessionName, evType,
+	).Scan(&n); err != nil {
+		t.Fatalf("count agent_events: %v", err)
+	}
+	return n
+}
+
+// seedEscalatePair seeds a coordinator + worker pair for the escalate tests
+// that drive the cobra command end-to-end. It returns the captured-call
+// pointer so callers can assert on what (if anything) was delivered.
+func seedEscalatePair(t *testing.T, d *db.DB, fromSession, toSession string) *capturedPromptCall {
+	t.Helper()
+	srv, captured := startEscalateHTTPStub(t)
+	port := extractTestServerPort(t, srv.URL)
+	httpClient = &http.Client{Timeout: 2 * time.Second}
+	seedSession(t, d, toSession, "active", intPtr(port), strPtr("oc-sid-"+toSession), strPtr("coordinator"), nil)
+	seedSession(t, d, fromSession, "active", nil, nil, strPtr("worker"), nil)
+	return captured
+}
+
+// ---------------------------------------------------------------------------
+// Part B — unambiguous success signal
+// ---------------------------------------------------------------------------
+
+func TestEscalate_PartB_HumanSuccessLine_StdoutAndStderr(t *testing.T) {
+	d := openPromptTestDB(t)
+	_ = seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+			t.Fatalf("runEscalateForSessionOpts: %v", err)
+		}
+	})
+
+	// AC: exactly one line on stdout, "OK" as the first word after "escalate: "
+	stdoutLines := splitNonEmptyLines(stdout)
+	if len(stdoutLines) != 1 {
+		t.Fatalf("stdout line count = %d, want 1; got: %q", len(stdoutLines), stdout)
+	}
+	line := stdoutLines[0]
+	if !strings.HasPrefix(line, "prism escalate: OK delivered to repo@main (delivery_id=") {
+		t.Errorf("stdout success line = %q, want prefix 'prism escalate: OK delivered to repo@main (delivery_id='", line)
+	}
+	if !strings.HasSuffix(line, ")") {
+		t.Errorf("stdout success line missing trailing ')': %q", line)
+	}
+
+	// AC: same line mirrored to stderr.
+	stderrLines := splitNonEmptyLines(stderr)
+	if len(stderrLines) != 1 {
+		t.Fatalf("stderr line count = %d, want 1; got: %q", len(stderrLines), stderr)
+	}
+	if stderrLines[0] != line {
+		t.Errorf("stderr line = %q, want %q (mirror of stdout)", stderrLines[0], line)
+	}
+
+	// AC: OK token is the first whitespace-delimited word after "escalate: ".
+	after := strings.TrimPrefix(line, "prism escalate: ")
+	firstWord := strings.SplitN(after, " ", 2)[0]
+	if firstWord != "OK" {
+		t.Errorf("first word after 'escalate: ' = %q, want 'OK'", firstWord)
+	}
+}
+
+func TestEscalate_PartB_JSON_HappyPath(t *testing.T) {
+	d := openPromptTestDB(t)
+	_ = seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{jsonOut: true, dedupWindow: escalateDefaultDedupWindow}); err != nil {
+			t.Fatalf("runEscalateForSessionOpts: %v", err)
+		}
+	})
+
+	stdoutLines := splitNonEmptyLines(stdout)
+	if len(stdoutLines) != 1 {
+		t.Fatalf("stdout line count = %d, want 1; got: %q", len(stdoutLines), stdout)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(stdoutLines[0]), &payload); err != nil {
+		t.Fatalf("stdout is not a single JSON object: %q (err=%v)", stdoutLines[0], err)
+	}
+	if payload["delivered_to"] != "repo@main" {
+		t.Errorf("delivered_to = %v, want repo@main", payload["delivered_to"])
+	}
+	if did, ok := payload["delivery_id"].(string); !ok || did == "" {
+		t.Errorf("delivery_id missing or empty: %v", payload["delivery_id"])
+	}
+	if replayed, ok := payload["replayed"].(bool); !ok || replayed {
+		t.Errorf("replayed = %v, want false", payload["replayed"])
+	}
+
+	// AC: human line may still print on stderr in --json mode for log capture.
+	if !strings.Contains(stderr, "prism escalate: OK delivered to repo@main") {
+		t.Errorf("stderr missing human mirror in --json mode: %q", stderr)
+	}
+	// AC: stdout in --json mode contains ONLY JSON, no human line.
+	if strings.Contains(stdout, "prism escalate: OK") {
+		t.Errorf("stdout contains human line in --json mode (mutual exclusion violated): %q", stdout)
+	}
+}
+
+func TestEscalate_PartB_JSON_ErrorPath(t *testing.T) {
+	d := openPromptTestDB(t)
+	// Only the worker — explicit --to to a nonexistent session triggers an
+	// error before any state transition (existing behaviour).
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	// Drive through the cobra command so the --json flag and error reporter
+	// fire. resetRootCmdFlags is called by openPromptTestDB.
+	rootCmd.SetArgs([]string{"escalate", "--prompt", "halp", "--to", "ghost-session", "--json"})
+	t.Setenv("PRISM_SESSION_NAME", "repo@feature")
+	stdout, stderr := captureStdoutStderr(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("expected non-nil error from rootCmd.Execute()")
+		}
+	})
+
+	// AC: stdout MUST be empty in --json error path.
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout = %q, want empty in --json error path", stdout)
+	}
+	stderrLines := splitNonEmptyLines(stderr)
+	if len(stderrLines) == 0 {
+		t.Fatalf("stderr is empty in --json error path: %q", stderr)
+	}
+	// Find the JSON error line — there should be exactly one and it should
+	// be the LAST non-empty stderr line (cobra may print nothing extra
+	// because SilenceUsage etc., but the quietExitErr suppresses main's
+	// fallback print).
+	var jsonLine string
+	for _, ln := range stderrLines {
+		if strings.HasPrefix(ln, "{") {
+			jsonLine = ln
+		}
+	}
+	if jsonLine == "" {
+		t.Fatalf("no JSON error envelope on stderr; got: %q", stderr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(jsonLine), &payload); err != nil {
+		t.Fatalf("stderr error envelope is not JSON: %q (err=%v)", jsonLine, err)
+	}
+	if msg, ok := payload["error"].(string); !ok || msg == "" {
+		t.Errorf("error envelope missing 'error': %v", payload)
+	}
+}
+
+func TestEscalate_PartB_HumanJSONMutualExclusion(t *testing.T) {
+	d := openPromptTestDB(t)
+	_ = seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{jsonOut: true, dedupWindow: escalateDefaultDedupWindow}); err != nil {
+			t.Fatalf("runEscalateForSessionOpts: %v", err)
+		}
+	})
+	if strings.Contains(stdout, "prism escalate: OK") {
+		t.Errorf("--json stdout contains human-readable 'prism escalate: OK' (mutual exclusion violated): %q", stdout)
+	}
+	stdoutLines := splitNonEmptyLines(stdout)
+	if len(stdoutLines) != 1 {
+		t.Errorf("--json stdout line count = %d, want exactly 1; got: %q", len(stdoutLines), stdout)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Part C — sender-side idempotency guard
+// ---------------------------------------------------------------------------
+
+func TestEscalate_PartC_ReplayWithinWindow_SkipsAllWrites(t *testing.T) {
+	d := openPromptTestDB(t)
+	captured := seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	// First invocation.
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+	busCountBefore := busRowCount(t, d, "repo@feature", "repo@main")
+	escEventsBefore := eventCount(t, d, "repo@feature", "escalation")
+	busEventsBefore := eventCount(t, d, "repo@feature", "session.escalated")
+	if busCountBefore != 1 {
+		t.Fatalf("bus_messages count after first call = %d, want 1", busCountBefore)
+	}
+
+	// Clear the captured prompt so we can detect any new delivery.
+	captured.body = nil
+
+	// Second invocation — same prompt, within window.
+	stdout, stderr := captureStdoutStderr(t, func() {
+		if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+			t.Fatalf("second runEscalateForSessionOpts: %v", err)
+		}
+	})
+
+	// AC: no new bus_messages, no new agent_events.
+	if got := busRowCount(t, d, "repo@feature", "repo@main"); got != busCountBefore {
+		t.Errorf("bus_messages count after replay = %d, want %d (no new row)", got, busCountBefore)
+	}
+	if got := eventCount(t, d, "repo@feature", "escalation"); got != escEventsBefore {
+		t.Errorf("escalation agent_events count after replay = %d, want %d", got, escEventsBefore)
+	}
+	if got := eventCount(t, d, "repo@feature", "session.escalated"); got != busEventsBefore {
+		t.Errorf("session.escalated agent_events count after replay = %d, want %d", got, busEventsBefore)
+	}
+
+	// AC: no re-delivery (captured.body would be set if the HTTP stub
+	// received a second prompt).
+	if captured.body != nil {
+		t.Errorf("replay re-delivered to coordinator (captured.body = %v); want no new delivery", captured.body)
+	}
+
+	// AC: state stays escalated.
+	st, _ := d.CurrentStatus("repo@feature")
+	if st == nil || st.State != string(agent.StateEscalated) {
+		t.Errorf("state after replay = %v, want escalated", stateOf(st))
+	}
+
+	// AC: replay line shape.
+	stdoutLines := splitNonEmptyLines(stdout)
+	if len(stdoutLines) != 1 {
+		t.Fatalf("replay stdout line count = %d, want 1; got: %q", len(stdoutLines), stdout)
+	}
+	line := stdoutLines[0]
+	if !strings.HasPrefix(line, "prism escalate: OK already delivered to repo@main (delivery_id=") {
+		t.Errorf("replay stdout = %q, want 'OK already delivered' prefix", line)
+	}
+	if !strings.Contains(line, "age=") {
+		t.Errorf("replay stdout missing 'age=': %q", line)
+	}
+	if !strings.Contains(stderr, line) {
+		t.Errorf("stderr does not mirror replay line: stderr=%q line=%q", stderr, line)
+	}
+}
+
+func TestEscalate_PartC_ReplayOutsideWindow_ProceedsNormally(t *testing.T) {
+	d := openPromptTestDB(t)
+	captured := seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	// First call — but set a window of effectively zero to force the second
+	// call to land outside the window.
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: time.Nanosecond}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+	// Wait long enough that any sane window has passed.
+	time.Sleep(10 * time.Millisecond)
+	captured.body = nil
+
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: time.Nanosecond}); err != nil {
+		t.Fatalf("second runEscalateForSessionOpts: %v", err)
+	}
+
+	// Both deliveries should have landed.
+	if got := busRowCount(t, d, "repo@feature", "repo@main"); got != 2 {
+		t.Errorf("bus_messages count after second-outside-window = %d, want 2", got)
+	}
+	if captured.body == nil {
+		t.Errorf("second invocation outside window did not re-deliver; captured.body is nil")
+	}
+}
+
+func TestEscalate_PartC_DifferentPrompt_ProceedsNormally(t *testing.T) {
+	d := openPromptTestDB(t)
+	captured := seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+	captured.body = nil
+	// Differ by one byte.
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp!", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("second runEscalateForSessionOpts: %v", err)
+	}
+
+	if got := busRowCount(t, d, "repo@feature", "repo@main"); got != 2 {
+		t.Errorf("bus_messages count with different prompt = %d, want 2", got)
+	}
+	if captured.body == nil {
+		t.Errorf("second invocation with different prompt did not deliver")
+	}
+}
+
+func TestEscalate_PartC_DedupWindowFlagOverride(t *testing.T) {
+	d := openPromptTestDB(t)
+	_ = seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	// First call — write a row.
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: time.Hour}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+	// Override window down to 1ns + sleep — second call should NOT dedup.
+	time.Sleep(5 * time.Millisecond)
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: time.Nanosecond}); err != nil {
+		t.Fatalf("second runEscalateForSessionOpts: %v", err)
+	}
+	if got := busRowCount(t, d, "repo@feature", "repo@main"); got != 2 {
+		t.Errorf("with --dedup-window=1ns, second call should NOT dedup; bus_messages count = %d, want 2", got)
+	}
+}
+
+func TestEscalate_PartC_QueuedNotYetDelivered_ShortCircuits(t *testing.T) {
+	d := openPromptTestDB(t)
+	// Seed a worker but NOT a coordinator HTTP stub — we synthesise a queued
+	// row directly to test the "delivered_at IS NULL" replay path.
+	seedSession(t, d, "repo@main", "active", nil, nil, strPtr("coordinator"), nil)
+	seedSession(t, d, "repo@feature", "active", nil, nil, strPtr("worker"), nil)
+
+	// Mark the worker as already in escalated state — the dedup guard only
+	// fires when current_state == escalated. The bus row would have been
+	// written by a prior delivery that hasn't yet been flushed.
+	if err := d.UpsertStatus("repo@feature", "repo", "/code/repo/main", string(agent.StateEscalated), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.WriteBusMessage(db.BusMessage{
+		ID:          "queued-prior-id",
+		FromSession: "repo@feature",
+		ToSession:   "repo@main",
+		Repo:        "repo",
+		Text:        "halp",
+		Urgency:     "normal",
+		SentAt:      time.Now(),
+	}); err != nil {
+		t.Fatalf("WriteBusMessage (queued): %v", err)
+	}
+
+	escEventsBefore := eventCount(t, d, "repo@feature", "escalation")
+	busCountBefore := busRowCount(t, d, "repo@feature", "repo@main")
+
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+			t.Fatalf("runEscalateForSessionOpts: %v", err)
+		}
+	})
+
+	// AC: no new bus_messages, no new escalation event.
+	if got := busRowCount(t, d, "repo@feature", "repo@main"); got != busCountBefore {
+		t.Errorf("bus_messages count after queued-replay = %d, want %d", got, busCountBefore)
+	}
+	if got := eventCount(t, d, "repo@feature", "escalation"); got != escEventsBefore {
+		t.Errorf("escalation event count after queued-replay = %d, want %d", got, escEventsBefore)
+	}
+	// AC: replay line surfaces the prior delivery_id.
+	if !strings.Contains(stdout, "delivery_id=queued-prior-id") {
+		t.Errorf("replay stdout missing prior delivery_id: %q", stdout)
+	}
+}
+
+func TestEscalate_PartC_StateNotEscalated_BypassesDedup(t *testing.T) {
+	d := openPromptTestDB(t)
+	captured := seedEscalatePair(t, d, "repo@feature", "repo@main")
+
+	// First invocation — transitions to escalated and writes a bus row.
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+
+	// Simulate a turn_start clearing the escalated state.
+	if err := d.UpsertStatus("repo@feature", "repo", "/code/repo/main", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(active): %v", err)
+	}
+	captured.body = nil
+
+	// Second invocation: same prompt, within window, but state is now
+	// `active` not `escalated`. The dedup guard MUST NOT fire — this is a
+	// genuine re-escalation.
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("second runEscalateForSessionOpts: %v", err)
+	}
+	if got := busRowCount(t, d, "repo@feature", "repo@main"); got != 2 {
+		t.Errorf("bus_messages count after state-bypass = %d, want 2", got)
+	}
+	if captured.body == nil {
+		t.Errorf("second invocation after state-cleared did not re-deliver")
+	}
+	st, _ := d.CurrentStatus("repo@feature")
+	if st == nil || st.State != string(agent.StateEscalated) {
+		t.Errorf("state after second invocation = %v, want escalated", stateOf(st))
+	}
+}
+
+func TestEscalate_PartC_DedupScopedToFromSession(t *testing.T) {
+	d := openPromptTestDB(t)
+	captured := seedEscalatePair(t, d, "repo@feature", "repo@main")
+	// Also seed a second worker in the same repo.
+	seedSession(t, d, "repo@feature-2", "active", nil, nil, strPtr("worker"), nil)
+
+	if err := runEscalateForSessionOpts(d, "repo@feature", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+	captured.body = nil
+	// A DIFFERENT worker sending the same prompt to the same coordinator
+	// must NOT be deduped against the first worker's bus row.
+	if err := runEscalateForSessionOpts(d, "repo@feature-2", "", "halp", escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("second-worker runEscalateForSessionOpts: %v", err)
+	}
+	// Two distinct from_sessions → two bus rows total to repo@main.
+	totalToCoord := busRowCount(t, d, "repo@feature", "repo@main") + busRowCount(t, d, "repo@feature-2", "repo@main")
+	if totalToCoord != 2 {
+		t.Errorf("cross-worker dedup leak: total bus rows to repo@main = %d, want 2", totalToCoord)
+	}
+	if captured.body == nil {
+		t.Errorf("cross-worker invocation did not deliver")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration test using sidecartest.NewIsolated — verifies that a replayed
+// `prism escalate` does not produce a second delivery to the target session.
+// ---------------------------------------------------------------------------
+
+func TestEscalate_PartC_ReplayDoesNotHitSidecar(t *testing.T) {
+	// Use the prism-test@ session-name prefix per AGENTS.md isolation contract.
+	target := "prism-test@coord-" + t.Name()
+	bus := sidecartest.NewIsolated(t, target)
+
+	// Seed a worker row in the same isolated DB.
+	worker := "prism-test@worker-" + t.Name()
+	if err := bus.DB.UpsertStatusWithRootAgent(worker, "prism-test", "/tmp/test-worker", "active", nil, nil, strPtr("worker"), nil); err != nil {
+		t.Fatalf("seed worker: %v", err)
+	}
+	if err := bus.DB.QueryRow("UPDATE agent_status SET harness = '' WHERE session_name = ? RETURNING 1", worker).Scan(new(int)); err != nil {
+		t.Fatalf("clear worker harness: %v", err)
+	}
+	// Set the target's root_agent_name so resolveEscalationTarget picks it up.
+	if err := bus.DB.QueryRow("UPDATE agent_status SET root_agent_name = 'coordinator' WHERE session_name = ? RETURNING 1", target).Scan(new(int)); err != nil {
+		t.Fatalf("set target root_agent_name: %v", err)
+	}
+
+	// Point the cmd-package DB resolver at the isolated DB by setting the
+	// test override and routing all openDB() calls there. Since runEscalateForSessionOpts
+	// takes the *db.DB directly, we don't need to override openDB.
+
+	const promptText = "stuck on review, please advise"
+
+	if err := runEscalateForSessionOpts(bus.DB, worker, target, promptText, escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("first runEscalateForSessionOpts: %v", err)
+	}
+	firstBodies := len(bus.CopyBodies())
+	if firstBodies == 0 {
+		t.Fatalf("first invocation did not deliver to sidecar; bodies=%v", bus.CopyBodies())
+	}
+
+	// Replay — expect NO new body delivered to the sidecar's HTTP server.
+	if err := runEscalateForSessionOpts(bus.DB, worker, target, promptText, escalateOptions{dedupWindow: escalateDefaultDedupWindow}); err != nil {
+		t.Fatalf("replay runEscalateForSessionOpts: %v", err)
+	}
+	secondBodies := len(bus.CopyBodies())
+	if secondBodies != firstBodies {
+		t.Errorf("replay produced new sidecar delivery: bodies grew from %d to %d", firstBodies, secondBodies)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func splitNonEmptyLines(s string) []string {
+	out := []string{}
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.TrimSpace(ln) != "" {
+			out = append(out, ln)
+		}
+	}
+	return out
+}
+
+func stateOf(st *db.Status) string {
+	if st == nil {
+		return "<nil status>"
+	}
+	return st.State
+}

--- a/modules/programs/prism/prism/cmd/escalate_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/escalate_proxy_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+// Tests for the container-side escalate proxy (proxyEscalate /
+// proxyEscalateWithWriters). These tests stand up a mock host-API on a Unix
+// socket, send an escalate request through proxyEscalateWithWriters, and
+// assert that the stdout/stderr returned by the host are forwarded
+// byte-for-byte to the caller's writers — closing the gap that the
+// review-context blocker on PR #2019 / issue #2018 round 1 surfaced:
+// without this round-trip, the container path is silent on success.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestProxyEscalate_ForwardsStdoutAndStderr verifies that on a 200 OK
+// response carrying stdout/stderr fields, the proxy writes both streams
+// to the caller's writers verbatim. This is the Part B AC for the
+// container code path.
+func TestProxyEscalate_ForwardsStdoutAndStderr(t *testing.T) {
+	wantStdout := "prism escalate: OK delivered to myrepo@main (delivery_id=abc-123-def)\n"
+	wantStderr := "prism escalate: OK delivered to myrepo@main (delivery_id=abc-123-def)\n"
+
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":` + jsonStringMust(wantStdout) +
+			`,"stderr":` + jsonStringMust(wantStderr) + `}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyEscalateWithWriters(srv.apiURL(), "", "halp", false, "", &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyEscalateWithWriters: %v", err)
+	}
+
+	if stdoutBuf.String() != wantStdout {
+		t.Errorf("stdout forwarded mismatch:\n  got:  %q\n  want: %q", stdoutBuf.String(), wantStdout)
+	}
+	if stderrBuf.String() != wantStderr {
+		t.Errorf("stderr forwarded mismatch:\n  got:  %q\n  want: %q", stderrBuf.String(), wantStderr)
+	}
+
+	// Body shape: prompt is required, json/dedup_window are omitted when not set.
+	select {
+	case body := <-gotBody:
+		if body["prompt"] != "halp" {
+			t.Errorf("prompt = %v, want halp", body["prompt"])
+		}
+		if _, ok := body["json"]; ok {
+			t.Errorf("json field present in body when jsonOut=false: %v", body["json"])
+		}
+		if _, ok := body["dedup_window"]; ok {
+			t.Errorf("dedup_window present when not overridden: %v", body["dedup_window"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+}
+
+// TestProxyEscalate_ForwardsJSONFlag verifies that --json is forwarded to
+// the host-side child so its stdout carries the JSON envelope (and stderr
+// the human mirror). The proxy then forwards both streams verbatim to the
+// container's local stdout/stderr — preserving the human/json mutual
+// exclusion on stdout.
+func TestProxyEscalate_ForwardsJSONFlag(t *testing.T) {
+	wantStdout := `{"delivered_to":"myrepo@main","delivery_id":"abc-123","replayed":false}` + "\n"
+	wantStderr := "prism escalate: OK delivered to myrepo@main (delivery_id=abc-123)\n"
+
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":` + jsonStringMust(wantStdout) +
+			`,"stderr":` + jsonStringMust(wantStderr) + `}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyEscalateWithWriters(srv.apiURL(), "", "halp", true, "", &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyEscalateWithWriters: %v", err)
+	}
+
+	if stdoutBuf.String() != wantStdout {
+		t.Errorf("stdout forwarded mismatch:\n  got:  %q\n  want: %q", stdoutBuf.String(), wantStdout)
+	}
+	if stderrBuf.String() != wantStderr {
+		t.Errorf("stderr forwarded mismatch:\n  got:  %q\n  want: %q", stderrBuf.String(), wantStderr)
+	}
+	// The forwarded stdout in --json mode must NOT contain the human line
+	// (mutual exclusion held end-to-end, including across the proxy).
+	if strings.Contains(stdoutBuf.String(), "prism escalate: OK") {
+		t.Errorf("forwarded stdout contains human line in --json mode: %q", stdoutBuf.String())
+	}
+
+	// Body shape carries json=true.
+	select {
+	case body := <-gotBody:
+		if body["json"] != true {
+			t.Errorf("json field = %v, want true", body["json"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+}
+
+// TestProxyEscalate_ForwardsToFlag verifies that --to is forwarded.
+func TestProxyEscalate_ForwardsToFlag(t *testing.T) {
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":"","stderr":""}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyEscalateWithWriters(srv.apiURL(), "myrepo@coord-2", "halp", false, "", &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyEscalateWithWriters: %v", err)
+	}
+	select {
+	case body := <-gotBody:
+		if body["to"] != "myrepo@coord-2" {
+			t.Errorf("to = %v, want myrepo@coord-2", body["to"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+}
+
+// TestProxyEscalate_ForwardsDedupWindow verifies that --dedup-window is
+// forwarded when explicitly set, and omitted otherwise.
+func TestProxyEscalate_ForwardsDedupWindow(t *testing.T) {
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":"","stderr":""}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyEscalateWithWriters(srv.apiURL(), "", "halp", false, "10m", &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyEscalateWithWriters: %v", err)
+	}
+	select {
+	case body := <-gotBody:
+		if body["dedup_window"] != "10m" {
+			t.Errorf("dedup_window = %v, want 10m", body["dedup_window"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+}
+
+// TestProxyEscalate_ForwardsErrorWithStdoutStderr verifies that on a non-2xx
+// response carrying stdout/stderr alongside an error, the proxy forwards
+// both streams to the caller's writers AND returns an error containing the
+// underlying message. Parity with proxyCleanupToHostAPIWithWriters (#1527).
+func TestProxyEscalate_ForwardsErrorWithStdoutStderr(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{` +
+			`"error":"escalate failed: exit status 1",` +
+			`"stdout":"",` +
+			`"stderr":"prism escalate: deliver prompt to myrepo@main: connection refused\n"` +
+			`}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	err := proxyEscalateWithWriters(srv.apiURL(), "", "halp", false, "", &stdoutBuf, &stderrBuf)
+	if err == nil {
+		t.Fatal("expected error from proxyEscalateWithWriters on 500 response")
+	}
+	if !strings.Contains(err.Error(), "escalate failed: exit status 1") {
+		t.Errorf("error %q should contain underlying cause", err.Error())
+	}
+	if !strings.Contains(stderrBuf.String(), "deliver prompt to myrepo@main") {
+		t.Errorf("stderr on error not forwarded: got %q", stderrBuf.String())
+	}
+}

--- a/modules/programs/prism/prism/internal/db/bus.go
+++ b/modules/programs/prism/prism/internal/db/bus.go
@@ -111,6 +111,41 @@ WHERE to_session = ?
 	return nil
 }
 
+// FindRecentEquivalentBusMessage returns the most recent bus_messages row
+// matching (fromSession, toSession, text) byte-equal whose sent_at is within
+// the given window (>= now - window). It returns (nil, nil) when no match
+// exists. failed_at must be NULL on the match — a previously-failed send is
+// not a valid prior delivery to dedup against; the caller is expected to
+// retry. delivered_at MAY be NULL (queued but not yet flushed) — that still
+// counts as a prior in-flight delivery the caller should not duplicate.
+//
+// This powers the sender-side idempotency guard in `prism escalate` so a
+// worker that re-runs the same `escalate` invocation within a short window
+// (default 5 minutes) does not produce a second delivery to the coordinator.
+// See issue #2018.
+func (d *DB) FindRecentEquivalentBusMessage(fromSession, toSession, text string, window time.Duration) (*BusMessage, error) {
+	threshold := time.Now().Add(-window).UnixMilli()
+	const q = `
+SELECT id, from_session, to_session, to_instance_id, repo, text, urgency, sent_at, delivered_at, failed_at
+FROM bus_messages
+WHERE from_session = ?
+  AND to_session = ?
+  AND text = ?
+  AND failed_at IS NULL
+  AND sent_at >= ?
+ORDER BY sent_at DESC
+LIMIT 1`
+	row := d.conn.QueryRow(q, fromSession, toSession, text, threshold)
+	m, err := scanBusMessage(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: find recent equivalent bus message: %w", err)
+	}
+	return &m, nil
+}
+
 // scanBusMessage scans a BusMessage from the given scanner.
 func scanBusMessage(s scanner) (BusMessage, error) {
 	var m BusMessage

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -2138,9 +2138,17 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		var req struct {
-			Prompt string `json:"prompt"`
-			To     string `json:"to,omitempty"`
-			From   string `json:"from,omitempty"`
+			Prompt      string `json:"prompt"`
+			To          string `json:"to,omitempty"`
+			From        string `json:"from,omitempty"`
+			// JSON forwards the --json flag to the host-side `prism escalate`
+			// child so its stdout carries the JSON envelope (and stderr the
+			// human mirror). The proxy on the container side then writes the
+			// captured streams verbatim to its own stdout/stderr. See #2018.
+			JSON        bool   `json:"json,omitempty"`
+			// DedupWindow forwards the hidden --dedup-window flag for tests
+			// and operator overrides. Empty string falls back to the default.
+			DedupWindow string `json:"dedup_window,omitempty"`
 		}
 		// /escalate body cap: default 1 MiB (issue #1848).
 		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
@@ -2170,7 +2178,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.To != "" {
 			args = append(args, "--to", req.To)
 		}
-		s.logger().Printf("sidecar: host-API /escalate: from=%s to=%s", fromSession, req.To)
+		if req.JSON {
+			args = append(args, "--json")
+		}
+		if strings.TrimSpace(req.DedupWindow) != "" {
+			args = append(args, "--dedup-window", req.DedupWindow)
+		}
+		s.logger().Printf("sidecar: host-API /escalate: from=%s to=%s json=%v", fromSession, req.To, req.JSON)
 
 		// Per-endpoint timeout: 30 s. `prism escalate` writes one bus event
 		// and may best-effort prompt the coordinator; it should return well
@@ -2183,18 +2197,36 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// is calling, bypassing the CWD walk that would otherwise resolve to
 		// the sidecar's own working directory.
 		cmd.Env = append(os.Environ(), "PRISM_SESSION_NAME="+fromSession, "PRISM_HOST_API=")
-		out, err := cmd.CombinedOutput()
+		// Capture stdout and stderr separately so the proxy on the container
+		// side can re-emit them on the matching local streams. Using
+		// CombinedOutput would mash them together and break --json mode
+		// (which writes JSON to stdout and the human mirror to stderr).
+		// See issue #2018 review-context blocker.
+		var stdoutBuf, stderrBuf bytes.Buffer
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		err := cmd.Run()
 		if err != nil {
 			if status, ok := contextErrStatus(ctx); ok {
 				s.logger().Printf("sidecar: host-API /escalate: context fired (%v): killed child after %v", ctx.Err(), 30*time.Second)
 				writeError(w, status, fmt.Sprintf("escalate aborted: %v", ctx.Err()))
 				return
 			}
-			s.logger().Printf("sidecar: host-API /escalate: %v: %s", err, out)
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("escalate failed: %v\n%s", err, strings.TrimSpace(string(out))))
+			combined := strings.TrimSpace(stdoutBuf.String() + "\n" + stderrBuf.String())
+			s.logger().Printf("sidecar: host-API /escalate: %v: %s", err, combined)
+			// Surface stdout + stderr alongside the error so the container
+			// caller can re-emit them locally (parity with /cleanup).
+			writeJSON(w, http.StatusInternalServerError, map[string]string{
+				"error":  fmt.Sprintf("escalate failed: %v", err),
+				"stdout": stdoutBuf.String(),
+				"stderr": stderrBuf.String(),
+			})
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]string{})
+		writeJSON(w, http.StatusOK, map[string]string{
+			"stdout": stdoutBuf.String(),
+			"stderr": stderrBuf.String(),
+		})
 	})
 
 	// POST /investigate

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_escalate_hostapi_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_escalate_hostapi_test.go
@@ -10,9 +10,14 @@ package sidecar
 // PR #1524 round 1).
 
 import (
+	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
 )
 
 // TestHostAPI_Escalate_WorkerCannotImpersonate verifies that a worker session
@@ -144,5 +149,185 @@ func TestHostAPI_Escalate_GetMethodRejected(t *testing.T) {
 
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want 405", rr.Code)
+	}
+}
+
+// newSidecarWithEscalateStub returns a Sidecar configured with a stub
+// `prism` binary that, when invoked with "escalate", writes a deterministic
+// success line to stdout and a mirror to stderr, then exits 0. This lets us
+// verify that the host-side /escalate handler captures both streams
+// separately and returns them in the JSON response body — the round-trip
+// the container proxy needs to re-emit the OK signal locally.
+func newSidecarWithEscalateStub(t *testing.T, sessionName, repo, role string, d *db.DB, stdoutLine, stderrLine string, exitCode int) *Sidecar {
+	t.Helper()
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Args: $1="escalate", rest=flags. We print fixed lines so tests can
+	// assert byte-for-byte equality; we don't try to parse the flags here.
+	stubScript := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"escalate\" ]; then\n" +
+		"  printf '%s' " + shellSingleQuote(stdoutLine) + "\n" +
+		"  printf '%s' " + shellSingleQuote(stderrLine) + " 1>&2\n" +
+		"  exit " + itoa(exitCode) + "\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub binary: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     sessionName,
+		Repo:            repo,
+		Worktree:        "/tmp/" + sessionName,
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       role,
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	return New(cfg)
+}
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// TestHostAPI_Escalate_SuccessReturnsStdoutAndStderr verifies that on a
+// successful host-side `prism escalate` invocation, the /escalate handler
+// returns the captured stdout AND stderr in the response body, with the
+// streams kept separate (NOT combined). The container-side proxy depends
+// on this to re-emit each stream locally. See PR #2019 review-context
+// blocker / issue #2018.
+func TestHostAPI_Escalate_SuccessReturnsStdoutAndStderr(t *testing.T) {
+	d := openTestDB(t)
+	const wantStdout = "prism escalate: OK delivered to myrepo@main (delivery_id=abc-123)\n"
+	const wantStderr = "prism escalate: OK delivered to myrepo@main (delivery_id=abc-123)\n"
+	sc := newSidecarWithEscalateStub(t, "myrepo@feature", "myrepo", "worker", d, wantStdout, wantStderr, 0)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", `{"prompt":"halp"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (body=%q)", err, rr.Body.String())
+	}
+	if resp["stdout"] != wantStdout {
+		t.Errorf("response stdout = %q, want %q", resp["stdout"], wantStdout)
+	}
+	if resp["stderr"] != wantStderr {
+		t.Errorf("response stderr = %q, want %q", resp["stderr"], wantStderr)
+	}
+	// Streams must be kept separate (no merging). Verify by giving the
+	// stub distinct lines on each stream and asserting they round-trip
+	// to the correct response field.
+	sc2 := newSidecarWithEscalateStub(t, "myrepo@feature", "myrepo", "worker", d,
+		"STDOUT-only-line\n", "STDERR-only-line\n", 0)
+	rr2 := doHostAPI(t, sc2, http.MethodPost, "/escalate", `{"prompt":"halp"}`)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("split-streams status = %d, body = %q", rr2.Code, rr2.Body.String())
+	}
+	var resp2 map[string]string
+	if err := json.Unmarshal(rr2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("unmarshal split-streams response: %v", err)
+	}
+	if resp2["stdout"] != "STDOUT-only-line\n" {
+		t.Errorf("split-streams stdout = %q, want STDOUT-only-line", resp2["stdout"])
+	}
+	if resp2["stderr"] != "STDERR-only-line\n" {
+		t.Errorf("split-streams stderr = %q, want STDERR-only-line", resp2["stderr"])
+	}
+}
+
+// TestHostAPI_Escalate_FailureIncludesStdoutAndStderr verifies that on a
+// non-zero exit from the host-side child, the /escalate handler returns
+// 500 with stdout/stderr alongside the error message so the proxy can
+// re-emit partial-success output and surface the underlying cause.
+func TestHostAPI_Escalate_FailureIncludesStdoutAndStderr(t *testing.T) {
+	d := openTestDB(t)
+	const wantStdout = ""
+	const wantStderr = "prism escalate: deliver prompt to myrepo@main: connection refused\n"
+	sc := newSidecarWithEscalateStub(t, "myrepo@feature", "myrepo", "worker", d, wantStdout, wantStderr, 1)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate", `{"prompt":"halp"}`)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %q, want 500", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v (body=%q)", err, rr.Body.String())
+	}
+	if !strings.Contains(resp["error"], "escalate failed") {
+		t.Errorf("error = %q, want substring 'escalate failed'", resp["error"])
+	}
+	if resp["stderr"] != wantStderr {
+		t.Errorf("failure stderr = %q, want %q", resp["stderr"], wantStderr)
+	}
+}
+
+// TestHostAPI_Escalate_ForwardsJSONAndDedupWindowFlags verifies that the
+// /escalate handler forwards json=true and dedup_window=<dur> to the
+// host-side child as --json and --dedup-window flags. The stub captures
+// its argv and prints it to stdout for the test to assert on.
+func TestHostAPI_Escalate_ForwardsJSONAndDedupWindowFlags(t *testing.T) {
+	d := openTestDB(t)
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// Echo the full argv to stdout so the test can assert flags.
+	stubScript := "#!/bin/sh\necho \"$@\"\nexit 0\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	sc := New(Config{
+		SessionName:     "myrepo@feature",
+		Repo:            "myrepo",
+		Worktree:        "/tmp/myrepo@feature",
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "worker",
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	})
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/escalate",
+		`{"prompt":"halp","json":true,"dedup_window":"10m"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	argv := resp["stdout"]
+	if !strings.Contains(argv, "--json") {
+		t.Errorf("argv %q missing --json", argv)
+	}
+	if !strings.Contains(argv, "--dedup-window 10m") {
+		t.Errorf("argv %q missing --dedup-window 10m", argv)
 	}
 }

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -751,6 +751,8 @@ The `--json` flag emits a single line to stdout instead:
 
 In `--json` mode the human-readable line is NOT emitted on stdout (mutual exclusion); it may still be mirrored to stderr for log capture. On error, `--json` emits `{"error": "<message>"}` to stderr and exits non-zero.
 
+The success signal reaches the caller identically from a direct-host invocation and from inside a bwrap / sandbox-exec / podman container: the container path's sidecar proxy captures the host-side child's stdout and stderr separately and re-emits them on the matching local streams, so the `OK` line lands on the container's stdout (and the mirror on stderr) byte-for-byte the same as a host invocation. `--json` is forwarded to the host child via the proxy request body, so the JSON envelope is also surfaced end-to-end.
+
 ### Sender-side idempotency — re-runs within 5 minutes are a no-op
 
 Running `prism escalate` a second time within 5 minutes with the same `(calling session, target, prompt text)` triple as a previously-delivered escalation is a **no-op that exits 0**. The replay invocation:

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -733,6 +733,45 @@ A same-repo coordinator candidate is any active (ended_at IS NULL) row in the sa
 - Payload carries: `source` (calling worker), `target` (coordinator session, empty when none), `prompt` (body), `pr_numbers` (open PRs whose head matches the worker's branch), `branch`, `head_sha`, `verdicts` (last review-cycle verdicts when discoverable), `occurred_at` (RFC3339).
 - The same payload is also written into the calling session's own event log as type `escalation` so `prism checkin <self>` shows the escalation context inline.
 
+### Success signal — the `OK` line is the verification
+
+On successful delivery `prism escalate` prints exactly one line to **stdout**, mirrored to **stderr** so combined-stream capture (e.g. a bash tool that merges both) always surfaces it:
+
+```
+prism escalate: OK delivered to <target> (delivery_id=<uuid>)
+```
+
+The `OK` token is the first whitespace-delimited word after `escalate: ` so callers can grep for it as the unambiguous success signal. **Do not re-run `prism escalate` to verify delivery** — the `OK` line is the verification. Re-running is the bug pattern issue #2018 fixed: a worker that interpreted a `(no output)` capture as failure and re-ran produced two distinct deliveries to the coordinator before the sender-side guard was added.
+
+The `--json` flag emits a single line to stdout instead:
+
+```json
+{"delivered_to": "<target>", "delivery_id": "<uuid>", "replayed": false}
+```
+
+In `--json` mode the human-readable line is NOT emitted on stdout (mutual exclusion); it may still be mirrored to stderr for log capture. On error, `--json` emits `{"error": "<message>"}` to stderr and exits non-zero.
+
+### Sender-side idempotency — re-runs within 5 minutes are a no-op
+
+Running `prism escalate` a second time within 5 minutes with the same `(calling session, target, prompt text)` triple as a previously-delivered escalation is a **no-op that exits 0**. The replay invocation:
+
+- does NOT write a new `bus_messages` row
+- does NOT write new `escalation` or `session.escalated` rows to `agent_events`
+- does NOT re-deliver the prompt to the coordinator's sidecar
+- does NOT re-transition `agent_status.state` (it stays `escalated`)
+
+The replay emits a distinct success line so the operator/agent can tell it was deduped:
+
+```
+prism escalate: OK already delivered to <target> (delivery_id=<prior>, age=<duration>)
+```
+
+The `<duration>` is the time since the prior `sent_at`, formatted as `Ns` / `Nm` / `Nh`. The `--json` form is `{"delivered_to": "<target>", "delivery_id": "<prior>", "replayed": true, "age_seconds": <int>}`.
+
+The dedup query is scoped to `from_session = self` exactly. A different worker in the same repo sending the same prompt to the same coordinator is a distinct escalation and lands as normal.
+
+The dedup guard additionally requires the calling session's `current_state` to still be `escalated`. If an incoming turn_start unstuck the worker between the two invocations, the second call is a genuine re-escalation: it transitions back to `escalated` and re-delivers.
+
 ### Delivery guarantee — exactly-once with optional replay marker
 
 The escalation prompt is delivered to the coordinator's harness **exactly once** per `prism escalate` invocation. The sidecar's `/prompt` handler is idempotent: each delivery carries a `delivery_id` (UUID minted by the sender), and repeats whose ID has been seen recently are dropped before they reach the harness pipe — the dedup set is bounded (LRU, capacity 256, in-memory per sidecar). Senders that retry with the same `delivery_id` see `{"replayed":true}` in the response so the retry is observable, not silent.
@@ -741,7 +780,7 @@ The one path that produces a second copy is the reconnect-replay case for AC #7:
 
 **Coordinator-side handling.** Coordinators receiving `prism prompt`-style frames do not need to deduplicate — the sidecar guarantees exactly-once for the same delivery_id. If you see `replay: true` on a prompt frame (visible in the assistant-side prompt body once the PI runtime exposes it; for now, observable only in raw frame archives), the delivery is a buffered resume of a partition-window escalation. Treat it informationally: the original was already accepted, this is the post-reconnect notification of that earlier acceptance.
 
-This contract supersedes the pre-fix behaviour where `prism escalate` could deliver the same prompt body multiple times under load (issue #1685).
+This contract supersedes the pre-fix behaviour where `prism escalate` could deliver the same prompt body multiple times under load (issue #1685). Sender-side double-invocation (a worker re-running `prism escalate` because the success signal was unclear) is covered by the idempotency guard above; see issue #2018.
 
 ### When to use `prism escalate` vs `prism prompt`
 


### PR DESCRIPTION
Closes #2018.

## Problem

When a worker runs `prism escalate` and pi's bash tool reports the command's stdout as `(no output)`, the worker can interpret that as failure and re-run the command. Each re-run produces a fresh `bus_messages` row, fresh `escalation` and `session.escalated` event rows, and a fresh delivery to the coordinator (different `delivery_id`, so the receiver-side dedup does not catch it). The coordinator receives the same prompt twice, 10–30 seconds apart.

## Fix

Two complementary changes in `cmd/escalate.go`, no protocol or sidecar changes:

**Part B — unambiguous success signal.** The stdout success line now reads:

```
prism escalate: OK delivered to <target> (delivery_id=<uuid>)
```

with `OK` as the first whitespace-delimited word after `escalate: ` so callers can grep for it. The same line is mirrored to stderr so a bash tool that captures the streams combined always surfaces the signal. A new `--json` flag emits a single JSON object to stdout instead (mutual exclusion with the human line); errors emit `{"error":"..."}` to stderr.

**Part C — sender-side idempotency guard.** Before any state transition or DB write, `prism escalate` queries `bus_messages` for a recent equivalent escalation matching `(from_session, to_session, byte-equal text)` within a 5-minute window. If a match exists AND the calling session is currently in `escalated` state, the second invocation short-circuits: no new bus row, no new agent_events rows, no re-delivery, no state-transition write. It emits:

```
prism escalate: OK already delivered to <target> (delivery_id=<prior>, age=<duration>)
```

and exits 0. Hidden `--dedup-window <duration>` flag for testing/operator override.

The dedup guard additionally requires `current_state == escalated` — if the worker was transitioned out of `escalated` between invocations (e.g. an incoming turn_start), the second call proceeds normally as a genuine re-escalation. The dedup is scoped to `from_session = self` exactly; a different worker sending the same prompt is independent.

## DB

- New helper `db.FindRecentEquivalentBusMessage(fromSession, toSession, text, window)`. Reuses the existing `scanBusMessage` scanner; no new access surface, no schema change. Excludes `failed_at IS NOT NULL` (a failed send is not a valid prior delivery — retry is allowed).
- `delivered_at IS NULL` rows DO count as a prior in-flight delivery — a second send cannot help a queued first.

## Tests

`cmd/escalate_idempotency_test.go` covers every AC in the issue:

- **Part B:** human stdout+stderr shape, `--json` happy path, `--json` error path, human/json mutual exclusion.
- **Part C:** replay-within-window skips all writes, replay-outside-window proceeds, different prompt proceeds, `--dedup-window` override, `delivered_at IS NULL` short-circuit, state-not-escalated bypass, cross-worker independence.
- **Integration:** `sidecartest.NewIsolated` test confirms a replayed invocation produces no second body delivery to the target sidecar's HTTP server. Uses the `prism-test@` session prefix per AGENTS.md isolation contract.

All capture helpers drain stdout/stderr concurrently per `docs/stdout-capture-testing.md`.

Local self-check: `go build ./...`, `go test ./cmd/ -run TestEscalate -race`, `nix build .#prism` all green.

## Docs

`skills/prism/SKILL.md` `prism escalate` section gains:

- **Success signal** subsection — the `OK` line is the verification; do NOT re-run to confirm; `--json` shape; mutual exclusion.
- **Sender-side idempotency** subsection — 5-minute no-op contract, replay line shape, `from_session` scope, state-bypass condition.
