### PR TITLE
overlay: pin openrazer to 3.12.3 (kernel 7.0 hid_report_raw_event fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1779600993,
-        "narHash": "sha256-Uu7EhMH+U3io7OPcK/saiflnFJyOI/j/21css7ZwYOQ=",
+        "lastModified": 1780017441,
+        "narHash": "sha256-7DXZXP0v6ttq1D0DTbawPH44QpPdLILh0KPzbpoBE84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e333c8669aa55464d84bafc3988d32d067ec0a92",
+        "rev": "1bf4bf10292fce2e2a5b112d9289ae2fa720cca6",
         "type": "github"
       },
       "original": {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -28,6 +28,49 @@ rec {
       claude-code = masterPkgs.claude-code;
       discord = masterPkgs.discord;
 
+      # openrazer userspace + kernel module: pinned to v3.12.3 to unblock
+      # builds on kernel 7.0+, which changed the `hid_report_raw_event`
+      # signature (5 args -> 6 args). openrazer 3.12.2 (still in our
+      # nixpkgs input via the nixos-unstable channel) calls it with 5
+      # args, so `razerkbd_driver.c` fails to compile against the latest
+      # kernel. v3.12.3 carries the fix.
+      #
+      # Upstream fix: https://github.com/openrazer/openrazer/pull/2809
+      # nixpkgs bump:  https://github.com/NixOS/nixpkgs/pull/523308
+      #                (merged as nixpkgs commit 99643def)
+      #
+      # The userspace packages (pylib + daemon) are pulled wholesale from
+      # `masterPkgs`. The kernel module is per-kernel and lives under
+      # `linuxPackages_latest` (both `tui` and `navi` use
+      # `pkgs.linuxPackages_latest`), so it gets `overrideAttrs`'d to swap
+      # in the v3.12.3 source.
+      #
+      # REMOVAL CONDITION: delete this block once our nixos-unstable
+      # channel pointer advances past nixpkgs commit 99643def
+      # (`python3Packages.openrazer: 3.12.2 -> 3.12.3`).
+      python3Packages = prev.python3Packages // {
+        openrazer = masterPkgs.python3Packages.openrazer;
+        openrazer-daemon = masterPkgs.python3Packages.openrazer-daemon;
+      };
+      # Use `.extend` (not attribute merging) on the kernel package set so
+      # that NixOS's `boot.kernelPackages.apply = kp: kp.extend (...)` hook
+      # preserves our override. A plain `prev.linuxPackages_latest // {...}`
+      # loses the override because NixOS re-extends from the underlying
+      # fixed-point.
+      linuxPackages_latest = prev.linuxPackages_latest.extend (
+        _kfinal: kprev: {
+          openrazer = kprev.openrazer.overrideAttrs (_old: {
+            version = "3.12.3-${kprev.kernel.version}";
+            src = prev.fetchFromGitHub {
+              owner = "openrazer";
+              repo = "openrazer";
+              tag = "v3.12.3";
+              hash = "sha256-X1NPqbugBdxD5Nt9wIwQADV4CuydGLpgKhlNazVdrIY=";
+            };
+          });
+        }
+      );
+
       # bitwarden-cli: pinned to nixpkgs-stable as the most-vetted source.
       # NOTE: pinning alone is no longer sufficient to prevent the `bw unlock
       # --raw` bogus-session regression (bitwarden/clients#20703, issue #1894).


### PR DESCRIPTION
## Why

The latest `update-flakes` CI run failed on `tui` with:

```
razerkbd_driver.c:4837: too few arguments to function 'hid_report_raw_event';
expected 6, have 5
```

Failing run:
https://github.com/prismatic-koi/nixos-config/actions/runs/26608070982/job/78407809220

Kernel 7.0 changed the `hid_report_raw_event()` signature from 5 args
to 6. openrazer 3.12.2 (which our `nixos-unstable`-tracked `nixpkgs`
input still ships) calls it with 5 args, so `razerkbd` fails to build
against the latest kernel. v3.12.3 carries the upstream fix.

Upstream references:
- openrazer PR #2809 — `razerkbd: Adjust to hid_report_raw_event() signature change`
  https://github.com/openrazer/openrazer/pull/2809
- nixpkgs PR #523308 — `python3Packages.openrazer: 3.12.2 -> 3.12.3`
  https://github.com/NixOS/nixpkgs/pull/523308 (merged as nixpkgs `99643def`)

## What this does

In `overlays/default.nix`, the `modifications` overlay now overrides:

1. `python3Packages.openrazer` → pulled wholesale from `masterPkgs`
2. `python3Packages.openrazer-daemon` → pulled wholesale from `masterPkgs`
3. `linuxPackages_latest.openrazer` → `overrideAttrs` to swap `src` +
   `version` to v3.12.3 (per-kernel, so can't be pulled wholesale).

The kernel-package override uses `prev.linuxPackages_latest.extend`
rather than attribute merging, because NixOS's
`boot.kernelPackages.apply = kp: kp.extend (...)` re-extends from the
underlying fixed-point — a plain `//` merge gets dropped. After the
fix, `config.boot.kernelPackages.openrazer.version` resolves to
`3.12.3-7.0.9` on both `tui` and `navi`.

A clear comment block above the overrides explains the kernel-7.0
break, links both upstream PRs, and names the removal condition.

### About the flake.lock change

`nixpkgs-master` was at `e333c866` (2026-05-24), exactly one commit
behind the `99643def` merge (2026-05-25). Without bumping
`nixpkgs-master`, `masterPkgs.python3Packages.openrazer.version` still
evaluates to `3.12.2` and the override is a no-op. The single-input
update is the minimum required for the overlay to actually pick up
3.12.3 — the rest of the lock is untouched.

## Verification

```
$ nix eval .#nixosConfigurations.tui.config.hardware.openrazer.packages.daemon.version
"3.12.3"

$ nix eval .#nixosConfigurations.tui.config.hardware.openrazer.packages.kernel.version
"3.12.3-7.0.9"

$ nix eval .#nixosConfigurations.navi.config.hardware.openrazer.packages.daemon.version
"3.12.3"

$ nix eval .#nixosConfigurations.navi.config.hardware.openrazer.packages.kernel.version
"3.12.3-7.0.9"
```

`nixfmt --check overlays/default.nix` produces no diff. A dry-run
`nix build` of the openrazer-daemon attr evaluates cleanly with no
build errors.

## Removal condition

Delete the openrazer override block in `overlays/default.nix` once the
`nixos-unstable` channel pointer advances past nixpkgs commit
`99643def59501d1eabb1ca01ef701b66d41908fe`
(`python3Packages.openrazer: 3.12.2 -> 3.12.3`).
