### PR TITLE
overlay: bump pi-coding-agent v0.75.3 -> v0.77.0

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -87,19 +87,19 @@ rec {
       pi-coding-agent =
         let
           newSrc = prev.fetchFromGitHub {
-            owner = "badlogic";
-            repo = "pi-mono";
-            tag = "v0.75.3";
-            hash = "sha256-c/+cxkp/EZ2PLERxTENN5edXHEs7M2oqzNepjRA4TIE=";
+            owner = "earendil-works";
+            repo = "pi";
+            tag = "v0.77.0";
+            hash = "sha256-PJyhLWfqoPjHoYl4pKJVD3uMD5YjQB5YIk5mBZvGi8E=";
           };
         in
         prev.pi-coding-agent.overrideAttrs (old: {
-          version = "0.75.3";
+          version = "0.77.0";
           src = newSrc;
           npmDeps = prev.fetchNpmDeps {
             inherit (old) npmWorkspace;
             src = newSrc;
-            hash = "sha256-/mWjrZFzRmtkbWYMJOXKnLPxFITFndq5hgdY0DnPfAg=";
+            hash = "sha256-X0qMLqAi5pgrtTw5+DfSPsgIEngUnHwGxqYE6PL8NJU=";
           };
           # Upstream nixpkgs' postInstall hard-codes the old
           # @mariozechner/* workspace names; in v0.75.0 the monorepo


### PR DESCRIPTION
## Summary

Bumps the `pi-coding-agent` overlay pin from **v0.75.3 → v0.77.0** and
switches the source from the old `badlogic/pi-mono` mirror to the canonical
`earendil-works/pi` repository.

Release notes: https://github.com/earendil-works/pi/releases/tag/v0.77.0

## Motivation

v0.77.0 adds Claude Opus 4.8 metadata to the runtime's model registry. Our
anthropic-oauth extension reads that registry, so the new metadata can't
appear in our model list until the pinned runtime knows about it.

**This PR is overlay-only.** It updates the runtime closure but does **not**
enable Opus 4.8. A follow-up PR will land the extension-side changes:

- `modules/programs/prism/pi/extensions/anthropic-oauth/` model fallback /
  model-config overrides / ccVersion
- `modules/programs/prism/profiles.nix` opus-4-7 → opus-4-8 flip

Those depend on this overlay change landing first.

## Changes

`overlays/default.nix` — only the four lines that need to change:

- `owner = "badlogic"` → `"earendil-works"`
- `repo = "pi-mono"` → `"pi"`
- `tag = "v0.75.3"` → `"v0.77.0"`
- `version = "0.75.3"` → `"0.77.0"`
- new `src` hash + new `npmDeps` hash (rediscovered the standard way)

The `postInstall` workspace mapping is unchanged in v0.77.0
(`@earendil-works/pi-{ai,agent-core,tui}` → `packages/{ai,agent,tui}`), so
no overrides needed there.

## API-surface check

v0.76.0 and v0.77.0 release notes show only **additive** extension-API
changes between 0.75.3 and 0.77.0:

- `InputEvent.streamingBehavior` (new optional field)
- `pi.getAllTools()` now exposes `promptGuidelines`

Our `prism.ts`, `anthropic-oauth/index.ts`, and `atlassian/index.ts`
extensions don't consume either. The closure builds cleanly end-to-end, so
the implicit type-check via the extension compile against the v0.77.0
declarations passed.

## Verification

- ✅ `nix build pkgs.pi-coding-agent` (via the modifications overlay)
  succeeds on x86_64-linux
- ✅ `./result/bin/pi --version` reports `0.77.0`
- ✅ `nix build .#nixosConfigurations.navi.config.system.build.toplevel`
  succeeds (navi consumes `pi-coding-agent` via the prism module)
- ✅ `nixfmt --check overlays/default.nix` clean
- ✅ Diff is minimal: only the four pin lines change; `postInstall`
  untouched

## Out of scope

- `modules/programs/prism/pi/extensions/**` — not touched
- `modules/programs/prism/profiles.nix` — not touched

Both are follow-ups that depend on this PR landing first.