### PR TITLE
anthropic-oauth: remove dead DEFAULT_OPUS_4_7 registry fallback

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
@@ -87,6 +87,13 @@ it is more actively maintained and is the source of the PR #193 fix.
    MD5 approach (`t_<8hex>`) instead of griffinmartin main's `mcp_` PascalCase
    approach. This is intentional — see PR #193 for the rationale.
 
+8. **`getAnthropicModels` returns the runtime registry verbatim — no hardcoded
+   fallback**. leohenon's `index.ts` carried a `DEFAULT_OPUS_4_7` literal that
+   was pushed when the registry lacked opus-4-7. Since pi v0.77.0 the
+   `@earendil-works/pi-ai` model catalog ships `claude-opus-4-7`/`-4-8`
+   directly, so the fallback was dead code and was removed. Do **not**
+   re-introduce a hardcoded model object — rely entirely on the registry.
+
 ## Port procedure for future upstream fixes
 
 When griffinmartin ships a fix you want to port:

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -37,18 +37,6 @@ import {
   parseSSEStream,
 } from "./stream.ts"
 
-const DEFAULT_OPUS_4_7: NonNullable<ProviderConfig["models"]>[number] = {
-  id: "claude-opus-4-7",
-  name: "Claude Opus 4.7",
-  api: "anthropic-messages",
-  reasoning: true,
-  input: ["text", "image"],
-  cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
-  contextWindow: 1000000,
-  maxTokens: 128000,
-  compat: undefined,
-}
-
 function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
   const modelRegistry = ModelRegistry.create(AuthStorage.inMemory())
   const models: NonNullable<ProviderConfig["models"]> = modelRegistry
@@ -65,10 +53,6 @@ function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
       maxTokens: model.maxTokens,
       compat: model.compat,
     }))
-
-  if (!models.some((model) => model.id === DEFAULT_OPUS_4_7.id)) {
-    models.push(DEFAULT_OPUS_4_7)
-  }
 
   return models
 }


### PR DESCRIPTION
## What

Removes the hardcoded `DEFAULT_OPUS_4_7` model object and its `models.push(...)`
guard from the vendored anthropic-oauth pi extension
(`modules/programs/prism/pi/extensions/anthropic-oauth/index.ts`).
`getAnthropicModels()` now returns the registry-derived list directly.

## Why this is dead code

The fallback was introduced in the original vendoring (#881) when the pinned pi
was much older and may not have shipped opus-4-7. Since the pi **v0.77.0** bump
(#2025, merged) the `@earendil-works/pi-ai` model registry
(`models.generated.ts`) ships a full `claude-opus-4-7` catalog entry (plus
`claude-opus-4-8`, etc.). So `models.some(m => m.id === "claude-opus-4-7")` is
always true and the `models.push(...)` branch never executes.

Profiles already flipped to `claude-opus-4-8` (#2026) and Opus 4.8 appears
purely from the registry with no extension fallback — confirming the 4.7
fallback adds nothing.

## Changes

- `index.ts`: delete the `DEFAULT_OPUS_4_7` const and the
  `if (!models.some(...)) { models.push(...) }` guard.
- `UPSTREAM.md`: add a brief "Known divergences" note recording that
  `getAnthropicModels` returns the runtime registry verbatim with no hardcoded
  fallback, so a future porter won't re-introduce one.

`ProviderConfig`, `ModelRegistry`, and `AuthStorage` imports remain in use
(return type, `oauth` cast, registry construction) — no import removed.

## Verification

- `tsx --test anthropic-oauth/*.test.ts` → **47 pass, 0 fail**.
- `tsx --check anthropic-oauth/index.ts` → exit 0 (no type/syntax error from the
  deletion).
- Scope: only `index.ts` and `UPSTREAM.md` touched. `LICENSE-leohenon` /
  `LICENSE-griffinmartin` untouched; `model-config.ts`, `profiles.nix`, and the
  overlay untouched.