### PR TITLE
test(container): canonicalise t.TempDir() to fix Darwin /private symlink mismatch

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -85,7 +85,16 @@ func newBwrapManager(cfg Config) *Manager {
 func bwrapFixture(t *testing.T, cfg Config) (m *Manager, fakeHome string, cleanup func()) {
 	t.Helper()
 
-	fakeHome = t.TempDir()
+	// Canonicalise the tempdir so it matches the production code, which resolves
+	// home paths through filepath.EvalSymlinks before composing bind args. On
+	// Darwin t.TempDir() returns a /var/folders/... path that is a symlink into
+	// /private/var/folders/...; without this the bind-arg substring assertions
+	// (which see the /private form) never match. On Linux this is a no-op.
+	var err error
+	fakeHome, err = filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)
+	}
 
 	// Pre-create directories that BuildArgs expects unconditionally.
 	dirs := []string{

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -967,12 +967,23 @@ func TestStagePIAgentConfigDir_SkillsSymlink_SymlinkedToNix(t *testing.T) {
 	// When ~/.pi/agent/skills is a symlink to a Nix-store directory, the
 	// staging dir must contain a symlink named "skills" pointing to the resolved
 	// (real) Nix-store path, not to the intermediate home-manager symlink.
-	fakeHome := t.TempDir()
+	// Canonicalise the tempdirs so they match the production code, which resolves
+	// the skills symlink chain through filepath.EvalSymlinks. On Darwin
+	// t.TempDir() returns a /var/folders/... path that is a symlink into
+	// /private/var/folders/...; without this the readlink-target assertion (which
+	// sees the /private form) never matches. On Linux this is a no-op.
+	fakeHome, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)
+	}
 	t.Setenv("HOME", fakeHome)
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	// Simulate a Nix-store derivation directory acting as the real skills dir.
-	nixStorePath := t.TempDir()
+	nixStorePath, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(nixStorePath, "my-skill.md"), []byte("# skill"), 0o644); err != nil {
 		t.Fatalf("write skill file: %v", err)
 	}


### PR DESCRIPTION
Closes #2023

## Summary

On Darwin `t.TempDir()` returns a non-canonical path under `/var/folders/.../T/...`, which is a symlink into `/private/var/folders/...`. The production bwrap-argument and skills-staging code resolve home/skills paths through `filepath.EvalSymlinks` before composing bind args / symlink targets, so the emitted values use the `/private/...` form. Test assertions compared against the raw `/var/...` `t.TempDir()` value, so the substring / target lookups missed.

CI is green because Linux `t.TempDir()` returns `/tmp/...` with no symlink layer, so the canonicalisation never fires there.

This is a **test-only** fix — no production code changed. It mirrors the existing production `EvalSymlinks` asymmetry in `internal/container/bwrap.go` (ssh-key/known_hosts resolution) and `internal/container/pi_invocation.go` (skills symlink resolution).

## Fix

- **`internal/container/bwrap_test.go`** — `bwrapFixture` now canonicalises `fakeHome` via `filepath.EvalSymlinks(t.TempDir())` centrally, with a fail-fast `t.Fatalf` on error. Every fixture-derived `TestBwrapBuildArgs_*` inherits the fix in one place.
- **`internal/container/pi_invocation_test.go`** — `TestStagePIAgentConfigDir_SkillsSymlink_SymlinkedToNix` canonicalises `fakeHome` and `nixStorePath` inline with the same pattern.

### Scope enumeration

I audited every EvalSymlinks-resolved comparison in both files:

- All `TestBwrapBuildArgs_*` EvalSymlinks comparisons are rooted at `fakeHome` (ssh keys, known_hosts, AWS readonly-config) → covered centrally by the fixture fix, incl. the named `TestBwrapBuildArgs_AWSReadonlyConfigROBound`.
- Worktree / BareRoot / WorktreeGitDir binds use the raw `cfg` value on **both** sides (no production EvalSymlinks) → no fix needed.
- The `pi_invocation_test.go` `auth.json` symlink tests compare against `filepath.Join(home, ...)` where production builds the target from raw `home` (no EvalSymlinks) → no fix needed.
- The skills `oldTarget`/`newTarget` idempotency test already resolves via `EvalSymlinks` → already correct.
- The skills `skillsTarget` combined test asserts only "is a symlink" with no target comparison → no fix needed.

The only target-value comparison against a raw `t.TempDir()` for an EvalSymlinks-resolved path was `nixStorePath` in `..._SymlinkedToNix`, now fixed.

## Tests fixed

- `TestBwrapBuildArgs_AWSReadonlyConfigROBound` (and all other fixture-derived `TestBwrapBuildArgs_*`)
- `TestStagePIAgentConfigDir_SkillsSymlink_SymlinkedToNix`

## Verification

- **Linux (machine-verified on this host):** `go build ./...`, `go vet ./internal/container/`, and `go test ./...` from `modules/programs/prism/prism/` all pass. `EvalSymlinks(t.TempDir())` is a no-op on Linux (`/tmp/...` has no `/private` symlink), so no regression.
- **Darwin (`aarch64-darwin`) ACs verified by inspection, NOT executed** — this worker ran on a Linux host and cannot machine-verify the Darwin-green ACs. The canonicalisation directly mirrors the production `EvalSymlinks` behaviour, so the `/private` form on both sides will match. Final Darwin signal relies on the reviewer + CI + the maintainer's Mac.

## Edge case

If `filepath.EvalSymlinks` fails on the tempdir for any reason, the test fails fast with a clear `t.Fatalf("EvalSymlinks(t.TempDir()): %v", err)` rather than producing a confusing downstream assertion mismatch.