### PR TITLE
fix(prism): GITHUB_TOKEN file fallback + zsh self-heal for Darwin sops decrypt race (#2029)

### DIFF
--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -6,6 +6,19 @@
 }:
 with config.theme;
 let
+  username = config.nx.username;
+  # Absolute path to the sops-decrypted GitHub token secret file. Threaded into
+  # config.json (github_token_path) so prism's credentialEnvVars can read the
+  # token directly when the inherited GITHUB_TOKEN env var is empty — the Darwin
+  # sops launchd decrypt race freezes an empty value into the tmux server env
+  # (#2029). Platform split mirrors modules/programs/git.nix:
+  #   Linux  — system sops secret.
+  #   Darwin — home-manager sops secret.
+  githubTokenPath =
+    if pkgs.stdenv.isDarwin then
+      config.home-manager.users.${username}.sops.secrets.github_token.path
+    else
+      config.sops.secrets.github_token.path;
   gitCfg = config.home-manager.users.${config.nx.username}.programs.git;
   # Extract the first includes entry that has user.name and user.email set.
   # This mirrors the values defined in modules/programs/git.nix.
@@ -62,6 +75,10 @@ let
     bwrap_concurrency_cap = config.nx.programs.prism.bwrapConcurrencyCap;
     sandbox_exec_concurrency_cap = config.nx.programs.prism.sandboxExecConcurrencyCap;
     pi_extension_dir = config.nx.programs.prism.piExtensionDir;
+    # github_token_path: absolute path to the sops-decrypted GitHub token file.
+    # Last-resort fallback read by credentialEnvVars when the inherited
+    # GITHUB_TOKEN is empty (Darwin sops decrypt race, #2029).
+    github_token_path = githubTokenPath;
   };
 in
 {

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -288,22 +288,23 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		harnessSessionID = *status.HarnessSessionID
 	}
 	ctrCfg := container.Config{
-		SessionName:       sessionName,
-		Worktree:          worktree,
-		BareRoot:          bareRoot,
-		WorktreeGitDir:    worktreeGitDir,
-		AllocatedPort:     port,
-		AgentRole:         agentRole,
-		GitUserName:       cfg.GitUserName,
-		GitUserEmail:      cfg.GitUserEmail,
-		SshAccessKeyName:  cfg.SshAccessKeyName,
-		SshSigningKeyName: cfg.SshSigningKeyName,
+		SessionName:         sessionName,
+		Worktree:            worktree,
+		BareRoot:            bareRoot,
+		WorktreeGitDir:      worktreeGitDir,
+		AllocatedPort:       port,
+		AgentRole:           agentRole,
+		GitUserName:         cfg.GitUserName,
+		GitUserEmail:        cfg.GitUserEmail,
+		SshAccessKeyName:    cfg.SshAccessKeyName,
+		SshSigningKeyName:   cfg.SshSigningKeyName,
+		GitHubTokenPath:     cfg.GitHubTokenPath,
 		HostAPISockPath:     hostAPISockPath,
 		HarnessPipeSockPath: harnessPipeSockPath,
 		RuntimeEnv:          runtimeEnv,
-		AgentEnvVars:      agentEnvVars,
-		Harness:           harnessName,
-		HarnessSessionID:  harnessSessionID,
+		AgentEnvVars:        agentEnvVars,
+		Harness:             harnessName,
+		HarnessSessionID:    harnessSessionID,
 	}
 
 	// PI-harness: populate PI-specific config fields from the active profile slot.

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -138,6 +138,7 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		SshAccessKeyName:  cfg.SshAccessKeyName,
 		SshSigningKeyName: cfg.SshSigningKeyName,
 		SshBin:            cfg.SshBin,
+		GitHubTokenPath:   cfg.GitHubTokenPath,
 		HostAPISockPath:   hostAPISockPath,
 		InstanceID:        instanceID,
 		RuntimeEnv:        sandboxRuntimeEnv,
@@ -210,11 +211,11 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 			// Strip any existing HOME and XDG vars from the filtered env —
 			// we replace them all with staging-HOME-relative paths below.
 			xdgKeys := map[string]bool{
-				"HOME":             true,
-				"XDG_CACHE_HOME":   true,
-				"XDG_DATA_HOME":    true,
-				"XDG_CONFIG_HOME":  true,
-				"XDG_STATE_HOME":   true,
+				"HOME":              true,
+				"XDG_CACHE_HOME":    true,
+				"XDG_DATA_HOME":     true,
+				"XDG_CONFIG_HOME":   true,
+				"XDG_STATE_HOME":    true,
 				"CFFIXED_USER_HOME": true,
 			}
 			filtered := make([]string, 0, len(env))

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -93,6 +93,13 @@ type Config struct {
 	// needing the system-network sandbox rules (dafsaData.bin etc.).
 	// When empty, GIT_SSH_COMMAND falls back to bare "ssh" (PATH lookup).
 	SshBin string `json:"ssh_bin"`
+	// GitHubTokenPath is the absolute path to the sops-decrypted GitHub token
+	// secret file on the host (e.g. ~/.config/sops-nix/secrets/github_token on
+	// Darwin). Threaded into container.Config so credentialEnvVars can read the
+	// token directly when the inherited GITHUB_TOKEN env var is empty — the
+	// Darwin sops launchd decrypt race freezes an empty value into the tmux
+	// server env (#2029). When empty, the file fallback is skipped.
+	GitHubTokenPath string `json:"github_token_path"`
 
 	// Restore behaviour.
 	// RestoreStaggerDelayMs is the delay in milliseconds inserted between
@@ -168,6 +175,7 @@ type parsedConfig struct {
 	SshAccessKeyName               string             `json:"ssh_access_key_name"`
 	SshSigningKeyName              string             `json:"ssh_signing_key_name"`
 	SshBin                         string             `json:"ssh_bin"`
+	GitHubTokenPath                string             `json:"github_token_path"`
 	PIExtensionDir                 string             `json:"pi_extension_dir"`
 	RestoreStaggerDelayMs          *int               `json:"restore_stagger_delay_ms"`
 	SidecarCircuitBreakerThreshold *int               `json:"sidecar_circuit_breaker_threshold"`
@@ -319,6 +327,9 @@ func load() Config {
 	}
 	if parsed.SshBin != "" {
 		cfg.SshBin = parsed.SshBin
+	}
+	if parsed.GitHubTokenPath != "" {
+		cfg.GitHubTokenPath = parsed.GitHubTokenPath
 	}
 	if parsed.PIExtensionDir != "" {
 		cfg.PIExtensionDir = parsed.PIExtensionDir

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -249,6 +249,15 @@ type Config struct {
 	// requires system-network sandbox rules). When empty, falls back to "ssh".
 	SshBin string
 
+	// GitHubTokenPath is the absolute path to the sops-decrypted GitHub token
+	// secret file on the host (e.g. ~/.config/sops-nix/secrets/github_token on
+	// Darwin). Used as a last-resort fallback by credentialEnvVars when neither
+	// the role-specific PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE> var nor the inherited
+	// GITHUB_TOKEN yields a non-empty value — this rescues agents from a Darwin
+	// sops launchd decrypt race that freezes an empty GITHUB_TOKEN into the tmux
+	// server env (#2029). When empty, the file fallback is skipped.
+	GitHubTokenPath string
+
 	// InitialPrompt is the initial prompt to deliver to the agent at startup.
 	// When non-empty, it is appended to the agent command as
 	// --agent <AgentRole> --prompt <text> so that the agent starts the session
@@ -358,7 +367,7 @@ func containerName(sessionName string) string {
 	return NameForSession(sessionName)
 }
 
-	// Manager manages the lifecycle of a single agent session sandbox.
+// Manager manages the lifecycle of a single agent session sandbox.
 type Manager struct {
 	cfg            Config
 	name           string
@@ -819,4 +828,3 @@ func (m *Manager) prepareVolumeDirs(perSessionState bool) error {
 
 	return nil
 }
-

--- a/modules/programs/prism/prism/internal/container/credentials.go
+++ b/modules/programs/prism/prism/internal/container/credentials.go
@@ -145,7 +145,6 @@ func (m *Manager) CredentialEnvVars() []string {
 	return m.credentialEnvVars()
 }
 
-
 // credentialEnvVars returns the environment variable assignments to inject into
 // the container based on the agent role and current host environment.
 // Only vars that are set on the host are forwarded — unset vars are skipped.
@@ -160,7 +159,11 @@ func (m *Manager) CredentialEnvVars() []string {
 //	PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER      — thankyou-payroll + worker
 //
 // Falls back to host GITHUB_TOKEN if the specific token is not set
-// (supports host-mode, --host-mode spawns, and migration period).
+// (supports host-mode, --host-mode spawns, and migration period). When that
+// is also empty, falls back to reading the sops secret file at
+// m.cfg.GitHubTokenPath directly (rescues the Darwin sops decrypt race that
+// freezes an empty GITHUB_TOKEN into the tmux server env, #2029). Precedence:
+// PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE> > inherited GITHUB_TOKEN > file fallback.
 func (m *Manager) credentialEnvVars() []string {
 	var vars []string
 
@@ -210,6 +213,25 @@ func (m *Manager) credentialEnvVars() []string {
 	// Fallback: use host GITHUB_TOKEN (supports --host-mode and migration period).
 	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
 		vars = append(vars, "GITHUB_TOKEN="+tok)
+		return vars
+	}
+
+	// Last-resort fallback: read the sops secret file directly. On Darwin a
+	// darwin-rebuild switch tears down and re-bootstraps the sops-nix launchd
+	// agent, which re-decrypts asynchronously. A shell that sources
+	// hm-session-vars.sh during that window freezes GITHUB_TOKEN="" (empty, not
+	// unset) into the sticky tmux server env, so the inherited value above is
+	// empty. Reading the file directly makes the agent independent of a
+	// correctly populated inherited environment (#2029). A missing or empty
+	// file is treated as "no token" — we never inject an empty GITHUB_TOKEN=.
+	// The contents are added only to the returned env slice; they are never
+	// logged.
+	if m.cfg.GitHubTokenPath != "" {
+		if data, err := os.ReadFile(m.cfg.GitHubTokenPath); err == nil {
+			if tok := strings.TrimSpace(string(data)); tok != "" {
+				vars = append(vars, "GITHUB_TOKEN="+tok)
+			}
+		}
 	}
 
 	// Note: GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL, GIT_COMMITTER_NAME, and

--- a/modules/programs/prism/prism/internal/container/credentials_token_fallback_test.go
+++ b/modules/programs/prism/prism/internal/container/credentials_token_fallback_test.go
@@ -1,0 +1,195 @@
+package container_test
+
+// credentials_token_fallback_test.go — unit tests for the GITHUB_TOKEN file
+// fallback added in #2029.
+//
+// On Darwin a darwin-rebuild switch tears down and re-bootstraps the sops-nix
+// launchd agent, which re-decrypts the GitHub token asynchronously. A shell
+// that sources hm-session-vars.sh during that window freezes GITHUB_TOKEN=""
+// (empty, not unset) into the sticky tmux server env. credentialEnvVars now
+// reads the sops secret file directly (cfg.GitHubTokenPath) as a last-resort
+// fallback so agents get a working token regardless of the inherited env state.
+//
+// Precedence asserted here:
+//   PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE> > inherited GITHUB_TOKEN > file fallback
+//
+// These are pure unit tests: they set env vars with t.Setenv, point the config
+// at a temp file with t.TempDir(), and assert the returned env slice. No
+// sidecar harness is constructed (per AGENTS.md #1608, the sidecar isolation
+// helper is only needed for tests that build a sidecar.Sidecar).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// clearTokenEnv blanks every env var credentialEnvVars consults so each test
+// starts from a known-empty baseline. t.Setenv restores the prior value at
+// test end.
+func clearTokenEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"GITHUB_TOKEN",
+		"PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER",
+		"PRISM_GITHUB_TOKEN_PRISMATIC_KOI_COORDINATOR",
+		"PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_WORKER",
+		"PRISM_GITHUB_TOKEN_THANKYOU_PAYROLL_COORDINATOR",
+		"ANTHROPIC_API_KEY",
+		"OPENROUTER_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// findGitHubToken returns the value of the GITHUB_TOKEN=… entry in vars, and
+// whether such an entry was present at all. A present-but-empty entry
+// (GITHUB_TOKEN=) returns ("", true) so tests can assert it is never produced.
+func findGitHubToken(vars []string) (string, bool) {
+	for _, v := range vars {
+		if len(v) >= len("GITHUB_TOKEN=") && v[:len("GITHUB_TOKEN=")] == "GITHUB_TOKEN=" {
+			return v[len("GITHUB_TOKEN="):], true
+		}
+	}
+	return "", false
+}
+
+// writeTokenFile writes contents to a fresh temp file and returns its path.
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "github_token")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writeTokenFile: %v", err)
+	}
+	return path
+}
+
+// TestCredentialEnvVars_FileFallback_EmptyEnv covers the primary #2029 case:
+// GITHUB_TOKEN is empty in the process env but the sops secret file exists and
+// is non-empty, so the file contents (trimmed) are injected.
+func TestCredentialEnvVars_FileFallback_EmptyEnv(t *testing.T) {
+	clearTokenEnv(t)
+	path := writeTokenFile(t, "ghp_fromfile\n")
+
+	m := container.New(container.Config{GitHubTokenPath: path})
+	tok, ok := findGitHubToken(m.CredentialEnvVars())
+	if !ok {
+		t.Fatal("expected GITHUB_TOKEN to be injected from the file fallback, got none")
+	}
+	if tok != "ghp_fromfile" {
+		t.Errorf("got GITHUB_TOKEN=%q, want %q (trailing newline must be stripped)", tok, "ghp_fromfile")
+	}
+}
+
+// TestCredentialEnvVars_TrailingNewlineStripped asserts the byte-for-byte value
+// matches what gh/git expect — a trailing newline (and surrounding whitespace)
+// is stripped before injection.
+func TestCredentialEnvVars_TrailingNewlineStripped(t *testing.T) {
+	clearTokenEnv(t)
+	path := writeTokenFile(t, "  ghp_padded  \n")
+
+	m := container.New(container.Config{GitHubTokenPath: path})
+	tok, ok := findGitHubToken(m.CredentialEnvVars())
+	if !ok {
+		t.Fatal("expected GITHUB_TOKEN to be injected, got none")
+	}
+	if tok != "ghp_padded" {
+		t.Errorf("got GITHUB_TOKEN=%q, want %q", tok, "ghp_padded")
+	}
+}
+
+// TestCredentialEnvVars_InheritedTokenWins asserts that a non-empty inherited
+// GITHUB_TOKEN is used as-is and the file is NOT read (no happy-path change).
+func TestCredentialEnvVars_InheritedTokenWins(t *testing.T) {
+	clearTokenEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_fromenv")
+	// Point the config at a file with a DIFFERENT value; it must be ignored.
+	path := writeTokenFile(t, "ghp_fromfile\n")
+
+	m := container.New(container.Config{GitHubTokenPath: path})
+	tok, ok := findGitHubToken(m.CredentialEnvVars())
+	if !ok {
+		t.Fatal("expected GITHUB_TOKEN to be injected from the inherited env, got none")
+	}
+	if tok != "ghp_fromenv" {
+		t.Errorf("got GITHUB_TOKEN=%q, want %q (inherited env must win over the file)", tok, "ghp_fromenv")
+	}
+}
+
+// TestCredentialEnvVars_RoleSpecificWins asserts the role-specific PAT takes
+// precedence over both the inherited GITHUB_TOKEN and the file fallback
+// (existing 4-PAT behaviour unchanged). A real bare repo is created so the
+// account ("prismatic-koi") is derived from the origin remote URL.
+func TestCredentialEnvVars_RoleSpecificWins(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	clearTokenEnv(t)
+	t.Setenv("GITHUB_TOKEN", "ghp_fromenv")
+	t.Setenv("PRISM_GITHUB_TOKEN_PRISMATIC_KOI_WORKER", "ghp_role_specific")
+	path := writeTokenFile(t, "ghp_fromfile\n")
+
+	bareRoot := t.TempDir()
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if out, err := exec.Command("git", "init", "--bare", bareDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "--git-dir", bareDir, "remote", "add", "origin",
+		"git@github.com:prismatic-koi/nixos-config.git").CombinedOutput(); err != nil {
+		t.Fatalf("git remote add origin: %v\n%s", err, out)
+	}
+	container.ClearGithubAccountCacheForTest()
+
+	m := container.New(container.Config{
+		BareRoot:        bareRoot,
+		AgentRole:       "worker",
+		GitHubTokenPath: path,
+	})
+	tok, ok := findGitHubToken(m.CredentialEnvVars())
+	if !ok {
+		t.Fatal("expected GITHUB_TOKEN to be injected, got none")
+	}
+	if tok != "ghp_role_specific" {
+		t.Errorf("got GITHUB_TOKEN=%q, want %q (role-specific PAT must win)", tok, "ghp_role_specific")
+	}
+}
+
+// TestCredentialEnvVars_MissingFile_NoInjection covers the negative edge case:
+// the inherited GITHUB_TOKEN is empty AND the secret file is missing, so no
+// GITHUB_TOKEN= entry is injected at all (an empty var is never produced).
+func TestCredentialEnvVars_MissingFile_NoInjection(t *testing.T) {
+	clearTokenEnv(t)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	m := container.New(container.Config{GitHubTokenPath: missing})
+	if tok, ok := findGitHubToken(m.CredentialEnvVars()); ok {
+		t.Errorf("expected no GITHUB_TOKEN entry for a missing file, got GITHUB_TOKEN=%q", tok)
+	}
+}
+
+// TestCredentialEnvVars_EmptyFile_NoInjection covers the edge case where the
+// file exists but is empty (or whitespace-only): no GITHUB_TOKEN= is injected.
+func TestCredentialEnvVars_EmptyFile_NoInjection(t *testing.T) {
+	clearTokenEnv(t)
+	path := writeTokenFile(t, "\n  \n")
+
+	m := container.New(container.Config{GitHubTokenPath: path})
+	if tok, ok := findGitHubToken(m.CredentialEnvVars()); ok {
+		t.Errorf("expected no GITHUB_TOKEN entry for an empty/whitespace file, got GITHUB_TOKEN=%q", tok)
+	}
+}
+
+// TestCredentialEnvVars_NoPath_NoInjection asserts that when no path is
+// configured and the env is empty, no GITHUB_TOKEN= is produced (matches the
+// pre-#2029 behaviour for non-Darwin / unconfigured hosts).
+func TestCredentialEnvVars_NoPath_NoInjection(t *testing.T) {
+	clearTokenEnv(t)
+
+	m := container.New(container.Config{})
+	if tok, ok := findGitHubToken(m.CredentialEnvVars()); ok {
+		t.Errorf("expected no GITHUB_TOKEN entry with no path and empty env, got GITHUB_TOKEN=%q", tok)
+	}
+}

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -172,8 +172,28 @@ in
                   }
                   precmd_functions+=(_prism_launch_precmd)
                 '';
+
+                # Darwin self-heal for the sops GITHUB_TOKEN decrypt race
+                # (#2029). hm-session-vars.sh exports
+                # GITHUB_TOKEN="$(cat <secret>)" once per shell. A
+                # darwin-rebuild switch tears down and re-bootstraps the
+                # sops-nix launchd agent, which re-decrypts asynchronously; a
+                # shell sourcing hm-session-vars.sh during that window freezes
+                # GITHUB_TOKEN="" (empty, not unset). This guard re-reads the
+                # secret file when the var is empty and the file is readable,
+                # bypassing the source-once cache. It uses the SAME sops secret
+                # path as the home.sessionVariables in modules/programs/git.nix
+                # so the two stay in lockstep. Linux is unaffected: there the
+                # var is set via environment.sessionVariables (normally
+                # non-empty), so the guard is a harmless no-op.
+                darwinInit = lib.optionalString isDarwin ''
+                  if [ -z "$GITHUB_TOKEN" ] && [ -r "${hmConfig.sops.secrets.github_token.path}" ]; then
+                    export GITHUB_TOKEN="$(cat ${hmConfig.sops.secrets.github_token.path})"
+                    export GITHUB_PACKAGES_TOKEN="$GITHUB_TOKEN"
+                  fi
+                '';
               in
-              lib.mkOrder 1000 commonInit;
+              lib.mkOrder 1000 (commonInit + darwinInit);
           };
 
           # NixOS-specific: Impermanence support


### PR DESCRIPTION
Closes #2029

## Problem

On Darwin, `GITHUB_TOKEN` intermittently becomes an **empty string** in
long-lived shells / the tmux server / prism agent sessions, breaking every
`gh` and `git push` an agent attempts. A `darwin-rebuild switch` does
`launchctl bootout` + `bootstrap` of the sops-nix launchd agent, which
re-decrypts asynchronously and prunes the prior generation (`keepGenerations:
1`). A shell sourcing `hm-session-vars.sh` during that window exports
`GITHUB_TOKEN=""` (empty, not unset). The source-once guard plus the sticky
tmux **server** env make it persist past a session restart, and
`credentials.go` silently dropped an empty token — so agents got no
`GITHUB_TOKEN` injected at all.

## Fix (A + B)

### Part A — Go file fallback (primary, unit-tested)

`credentialEnvVars()` gains a third tier. When neither the role-specific
`PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE>` var nor the inherited `GITHUB_TOKEN`
yields a non-empty value, it reads the sops secret file directly and uses its
trimmed contents. Precedence is preserved:

```
PRISM_GITHUB_TOKEN_<ACCOUNT>_<ROLE>  >  inherited GITHUB_TOKEN  >  file fallback
```

- Trailing whitespace/newline stripped (`strings.TrimSpace`).
- Missing/empty file → inject nothing (never an empty `GITHUB_TOKEN=`).
- Contents are added only to the sandbox env slice — never logged.

The secret path is carried by a new `github_token_path` config field, threaded
the same way as the existing `ssh_bin` field: `prism-tui.nix` → `config.json`
→ `config.Config` → `container.Config` → `credentialEnvVars`. `prism-tui.nix`
sources the path from the **same** sops secret `git.nix` references, with a
Linux/Darwin platform split (`/run/secrets/github_token` on Linux,
`~/.config/sops-nix/secrets/github_token` on Darwin).

### Part B — zsh self-heal (Darwin-gated, verified by inspection)

A Darwin-only `initContent` guard re-reads the secret file when `GITHUB_TOKEN`
is empty and the file is readable, bypassing the source-once cache for new
shells/panes:

```sh
if [ -z "$GITHUB_TOKEN" ] && [ -r "<secret-path>" ]; then
  export GITHUB_TOKEN="$(cat <secret-path>)"
  export GITHUB_PACKAGES_TOKEN="$GITHUB_TOKEN"
fi
```

It uses the same sops path as `git.nix`'s `home.sessionVariables` so the two
stay in lockstep. Linux is unaffected — there the var is set via
`environment.sessionVariables` (normally non-empty), so the guard is a harmless
no-op.

## Verification

- `go build ./...` and `go test ./...` from `modules/programs/prism/prism/`
  pass on Linux. New unit tests in `credentials_token_fallback_test.go` cover:
  empty-env file fallback, trailing-newline strip, inherited-wins,
  role-specific-wins (real bare repo), and missing-file / empty-file / no-path
  negatives. Pure unit tests (`t.Setenv` + `t.TempDir`); no sidecar harness.
- `nix build .#prism` succeeds.
- `nix eval` confirms the Darwin config emits the self-heal guard with the
  correct path (`/Users/.../​.config/sops-nix/secrets/github_token`) and
  `github_token_path` in `config.json`; the Linux config emits **no** guard
  and resolves `github_token_path` to `/run/secrets/github_token`.
- The end-to-end Darwin symptom (launchd decrypt race) only reproduces on
  macOS — **Part B was verified by inspection** (this worker ran on Linux),
  while **Part A is unit-tested on the CI Linux runner**.

## Out of scope (per #2029)

- Closing the launchd decrypt race itself (ordering the sops decrypt strictly
  before any login shell on Darwin). More invasive, Darwin-specific, can be a
  follow-up if A+B prove insufficient.
- The Linux path — already mitigated by the `/bin/sh` pinning in `bwrap.go`.