### PR TITLE
prism: inject role system-prompt from PI extension (additive, PR1 of #2031)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -58,6 +58,12 @@ import {
   // Mid-tool heartbeat (issue #1761)
   startToolHeartbeat,
   TOOL_HEARTBEAT_INTERVAL_MS,
+  // Role system-prompt injection (issue #2032)
+  ROLE_PROMPT_INJECT_ENV,
+  roledPromptInjectionEnabled,
+  prismAgentRolePath,
+  readRolePrompt,
+  composeRoleSystemPrompt,
 } from "./prism.ts"
 import prismExtension from "./prism.ts"
 
@@ -3649,5 +3655,153 @@ describe("#1787: tool_call/tool_result emit parentMessageId from message_start",
         reject(new Error("timeout"))
       }, 1000).unref()
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Role system-prompt injection (issue #2032)
+// ---------------------------------------------------------------------------
+
+describe("roledPromptInjectionEnabled", () => {
+  it("defaults OFF when the env var is unset (additive PR1 — no double-inject)", () => {
+    assert.equal(roledPromptInjectionEnabled({}), false)
+  })
+
+  it("is OFF when the env var is empty", () => {
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "" }), false)
+  })
+
+  it("is OFF for explicit disable values 0 / false", () => {
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "0" }), false)
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "false" }), false)
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "False" }), false)
+  })
+
+  it("is ON for any other non-empty value", () => {
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "1" }), true)
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "true" }), true)
+    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "yes" }), true)
+  })
+})
+
+describe("prismAgentRolePath — role→file resolution", () => {
+  it("returns '' for an empty role (no-op short-circuit)", () => {
+    assert.equal(prismAgentRolePath("", { HOME: "/home/u" }), "")
+  })
+
+  it("respects XDG_CONFIG_HOME when set", () => {
+    assert.equal(
+      prismAgentRolePath("worker", { XDG_CONFIG_HOME: "/xdg", HOME: "/home/u" }),
+      "/xdg/prism/agents/worker.md",
+    )
+  })
+
+  it("falls back to $HOME/.config when XDG_CONFIG_HOME is unset", () => {
+    assert.equal(
+      prismAgentRolePath("coordinator", { HOME: "/home/u" }),
+      "/home/u/.config/prism/agents/coordinator.md",
+    )
+  })
+
+  it("falls back to $HOME/.config when XDG_CONFIG_HOME is empty", () => {
+    assert.equal(
+      prismAgentRolePath("review-goal", { XDG_CONFIG_HOME: "", HOME: "/home/u" }),
+      "/home/u/.config/prism/agents/review-goal.md",
+    )
+  })
+
+  it("maps each canonical role to its matching <role>.md filename", () => {
+    const roles = [
+      "coordinator",
+      "worker",
+      "review-goal",
+      "review-code",
+      "review-security",
+      "review-qa",
+      "review-context",
+    ]
+    for (const role of roles) {
+      assert.equal(
+        prismAgentRolePath(role, { XDG_CONFIG_HOME: "/c", HOME: "/h" }),
+        `/c/prism/agents/${role}.md`,
+      )
+    }
+  })
+})
+
+describe("readRolePrompt — file read + missing-file no-op", () => {
+  it("reads the role file contents when present", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-2032-"))
+    try {
+      const agentsDir = path.join(dir, "prism", "agents")
+      fs.mkdirSync(agentsDir, { recursive: true })
+      fs.writeFileSync(path.join(agentsDir, "worker.md"), "ROLE: worker prompt body")
+      assert.equal(
+        readRolePrompt("worker", { XDG_CONFIG_HOME: dir }),
+        "ROLE: worker prompt body",
+      )
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns undefined when the role file does not exist (graceful no-op)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-2032-"))
+    try {
+      assert.equal(readRolePrompt("worker", { XDG_CONFIG_HOME: dir }), undefined)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns undefined when the role is empty", () => {
+    assert.equal(readRolePrompt("", { XDG_CONFIG_HOME: "/c" }), undefined)
+  })
+
+  it("returns undefined for an empty/whitespace-only role file", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-2032-"))
+    try {
+      const agentsDir = path.join(dir, "prism", "agents")
+      fs.mkdirSync(agentsDir, { recursive: true })
+      fs.writeFileSync(path.join(agentsDir, "worker.md"), "   \n\t\n")
+      assert.equal(readRolePrompt("worker", { XDG_CONFIG_HOME: dir }), undefined)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("composeRoleSystemPrompt — APPEND semantics preserved", () => {
+  it("appends the role prompt after the base, preserving the default", () => {
+    assert.equal(
+      composeRoleSystemPrompt("BASE PROMPT", "ROLE PROMPT"),
+      "BASE PROMPT\n\nROLE PROMPT",
+    )
+  })
+
+  it("normalises trailing whitespace on the base to exactly one blank line", () => {
+    assert.equal(
+      composeRoleSystemPrompt("BASE PROMPT\n\n  \n", "ROLE PROMPT"),
+      "BASE PROMPT\n\nROLE PROMPT",
+    )
+  })
+
+  it("returns the role prompt alone when the base is empty", () => {
+    assert.equal(composeRoleSystemPrompt("", "ROLE PROMPT"), "ROLE PROMPT")
+  })
+
+  it("returns undefined (no override → keep base) when there is no role prompt", () => {
+    assert.equal(composeRoleSystemPrompt("BASE", undefined), undefined)
+    assert.equal(composeRoleSystemPrompt("BASE", ""), undefined)
+    assert.equal(composeRoleSystemPrompt("BASE", "   \n  "), undefined)
+  })
+
+  it("is idempotent across turns: recomposing from the same base does not accumulate", () => {
+    const base = "BASE PROMPT"
+    const role = "ROLE PROMPT"
+    const turn1 = composeRoleSystemPrompt(base, role)
+    const turn2 = composeRoleSystemPrompt(base, role)
+    assert.equal(turn1, turn2)
+    assert.equal(turn1, "BASE PROMPT\n\nROLE PROMPT")
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -64,6 +64,8 @@ import {
   prismAgentRolePath,
   readRolePrompt,
   composeRoleSystemPrompt,
+  resolveRolePromptForTurn,
+  type RolePromptCache,
 } from "./prism.ts"
 import prismExtension from "./prism.ts"
 
@@ -3803,5 +3805,118 @@ describe("composeRoleSystemPrompt — APPEND semantics preserved", () => {
     const turn2 = composeRoleSystemPrompt(base, role)
     assert.equal(turn1, turn2)
     assert.equal(turn1, "BASE PROMPT\n\nROLE PROMPT")
+  })
+})
+
+describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", () => {
+  const newCache = (): RolePromptCache => ({ resolved: false, cached: undefined })
+
+  it("returns undefined and does NOT latch when the flag is disabled", () => {
+    const cache = newCache()
+    const out = resolveRolePromptForTurn(
+      { enabled: false, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      cache,
+      () => "ROLE",
+    )
+    assert.equal(out, undefined)
+    assert.equal(cache.resolved, false) // not latched — flag off
+  })
+
+  it("returns undefined and does NOT latch when the handshake is incomplete", () => {
+    const cache = newCache()
+    const out = resolveRolePromptForTurn(
+      { enabled: true, handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
+      cache,
+      () => "ROLE",
+    )
+    assert.equal(out, undefined)
+    assert.equal(cache.resolved, false) // critical: must NOT latch pre-handshake
+  })
+
+  it("injects once the handshake completes and the role is known", () => {
+    const cache = newCache()
+    const out = resolveRolePromptForTurn(
+      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      cache,
+      (role) => (role === "worker" ? "WORKER ROLE" : undefined),
+    )
+    assert.equal(out, "BASE\n\nWORKER ROLE")
+    assert.equal(cache.resolved, true)
+    assert.equal(cache.cached, "WORKER ROLE")
+  })
+
+  it("first turn before handshake must not poison the cache (the review-code race)", () => {
+    const cache = newCache()
+    let reads = 0
+    const readRole = (role: string): string | undefined => {
+      reads++
+      return role === "worker" ? "WORKER ROLE" : undefined
+    }
+
+    // Turn 1 fires BEFORE hello_ack: handshake incomplete, sessionRole still "".
+    const turn1 = resolveRolePromptForTurn(
+      { enabled: true, handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
+      cache,
+      readRole,
+    )
+    assert.equal(turn1, undefined)
+    assert.equal(cache.resolved, false)
+    assert.equal(reads, 0) // no read attempted pre-handshake
+
+    // Turn 2 fires AFTER hello_ack populated sessionRole="worker".
+    const turn2 = resolveRolePromptForTurn(
+      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      cache,
+      readRole,
+    )
+    assert.equal(turn2, "BASE\n\nWORKER ROLE") // role IS injected, not poisoned
+    assert.equal(reads, 1)
+  })
+
+  it("memoises the file read across turns (disk touched at most once)", () => {
+    const cache = newCache()
+    let reads = 0
+    const readRole = (): string | undefined => {
+      reads++
+      return "ROLE"
+    }
+    const args = {
+      enabled: true,
+      handshakeComplete: true,
+      sessionRole: "worker",
+      baseSystemPrompt: "BASE",
+    }
+    const t1 = resolveRolePromptForTurn(args, cache, readRole)
+    const t2 = resolveRolePromptForTurn(args, cache, readRole)
+    const t3 = resolveRolePromptForTurn(args, cache, readRole)
+    assert.equal(reads, 1) // read once, reused thereafter
+    assert.equal(t1, "BASE\n\nROLE")
+    assert.equal(t1, t2) // idempotent across turns
+    assert.equal(t2, t3)
+  })
+
+  it("missing role file resolves to a no-op (undefined) and stays latched", () => {
+    const cache = newCache()
+    let reads = 0
+    const out = resolveRolePromptForTurn(
+      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      cache,
+      () => {
+        reads++
+        return undefined
+      },
+    )
+    assert.equal(out, undefined)
+    assert.equal(cache.resolved, true) // latched after handshake even for no-op
+    // A second turn does not re-read — the no-op is memoised.
+    resolveRolePromptForTurn(
+      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      cache,
+      () => {
+        reads++
+        return undefined
+      },
+    )
+    assert.equal(reads, 1)
   })
 })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1650,6 +1650,52 @@ export function composeRoleSystemPrompt(
   return base.replace(/\s+$/, "") + "\n\n" + rolePrompt
 }
 
+/** Mutable cache the before_agent_start handler threads through
+ * resolveRolePromptForTurn so the role file is read at most once per session. */
+export interface RolePromptCache {
+  /** true once the role file has been resolved (read or no-op). */
+  resolved: boolean
+  /** the role file contents, or undefined (no file / empty / read error). */
+  cached: string | undefined
+}
+
+/**
+ * Pure decision for one before_agent_start turn. Encapsulates the gating and
+ * latch logic so it is unit-testable independently of the PI runtime:
+ *
+ *   - Injection is gated on BOTH `enabled` (PRISM_INJECT_ROLE_PROMPT) AND
+ *     `handshakeComplete`. The handshake gate is load-bearing: `sessionRole`
+ *     is only populated by the async hello_ack handler, so resolving the
+ *     cache before the handshake would latch the session to "no role"
+ *     permanently. Pre-handshake turns return undefined WITHOUT latching.
+ *   - Once resolved, the file read is memoised (cache.resolved) so disk is
+ *     touched at most once per session.
+ *   - The result is recomposed from `baseSystemPrompt` every turn, so it is
+ *     idempotent and never accumulates the role prompt across turns.
+ *
+ * Mutates `cache` in place (sets resolved/cached on first post-handshake call)
+ * and returns the systemPrompt override to send, or undefined to keep the base.
+ */
+export function resolveRolePromptForTurn(
+  opts: {
+    enabled: boolean
+    handshakeComplete: boolean
+    sessionRole: string
+    baseSystemPrompt: string
+  },
+  cache: RolePromptCache,
+  readRole: (role: string) => string | undefined = readRolePrompt,
+): string | undefined {
+  if (!opts.enabled || !opts.handshakeComplete) {
+    return undefined
+  }
+  if (!cache.resolved) {
+    cache.cached = readRole(opts.sessionRole)
+    cache.resolved = true
+  }
+  return composeRoleSystemPrompt(opts.baseSystemPrompt, cache.cached)
+}
+
 // ---------------------------------------------------------------------------
 // Connection guard helper (exported for testing).
 // ---------------------------------------------------------------------------
@@ -1725,11 +1771,9 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
   // Role system-prompt injection cache (issue #2032). The role file is read
   // once per session (load-once), then recomposed against event.systemPrompt
-  // on every before_agent_start. roleSystemPromptResolved guards the read so
-  // disk is touched at most once; roleSystemPromptCached holds the file
-  // contents or undefined (no role file / empty / read error).
-  let roleSystemPromptResolved = false
-  let roleSystemPromptCached: string | undefined
+  // on every before_agent_start. The cache is only latched once the handshake
+  // has completed (sessionRole known) — see resolveRolePromptForTurn.
+  const roleSystemPromptCache: RolePromptCache = { resolved: false, cached: undefined }
   let sessionBranch = extractBranch(process.env.PRISM_SESSION_NAME ?? "")
   let sessionIsolationMode = ""
 
@@ -2143,20 +2187,23 @@ export default function prismExtension(pi: ExtensionAPI): void {
     // not double-inject with the still-present APPEND_SYSTEM.md, whose content
     // is already baked into event.systemPrompt. See the helpers above for the
     // replace-vs-append and per-turn-fire analysis.
-    if (roledPromptInjectionEnabled()) {
-      // Memoise the file read across turns: before_agent_start fires per turn,
-      // but the role file is load-once. roleSystemPromptCached is undefined
-      // until first resolved (whether to a string or a sentinel no-op).
-      if (!roleSystemPromptResolved) {
-        roleSystemPromptCached = readRolePrompt(sessionRole)
-        roleSystemPromptResolved = true
-      }
-      // Recompose from event.systemPrompt (the base) every turn so the result
-      // is idempotent and never accumulates the role prompt across turns.
-      const composed = composeRoleSystemPrompt(event.systemPrompt, roleSystemPromptCached)
-      if (composed !== undefined) {
-        return { systemPrompt: composed }
-      }
+    //
+    // resolveRolePromptForTurn gates on BOTH the flag AND handshakeComplete:
+    // sessionRole is only populated by the async hello_ack handler, so
+    // latching the cache before the handshake would pin the session to
+    // "no role" permanently. Pre-handshake turns return undefined without
+    // latching; the next turn resolves correctly.
+    const composed = resolveRolePromptForTurn(
+      {
+        enabled: roledPromptInjectionEnabled(),
+        handshakeComplete,
+        sessionRole,
+        baseSystemPrompt: event.systemPrompt,
+      },
+      roleSystemPromptCache,
+    )
+    if (composed !== undefined) {
+      return { systemPrompt: composed }
     }
     return undefined
   })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -59,6 +59,9 @@
 // applied only on the wire copy; PI retains the full data internally.
 
 import * as net from "node:net"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 import type {
   ExtensionAPI,
   ExtensionContext,
@@ -1527,6 +1530,127 @@ export function shouldActivate(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Role system-prompt injection (issue #2032 / design #2031).
+// ---------------------------------------------------------------------------
+//
+// The agent role prompt (coordinator / worker / review-*) is read at
+// `before_agent_start` from ~/.config/prism/agents/<role>.md and injected into
+// the system prompt. This is the runtime counterpart to the per-session
+// APPEND_SYSTEM.md staging file (StagePIAgentConfigDir, pi_invocation.go).
+//
+// Replace-vs-append semantics (verified against pi's agent-session.js):
+//   - Returning { systemPrompt } from before_agent_start REPLACES the whole
+//     prompt wholesale (`this.agent.state.systemPrompt = result.systemPrompt`).
+//   - The event carries the fully assembled default in `event.systemPrompt`
+//     (which the runtime passes as `this._baseSystemPrompt`).
+//   - To match today's APPEND semantics we therefore concatenate
+//     `event.systemPrompt + "\n\n" + rolePrompt` so the default prompt is
+//     preserved in addition to the role prompt (not clobbered).
+//
+// Per-turn re-fire:
+//   - before_agent_start fires once PER TURN, not once per session. Because the
+//     handler recomputes from the constant `event.systemPrompt` (always the
+//     base) each turn, returning `base + "\n\n" + rolePrompt` is idempotent —
+//     the role prompt never accumulates across turns. The file read is memoised
+//     so disk is touched at most once per session regardless.
+//
+// Double-injection with the still-present APPEND_SYSTEM.md:
+//   - This PR (PR1 of #2031) keeps APPEND_SYSTEM.md, whose content is already
+//     baked into `event.systemPrompt` by pi's resource loader. Appending the
+//     role prompt on top of that would inject it TWICE. To stay strictly
+//     additive and avoid observable double-injection on the default path, the
+//     extension injection is GATED behind PRISM_INJECT_ROLE_PROMPT and defaults
+//     OFF. PR2 (#2033) removes APPEND_SYSTEM.md and flips this on.
+
+/**
+ * Name of the env var that enables extension-driven role-prompt injection.
+ * Defaults OFF in PR1 because APPEND_SYSTEM.md is still written — see the
+ * double-injection note above. Any non-empty value other than "0"/"false"
+ * enables it.
+ */
+export const ROLE_PROMPT_INJECT_ENV = "PRISM_INJECT_ROLE_PROMPT"
+
+/**
+ * Returns true when extension-driven role-prompt injection is enabled.
+ * Mirrors the disable-flag idiom used elsewhere but inverted: this is an
+ * OPT-IN flag (default off) so the additive PR1 does not double-inject with
+ * the still-present APPEND_SYSTEM.md.
+ */
+export function roledPromptInjectionEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env[ROLE_PROMPT_INJECT_ENV]
+  if (typeof v !== "string" || v.length === 0) {
+    return false
+  }
+  return v !== "0" && v.toLowerCase() !== "false"
+}
+
+/**
+ * Resolves the absolute path to the role prompt markdown file for `role`,
+ * mirroring the host-side prismAgentRolePath (cmd/spawn.go): respect
+ * XDG_CONFIG_HOME, else fall back to $HOME/.config. Returns "" when role is
+ * empty so callers can short-circuit to a no-op.
+ */
+export function prismAgentRolePath(role: string, env: NodeJS.ProcessEnv = process.env): string {
+  if (typeof role !== "string" || role.length === 0) {
+    return ""
+  }
+  let base = env.XDG_CONFIG_HOME
+  if (typeof base !== "string" || base.length === 0) {
+    const home = env.HOME && env.HOME.length > 0 ? env.HOME : os.homedir()
+    base = path.join(home, ".config")
+  }
+  return path.join(base, "prism", "agents", role + ".md")
+}
+
+/**
+ * Reads the role prompt markdown for `role`, returning its contents or
+ * undefined when the role is empty, the path cannot be resolved, or the file
+ * does not exist / cannot be read. Trailing whitespace-only contents (e.g. an
+ * empty file) yield undefined so an empty file is treated as "no role prompt".
+ *
+ * Mirrors today's edge case where a missing systemPromptPath simply omits
+ * APPEND_SYSTEM.md (graceful no-op, no error).
+ */
+export function readRolePrompt(role: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const p = prismAgentRolePath(role, env)
+  if (p === "") {
+    return undefined
+  }
+  let content: string
+  try {
+    content = fs.readFileSync(p, "utf8")
+  } catch {
+    // Missing file or unreadable → graceful no-op (matches APPEND_SYSTEM.md).
+    return undefined
+  }
+  if (content.trim().length === 0) {
+    return undefined
+  }
+  return content
+}
+
+/**
+ * Composes the system prompt for a turn: preserves pi's default prompt
+ * (`baseSystemPrompt`) and appends the role prompt, matching APPEND_SYSTEM.md
+ * semantics. Returns undefined (caller returns no override, keeping the base)
+ * when there is no role prompt to inject. Trailing newline on the base is
+ * normalised so the separator is exactly one blank line.
+ */
+export function composeRoleSystemPrompt(
+  baseSystemPrompt: string,
+  rolePrompt: string | undefined,
+): string | undefined {
+  if (typeof rolePrompt !== "string" || rolePrompt.trim().length === 0) {
+    return undefined
+  }
+  const base = typeof baseSystemPrompt === "string" ? baseSystemPrompt : ""
+  if (base.length === 0) {
+    return rolePrompt
+  }
+  return base.replace(/\s+$/, "") + "\n\n" + rolePrompt
+}
+
+// ---------------------------------------------------------------------------
 // Connection guard helper (exported for testing).
 // ---------------------------------------------------------------------------
 
@@ -1598,6 +1722,14 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
   // Session identity captured from hello_ack. Used for status bar display.
   let sessionRole = ""
+
+  // Role system-prompt injection cache (issue #2032). The role file is read
+  // once per session (load-once), then recomposed against event.systemPrompt
+  // on every before_agent_start. roleSystemPromptResolved guards the read so
+  // disk is touched at most once; roleSystemPromptCached holds the file
+  // contents or undefined (no role file / empty / read error).
+  let roleSystemPromptResolved = false
+  let roleSystemPromptCached: string | undefined
   let sessionBranch = extractBranch(process.env.PRISM_SESSION_NAME ?? "")
   let sessionIsolationMode = ""
 
@@ -2000,10 +2132,31 @@ export default function prismExtension(pi: ExtensionAPI): void {
     }
   })
 
-  pi.on("before_agent_start", async (_event, ctx) => {
+  pi.on("before_agent_start", async (event, ctx) => {
     lastCtx = ctx
     if (writer && handshakeComplete) {
       writer.write({ type: "state_change", state: "active" })
+    }
+
+    // Role system-prompt injection (issue #2032). Gated behind
+    // PRISM_INJECT_ROLE_PROMPT (default off) so PR1 stays additive and does
+    // not double-inject with the still-present APPEND_SYSTEM.md, whose content
+    // is already baked into event.systemPrompt. See the helpers above for the
+    // replace-vs-append and per-turn-fire analysis.
+    if (roledPromptInjectionEnabled()) {
+      // Memoise the file read across turns: before_agent_start fires per turn,
+      // but the role file is load-once. roleSystemPromptCached is undefined
+      // until first resolved (whether to a string or a sentinel no-op).
+      if (!roleSystemPromptResolved) {
+        roleSystemPromptCached = readRolePrompt(sessionRole)
+        roleSystemPromptResolved = true
+      }
+      // Recompose from event.systemPrompt (the base) every turn so the result
+      // is idempotent and never accumulates the role prompt across turns.
+      const composed = composeRoleSystemPrompt(event.systemPrompt, roleSystemPromptCached)
+      if (composed !== undefined) {
+        return { systemPrompt: composed }
+      }
     }
     return undefined
   })

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -238,11 +238,32 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 			ReadOnly:          true,
 			OptionalIfMissing: true,
 		},
+
+		// ── prism agent role prompts (RO, conditional) ───────────────────
+		// Host: ~/.config/prism/agents/ (deployed via pi.nix:240 →
+		// xdg.configFile."prism/agents".source = ./agents). One markdown file
+		// per role (coordinator.md, worker.md, review-*.md). The prism PI
+		// extension reads <role>.md at before_agent_start and injects it as the
+		// role system prompt (issue #2032).
+		//
+		// Mounted UNCONDITIONALLY for every role, including review-*. The dir
+		// is pure markdown with no secrets, so there is no isolation value in
+		// hiding sibling role prompts from a review agent (locked decision on
+		// design #2031). Read-only — agents never write their own prompt.
+		//
+		// SandboxPath == HostPath: under bwrap sandboxHomeDir == hostHome, so
+		// the extension's XDG_CONFIG_HOME-else-$HOME/.config resolution lands
+		// on exactly this path inside the sandbox.
+		{
+			HostPath:          filepath.Join(hostHome, ".config", "prism", "agents"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".config", "prism", "agents"),
+			ReadOnly:          true,
+			OptionalIfMissing: true,
+		},
 	}
 
 	return specs
 }
-
 
 // appendPodmanVolume appends a podman --volume argument pair for the given
 // MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -19,8 +19,10 @@ package container
 //     list) can locate the user's login keychain. The SBPL profile grants
 //     file-read* on the resolved path via (literal login.keychain-db) (#1487).
 //
-//  2. .config/prism/agents/ is role-conditional: included as a symlink for
-//     non-review roles, omitted for review-prefixed roles. Mirrors bwrap.go:447-448.
+//  2. .config/prism/agents/ is symlinked into the staging HOME for ALL roles
+//     (including review-*) so the prism PI extension can read <role>.md at
+//     before_agent_start. The dir is pure markdown with no secrets, so the
+//     former review-prefix exclusion was dropped (issue #2032; design #2031).
 //
 //  3. .cache/nix/ is included as an RW symlink to ~/.cache/nix (matches bwrap
 //     unconditional RW bind at bwrap.go:333-335).
@@ -76,8 +78,10 @@ func (m *Manager) sandboxExecHomePath() (string, error) {
 //   - Generated regular files (.gitconfig, .ssh/config, opencode.json) are
 //     written as regular files, not symlinks.
 //   - .cache/nix/ is always included as an RW symlink to ~/.cache/nix.
-//   - .config/prism/agents/ is only included when AgentRole does NOT start
-//     with "review-" (mirrors bwrap.go:447-448).
+//   - .config/prism/agents/ is symlinked in for ALL roles (including review-*)
+//     so the PI extension can read <role>.md (issue #2032). The former
+//     review-prefix exclusion was dropped — the dir is pure markdown with no
+//     secrets, so there is no isolation value in hiding sibling role prompts.
 //   - .claude/ is a symlink to host ~/.claude with a comment explaining the
 //     Darwin write-through behaviour.
 //
@@ -105,6 +109,7 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".kube"),
 		filepath.Join(stagingHome, ".cache"),
 		filepath.Join(stagingHome, ".pi"),
+		filepath.Join(stagingHome, ".config", "prism"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o700); err != nil {
@@ -242,6 +247,19 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// points at the stable intermediate (~/.config/kube/agents-config) rather
 	// than the fully-resolved sops concrete path that rotates on each
 	// darwin-rebuild switch (issue #1573).
+	// ── prism agent role prompts (issue #2032) ─────────────────────────
+	// Symlink ~/.config/prism/agents (deployed by pi.nix) into the staging
+	// HOME at the canonical XDG path so the prism PI extension can read
+	// <role>.md at before_agent_start. Included for ALL roles, including
+	// review-* — the dir is pure markdown with no secrets (locked decision on
+	// design #2031). collectStagingHomeSymlinkTargets scans .config/prism and
+	// emits the SBPL read-allow for the resolved target, so no manual
+	// generateProfile rule is needed.
+	symlinkIfExists(
+		filepath.Join(home, ".config", "prism", "agents"),
+		filepath.Join(stagingHome, ".config", "prism", "agents"),
+	)
+
 	symlinkIfExists(
 		filepath.Join(home, ".config", "kube", "agents-config"),
 		filepath.Join(stagingHome, ".kube", "config"),
@@ -583,6 +601,7 @@ type StagingSymlinkTarget struct {
 	//   RW: .cache/opencode, .cache/bun, .cache/nix,
 	//       .claude (write-through for credentials), .mcp-auth
 	//   RO: .ssh keys, .aws staged entries, .kube/config, .config/opencode/*,
+	//       .config/prism/agents (role prompts; issue #2032),
 	//       .cache/prism/clipboard (read-only; mirrors bwrap.go --ro-bind)
 	Writable bool
 }
@@ -682,8 +701,8 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 		// against EKS also fails (its exec-credential plugin shells out to aws).
 		// Mirrors bwrap's --bind (RW) treatment — awsSSOReadOnly/awsCLIReadOnly
 		// are both false in mounts.go (issue #1558).
-		".aws/sso":                      true, // AWS SSO token refresh writes
-		".aws/cli":                      true, // AWS CLI STS token cache writes
+		".aws/sso": true, // AWS SSO token refresh writes
+		".aws/cli": true, // AWS CLI STS token cache writes
 	}
 
 	seen := map[string]bool{}
@@ -758,6 +777,8 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 	}
 	// Also scan .cache/prism if it exists.
 	scanDir(".cache/prism")
+	// Scan .config/prism for the prism/agents role-prompt symlink (issue #2032).
+	scanDir(".config/prism")
 
 	return targets, nil
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
@@ -1,0 +1,184 @@
+//go:build darwin
+
+package integration_test
+
+// Integration tests for the prism agent role-prompt directory under
+// sandbox-exec (issue #2032). The prism PI extension reads
+// ~/.config/prism/agents/<role>.md at before_agent_start and injects it as the
+// role system prompt. For that to work inside a sandbox-exec session,
+// PrepareSandboxExecHome must symlink ~/.config/prism/agents into the staging
+// HOME, and the generated SBPL profile (via collectStagingHomeSymlinkTargets)
+// must grant file-read* on the resolved target.
+//
+// Per the #1192 convention, the change to PrepareSandboxExecHome is paired with
+// a positive integration test (the dir is readable through the staging symlink
+// under the production profile) and a negative test (mutating the profile to
+// drop the read-allow for the resolved target proves the rule is load-bearing).
+//
+// Build tag: darwin (sandbox-exec is Darwin-only).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// roledPromptContent is the sentinel written into the test worker.md so the
+// positive test can assert the bytes round-trip through the sandbox.
+const rolePromptSentinelContent = "PRISM-2032-ROLE-PROMPT-SENTINEL"
+
+// prepareRolePromptSentinel creates ~/.config/prism/agents/worker.md under the
+// user's real HOME (NOT t.TempDir, which resolves under /private/var/folders
+// and is broadly allowed) and plants a sentinel inside it. Returns the resolved
+// (EvalSymlinks) path of the agents directory — that is the path the SBPL
+// read-allow targets — and the path of the worker.md file as seen through the
+// staging HOME symlink chain.
+//
+// Skips when the directory cannot be created (e.g. running inside a restricted
+// sandbox that denies writes to ~/.config).
+func prepareRolePromptSentinel(t *testing.T) (resolvedAgentsDir string) {
+	t.Helper()
+	home := realUserHome(t)
+	agentsDir := filepath.Join(home, ".config", "prism", "agents")
+
+	agentsDirExisted := false
+	if _, statErr := os.Stat(agentsDir); statErr == nil {
+		agentsDirExisted = true
+	}
+	if mkErr := os.MkdirAll(agentsDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.config/prism/agents for test: %v", mkErr)
+	}
+
+	workerMD := filepath.Join(agentsDir, "worker.md")
+	workerMDExisted := false
+	if _, statErr := os.Stat(workerMD); statErr == nil {
+		workerMDExisted = true
+	}
+	if wErr := os.WriteFile(workerMD, []byte(rolePromptSentinelContent), 0o600); wErr != nil {
+		t.Skipf("cannot plant worker.md sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+
+	if workerMDExisted {
+		// Pre-existing worker.md (e.g. the real deployed prompt) — do not
+		// clobber it on cleanup. We cannot restore the original bytes, so the
+		// test deliberately skips when worker.md already exists to avoid
+		// trashing a developer's deployed prompt.
+		t.Skip("~/.config/prism/agents/worker.md already exists; skipping to avoid overwriting the deployed prompt")
+	}
+	if agentsDirExisted {
+		t.Cleanup(func() { _ = os.Remove(workerMD) })
+	} else {
+		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(home, ".config", "prism")) })
+	}
+
+	resolved, evalErr := filepath.EvalSymlinks(agentsDir)
+	if evalErr != nil {
+		resolved = agentsDir
+	}
+	return resolved
+}
+
+// TestSandboxExecProfile_RolePromptReadable is the positive integration test
+// for issue #2032: the prism agent role-prompt dir, symlinked into the staging
+// HOME by PrepareSandboxExecHome, is readable through the staging symlink under
+// the production profile. This exercises the same path the PI extension uses to
+// read <role>.md at before_agent_start.
+func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	resolvedAgentsDir := prepareRolePromptSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// The staging HOME must contain the .config/prism/agents symlink.
+	agentsLink := filepath.Join(stagingHome, ".config", "prism", "agents")
+	if _, lstatErr := os.Lstat(agentsLink); lstatErr != nil {
+		t.Fatalf("staging HOME must have a .config/prism/agents symlink after PrepareSandboxExecHome: %v", lstatErr)
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The production profile must grant file-read* on the resolved agents dir.
+	expectedRule := "(subpath " + sbplQuoteForTest(resolvedAgentsDir) + ")"
+	if !strings.Contains(prepared.content, expectedRule) {
+		t.Fatalf("generated profile does not contain a read-allow subpath for the resolved agents dir.\n"+
+			"Expected to find: %q\nProfile:\n%s", expectedRule, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Read worker.md through the staging HOME symlink from inside the sandbox.
+	workerMDViaStaging := filepath.Join(agentsLink, "worker.md")
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(workerMDViaStaging))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("reading worker.md through the staging symlink failed under the production profile.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
+			runErr, string(out), testProfilePath, workerMDViaStaging)
+	}
+	if !strings.Contains(string(out), rolePromptSentinelContent) {
+		t.Errorf("worker.md read did not return the sentinel content.\nGot: %s", string(out))
+	}
+}
+
+// TestSandboxExecProfile_RolePromptDeniedWithoutAllow is the paired negative
+// test for RolePromptReadable. It removes the read-allow (subpath ...) for the
+// resolved agents dir from the profile and asserts the same read fails —
+// proving the read-allow rule is load-bearing and the positive is not green by
+// accident (#1192).
+func TestSandboxExecProfile_RolePromptDeniedWithoutAllow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	resolvedAgentsDir := prepareRolePromptSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	agentsLink := filepath.Join(stagingHome, ".config", "prism", "agents")
+
+	// Remove the (subpath "<resolvedAgentsDir>") read-allow line. The
+	// collectStagingHomeSymlinkTargets RO block emits each target on its own
+	// indented line: "  (subpath \"<resolved>\")\n". Stripping that single
+	// line simulates the pre-#2032 state where the agents dir was not allowed.
+	target := "  (subpath " + sbplQuoteForTest(resolvedAgentsDir) + ")\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.Replace(p, target, "", 1)
+	})
+
+	workerMDViaStaging := filepath.Join(agentsLink, "worker.md")
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(workerMDViaStaging))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("reading worker.md succeeded WITHOUT the read-allow subpath for the agents dir.\n"+
+			"The (subpath \"%s\") rule is not load-bearing — investigate.\n"+
+			"Output: %s\nMutated profile: %s", resolvedAgentsDir, string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — agents dir read correctly denied without the read-allow subpath (exit: %v)", runErr)
+	}
+}


### PR DESCRIPTION
## Summary

PR1 of design #2031. Inject the agent role system-prompt from the prism PI
extension (`pi/extensions/prism.ts`) at runtime, reading
`~/.config/prism/agents/<role>.md` at `before_agent_start`, instead of relying
solely on the per-session `APPEND_SYSTEM.md` file.

**Additive:** `APPEND_SYSTEM.md` staging stays in place this PR; its removal is
PR2 (#2033). The extension injection is gated OFF by default — see the
double-injection mitigation below.

Refs #2031

## What changed

- **Mount `~/.config/prism/agents/` for ALL roles (incl. `review-*`)** in both
  isolation modes:
  - **bwrap**: added an RO `MountSpec` to `StandardSandboxMounts` (`mounts.go`),
    `HostPath → SandboxPath` = `~/.config/prism/agents` (under bwrap
    `sandboxHomeDir == hostHome`, so the extension's
    `XDG_CONFIG_HOME`-else-`$HOME/.config` resolution lands on it).
  - **sandbox-exec**: `PrepareSandboxExecHome` now symlinks
    `<stagingHome>/.config/prism/agents → ~/.config/prism/agents`, and
    `collectStagingHomeSymlinkTargets` scans `.config/prism`, so
    `generateProfile` emits the read-allow `(subpath …)` for the resolved
    target automatically (no manual SBPL rule added).
  - The former `review-`prefix exclusion is dropped (locked decision on #2031);
    only stale doc comments referenced it — the conditional code had already
    been removed in an earlier refactor. Doc comments updated.
- **Extension injection** (`prism.ts`): new exported helpers
  `prismAgentRolePath` / `readRolePrompt` / `composeRoleSystemPrompt` /
  `roledPromptInjectionEnabled`, wired into the `before_agent_start` handler.
- **Darwin integration test** (positive + negative) for the
  `PrepareSandboxExecHome` change, per AGENTS.md #1192.
- **tsx unit tests** for role→file resolution, the missing-file no-op, and the
  compose/idempotency semantics.

## Required findings

### Replace-vs-append semantics — **REPLACES wholesale**

Verified empirically against the installed pi runtime
(`dist/core/agent-session.js`): when a `before_agent_start` handler returns
`{ systemPrompt }`, the runtime does
`this.agent.state.systemPrompt = result.systemPrompt` — a full replacement.
The event carries the fully-assembled default in `event.systemPrompt` (passed
as `this._baseSystemPrompt`). To preserve today's APPEND semantics the handler
concatenates `event.systemPrompt + "\n\n" + rolePrompt` (via
`composeRoleSystemPrompt`), so PI's default prompt is preserved **in addition
to** the role prompt, not clobbered.

### Per-turn re-fire — **fires per turn; injection is idempotent**

`emitBeforeAgentStart` is called inside the per-turn prompt loop, so
`before_agent_start` fires **once per turn**, not once per session. The handler
recomputes from the constant `event.systemPrompt` (always the base — the
runtime resets to `_baseSystemPrompt` each turn when no override is returned),
so returning `base + "\n\n" + rolePrompt` every turn is **idempotent**: the
role prompt never accumulates. The file read itself is memoised
(`roleSystemPromptResolved`/`roleSystemPromptCached`) so disk is touched at
most once per session.

### Double-injection with the still-present `APPEND_SYSTEM.md` — **mitigated by gating OFF (option a)**

`APPEND_SYSTEM.md` content is already baked into `event.systemPrompt` by pi's
resource loader (`_rebuildSystemPrompt` → `appendSystemPrompt`). Appending the
role prompt on top of that would inject it **twice**. Per the design's
mitigation menu I chose **(a): gate the extension injection behind a flag,
default OFF** — `PRISM_INJECT_ROLE_PROMPT` (any non-empty value other than
`0`/`false` enables it). With the flag off, main behaviour is unchanged
(APPEND_SYSTEM.md remains the live mechanism, no double-injection). The
extension code path is fully implemented and unit/integration-tested. **PR2
(#2033)** removes `APPEND_SYSTEM.md` and flips this on.

### #1192 integration-test requirement — **applies; test added**

I changed `PrepareSandboxExecHome` (added the agents symlink + `.config/prism`
dir). I did **not** edit `generateProfile` directly — the SBPL read-allow comes
through the existing `collectStagingHomeSymlinkTargets` machinery. Per the
convention, the `PrepareSandboxExecHome` change is paired with a Darwin
integration test in `internal/integration/sandbox_exec_role_prompt_darwin_test.go`:
- **Positive**: the agents dir is readable through the staging symlink under
  the production profile (`worker.md` sentinel round-trips).
- **Negative**: `withMutatedProfile` strips the read-allow `(subpath …)` for
  the resolved target and asserts the same read is denied — proving the rule is
  load-bearing.

## Verification

- `tsx --test --test-force-exit prism.test.ts` — 292 pass (was 274; +18 new),
  0 fail.
- `go build ./...` + `go test ./...` (from `modules/programs/prism/prism/`) —
  all green.
- `nix build .#prism` — succeeds.
- **Isolation modes:** behaviour with the flag default-off is identical to main
  in all three modes (host/bwrap/sandbox-exec) — APPEND_SYSTEM.md is unchanged.
  The new agents-dir mount is verified readable: bwrap via the unconditional
  RO bind in `StandardSandboxMounts`; sandbox-exec via the paired Darwin
  integration test (positive read + negative deny); host mode resolves
  `$HOME/.config/prism/agents` directly (no sandbox). The Darwin
  integration tests must run on a macOS runner (`//go:build darwin`).

## Out of scope (deferred to later PRs of #2031)

- Removing `APPEND_SYSTEM.md` and enabling injection by default (PR2 #2033).
- Collapsing the per-session pi-agent staging dir to a shared mount (PR3 #2034).
