### PR TITLE
prism: remove APPEND_SYSTEM.md staging; role prompt now from PI extension (PR2 of #2031)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -58,9 +58,7 @@ import {
   // Mid-tool heartbeat (issue #1761)
   startToolHeartbeat,
   TOOL_HEARTBEAT_INTERVAL_MS,
-  // Role system-prompt injection (issue #2032)
-  ROLE_PROMPT_INJECT_ENV,
-  roledPromptInjectionEnabled,
+  // Role system-prompt injection (issue #2032 / #2033)
   prismAgentRolePath,
   readRolePrompt,
   composeRoleSystemPrompt,
@@ -3664,28 +3662,6 @@ describe("#1787: tool_call/tool_result emit parentMessageId from message_start",
 // Role system-prompt injection (issue #2032)
 // ---------------------------------------------------------------------------
 
-describe("roledPromptInjectionEnabled", () => {
-  it("defaults OFF when the env var is unset (additive PR1 — no double-inject)", () => {
-    assert.equal(roledPromptInjectionEnabled({}), false)
-  })
-
-  it("is OFF when the env var is empty", () => {
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "" }), false)
-  })
-
-  it("is OFF for explicit disable values 0 / false", () => {
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "0" }), false)
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "false" }), false)
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "False" }), false)
-  })
-
-  it("is ON for any other non-empty value", () => {
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "1" }), true)
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "true" }), true)
-    assert.equal(roledPromptInjectionEnabled({ [ROLE_PROMPT_INJECT_ENV]: "yes" }), true)
-  })
-})
-
 describe("prismAgentRolePath — role→file resolution", () => {
   it("returns '' for an empty role (no-op short-circuit)", () => {
     assert.equal(prismAgentRolePath("", { HOME: "/home/u" }), "")
@@ -3811,21 +3787,21 @@ describe("composeRoleSystemPrompt — APPEND semantics preserved", () => {
 describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", () => {
   const newCache = (): RolePromptCache => ({ resolved: false, cached: undefined })
 
-  it("returns undefined and does NOT latch when the flag is disabled", () => {
+  it("injects unconditionally once the handshake completes (no gating flag — PR2 of #2031)", () => {
     const cache = newCache()
     const out = resolveRolePromptForTurn(
-      { enabled: false, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       () => "ROLE",
     )
-    assert.equal(out, undefined)
-    assert.equal(cache.resolved, false) // not latched — flag off
+    assert.equal(out, "BASE\n\nROLE") // injected — no flag required
+    assert.equal(cache.resolved, true)
   })
 
   it("returns undefined and does NOT latch when the handshake is incomplete", () => {
     const cache = newCache()
     const out = resolveRolePromptForTurn(
-      { enabled: true, handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
+      { handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
       cache,
       () => "ROLE",
     )
@@ -3836,7 +3812,7 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
   it("injects once the handshake completes and the role is known", () => {
     const cache = newCache()
     const out = resolveRolePromptForTurn(
-      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       (role) => (role === "worker" ? "WORKER ROLE" : undefined),
     )
@@ -3855,7 +3831,7 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
 
     // Turn 1 fires BEFORE hello_ack: handshake incomplete, sessionRole still "".
     const turn1 = resolveRolePromptForTurn(
-      { enabled: true, handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
+      { handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
       cache,
       readRole,
     )
@@ -3865,7 +3841,7 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
 
     // Turn 2 fires AFTER hello_ack populated sessionRole="worker".
     const turn2 = resolveRolePromptForTurn(
-      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       readRole,
     )
@@ -3881,7 +3857,6 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
       return "ROLE"
     }
     const args = {
-      enabled: true,
       handshakeComplete: true,
       sessionRole: "worker",
       baseSystemPrompt: "BASE",
@@ -3899,7 +3874,7 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
     const cache = newCache()
     let reads = 0
     const out = resolveRolePromptForTurn(
-      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       () => {
         reads++
@@ -3910,7 +3885,7 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
     assert.equal(cache.resolved, true) // latched after handshake even for no-op
     // A second turn does not re-read — the no-op is memoised.
     resolveRolePromptForTurn(
-      { enabled: true, handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       () => {
         reads++

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1554,35 +1554,13 @@ export function shouldActivate(env: NodeJS.ProcessEnv = process.env): boolean {
 //     the role prompt never accumulates across turns. The file read is memoised
 //     so disk is touched at most once per session regardless.
 //
-// Double-injection with the still-present APPEND_SYSTEM.md:
-//   - This PR (PR1 of #2031) keeps APPEND_SYSTEM.md, whose content is already
-//     baked into `event.systemPrompt` by pi's resource loader. Appending the
-//     role prompt on top of that would inject it TWICE. To stay strictly
-//     additive and avoid observable double-injection on the default path, the
-//     extension injection is GATED behind PRISM_INJECT_ROLE_PROMPT and defaults
-//     OFF. PR2 (#2033) removes APPEND_SYSTEM.md and flips this on.
-
-/**
- * Name of the env var that enables extension-driven role-prompt injection.
- * Defaults OFF in PR1 because APPEND_SYSTEM.md is still written — see the
- * double-injection note above. Any non-empty value other than "0"/"false"
- * enables it.
- */
-export const ROLE_PROMPT_INJECT_ENV = "PRISM_INJECT_ROLE_PROMPT"
-
-/**
- * Returns true when extension-driven role-prompt injection is enabled.
- * Mirrors the disable-flag idiom used elsewhere but inverted: this is an
- * OPT-IN flag (default off) so the additive PR1 does not double-inject with
- * the still-present APPEND_SYSTEM.md.
- */
-export function roledPromptInjectionEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  const v = env[ROLE_PROMPT_INJECT_ENV]
-  if (typeof v !== "string" || v.length === 0) {
-    return false
-  }
-  return v !== "0" && v.toLowerCase() !== "false"
-}
+// Single source of truth (PR2 of #2031):
+//   - The per-session APPEND_SYSTEM.md staging file has been REMOVED
+//     (StagePIAgentConfigDir no longer writes it). The extension is now the
+//     SOLE source of the role prompt, so injection is unconditional — there is
+//     no PRISM_INJECT_ROLE_PROMPT gate any more. With APPEND_SYSTEM.md gone
+//     there is nothing for `event.systemPrompt` to double up against, so the
+//     double-injection risk the PR1 gate guarded against no longer exists.
 
 /**
  * Resolves the absolute path to the role prompt markdown file for `role`,
@@ -1660,14 +1638,16 @@ export interface RolePromptCache {
 }
 
 /**
- * Pure decision for one before_agent_start turn. Encapsulates the gating and
- * latch logic so it is unit-testable independently of the PI runtime:
+ * Pure decision for one before_agent_start turn. Encapsulates the latch logic
+ * so it is unit-testable independently of the PI runtime:
  *
- *   - Injection is gated on BOTH `enabled` (PRISM_INJECT_ROLE_PROMPT) AND
- *     `handshakeComplete`. The handshake gate is load-bearing: `sessionRole`
- *     is only populated by the async hello_ack handler, so resolving the
- *     cache before the handshake would latch the session to "no role"
- *     permanently. Pre-handshake turns return undefined WITHOUT latching.
+ *   - Injection is unconditional once the handshake completes — PR2 of #2031
+ *     removed APPEND_SYSTEM.md, so the extension is the sole source of the role
+ *     prompt and there is no gating flag any more.
+ *   - The handshake gate is load-bearing: `sessionRole` is only populated by
+ *     the async hello_ack handler, so resolving the cache before the handshake
+ *     would latch the session to "no role" permanently. Pre-handshake turns
+ *     return undefined WITHOUT latching.
  *   - Once resolved, the file read is memoised (cache.resolved) so disk is
  *     touched at most once per session.
  *   - The result is recomposed from `baseSystemPrompt` every turn, so it is
@@ -1678,7 +1658,6 @@ export interface RolePromptCache {
  */
 export function resolveRolePromptForTurn(
   opts: {
-    enabled: boolean
     handshakeComplete: boolean
     sessionRole: string
     baseSystemPrompt: string
@@ -1686,7 +1665,7 @@ export function resolveRolePromptForTurn(
   cache: RolePromptCache,
   readRole: (role: string) => string | undefined = readRolePrompt,
 ): string | undefined {
-  if (!opts.enabled || !opts.handshakeComplete) {
+  if (!opts.handshakeComplete) {
     return undefined
   }
   if (!cache.resolved) {
@@ -2182,20 +2161,19 @@ export default function prismExtension(pi: ExtensionAPI): void {
       writer.write({ type: "state_change", state: "active" })
     }
 
-    // Role system-prompt injection (issue #2032). Gated behind
-    // PRISM_INJECT_ROLE_PROMPT (default off) so PR1 stays additive and does
-    // not double-inject with the still-present APPEND_SYSTEM.md, whose content
-    // is already baked into event.systemPrompt. See the helpers above for the
-    // replace-vs-append and per-turn-fire analysis.
+    // Role system-prompt injection (issue #2032 / #2033). PR2 of #2031 removed
+    // the per-session APPEND_SYSTEM.md staging file, so the extension is now
+    // the SOLE source of the role prompt and injection is unconditional — no
+    // gating flag. See the helpers above for the replace-vs-append and
+    // per-turn-fire analysis.
     //
-    // resolveRolePromptForTurn gates on BOTH the flag AND handshakeComplete:
-    // sessionRole is only populated by the async hello_ack handler, so
-    // latching the cache before the handshake would pin the session to
-    // "no role" permanently. Pre-handshake turns return undefined without
-    // latching; the next turn resolves correctly.
+    // resolveRolePromptForTurn still gates on handshakeComplete: sessionRole
+    // is only populated by the async hello_ack handler, so latching the cache
+    // before the handshake would pin the session to "no role" permanently.
+    // Pre-handshake turns return undefined without latching; the next turn
+    // resolves correctly.
     const composed = resolveRolePromptForTurn(
       {
-        enabled: roledPromptInjectionEnabled(),
         handshakeComplete,
         sessionRole,
         baseSystemPrompt: event.systemPrompt,

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -667,10 +667,10 @@ func logTimingTo(logFile *os.File, phase string, d time.Duration) {
 //  1. Loads profiles.json and resolves the active profile.
 //  2. Looks up the slot for the session's agent role — returns a clear error if
 //     the profile does not define a slot for this role.
-//  3. Calls StagePIAgentConfigDir to create the per-session staging directory
-//     and write APPEND_SYSTEM.md (if a system prompt is configured). Records
-//     the host/sandbox paths on ctrCfg so bwrap can bind-mount the directory
-//     and set PI_CODING_AGENT_DIR.
+//  3. Calls StagePIAgentConfigDir to create the per-session staging directory.
+//     Records the host/sandbox paths on ctrCfg so bwrap can bind-mount the
+//     directory and set PI_CODING_AGENT_DIR. The role system-prompt is injected
+//     at runtime by the prism PI extension, not staged here (design #2031).
 //  4. Populates PIExtensionHostDir from cfg.PIExtensionDir (set by Nix).
 //  5. Copies PIProvider, PIModel, PIThinking from the profile slot.
 func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, cfg config.Config) error {
@@ -697,9 +697,11 @@ func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, c
 	}
 	slot, _ := config.SlotForRole(pf, profileName, agentRole)
 
-	// Stage the PI agent config directory (and optionally APPEND_SYSTEM.md)
-	// before bwrap launches, so PI sees the file on its first read.
-	hostDir, sandboxDir, err := container.StagePIAgentConfigDir(slot, sessionName)
+	// Stage the PI agent config directory before bwrap launches. The role
+	// system-prompt is no longer staged here — it is injected at runtime by the
+	// prism PI extension (before_agent_start) from ~/.config/prism/agents/<role>.md
+	// (design #2031, PR2 #2033).
+	hostDir, sandboxDir, err := container.StagePIAgentConfigDir(sessionName)
 	if err != nil {
 		return fmt.Errorf("pi: stage agent config dir: %w", err)
 	}

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -303,8 +303,10 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		env = append(env, fmt.Sprintf("PRISM_HARNESS_PIPE=tcp://127.0.0.1:%d", ctrCfg.HarnessPipeTCPPort))
 	}
 
-	// For PI sessions, set PI_CODING_AGENT_DIR so PI discovers APPEND_SYSTEM.md
-	// from the per-session staging directory. On Darwin (sandbox-exec), the
+	// For PI sessions, set PI_CODING_AGENT_DIR so PI discovers settings.json /
+	// themes / AGENTS.md / skills from the per-session staging directory. The
+	// role system-prompt is injected at runtime by the prism PI extension, not
+	// staged here (design #2031). On Darwin (sandbox-exec), the
 	// staging dir is on the host filesystem, so the "sandbox path" override set
 	// in populatePIConfig points at the host path directly.
 	if ctrCfg.Harness == "pi" && ctrCfg.PIAgentConfigSandboxDir != "" {

--- a/modules/programs/prism/prism/cmd/profile.go
+++ b/modules/programs/prism/prism/cmd/profile.go
@@ -492,10 +492,9 @@ func resolveCoordinatorSession(d *db.DB, coordinatorFlag string) (string, error)
 
 // profileSlotJSON is the snake_case JSON shape for a single role slot.
 type profileSlotJSON struct {
-	Provider         string `json:"provider"`
-	Model            string `json:"model"`
-	Thinking         string `json:"thinking"`
-	SystemPromptPath string `json:"system_prompt_path"`
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	Thinking string `json:"thinking"`
 }
 
 // profileJSON is the snake_case JSON shape for a single profile entry. The
@@ -512,10 +511,9 @@ func buildProfileJSON(name string, entry config.ProfileEntry, active string) pro
 	slots := make(map[string]profileSlotJSON, len(entry))
 	for role, slot := range entry {
 		slots[role] = profileSlotJSON{
-			Provider:         slot.Provider,
-			Model:            slot.Model,
-			Thinking:         slot.Thinking,
-			SystemPromptPath: slot.SystemPromptPath,
+			Provider: slot.Provider,
+			Model:    slot.Model,
+			Thinking: slot.Thinking,
 		}
 	}
 	return profileJSON{

--- a/modules/programs/prism/prism/cmd/profile_json_test.go
+++ b/modules/programs/prism/prism/cmd/profile_json_test.go
@@ -56,15 +56,17 @@ func TestBuildProfileJSON_SnakeCaseAndActiveFlag(t *testing.T) {
 	}
 
 	coord := slots["coordinator"].(map[string]interface{})
-	for _, k := range []string{"provider", "model", "thinking", "system_prompt_path"} {
+	for _, k := range []string{"provider", "model", "thinking"} {
 		if _, ok := coord[k]; !ok {
 			t.Errorf("slots.coordinator missing snake_case key %q", k)
 		}
 	}
-	// Reject camelCase leftovers.
-	for _, badK := range []string{"systemPromptPath"} {
+	// The role system-prompt is no longer carried in the slot (design #2031):
+	// it is injected at runtime by the prism PI extension. Neither the
+	// snake_case nor the camelCase key should appear.
+	for _, badK := range []string{"system_prompt_path", "systemPromptPath"} {
 		if _, ok := coord[badK]; ok {
-			t.Errorf("slots.coordinator must not have camelCase key %q", badK)
+			t.Errorf("slots.coordinator must not have removed key %q", badK)
 		}
 	}
 }

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -44,13 +44,14 @@ import (
 //   - Model: model identifier for this role's session.
 //   - Thinking: reasoning level. Rendered as pi's `variant` field via
 //     variantFromThinking ("off" → "none").
-//   - SystemPromptPath: absolute path to the role's system prompt file,
-//     e.g. "/home/user/.config/prism/agents/worker.md".
+//
+// The role system-prompt is no longer carried in the slot: it is injected at
+// runtime by the prism PI extension (before_agent_start) from
+// ~/.config/prism/agents/<role>.md (design #2031).
 type RoleSlot struct {
-	Provider         string `json:"provider,omitempty"`
-	Model            string `json:"model"`
-	Thinking         string `json:"thinking,omitempty"`
-	SystemPromptPath string `json:"systemPromptPath,omitempty"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model"`
+	Thinking string `json:"thinking,omitempty"`
 }
 
 // ProfileEntry maps session role names ("coordinator", "worker", "review-goal",

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -291,7 +291,9 @@ type Config struct {
 	// ~/.local/state/prism/run/<hash>/pi-agent/). When non-empty and
 	// Harness == "pi", BuildArgs (bwrap) bind-mounts this directory read-only
 	// into the sandbox at PIAgentConfigSandboxDir and sets PI_CODING_AGENT_DIR
-	// to that in-sandbox path. PI discovers APPEND_SYSTEM.md automatically.
+	// to that in-sandbox path so PI discovers settings.json / themes /
+	// AGENTS.md / skills. The role system-prompt is injected at runtime by the
+	// prism PI extension, not staged here (design #2031).
 	PIAgentConfigHostDir string
 
 	// PIAgentConfigSandboxDir is the in-sandbox path at which the PI agent

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -4,10 +4,12 @@ package container
 //
 // When a bwrap session has harness=pi, agent-run must:
 //  1. Stage a per-session PI agent config directory on the host before bwrap
-//     launches. If a system prompt is configured for the session's role, write
-//     APPEND_SYSTEM.md into that directory. PI discovers APPEND_SYSTEM.md
-//     automatically via the PI_CODING_AGENT_DIR environment variable — no
-//     --append-system-prompt CLI flag is needed.
+//     launches. This directory carries the auth.json symlink, settings.json,
+//     themes/, AGENTS.md, and skills/ — it no longer carries any role prompt.
+//     The role system-prompt is injected at runtime by the prism PI extension
+//     (pi/extensions/prism.ts, before_agent_start), which reads
+//     ~/.config/prism/agents/<role>.md; the former APPEND_SYSTEM.md file is no
+//     longer written (design #2031, PR2 #2033).
 //  2. Bind-mount the staging directory read-only into the bwrap sandbox at a
 //     fixed in-sandbox path and set PI_CODING_AGENT_DIR to that path.
 //  3. Bind-mount the prism PI extension directory read-only into the bwrap
@@ -16,8 +18,7 @@ package container
 //     terminator.
 //
 // This file provides PIInvocation (analogous to HarnessInvocation) and
-// StagePIAgentConfigDir which prepares the per-session staging directory and
-// optionally writes APPEND_SYSTEM.md.
+// StagePIAgentConfigDir which prepares the per-session staging directory.
 
 import (
 	"crypto/sha256"
@@ -27,25 +28,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/prismatic-koi/prism/internal/config"
 )
 
 const (
 	// piAgentConfigSandboxDefault is the in-sandbox directory path at which
 	// the per-session PI agent config directory is bind-mounted when the caller
 	// has not overridden PIAgentConfigSandboxDir. PI_CODING_AGENT_DIR is set to
-	// this path so PI discovers APPEND_SYSTEM.md automatically.
+	// this path so PI discovers settings.json / themes / AGENTS.md / skills.
 	piAgentConfigSandboxDefault = "/run/prism/pi-agent"
 
 	// piAgentConfigSubdir is the subdirectory name created under the per-session
 	// run directory to hold the PI agent config staging files.
 	piAgentConfigSubdir = "pi-agent"
-
-	// piAppendSystemFilename is the filename written into the PI agent config
-	// staging directory to append a role prompt to PI's default system prompt.
-	// PI discovers this file automatically when PI_CODING_AGENT_DIR is set.
-	piAppendSystemFilename = "APPEND_SYSTEM.md"
 
 	// piExtensionSandboxDefault is the in-sandbox directory path at which
 	// the PI extension directory is bind-mounted when the caller has not
@@ -70,10 +64,12 @@ const (
 //	                                       file exists — see piResolveResumeSession)
 //	<cfg.InitialPrompt>                   (bare positional arg, when non-empty)
 //
-// The system prompt is delivered via PI_CODING_AGENT_DIR (set in the bwrap
-// environment) pointing at the per-session staging directory that contains
-// APPEND_SYSTEM.md. No --append-system-prompt flag is needed — PI discovers
-// APPEND_SYSTEM.md automatically from its agent config directory.
+// The role system prompt is NOT delivered via this staging directory. It is
+// injected at runtime by the prism PI extension (pi/extensions/prism.ts,
+// before_agent_start), which reads ~/.config/prism/agents/<role>.md and
+// appends it to PI's default system prompt. The staging directory referenced
+// by PI_CODING_AGENT_DIR only carries settings.json / themes / AGENTS.md /
+// skills / auth.json.
 //
 // Conversation resume (issue #1838): when cfg.HarnessSessionID is non-empty,
 // PIInvocation looks up the on-disk session JSONL via
@@ -288,9 +284,8 @@ func piAgentRunLogPath(sessionName string) (string, error) {
 }
 
 // StagePIAgentConfigDir prepares the per-session PI agent config staging
-// directory and, when a system prompt is configured, writes APPEND_SYSTEM.md
-// into it. It returns the host path to the staging directory and the canonical
-// in-sandbox path (piAgentConfigSandboxDefault).
+// directory. It returns the host path to the staging directory and the
+// canonical in-sandbox path (piAgentConfigSandboxDefault).
 //
 // The staging directory is created at:
 //
@@ -301,13 +296,16 @@ func piAgentRunLogPath(sessionName string) (string, error) {
 // run-dir (subpath ...) rule on Darwin — no additional sandbox-exec profile
 // rule is required (confirmed issue #1285).
 //
-// If slot.SystemPromptPath is empty or the file does not exist, the staging
-// directory is still created but APPEND_SYSTEM.md is omitted — PI will start
-// without a role prompt rather than erroring (edge-case AC).
+// The directory carries auth.json (symlink), settings.json, themes/, AGENTS.md,
+// and skills/. It no longer carries any role prompt: the role system-prompt is
+// injected at runtime by the prism PI extension (pi/extensions/prism.ts,
+// before_agent_start) from ~/.config/prism/agents/<role>.md (design #2031).
+// A role with no <role>.md file simply starts with PI's default prompt — the
+// extension returns no override, no error (edge-case AC).
 //
 // The staging directory is isolated per session (via the sessionDirHash), so
 // two concurrent spawns for different roles never share a staging dir.
-func StagePIAgentConfigDir(slot config.RoleSlot, sessionName string) (hostDir, sandboxDir string, err error) {
+func StagePIAgentConfigDir(sessionName string) (hostDir, sandboxDir string, err error) {
 	runDir, err := sessionRunDir(sessionName)
 	if err != nil {
 		return "", "", fmt.Errorf("pi: session %q: resolve run dir: %w", sessionName, err)
@@ -318,22 +316,10 @@ func StagePIAgentConfigDir(slot config.RoleSlot, sessionName string) (hostDir, s
 		return "", "", fmt.Errorf("pi: session %q: create pi-agent staging dir %s: %w", sessionName, stagingDir, mkErr)
 	}
 
-	// Write APPEND_SYSTEM.md only when a system prompt path is configured and
-	// the file exists. Missing or empty SystemPromptPath is silently skipped —
-	// PI starts without the role prompt rather than failing.
-	if slot.SystemPromptPath != "" {
-		content, readErr := os.ReadFile(slot.SystemPromptPath)
-		if readErr != nil {
-			// Non-fatal: log a warning and skip writing APPEND_SYSTEM.md.
-			// The staging dir is still returned so PI gets PI_CODING_AGENT_DIR.
-			_ = readErr // PI will start without the role prompt.
-		} else {
-			dest := filepath.Join(stagingDir, piAppendSystemFilename)
-			if writeErr := os.WriteFile(dest, content, 0o600); writeErr != nil {
-				return "", "", fmt.Errorf("pi: session %q: write %s: %w", sessionName, dest, writeErr)
-			}
-		}
-	}
+	// The role system-prompt is no longer staged here. It is injected at runtime
+	// by the prism PI extension (before_agent_start) from
+	// ~/.config/prism/agents/<role>.md — see pi/extensions/prism.ts (design
+	// #2031, PR2 #2033). The former APPEND_SYSTEM.md write has been removed.
 
 	// Symlink auth.json from the staging dir to the real ~/.pi/agent/auth.json.
 	// This allows OAuth token refreshes performed inside the sandbox to be
@@ -545,7 +531,7 @@ func PIExtensionSandboxPath(sandboxDirOverride string) string {
 //
 //   - PI agent config directory: cfg.PIAgentConfigHostDir → cfg.PIAgentConfigSandboxDir
 //     (read-only). Sets PI_CODING_AGENT_DIR env var to the sandbox path so PI
-//     discovers APPEND_SYSTEM.md automatically.
+//     discovers settings.json / themes / AGENTS.md / skills.
 //   - Extension directory: cfg.PIExtensionHostDir → cfg.PIExtensionSandboxDir
 //     (read-only).
 //
@@ -568,7 +554,8 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 	// ── PI agent config directory ────────────────────────────────────────────
 	// The staging directory is always created by StagePIAgentConfigDir before
 	// bwrap launches. Bind-mount it read-only and set PI_CODING_AGENT_DIR to
-	// the in-sandbox path so PI discovers APPEND_SYSTEM.md automatically.
+	// the in-sandbox path so PI discovers settings.json / themes / AGENTS.md /
+	// skills.
 	agentConfigHostDir := cfg.PIAgentConfigHostDir
 	agentConfigSandboxDir := cfg.PIAgentConfigSandboxDir
 	if agentConfigSandboxDir == "" {
@@ -592,8 +579,8 @@ func appendPIBwrapMounts(args []string, cfg Config) ([]string, error) {
 		// This bind MUST be emitted after the staging-dir bind above so that
 		// bwrap applies it as an overlay (later --bind entries take effect on
 		// top of earlier ones at the same mount point). The staging dir keeps
-		// providing APPEND_SYSTEM.md / settings.json / themes / AGENTS.md /
-		// skills / auth.json; only the `sessions/` subdirectory is redirected.
+		// providing settings.json / themes / AGENTS.md / skills / auth.json;
+		// only the `sessions/` subdirectory is redirected.
 		//
 		// We create the host directory if it does not exist so a fresh install
 		// (no prior pi history) does not fail the spawn — bwrap requires the

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/prismatic-koi/prism/internal/config"
 )
 
 // ── PIInvocation ─────────────────────────────────────────────────────────────
@@ -40,8 +38,9 @@ func TestPIInvocation_BasicFlags(t *testing.T) {
 	if hasArg(args, "--no-session") {
 		t.Errorf("--no-session must not appear in PIInvocation args; got %v", args)
 	}
-	// --append-system-prompt must NOT appear — system prompt is delivered via
-	// PI_CODING_AGENT_DIR / APPEND_SYSTEM.md, not via a CLI flag.
+	// --append-system-prompt must NOT appear — the role system prompt is
+	// injected at runtime by the prism PI extension (before_agent_start), not
+	// via a CLI flag or a staged file (design #2031).
 	if hasArg(args, "--append-system-prompt") {
 		t.Errorf("--append-system-prompt must not appear in PIInvocation args; got %v", args)
 	}
@@ -139,26 +138,15 @@ func hasTriple(args []string, flag, val1, val2 string) bool {
 
 // ── StagePIAgentConfigDir ─────────────────────────────────────────────────────
 
-func TestStagePIAgentConfigDir_WritesAppendSystem(t *testing.T) {
-	// Prepare a source system-prompt file.
-	srcDir := t.TempDir()
-	srcFile := filepath.Join(srcDir, "agent-instructions.md")
-	content := "# System Prompt\nDo great things."
-	if err := os.WriteFile(srcFile, []byte(content), 0o600); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-
-	slot := config.RoleSlot{
-		Provider:         "anthropic",
-		Model:            "anthropic/claude-opus-4",
-		SystemPromptPath: srcFile,
-	}
-
-	// Override XDG_STATE_HOME so staging lands in t.TempDir().
+func TestStagePIAgentConfigDir_DoesNotWriteAppendSystem(t *testing.T) {
+	// PR2 of #2031: the role system-prompt is no longer staged as
+	// APPEND_SYSTEM.md. It is injected at runtime by the prism PI extension.
+	// StagePIAgentConfigDir must create the staging dir WITHOUT writing
+	// APPEND_SYSTEM.md.
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
-	hostDir, sandboxDir, err := StagePIAgentConfigDir(slot, "test-session@main")
+	hostDir, sandboxDir, err := StagePIAgentConfigDir("test-session@main")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -168,14 +156,15 @@ func TestStagePIAgentConfigDir_WritesAppendSystem(t *testing.T) {
 		t.Errorf("sandboxDir = %q, want %q", sandboxDir, piAgentConfigSandboxDefault)
 	}
 
-	// APPEND_SYSTEM.md must exist and contain the source content.
-	appendSystemPath := filepath.Join(hostDir, piAppendSystemFilename)
-	got, err := os.ReadFile(appendSystemPath)
-	if err != nil {
-		t.Fatalf("read APPEND_SYSTEM.md at %q: %v", appendSystemPath, err)
+	// APPEND_SYSTEM.md must NOT exist — the write path has been removed.
+	appendSystemPath := filepath.Join(hostDir, "APPEND_SYSTEM.md")
+	if _, statErr := os.Stat(appendSystemPath); statErr == nil {
+		t.Errorf("APPEND_SYSTEM.md must not be written (removed in PR2 of #2031)")
 	}
-	if string(got) != content {
-		t.Errorf("APPEND_SYSTEM.md content = %q, want %q", string(got), content)
+
+	// Staging dir must still exist.
+	if _, statErr := os.Stat(hostDir); statErr != nil {
+		t.Errorf("staging dir %q does not exist: %v", hostDir, statErr)
 	}
 
 	// hostDir must be a subdirectory named pi-agent under the run dir.
@@ -184,16 +173,18 @@ func TestStagePIAgentConfigDir_WritesAppendSystem(t *testing.T) {
 	}
 }
 
-func TestStagePIAgentConfigDir_EmptySystemPromptPath(t *testing.T) {
-	// When SystemPromptPath is empty, staging dir is created but APPEND_SYSTEM.md
-	// is omitted — no error (edge-case AC).
-	slot := config.RoleSlot{}
+func TestStagePIAgentConfigDir_NoRolePromptArtifact(t *testing.T) {
+	// Edge-case AC: a session whose role has no <role>.md file starts cleanly
+	// with PI's default prompt only. Since the prompt is injected by the
+	// extension (not staged), StagePIAgentConfigDir simply creates the dir and
+	// never errors regardless of role-prompt availability — and never writes
+	// APPEND_SYSTEM.md.
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
-	hostDir, sandboxDir, err := StagePIAgentConfigDir(slot, "test-session@main")
+	hostDir, sandboxDir, err := StagePIAgentConfigDir("test-session@main")
 	if err != nil {
-		t.Fatalf("expected no error for empty SystemPromptPath; got %v", err)
+		t.Fatalf("expected no error; got %v", err)
 	}
 	if hostDir == "" || sandboxDir == "" {
 		t.Fatalf("expected non-empty hostDir and sandboxDir; got %q, %q", hostDir, sandboxDir)
@@ -203,48 +194,19 @@ func TestStagePIAgentConfigDir_EmptySystemPromptPath(t *testing.T) {
 		t.Errorf("staging dir %q does not exist: %v", hostDir, statErr)
 	}
 	// APPEND_SYSTEM.md must NOT exist.
-	appendSystemPath := filepath.Join(hostDir, piAppendSystemFilename)
+	appendSystemPath := filepath.Join(hostDir, "APPEND_SYSTEM.md")
 	if _, statErr := os.Stat(appendSystemPath); statErr == nil {
-		t.Errorf("APPEND_SYSTEM.md should not exist when SystemPromptPath is empty")
-	}
-}
-
-func TestStagePIAgentConfigDir_MissingSourceFile(t *testing.T) {
-	// When SystemPromptPath points to a missing file, staging dir is created
-	// but APPEND_SYSTEM.md is omitted — no error (edge-case AC: non-fatal).
-	slot := config.RoleSlot{
-		SystemPromptPath: "/nonexistent/path/agent.md",
-	}
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
-
-	hostDir, _, err := StagePIAgentConfigDir(slot, "test-session@main")
-	if err != nil {
-		t.Fatalf("expected no error for missing source file; got %v", err)
-	}
-	// Staging dir must still exist.
-	if _, statErr := os.Stat(hostDir); statErr != nil {
-		t.Errorf("staging dir %q does not exist: %v", hostDir, statErr)
-	}
-	// APPEND_SYSTEM.md must NOT exist.
-	appendSystemPath := filepath.Join(hostDir, piAppendSystemFilename)
-	if _, statErr := os.Stat(appendSystemPath); statErr == nil {
-		t.Errorf("APPEND_SYSTEM.md should not exist when source file is missing")
+		t.Errorf("APPEND_SYSTEM.md should never be written")
 	}
 }
 
 func TestStagePIAgentConfigDir_IsolatedPerSession(t *testing.T) {
 	// Two concurrent spawns for different session names must use different
 	// staging dirs — no cross-session contamination (edge-case AC).
-	srcFile := filepath.Join(t.TempDir(), "prompt.md")
-	if err := os.WriteFile(srcFile, []byte("role prompt"), 0o600); err != nil {
-		t.Fatalf("write src: %v", err)
-	}
-	slot := config.RoleSlot{SystemPromptPath: srcFile}
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
-	dir1, _, err1 := StagePIAgentConfigDir(slot, "nixos-config@feature-a")
-	dir2, _, err2 := StagePIAgentConfigDir(slot, "nixos-config@feature-b")
+	dir1, _, err1 := StagePIAgentConfigDir("nixos-config@feature-a")
+	dir2, _, err2 := StagePIAgentConfigDir("nixos-config@feature-b")
 	if err1 != nil || err2 != nil {
 		t.Fatalf("StagePIAgentConfigDir errors: %v, %v", err1, err2)
 	}
@@ -672,7 +634,7 @@ func TestStagePIAgentConfigDir_SymlinksAuthJSON(t *testing.T) {
 		t.Fatalf("write auth.json: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@symlink-test")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@symlink-test")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -708,7 +670,7 @@ func TestStagePIAgentConfigDir_AuthJSONSymlinkDanglingWhenTargetAbsent(t *testin
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	// Deliberately do NOT create ~/.pi/agent/auth.json.
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@dangling-auth")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@dangling-auth")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v (must not error even with dangling symlink)", err)
 	}
@@ -740,7 +702,7 @@ func TestStagePIAgentConfigDir_CopiesSettings(t *testing.T) {
 		t.Fatalf("write settings.json: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@settings-test")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@settings-test")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -769,7 +731,7 @@ func TestStagePIAgentConfigDir_CopiesThemesDir(t *testing.T) {
 		t.Fatalf("write theme file: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@themes-test")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@themes-test")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -792,7 +754,7 @@ func TestStagePIAgentConfigDir_MissingHostFiles(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	// Deliberately do NOT create ~/.pi/agent.
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@missing-pi")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@missing-pi")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -840,7 +802,7 @@ func TestStagePIAgentConfigDir_CopiesAGENTSMd(t *testing.T) {
 		t.Fatalf("write AGENTS.md: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@agents-md-test")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@agents-md-test")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -895,7 +857,7 @@ func TestStagePIAgentConfigDir_AGENTSMdIdempotentOnReSpawn(t *testing.T) {
 	if err := os.WriteFile(hostAgentsPath, []byte(contentA), 0o600); err != nil {
 		t.Fatalf("write AGENTS.md (v1): %v", err)
 	}
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@agents-md-idempotent")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@agents-md-idempotent")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir (first call): %v", err)
 	}
@@ -910,7 +872,7 @@ func TestStagePIAgentConfigDir_AGENTSMdIdempotentOnReSpawn(t *testing.T) {
 	if err := os.WriteFile(hostAgentsPath, []byte(contentB), 0o600); err != nil {
 		t.Fatalf("write AGENTS.md (v2): %v", err)
 	}
-	_, _, err = StagePIAgentConfigDir(config.RoleSlot{}, "test-session@agents-md-idempotent")
+	_, _, err = StagePIAgentConfigDir("test-session@agents-md-idempotent")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir (second call): %v", err)
 	}
@@ -998,7 +960,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_SymlinkedToNix(t *testing.T) {
 		t.Fatalf("symlink skills: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-nix")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@skills-nix")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -1046,7 +1008,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_RegularDir(t *testing.T) {
 		t.Fatalf("write skill file: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-regular")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@skills-regular")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -1081,7 +1043,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_Absent(t *testing.T) {
 		t.Fatalf("mkdir ~/.pi/agent: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-absent")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@skills-absent")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -1120,7 +1082,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_BrokenSymlink(t *testing.T) {
 	}
 
 	// Must not return an error despite the broken symlink.
-	_, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-broken")
+	_, _, err := StagePIAgentConfigDir("test-session@skills-broken")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir must not error on broken symlink; got: %v", err)
 	}
@@ -1128,7 +1090,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_BrokenSymlink(t *testing.T) {
 
 func TestStagePIAgentConfigDir_SkillsDoesNotAffectOtherEntries(t *testing.T) {
 	// Adding skills staging must not alter auth.json, settings.json, themes/,
-	// or APPEND_SYSTEM.md behaviour. Verify all four are still produced
+	// behaviour. Verify the non-prompt artifacts are still produced
 	// correctly when skills/ is also present.
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
@@ -1154,14 +1116,7 @@ func TestStagePIAgentConfigDir_SkillsDoesNotAffectOtherEntries(t *testing.T) {
 		t.Fatalf("symlink skills: %v", err)
 	}
 
-	// Write a system prompt so APPEND_SYSTEM.md is produced.
-	promptFile := filepath.Join(t.TempDir(), "prompt.md")
-	if err := os.WriteFile(promptFile, []byte("role prompt"), 0o600); err != nil {
-		t.Fatalf("write prompt: %v", err)
-	}
-	slot := config.RoleSlot{SystemPromptPath: promptFile}
-
-	hostDir, _, err := StagePIAgentConfigDir(slot, "test-session@skills-combined")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@skills-combined")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", err)
 	}
@@ -1189,13 +1144,10 @@ func TestStagePIAgentConfigDir_SkillsDoesNotAffectOtherEntries(t *testing.T) {
 		t.Errorf("themes/t.json not accessible: %v", statErr)
 	}
 
-	// APPEND_SYSTEM.md must contain the prompt.
-	got, readErr := os.ReadFile(filepath.Join(hostDir, piAppendSystemFilename))
-	if readErr != nil {
-		t.Fatalf("APPEND_SYSTEM.md not in staging dir: %v", readErr)
-	}
-	if string(got) != "role prompt" {
-		t.Errorf("APPEND_SYSTEM.md = %q, want %q", string(got), "role prompt")
+	// APPEND_SYSTEM.md must NOT exist — the role prompt is injected by the
+	// extension, not staged (PR2 of #2031).
+	if _, statErr := os.Stat(filepath.Join(hostDir, "APPEND_SYSTEM.md")); statErr == nil {
+		t.Errorf("APPEND_SYSTEM.md must not be written")
 	}
 
 	// skills/ must be a symlink pointing to the resolved skillsTarget.
@@ -1236,7 +1188,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_UpdatesOnSecondCall(t *testing.T) {
 		t.Fatalf("symlink skills to oldTarget: %v", err)
 	}
 
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-update")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@skills-update")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir (first call): %v", err)
 	}
@@ -1264,7 +1216,7 @@ func TestStagePIAgentConfigDir_SkillsSymlink_UpdatesOnSecondCall(t *testing.T) {
 	}
 
 	// Second call (same session, same staging dir).
-	_, _, err = StagePIAgentConfigDir(config.RoleSlot{}, "test-session@skills-update")
+	_, _, err = StagePIAgentConfigDir("test-session@skills-update")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir (second call): %v", err)
 	}
@@ -1297,7 +1249,7 @@ func TestStagePIAgentConfigDir_AuthJSONSymlink_UpdatesOnSecondCall(t *testing.T)
 	expectedTarget := filepath.Join(piAgentDir, "auth.json")
 
 	// First call.
-	hostDir, _, err := StagePIAgentConfigDir(config.RoleSlot{}, "test-session@auth-update")
+	hostDir, _, err := StagePIAgentConfigDir("test-session@auth-update")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir (first call): %v", err)
 	}
@@ -1311,7 +1263,7 @@ func TestStagePIAgentConfigDir_AuthJSONSymlink_UpdatesOnSecondCall(t *testing.T)
 	}
 
 	// Second call: must not fail due to EEXIST and must leave symlink intact.
-	_, _, err = StagePIAgentConfigDir(config.RoleSlot{}, "test-session@auth-update")
+	_, _, err = StagePIAgentConfigDir("test-session@auth-update")
 	if err != nil {
 		t.Fatalf("StagePIAgentConfigDir (second call): %v", err)
 	}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_agent_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_agent_darwin_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
 )
 
@@ -116,7 +115,7 @@ func TestSandboxExecPI_AgentDirReadable(t *testing.T) {
 	// staging dir. We use a synthetic session name; XDG_STATE_HOME is not
 	// overridden so staging lands under the real state dir.
 	piStagingHostDir, _, stageErr := container.StagePIAgentConfigDir(
-		config.RoleSlot{}, "integration-test-1305@pi-agent-readable")
+		"integration-test-1305@pi-agent-readable")
 	if stageErr != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", stageErr)
 	}
@@ -175,7 +174,7 @@ func TestSandboxExecPI_AgentDirDeniedWithoutSubpathAllow(t *testing.T) {
 
 	// Create a minimal auth.json directly in a temp staging dir to test with.
 	piStagingHostDir, _, stageErr := container.StagePIAgentConfigDir(
-		config.RoleSlot{}, "integration-test-1305@pi-agent-denied")
+		"integration-test-1305@pi-agent-denied")
 	if stageErr != nil {
 		t.Fatalf("StagePIAgentConfigDir: %v", stageErr)
 	}

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -38,7 +38,10 @@
           #   - provider:         the routing provider
           #   - model:            the model identifier
           #   - thinking:         the reasoning level (rendered as pi "variant")
-          #   - systemPromptPath: absolute path to the role's system prompt file
+          #
+          # The role system-prompt is no longer carried in the slot: it is
+          # injected at runtime by the prism PI extension (before_agent_start)
+          # from ~/.config/prism/agents/<role>.md (design #2031).
 
           # The canonical set of pi agent roles (mirrors the files in ./agents/).
           piRoles = [
@@ -54,15 +57,13 @@
             "review-context"
           ];
 
-          # Map a role name to its agent prompt file (sans .md extension).
-          # Since filenames now match role names directly, this is an identity map.
-          roleToAgentFile = lib.genAttrs piRoles (role: role);
-
-          # Convenience: build a slot with a systemPromptPath derived from
-          # the role's agent file. `thinking` defaults to "off" (the PI
-          # harness zero value). `provider` defaults to "".
+          # Convenience: build a slot. `thinking` defaults to "off" (the PI
+          # harness zero value). `provider` defaults to "". The `role` arg is
+          # retained for call-site readability but no longer affects the slot
+          # (the role system-prompt is injected by the PI extension, not staged
+          # via a per-role path — design #2031).
           slot =
-            role:
+            _role:
             {
               provider ? "",
               model,
@@ -70,7 +71,6 @@
             }:
             {
               inherit provider model thinking;
-              systemPromptPath = "$HOME/.config/prism/agents/${roleToAgentFile.${role}}.md";
             };
 
           # Build a profile entry by calling `fn role` for every pi role.
@@ -88,13 +88,7 @@
               let
                 s = slotMap.${role} or slotMap._default or null;
               in
-              if s == null then
-                throw "profiles.nix: no slot defined for role '${role}' and no _default"
-              else
-                s
-                // {
-                  systemPromptPath = "$HOME/.config/prism/agents/${roleToAgentFile.${role}}.md";
-                }
+              if s == null then throw "profiles.nix: no slot defined for role '${role}' and no _default" else s
             );
 
           # ── Profiles ────────────────────────────────────────────────────────────
@@ -212,14 +206,15 @@
               }
               // {
                 # Profiles are role-keyed. Each slot is emitted with its full
-                # record (provider, model, thinking, systemPromptPath).
+                # record (provider, model, thinking). The role system-prompt is
+                # injected at runtime by the prism PI extension, not carried in
+                # the slot (design #2031).
                 profiles = lib.mapAttrs (
                   _name: profileEntry:
                   lib.mapAttrs (_role: roleSlot: {
                     provider = roleSlot.provider or "";
                     model = roleSlot.model;
                     thinking = roleSlot.thinking or "off";
-                    systemPromptPath = expandHome (roleSlot.systemPromptPath or "");
                   }) profileEntry
                 ) config.nx.programs.prism.profiles.data.profiles;
                 # Agent environment variables to inject into host-mode agent processes.


### PR DESCRIPTION
## Summary

PR2 of design #2031. Completes the switchover begun in PR1 (#2037): **stop
writing the per-session `APPEND_SYSTEM.md` file AND make the extension's
role-prompt injection live, in the same PR**, so role prompts never vanish.

After this PR the agent role prompt (coordinator / worker / review-*) is
delivered **only** by the prism PI extension (`pi/extensions/prism.ts`,
`before_agent_start`), which reads `~/.config/prism/agents/<role>.md` and
appends it to PI's default system prompt.

Refs #2031

## What changed

### 1. Removed the `APPEND_SYSTEM.md` write
- `StagePIAgentConfigDir` (`internal/container/pi_invocation.go`) no longer
  reads `slot.SystemPromptPath` or writes `APPEND_SYSTEM.md`. The
  `piAppendSystemFilename` const is removed. The function signature dropped its
  now-unused `slot config.RoleSlot` parameter (the only consumer of the slot in
  that function was the prompt write).
- The staging dir still carries auth.json (symlink), settings.json, themes/,
  AGENTS.md, skills/ — **the per-session staging dir is NOT collapsed** (that is
  PR3 / #2034).

### 2. Made the extension injection unconditional — **gate removed (preferred path)**
I chose the **preferred** option: remove the `PRISM_INJECT_ROLE_PROMPT` gate
entirely rather than flip it on. Rationale: the flag existed *solely* to prevent
double-injection while `APPEND_SYSTEM.md` was still written (its content is
baked into `event.systemPrompt` by pi's resource loader). With
`APPEND_SYSTEM.md` gone there is nothing to double up against, so the gate has
no remaining purpose. Removing it is less surface than wiring the env var
through every runtime-env injection path (sandbox-exec / bwrap / host).
- Deleted `ROLE_PROMPT_INJECT_ENV`, `roledPromptInjectionEnabled`, and the
  `enabled:` field of `resolveRolePromptForTurn`'s opts.
- Injection now gates only on `handshakeComplete` (still load-bearing —
  `sessionRole` is populated by the async hello_ack handler; latching before
  that would pin the session to "no role").

### 3. `systemPromptPath` plumbing — **fully removed (no remaining consumer)**
After the write was removed, the only references to `SystemPromptPath` were the
write itself and a debug passthrough in `prism profile --json`. No host-mode or
non-PI path consumes it (the extension resolves the prompt by `<role>.md`
convention, not via this path). Removed from:
- `config.RoleSlot` (Go struct)
- `cmd/profile.go` `profileSlotJSON` + `buildProfileJSON`
- `profiles.nix` (`slot` helper, `profileFromSlots`, and the profiles.json
  emit). The now-unused `roleToAgentFile` identity map was dropped too.

### 4. Doc comments updated
All `APPEND_SYSTEM.md` discovery descriptions in `pi_invocation.go`,
`container.go`, `agent_run.go`, `agent_run_sandbox_exec_darwin.go`, and the
extension header comment now describe the extension mechanism.

## Verification — no prompt is lost (the central correctness check)

Empirically confirmed every role still receives its prompt via the extension,
by running the extension's pure helpers against the real
`modules/programs/prism/agents/` directory:

```
coordinator:     prompt=16938B injected=true -> OK
worker:          prompt=11392B injected=true -> OK
review-goal:     prompt=8218B  injected=true -> OK
review-code:     prompt=6617B  injected=true -> OK
review-security: prompt=6862B  injected=true -> OK
review-qa:       prompt=7115B  injected=true -> OK
review-context:  prompt=6392B  injected=true -> OK
no-such-role:    override=undefined (PI default only) -> OK
```

Each role's `<role>.md` is read and composed as `event.systemPrompt + "\n\n" +
rolePrompt` (PI default preserved). A role with no file yields no override — PI
starts with its default prompt only, no error (edge-case AC).

**No double-injection:** `APPEND_SYSTEM.md` is gone, so the extension is the
sole source.

## Tests / gates
- `go build ./...` + `go test ./...` (incl. `-race` on container/cmd/config) — all green.
- Updated/removed Go tests that asserted `APPEND_SYSTEM.md` was written or the
  empty/missing-`SystemPromptPath` skip path; new tests assert
  `APPEND_SYSTEM.md` is **never** written and the no-role-file edge case starts
  cleanly. `profile_json_test.go` now asserts the slot JSON has no
  `system_prompt_path` key.
- `tsx --test prism.test.ts` — 294 pass, 0 fail. Removed the
  `roledPromptInjectionEnabled` describe block and dropped `enabled:` from the
  `resolveRolePromptForTurn` cases; added an "injects unconditionally once the
  handshake completes" case.
- `nix build .#prism` — succeeds.
- `nixfmt` applied to `profiles.nix`.

No `generateProfile` / `PrepareSandboxExec*` changes in this PR (PR1 already
added the agents-dir Darwin integration test), so no new #1192 test is needed.

## Out of scope (deferred)
- Collapsing the per-session pi-agent staging dir to a shared mount — PR3 (#2034),
  which also `Closes` the parent design.