### PR TITLE
anthropic-oauth: send adaptive thinking payload for opus-4-8 (forceAdaptiveThinking)

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
@@ -36,6 +36,7 @@ it is more actively maintained and is the source of the PR #193 fix.
 | `index.ts` | leohenon (pi-specific) | `src/index.ts` (different API, skip when porting) | `src/index.ts` |
 | `auth.ts` | leohenon | `src/credentials.ts` (OAuth helpers only, no callback server) | `src/auth.ts` |
 | `stream.ts` | leohenon | *(no equivalent — opencode uses different streaming)* | `src/stream.ts`, `src/convert.ts`, `src/prompt.ts` |
+| `request-body.ts` | pi-ai built-in | *(no equivalent — see divergence 9)* | *(no equivalent)* |
 | `credentials.ts` | griffinmartin | `src/credentials.ts` | `src/auth.ts` (partial) |
 | `transforms.ts` | griffinmartin PR #193 | `src/transforms.ts` | *(no equivalent)* |
 | `betas.ts` | griffinmartin | `src/betas.ts` | *(no equivalent)* |
@@ -93,6 +94,56 @@ it is more actively maintained and is the source of the PR #193 fix.
    `@earendil-works/pi-ai` model catalog ships `claude-opus-4-7`/`-4-8`
    directly, so the fallback was dead code and was removed. Do **not**
    re-introduce a hardcoded model object — rely entirely on the registry.
+
+9. **Adaptive thinking handling lives in `request-body.ts` and is ported from
+   pi-ai — NOT from griffinmartin**. Issue #2044 fixed an erratic-behaviour
+   bug on `claude-opus-4-8` (and a silent degradation on `-4-6` / `-4-7`)
+   where our `streamSimple` was sending the legacy budget-based thinking
+   payload (`thinking: {type:"enabled", budget_tokens:N}`) for all anthropic
+   models. Models flagged with `compat.forceAdaptiveThinking === true` in the
+   pi-ai registry (currently `claude-opus-4-6/4-7/4-8`) REQUIRE the adaptive
+   form: `thinking: {type:"adaptive", display:"summarized"}` +
+   `output_config: {effort}`.
+
+   As of griffinmartin SHA `ffefe9d` (release 1.5.4, 2026-04), griffinmartin
+   upstream has not implemented adaptive thinking — their `transforms.ts`
+   still treats effort as a haiku-only strip target. So the port for this
+   change came from pi-ai's built-in handler:
+   `@earendil-works/pi-ai/src/providers/anthropic.ts`. Key references:
+
+   - `mapThinkingLevelToEffort` (~710-731) — pi reasoning level → Anthropic
+     effort, honouring the model's `thinkingLevelMap`.
+   - `streamSimpleAnthropic` dispatch (~748-770) — selects adaptive vs
+     budget-based based on `compat.forceAdaptiveThinking`.
+   - `buildParams` body assembly (~937-981) — the wire-form details:
+     `display: "summarized"` on BOTH branches; `output_config: {effort}` for
+     adaptive; `budget_tokens` for legacy; and the temperature-suppression
+     guard at ~937-940.
+   - `createClient` interleaved-thinking gate (~789) — adaptive models have
+     interleaved thinking built in, so the
+     `interleaved-thinking-2025-05-14` beta header is suppressed. Mirrored in
+     our `betas.ts::getModelBetas` via the new `ctx.forceAdaptiveThinking`
+     argument.
+
+   When griffinmartin eventually ports adaptive thinking, prefer their
+   implementation if it lands in a logical home file (likely a new
+   `request-body.ts` analogue or an addition to `transforms.ts`). If their
+   shape diverges, keep the pi-ai-faithful behaviour and add a note here.
+
+   Smoke-test references in pi-ai:
+   - `test/anthropic-opus-4-8-smoke.test.ts` (live API smoke).
+   - `test/anthropic-force-adaptive-thinking.test.ts` (offline wire-form
+     capture, including the `forceAdaptiveThinking: false` opt-out case).
+   Our offline parity lives in `request-body.test.ts`.
+
+10. **`model-config.ts` `4-8` override and `betas.ts` adaptive
+    suppression**: Both changes from issue #2044. The `4-8` entry mirrors
+    the existing `4-6`/`4-7` pattern (substring match adds the
+    `effort-2025-11-24` beta). The `forceAdaptiveThinking`-driven
+    suppression of `interleaved-thinking-2025-05-14` in `getModelBetas` is
+    keyed off the model's compat flag at call time — it does NOT rely on
+    substring matching, so any future adaptive model from the registry
+    benefits automatically without a `model-config.ts` change.
 
 ## Port procedure for future upstream fixes
 

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/betas.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/betas.ts
@@ -90,9 +90,23 @@ export function isEnable1mContext(): boolean {
   return false
 }
 
+export interface GetModelBetasContext {
+  /**
+   * Whether the model uses adaptive thinking
+   * (`compat.forceAdaptiveThinking === true`). When true,
+   * `interleaved-thinking-2025-05-14` is suppressed because adaptive thinking
+   * models have interleaved thinking built in — mirrors pi-ai's
+   * `anthropic.ts::createClient` (~line 789):
+   *   "Adaptive thinking models have interleaved thinking built in,
+   *    so skip the beta header."
+   */
+  forceAdaptiveThinking?: boolean
+}
+
 export function getModelBetas(
   modelId: string,
   excluded?: Set<string>,
+  ctx?: GetModelBetasContext,
 ): string[] {
   const betas = [...getRequiredBetas()]
 
@@ -122,6 +136,15 @@ export function getModelBetas(
         if (!betas.includes(add)) betas.push(add)
       }
     }
+  }
+
+  // Adaptive thinking models have interleaved thinking built in — drop the
+  // beta header. Mirrors pi-ai's `anthropic.ts::createClient` ~789. The
+  // legacy beta is harmless for non-adaptive Claude 4.x models and is left in
+  // place there to preserve the existing wire form. Issue #2044.
+  if (ctx?.forceAdaptiveThinking) {
+    const idx = betas.indexOf("interleaved-thinking-2025-05-14")
+    if (idx !== -1) betas.splice(idx, 1)
   }
 
   // Filter out excluded betas (from previous failed requests due to long context errors)

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -29,13 +29,8 @@ import { transformBody, transformResponseStream } from "./transforms.ts"
 import { streamSimpleAnthropic } from "@earendil-works/pi-ai"
 import { getModelBetas, getExcludedBetas } from "./betas.ts"
 import { config } from "./model-config.ts"
-import {
-  buildAnthropicSystemPrompt,
-  convertPiMessagesToAnthropic,
-  convertPiToolsToAnthropic,
-  fromClaudeCodeToolName,
-  parseSSEStream,
-} from "./stream.ts"
+import { fromClaudeCodeToolName, parseSSEStream } from "./stream.ts"
+import { buildRequestBody } from "./request-body.ts"
 
 function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
   const modelRegistry = ModelRegistry.create(AuthStorage.inMemory())
@@ -130,7 +125,10 @@ export default function (pi: ExtensionAPI) {
               const creds = getCachedCredentials()
               const token = creds?.accessToken ?? apiKey
               const excluded = getExcludedBetas(model.id)
-              const betas = getModelBetas(model.id, excluded)
+              const betas = getModelBetas(model.id, excluded, {
+                forceAdaptiveThinking:
+                  model.compat?.forceAdaptiveThinking === true,
+              })
               headers.set("authorization", `Bearer ${token}`)
               headers.set("anthropic-version", "2023-06-01")
               headers.set("anthropic-beta", betas.join(","))
@@ -150,50 +148,12 @@ export default function (pi: ExtensionAPI) {
             return headers
           }
 
-          const maxTokens =
-            options?.maxTokens || Math.floor(model.maxTokens / 3)
-
-          const body: Record<string, unknown> = {
-            model: model.id,
-            max_tokens: maxTokens,
-            stream: true,
-          }
-
-          body.messages = convertPiMessagesToAnthropic(
-            context.messages,
-            isOAuth,
-          )
-
-          const system = buildAnthropicSystemPrompt(
-            context.systemPrompt,
-            isOAuth,
-          )
-          if (system) body.system = system
-
-          if (context.tools?.length) {
-            body.tools = convertPiToolsToAnthropic(context.tools, isOAuth)
-          }
-
-          if (options?.reasoning && model.reasoning && maxTokens > 1) {
-            const defaultBudgets: Record<string, number> = {
-              minimal: 1024,
-              low: 4096,
-              medium: 10240,
-              high: 20480,
-              xhigh: 32000,
-            }
-            const customBudget =
-              options.thinkingBudgets?.[
-                options.reasoning as keyof typeof options.thinkingBudgets
-              ]
-            const requestedBudget =
-              customBudget ?? defaultBudgets[options.reasoning] ?? 10240
-            body.thinking = {
-              type: "enabled",
-              budget_tokens: Math.min(requestedBudget, maxTokens - 1),
-            }
-          }
-
+          const body = buildRequestBody(model, context, options, isOAuth)
+          // NOTE: temperature is intentionally not set anywhere in body —
+          // Anthropic rejects extended-thinking requests that also pass
+          // temperature with a 400. Mirrors pi-ai's guard
+          // (`anthropic.ts` ~937-940). If a future change adds a
+          // temperature path, gate it on `!body.thinking`.
           const bodyStr = JSON.stringify(body)
           const transformedBody = isOAuth ? transformBody(bodyStr) : bodyStr
           const headers = buildHeaders()

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/model-config.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/model-config.ts
@@ -38,6 +38,9 @@ export const config: ModelConfig = {
     "4-7": {
       add: ["effort-2025-11-24"],
     },
+    "4-8": {
+      add: ["effort-2025-11-24"],
+    },
   },
 }
 

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/request-body.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/request-body.test.ts
@@ -1,0 +1,306 @@
+// Wire-form tests for buildRequestBody — the thinking-payload selection
+// that fixes issue #2044 (opus-4-8 erratic behaviour).
+//
+// Mirrors the assertions from pi-ai's own smoke + force-adaptive tests:
+//   - test/anthropic-opus-4-8-smoke.test.ts
+//   - test/anthropic-force-adaptive-thinking.test.ts
+//
+// Run with: tsx --test request-body.test.ts  (Node 20+, zero new deps)
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import type { Context, Model } from "@earendil-works/pi-ai"
+import {
+  buildRequestBody,
+  mapThinkingLevelToEffort,
+} from "./request-body.ts"
+import { getModelBetas } from "./betas.ts"
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal model + context fixtures.
+//
+// We do not use the live pi registry here so the tests stay hermetic and do
+// not depend on a specific pi-ai version pinning a specific model id.
+// ---------------------------------------------------------------------------
+
+function makeAdaptiveModel(
+  overrides: Partial<Model<"anthropic-messages">> = {},
+): Model<"anthropic-messages"> {
+  return {
+    id: "claude-opus-4-8",
+    name: "Claude Opus 4.8",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 32000,
+    compat: { forceAdaptiveThinking: true },
+    thinkingLevelMap: { xhigh: "xhigh" },
+    ...overrides,
+  } as Model<"anthropic-messages">
+}
+
+function makeLegacyModel(
+  overrides: Partial<Model<"anthropic-messages">> = {},
+): Model<"anthropic-messages"> {
+  // A non-adaptive anthropic-messages model — no forceAdaptiveThinking,
+  // no thinkingLevelMap. Represents older Claude models (e.g. opus-4-5,
+  // sonnet 3.x) and corporate-proxy custom ids that have not opted into
+  // adaptive thinking.
+  return {
+    id: "claude-sonnet-3-5",
+    name: "Claude Sonnet 3.5",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 8192,
+    ...overrides,
+  } as Model<"anthropic-messages">
+}
+
+function makeContext(): Context {
+  return {
+    systemPrompt: "You are a precise assistant.",
+    messages: [
+      { role: "user", content: "Hello", timestamp: Date.now() },
+    ],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// [functional] Adaptive wire form for forceAdaptiveThinking models
+// ---------------------------------------------------------------------------
+describe("buildRequestBody — adaptive thinking (forceAdaptiveThinking)", () => {
+  it("sends {type:'adaptive', display:'summarized'} + output_config.effort='medium' for reasoning='medium'", () => {
+    const body = buildRequestBody(
+      makeAdaptiveModel(),
+      makeContext(),
+      { reasoning: "medium", maxTokens: 1024 },
+      false,
+    )
+
+    assert.deepEqual(body.thinking, { type: "adaptive", display: "summarized" })
+    assert.deepEqual(body.output_config, { effort: "medium" })
+  })
+
+  it("maps reasoning='high' to effort='high'", () => {
+    const body = buildRequestBody(
+      makeAdaptiveModel(),
+      makeContext(),
+      { reasoning: "high", maxTokens: 1024 },
+      false,
+    )
+    assert.deepEqual(body.output_config, { effort: "high" })
+  })
+
+  it("maps reasoning='minimal' to effort='low'", () => {
+    const body = buildRequestBody(
+      makeAdaptiveModel(),
+      makeContext(),
+      { reasoning: "minimal", maxTokens: 1024 },
+      false,
+    )
+    assert.deepEqual(body.output_config, { effort: "low" })
+  })
+
+  it("honours the model's thinkingLevelMap (xhigh → 'xhigh' for opus-4-7/4-8)", () => {
+    const body = buildRequestBody(
+      makeAdaptiveModel(), // thinkingLevelMap: { xhigh: "xhigh" }
+      makeContext(),
+      { reasoning: "xhigh", maxTokens: 1024 },
+      false,
+    )
+    assert.deepEqual(body.output_config, { effort: "xhigh" })
+  })
+
+  it("honours the model's thinkingLevelMap (xhigh → 'max' for opus-4-6)", () => {
+    const model = makeAdaptiveModel({
+      id: "claude-opus-4-6",
+      thinkingLevelMap: { xhigh: "max" },
+    } as Partial<Model<"anthropic-messages">>)
+    const body = buildRequestBody(
+      model,
+      makeContext(),
+      { reasoning: "xhigh", maxTokens: 1024 },
+      false,
+    )
+    assert.deepEqual(body.output_config, { effort: "max" })
+  })
+
+  it("does NOT set body.temperature when thinking is enabled (pi-ai parity)", () => {
+    const body = buildRequestBody(
+      makeAdaptiveModel(),
+      makeContext(),
+      { reasoning: "medium", maxTokens: 1024 },
+      false,
+    )
+    assert.ok(!("temperature" in body), "temperature must not be set")
+  })
+
+  it("does NOT set body.thinking when reasoning is absent", () => {
+    const body = buildRequestBody(
+      makeAdaptiveModel(),
+      makeContext(),
+      { maxTokens: 1024 },
+      false,
+    )
+    assert.equal(body.thinking, undefined)
+    assert.equal(body.output_config, undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [edge-case] Legacy wire form for non-adaptive models — no regression
+// ---------------------------------------------------------------------------
+describe("buildRequestBody — legacy budget thinking (no forceAdaptiveThinking)", () => {
+  it("sends {type:'enabled', budget_tokens:N, display:'summarized'} for non-adaptive models", () => {
+    const body = buildRequestBody(
+      makeLegacyModel(),
+      makeContext(),
+      { reasoning: "medium", maxTokens: 8192 },
+      false,
+    )
+
+    assert.ok(body.thinking, "body.thinking should be set")
+    const thinking = body.thinking as {
+      type: string
+      budget_tokens: number
+      display: string
+    }
+    assert.equal(thinking.type, "enabled")
+    assert.equal(thinking.display, "summarized")
+    assert.equal(typeof thinking.budget_tokens, "number")
+    assert.ok(thinking.budget_tokens > 0)
+    // Default budget for "medium" is 10240, clamped to maxTokens-1=8191.
+    assert.equal(thinking.budget_tokens, 8191)
+    assert.equal(body.output_config, undefined)
+  })
+
+  it("honours custom thinkingBudgets when provided", () => {
+    const body = buildRequestBody(
+      makeLegacyModel(),
+      makeContext(),
+      {
+        reasoning: "low",
+        maxTokens: 8192,
+        thinkingBudgets: { low: 2000 },
+      },
+      false,
+    )
+    const thinking = body.thinking as { budget_tokens: number }
+    assert.equal(thinking.budget_tokens, 2000)
+  })
+
+  it("treats compat.forceAdaptiveThinking=false as opt-out (legacy form)", () => {
+    // Mirrors pi-ai's `anthropic-force-adaptive-thinking.test.ts`:
+    //   "allows built-in adaptive models to opt out with
+    //    compat.forceAdaptiveThinking false".
+    const model = makeAdaptiveModel({
+      compat: { forceAdaptiveThinking: false },
+    })
+    const body = buildRequestBody(
+      model,
+      makeContext(),
+      { reasoning: "medium", maxTokens: 8192 },
+      false,
+    )
+    const thinking = body.thinking as { type: string }
+    assert.equal(thinking.type, "enabled")
+    assert.equal(body.output_config, undefined)
+  })
+
+  it("does NOT set body.temperature for legacy thinking either", () => {
+    const body = buildRequestBody(
+      makeLegacyModel(),
+      makeContext(),
+      { reasoning: "medium", maxTokens: 8192 },
+      false,
+    )
+    assert.ok(!("temperature" in body), "temperature must not be set")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [functional] mapThinkingLevelToEffort unit checks (mirrors pi-ai's helper)
+// ---------------------------------------------------------------------------
+describe("mapThinkingLevelToEffort", () => {
+  it("returns 'low' for minimal and low", () => {
+    const m = makeAdaptiveModel({
+      thinkingLevelMap: undefined,
+    } as Partial<Model<"anthropic-messages">>)
+    assert.equal(mapThinkingLevelToEffort(m, "minimal"), "low")
+    assert.equal(mapThinkingLevelToEffort(m, "low"), "low")
+  })
+
+  it("returns 'medium' for medium", () => {
+    const m = makeAdaptiveModel({
+      thinkingLevelMap: undefined,
+    } as Partial<Model<"anthropic-messages">>)
+    assert.equal(mapThinkingLevelToEffort(m, "medium"), "medium")
+  })
+
+  it("returns 'high' for high and as the default", () => {
+    const m = makeAdaptiveModel({
+      thinkingLevelMap: undefined,
+    } as Partial<Model<"anthropic-messages">>)
+    assert.equal(mapThinkingLevelToEffort(m, "high"), "high")
+    assert.equal(mapThinkingLevelToEffort(m, undefined), "high")
+  })
+
+  it("prefers the model's thinkingLevelMap over the default mapping", () => {
+    const m = makeAdaptiveModel({
+      thinkingLevelMap: { high: "max" },
+    } as Partial<Model<"anthropic-messages">>)
+    assert.equal(mapThinkingLevelToEffort(m, "high"), "max")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [functional] getModelBetas — interleaved-thinking suppression for adaptive
+// ---------------------------------------------------------------------------
+describe("getModelBetas — interleaved-thinking suppression for adaptive models", () => {
+  it("includes interleaved-thinking-2025-05-14 for non-adaptive models (no regression)", () => {
+    const betas = getModelBetas("claude-sonnet-3-5", undefined, {
+      forceAdaptiveThinking: false,
+    })
+    assert.ok(
+      betas.includes("interleaved-thinking-2025-05-14"),
+      "legacy models should still receive the interleaved-thinking beta",
+    )
+  })
+
+  it("includes interleaved-thinking-2025-05-14 when no ctx is passed (backwards-compatible default)", () => {
+    const betas = getModelBetas("claude-sonnet-3-5")
+    assert.ok(
+      betas.includes("interleaved-thinking-2025-05-14"),
+      "backwards-compatible default should still include the beta",
+    )
+  })
+
+  it("suppresses interleaved-thinking-2025-05-14 for forceAdaptiveThinking models (pi-ai parity)", () => {
+    const betas = getModelBetas("claude-opus-4-8", undefined, {
+      forceAdaptiveThinking: true,
+    })
+    assert.ok(
+      !betas.includes("interleaved-thinking-2025-05-14"),
+      "adaptive models have interleaved thinking built in; the beta header is redundant — pi-ai anthropic.ts ~789",
+    )
+  })
+
+  it("still adds effort-2025-11-24 for the 4-8 substring match", () => {
+    const betas = getModelBetas("claude-opus-4-8", undefined, {
+      forceAdaptiveThinking: true,
+    })
+    assert.ok(
+      betas.includes("effort-2025-11-24"),
+      "4-8 model-config override should still add the effort beta",
+    )
+  })
+})

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/request-body.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/request-body.ts
@@ -1,0 +1,131 @@
+// Pure helpers for the Anthropic /v1/messages request body.
+//
+// Lives in its own file (separate from index.ts) so unit tests can import
+// it without pulling in `@earendil-works/pi-coding-agent` — the bundled
+// extension runtime — which is not resolvable in a bare `tsx --test` run.
+//
+// Mirrors pi-ai's built-in `buildParams` in
+// `@earendil-works/pi-ai/src/providers/anthropic.ts` (~lines 710-731 for
+// the effort mapping, ~937-981 for the body assembly).
+
+import type {
+  AnthropicEffort,
+  Context,
+  Model,
+  SimpleStreamOptions,
+  ThinkingLevel,
+} from "@earendil-works/pi-ai"
+import {
+  buildAnthropicSystemPrompt,
+  convertPiMessagesToAnthropic,
+  convertPiToolsToAnthropic,
+} from "./stream.ts"
+
+/**
+ * Map a pi reasoning level to an Anthropic effort string for the adaptive
+ * thinking payload. Honours the model's `thinkingLevelMap` when present,
+ * mirroring pi-ai's `mapThinkingLevelToEffort`
+ * (`@earendil-works/pi-ai` src/providers/anthropic.ts ~710-731).
+ */
+export function mapThinkingLevelToEffort(
+  model: Model<"anthropic-messages">,
+  level: ThinkingLevel | undefined,
+): AnthropicEffort {
+  const thinkingLevelMap = (
+    model as { thinkingLevelMap?: Record<string, string | null> }
+  ).thinkingLevelMap
+  const mapped = level ? thinkingLevelMap?.[level] : undefined
+  if (typeof mapped === "string") return mapped as AnthropicEffort
+
+  switch (level) {
+    case "minimal":
+    case "low":
+      return "low"
+    case "medium":
+      return "medium"
+    case "high":
+      return "high"
+    default:
+      return "high"
+  }
+}
+
+/**
+ * Build the JSON request body sent to Anthropic's /v1/messages endpoint.
+ *
+ * Pure helper exported for unit testing. Mirrors pi-ai's built-in
+ * `buildParams` in `src/providers/anthropic.ts` (~952-981) for the
+ * thinking-payload selection:
+ *
+ *   - Models with `compat.forceAdaptiveThinking === true` get the adaptive
+ *     payload: `thinking: {type:"adaptive", display:"summarized"}` plus
+ *     `output_config: {effort}` (effort derived from the pi reasoning level
+ *     via `mapThinkingLevelToEffort`, honouring the model's thinkingLevelMap).
+ *   - All other anthropic models keep the legacy budget-based form:
+ *     `thinking: {type:"enabled", budget_tokens:N, display:"summarized"}`.
+ *     `display: "summarized"` matches the documented Anthropic default and
+ *     pi-ai's legacy-path behaviour.
+ *
+ * Temperature is intentionally NOT set on the body when thinking is enabled
+ * (this helper never sets temperature — Anthropic rejects requests that
+ * combine extended thinking with a temperature override with a 400). Mirrors
+ * pi-ai's guard at `anthropic.ts` ~937-940. If a future change adds a
+ * temperature path, gate it on `!body.thinking`.
+ */
+export function buildRequestBody(
+  model: Model<"anthropic-messages">,
+  context: Context,
+  options: SimpleStreamOptions | undefined,
+  isOAuth: boolean,
+): Record<string, unknown> {
+  const maxTokens = options?.maxTokens || Math.floor(model.maxTokens / 3)
+
+  const body: Record<string, unknown> = {
+    model: model.id,
+    max_tokens: maxTokens,
+    stream: true,
+  }
+
+  body.messages = convertPiMessagesToAnthropic(context.messages, isOAuth)
+
+  const system = buildAnthropicSystemPrompt(context.systemPrompt, isOAuth)
+  if (system) body.system = system
+
+  if (context.tools?.length) {
+    body.tools = convertPiToolsToAnthropic(context.tools, isOAuth)
+  }
+
+  if (options?.reasoning && model.reasoning && maxTokens > 1) {
+    const display = "summarized" as const
+    if (model.compat?.forceAdaptiveThinking === true) {
+      // Adaptive thinking (opus-4-6/4-7/4-8 and any other model that opts in
+      // via compat). The legacy budget_tokens form produces a degraded /
+      // erratic response from these models — see issue #2044.
+      body.thinking = { type: "adaptive", display }
+      const effort = mapThinkingLevelToEffort(model, options.reasoning)
+      body.output_config = { effort }
+    } else {
+      // Legacy budget-based thinking for older / non-adaptive Claude models.
+      const defaultBudgets: Record<string, number> = {
+        minimal: 1024,
+        low: 4096,
+        medium: 10240,
+        high: 20480,
+        xhigh: 32000,
+      }
+      const customBudget =
+        options.thinkingBudgets?.[
+          options.reasoning as keyof typeof options.thinkingBudgets
+        ]
+      const requestedBudget =
+        customBudget ?? defaultBudgets[options.reasoning] ?? 10240
+      body.thinking = {
+        type: "enabled",
+        budget_tokens: Math.min(requestedBudget, maxTokens - 1),
+        display,
+      }
+    }
+  }
+
+  return body
+}


### PR DESCRIPTION
Closes #2044.

## Summary

Our vendored `anthropic-oauth` pi extension was sending the **legacy budget-based** thinking payload (`thinking: {type:"enabled", budget_tokens:N}`) for ALL anthropic models. `claude-opus-4-6/4-7/4-8` carry `compat.forceAdaptiveThinking=true` in the pi-ai registry and REQUIRE the **adaptive** payload form (`thinking: {type:"adaptive", display:"summarized"}` + `output_config: {effort}`).

- `opus-4-7` limped along because its `effort-2025-11-24` beta header made the API tolerant of the legacy shape.
- `opus-4-8` had no `model-config.ts` override → no beta → no tolerance → degraded state: random tool calls, fabricated PR numbers, phantom "pushed" commits, early no-op `end_turn` finishes.

Ported from pi-ai's built-in handler (`@earendil-works/pi-ai/src/providers/anthropic.ts`). griffinmartin upstream (SHA `ffefe9d`, release 1.5.4) has not yet implemented adaptive thinking — their `transforms.ts` still treats effort as a haiku-only strip target — so this is a pi-ai port. See `UPSTREAM.md` divergence note 9.

## Changes

- **`model-config.ts`** — add `"4-8": { add: ["effort-2025-11-24"] }`, mirroring `4-6` / `4-7`.
- **`request-body.ts` (new)** — extracted, pure helper:
  - `buildRequestBody(model, context, options, isOAuth)` branches on `model.compat?.forceAdaptiveThinking === true`:
    - adaptive: `thinking: {type:"adaptive", display:"summarized"}` + `output_config: {effort:<mapped>}`.
    - legacy: `thinking: {type:"enabled", budget_tokens:N, display:"summarized"}` (added `display:"summarized"` for pi-ai parity; matches the documented Anthropic default).
  - `mapThinkingLevelToEffort(model, level)` honours the model's `thinkingLevelMap` (so `xhigh` → `max` on `4-6` and `xhigh` → `xhigh` on `4-7`/`4-8`).
  - **Temperature is intentionally never set** on the body — Anthropic 400s when temperature is combined with extended thinking. Mirrors pi-ai's guard at `anthropic.ts` ~937-940. A code comment in `index.ts` documents that future temperature paths must gate on `!body.thinking`.
- **`index.ts`** — `streamSimple` now delegates body construction to `buildRequestBody`, and passes the `forceAdaptiveThinking` flag through to `getModelBetas`.
- **`betas.ts`** — `getModelBetas` accepts a new optional `ctx: { forceAdaptiveThinking?: boolean }`. When true, the `interleaved-thinking-2025-05-14` beta is suppressed (adaptive models have interleaved thinking built in — mirrors pi-ai `anthropic.ts` ~789 `createClient`). The previous 2-arg call sites and the no-ctx default are backwards-compatible.
- **`request-body.test.ts` (new)** — 19 wire-form assertions mirroring pi-ai's `anthropic-opus-4-8-smoke.test.ts` and `anthropic-force-adaptive-thinking.test.ts`:
  - adaptive form for `forceAdaptiveThinking=true` (display + effort, mapping per `reasoning` level);
  - legacy form for non-adaptive models (no regression);
  - opt-out via `compat.forceAdaptiveThinking=false` (mirrors pi-ai's opt-out test);
  - `thinkingLevelMap` honoured for `xhigh` on `4-6` (→`max`) and `4-7`/`4-8` (→`xhigh`);
  - temperature never set on either branch;
  - `interleaved-thinking-2025-05-14` suppressed for adaptive, retained for legacy and the backwards-compatible no-ctx default.
- **`UPSTREAM.md`** — divergence notes 9 and 10 documenting the pi-ai provenance (with source line citations: ~710-731, ~748-770, ~789, ~937-981) and the substring-vs-compat split (model-config additions are substring-keyed; the interleaved-thinking suppression is compat-keyed, so any future adaptive model from the registry benefits without a model-config change).

## Acceptance criteria (from #2044)

- [x] `model-config.ts` `modelOverrides` includes a `"4-8"` entry adding `effort-2025-11-24`.
- [x] `streamSimple` sends `thinking: {type:"adaptive", display:"summarized"}` + `output_config: {effort:<mapped>}` for `forceAdaptiveThinking=true` models; legacy `{type:"enabled", budget_tokens:N}` (now also `display:"summarized"`) otherwise.
- [x] pi reasoning level → Anthropic effort mapping honours `thinkingLevelMap` (mirrors pi-ai's `mapThinkingLevelToEffort`).
- [x] Temperature is never set on the request body when thinking is enabled.
- [x] Non-adaptive anthropic model still receives the legacy budget-based form (regression covered in `request-body.test.ts`).
- [x] Extension test asserts adaptive form (`{type:"adaptive",display:"summarized"}` + `{effort:"medium"}` for medium) AND legacy form. `tsx --test` green: 66/66 tests pass across all `*.test.ts` files in the extension.
- [x] Interleaved-thinking-beta question resolved: **suppressed** for `forceAdaptiveThinking=true` models with rationale in code comments (`betas.ts`) and the UPSTREAM.md divergence note. Mirrors pi-ai `anthropic.ts` ~789.
- [x] `nix build .#prism` succeeds locally.

## Validation

The TRUE end-to-end validation — running a worker on opus-4-8 and confirming it's no longer erratic — happens **after merge**, when the coordinator switches the agent profile back to opus-4-8 from the interim opus-4-7 workaround. This author ran on opus-4-7 specifically to avoid hitting the bug being fixed.

## CI note

This PR touches only `modules/programs/prism/pi/extensions/anthropic-oauth/**`. It does not touch `modules/programs/prism/prism/**`, `pkgs/prism.nix`, or any `go.mod`/`go.sum`, so the path-filtered `go-tests` and `nix-build-prism-checked` jobs in `.github/workflows/pr-gate.yml` will short-circuit to a single echo step. This matches the relaxation introduced in #1441 for non-prism-Go paths.