### PR TITLE
anthropic-oauth: instrument parseSSEStream for diagnostic capture (#2048)

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/stream.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/stream.test.ts
@@ -18,7 +18,9 @@
 
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { sanitizeSystemText, buildAnthropicSystemPrompt } from "./stream.ts"
+import { PassThrough } from "node:stream"
+import { sanitizeSystemText, buildAnthropicSystemPrompt, parseSSEStream } from "./stream.ts"
+import { initLogger, closeLogger } from "./logger.ts"
 
 // ---------------------------------------------------------------------------
 // Helper: reference implementation of the *prior* sanitizeSystemText behaviour
@@ -392,5 +394,277 @@ describe("sanitizeSystemText — real coordinator-shaped system prompt", () => {
       contentBlock.text.includes("Use Claude Code to invoke the agent."),
       "prose pi → Claude Code substitution should still work",
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// [functional] parseSSEStream diagnostic instrumentation (issue #2048)
+//
+// Asserts:
+//   - With PI_ANTHROPIC_OAUTH_DEBUG unset / logger disabled, parseSSEStream
+//     emits no log lines and parses the stream identically.
+//   - With the logger enabled (via initLogger({ stream }), the same mechanism
+//     the runtime uses), per-event logs, the event:error log, and the
+//     terminal summary all appear with the expected compact field shapes.
+//   - No request/response bodies, headers, tokens, or message content appear
+//     in the captured log output — frame metadata only.
+// ---------------------------------------------------------------------------
+
+// Build a Response whose body is a ReadableStream emitting `chunks` as raw
+// SSE bytes. Each chunk is delivered as a separate Uint8Array, which is
+// closer to how the network actually fragments frames.
+function makeSSEResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c))
+      controller.close()
+    },
+  })
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  })
+}
+
+// A no-op AssistantMessageEventStream that just collects pushed events.
+// Typed loosely — we don't assert on stream events, only on log output.
+function makeFakeStream(): { push: (e: unknown) => void; events: unknown[] } {
+  const events: unknown[] = []
+  return { push: (e) => events.push(e), events }
+}
+
+// Minimal Model / Context shaped to satisfy parseSSEStream. We never read
+// network or invoke a tool; these are only assigned onto `output`.
+function makeModelAndContext() {
+  const model = {
+    id: "claude-test",
+    api: "anthropic",
+    provider: "anthropic",
+  } as unknown as Parameters<typeof parseSSEStream>[1]
+  const context = { tools: [] } as unknown as Parameters<typeof parseSSEStream>[2]
+  return { model, context }
+}
+
+// Canonical, well-formed SSE transcript covering each event arm we log.
+const HEALTHY_TRANSCRIPT = [
+  // message_start
+  'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}\n\n',
+  // content_block_start (text)
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+  // content_block_delta (text)
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n',
+  // content_block_stop
+  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+  // content_block_start (tool_use)
+  'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"Read","input":{}}}\n\n',
+  // content_block_delta (input_json)
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}\n\n',
+  // content_block_stop
+  'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+  // message_delta with stop_reason
+  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}\n\n',
+  // message_stop
+  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+]
+
+function parseLogLines(buf: string): Array<Record<string, unknown>> {
+  return buf
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+}
+
+describe("parseSSEStream — diagnostic instrumentation (#2048)", () => {
+  it("emits zero log lines when the logger is disabled (env-flag unset default)", async () => {
+    // Ensure no leaked state from a prior test re-enables the logger.
+    closeLogger()
+
+    // Capture writes to the logger's stream sink: install one, then close it
+    // again to flip mode back to "disabled". After this, log() must be a no-op.
+    const sink = new PassThrough()
+    let captured = ""
+    sink.on("data", (chunk) => {
+      captured += chunk.toString()
+    })
+
+    // (Sanity: with no initLogger call, logger is disabled by default.)
+    const { model, context } = makeModelAndContext()
+    const fakeStream = makeFakeStream()
+    const response = makeSSEResponse(HEALTHY_TRANSCRIPT)
+
+    const out = await parseSSEStream(
+      response,
+      model,
+      context,
+      false,
+      fakeStream as unknown as Parameters<typeof parseSSEStream>[4],
+    )
+
+    assert.equal(captured, "", "no log bytes should be written when logger is disabled")
+    // Behavioural sanity: parse still works.
+    assert.equal(out.role, "assistant")
+    assert.equal(out.content.length, 2, "text + toolCall block parsed")
+    assert.equal(out.stopReason, "toolUse")
+  })
+
+  it("emits per-event, error, and terminal-summary log lines with compact field shapes when enabled", async () => {
+    const sink = new PassThrough()
+    let captured = ""
+    sink.on("data", (chunk) => {
+      captured += chunk.toString()
+    })
+    initLogger({ stream: sink })
+
+    try {
+      const { model, context } = makeModelAndContext()
+      const fakeStream = makeFakeStream()
+
+      // Include a mid-stream `event: error` frame to assert the error-arm log.
+      // The parser's silent-fall-through behaviour for errors is preserved
+      // (no error arm in the switch); we only assert that the raw payload was
+      // logged BEFORE that fall-through.
+      const transcriptWithError = [
+        ...HEALTHY_TRANSCRIPT.slice(0, 3),
+        'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"x"}}\n\n',
+        ...HEALTHY_TRANSCRIPT.slice(3),
+      ]
+      const response = makeSSEResponse(transcriptWithError)
+
+      const out = await parseSSEStream(
+        response,
+        model,
+        context,
+        false,
+        fakeStream as unknown as Parameters<typeof parseSSEStream>[4],
+      )
+
+      const lines = parseLogLines(captured)
+      assert.ok(lines.length > 0, "some log lines should have been emitted")
+
+      // Every log entry has the logger's standard envelope: ts + event + payload.
+      for (const entry of lines) {
+        assert.equal(typeof entry.ts, "string")
+        assert.equal(typeof entry.event, "string")
+      }
+
+      // Per-event logs: one sse_event per parsed SSE frame.
+      const perEvent = lines.filter((l) => l.event === "sse_event")
+      const types = perEvent.map((l) => l.t)
+      assert.deepEqual(
+        types,
+        [
+          "message_start",
+          "content_block_start",
+          "content_block_delta",
+          // NOTE: event:error frame is logged separately as sse_event_error;
+          // it ALSO produces a per-event log because the parser still JSON-
+          // parses the data and routes through the switch with type "error".
+          "error",
+          "content_block_stop",
+          "content_block_start",
+          "content_block_delta",
+          "content_block_stop",
+          "message_delta",
+          "message_stop",
+        ],
+        "per-event log should cover every parsed frame in order",
+      )
+
+      // content_block_start carries the cb (content_block type) field.
+      const blockStarts = perEvent.filter((l) => l.t === "content_block_start")
+      assert.deepEqual(
+        blockStarts.map((l) => l.cb),
+        ["text", "tool_use"],
+        "content_block_start logs include cb field",
+      )
+      // and an index.
+      for (const bs of blockStarts) assert.equal(typeof bs.i, "number")
+
+      // content_block_delta carries the d (delta type) field.
+      const blockDeltas = perEvent.filter((l) => l.t === "content_block_delta")
+      assert.deepEqual(
+        blockDeltas.map((l) => l.d),
+        ["text_delta", "input_json_delta"],
+        "content_block_delta logs include d field",
+      )
+
+      // message_delta carries the sr (stop_reason) field.
+      const msgDeltas = perEvent.filter((l) => l.t === "message_delta")
+      assert.equal(msgDeltas.length, 1)
+      assert.equal(msgDeltas[0].sr, "tool_use", "message_delta log includes sr field")
+
+      // event:error frame produces a dedicated sse_event_error log with raw data.
+      const errLogs = lines.filter((l) => l.event === "sse_event_error")
+      assert.equal(errLogs.length, 1, "exactly one sse_event_error log expected")
+      assert.equal(typeof errLogs[0].data, "string")
+      assert.ok(
+        (errLogs[0].data as string).includes("overloaded_error"),
+        "raw error payload should be captured",
+      )
+
+      // Terminal summary: exactly one, emitted last.
+      const ends = lines.filter((l) => l.event === "sse_stream_end")
+      assert.equal(ends.length, 1, "exactly one sse_stream_end summary expected")
+      assert.equal(lines[lines.length - 1].event, "sse_stream_end", "summary is last")
+      const summary = ends[0]
+      assert.equal(summary.contentLen, 2, "text + toolCall content blocks")
+      assert.equal(summary.toolCalls, 1, "one toolCall block")
+      assert.equal(summary.stopReason, "toolUse")
+      assert.equal(summary.sawMessageStop, true)
+
+      // Security: no message content or token strings leaked into the log.
+      // The transcript contains the text "hi" inside a text_delta. The
+      // per-event logger MUST NOT include it (we only log frame metadata).
+      assert.ok(!captured.includes('"hi"'), "message text must not appear in logs")
+      // No usage tokens fields either.
+      assert.ok(
+        !captured.includes("input_tokens"),
+        "raw usage fields should not appear in per-event logs",
+      )
+
+      // Behavioural sanity: parse still returns the same shape as the
+      // disabled-logger case.
+      assert.equal(out.content.length, 2)
+      assert.equal(out.stopReason, "toolUse")
+    } finally {
+      closeLogger()
+    }
+  })
+
+  it("terminal summary reports sawMessageStop=false when the stream ends without one", async () => {
+    const sink = new PassThrough()
+    let captured = ""
+    sink.on("data", (chunk) => {
+      captured += chunk.toString()
+    })
+    initLogger({ stream: sink })
+
+    try {
+      // Same transcript but drop the trailing message_stop frame.
+      const truncated = HEALTHY_TRANSCRIPT.slice(0, HEALTHY_TRANSCRIPT.length - 1)
+      const { model, context } = makeModelAndContext()
+      const fakeStream = makeFakeStream()
+      const response = makeSSEResponse(truncated)
+
+      await parseSSEStream(
+        response,
+        model,
+        context,
+        false,
+        fakeStream as unknown as Parameters<typeof parseSSEStream>[4],
+      )
+
+      const lines = parseLogLines(captured)
+      const ends = lines.filter((l) => l.event === "sse_stream_end")
+      assert.equal(ends.length, 1)
+      assert.equal(
+        ends[0].sawMessageStop,
+        false,
+        "missing message_stop must be observable in the summary",
+      )
+    } finally {
+      closeLogger()
+    }
   })
 })

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts
@@ -23,6 +23,8 @@ import type {
   Tool,
 } from "@earendil-works/pi-ai"
 
+import { log } from "./logger.ts"
+
 // ──────────────────────────────────────────────
 // Type helpers
 // ──────────────────────────────────────────────
@@ -476,6 +478,11 @@ export async function parseSSEStream(
 
   const blocks = output.content as IndexedBlock[]
 
+  // Diagnostic instrumentation (issue #2048): track whether the API ever
+  // emitted a terminal `message_stop` event. Observation only — NOT an
+  // assertion. The parser's behaviour is unchanged.
+  let sawMessageStop = false
+
   const processEvent = (eventText: string) => {
     const lines = eventText.split("\n")
     let eventType = ""
@@ -489,6 +496,16 @@ export async function parseSSEStream(
       }
     }
 
+    // Diagnostic instrumentation (issue #2048): log any `event: error` frame
+    // with its raw payload BEFORE deciding what to do with it. Today these
+    // frames silently fall through (no `error` arm in the switch below);
+    // that behaviour is intentionally preserved here — this is logging only.
+    // This is the single highest-signal line for distinguishing parser-side
+    // silent data loss from genuine model behaviour.
+    if (eventType === "error") {
+      log("sse_event_error", { data: dataStr })
+    }
+
     if (!dataStr || dataStr === "[DONE]") return
 
     let event: Record<string, unknown>
@@ -499,6 +516,26 @@ export async function parseSSEStream(
     }
 
     const type = (event.type as string) ?? eventType
+
+    // Diagnostic instrumentation (issue #2048): per-event log of frame
+    // metadata only. No request/response bodies, no message content — just
+    // event names, content-block type tags, delta type tags, and stop_reason
+    // values. Compact field names keep long sessions from blowing out the log.
+    {
+      const meta: Record<string, unknown> = { t: type }
+      if (typeof event.index === "number") meta.i = event.index
+      if (type === "content_block_start") {
+        const cb = event.content_block as { type?: string } | undefined
+        if (cb?.type) meta.cb = cb.type
+      } else if (type === "content_block_delta") {
+        const d = event.delta as { type?: string } | undefined
+        if (d?.type) meta.d = d.type
+      } else if (type === "message_delta") {
+        const d = event.delta as { stop_reason?: string | null } | undefined
+        if (d && "stop_reason" in d) meta.sr = d.stop_reason ?? null
+      }
+      log("sse_event", meta)
+    }
 
     if (type === "message_start") {
       const msg = event.message as {
@@ -673,6 +710,13 @@ export async function parseSSEStream(
           output.usage.cacheWrite
       }
     }
+
+    if (type === "message_stop") {
+      // Diagnostic instrumentation (issue #2048): observe terminal frame.
+      // No behavioural change — the parser already implicitly tolerated
+      // missing message_stop; this just records that we saw it.
+      sawMessageStop = true
+    }
   }
 
   // Read the SSE stream chunk by chunk
@@ -693,6 +737,22 @@ export async function parseSSEStream(
 
   // Process any remaining buffer
   if (buffer.trim()) processEvent(buffer)
+
+  // Diagnostic instrumentation (issue #2048): terminal summary emitted
+  // exactly once immediately before returning. Frame metadata only — counts,
+  // stop_reason value, and whether message_stop was observed.
+  {
+    let toolCalls = 0
+    for (const b of output.content) {
+      if ((b as { type?: string }).type === "toolCall") toolCalls++
+    }
+    log("sse_stream_end", {
+      contentLen: output.content.length,
+      toolCalls,
+      stopReason: output.stopReason,
+      sawMessageStop,
+    })
+  }
 
   return output
 }


### PR DESCRIPTION
Closes #2048

## What this does

Adds env-gated (`PI_ANTHROPIC_OAUTH_DEBUG`) per-event logging to the vendored SSE parser at `modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts`. Routes through the existing `logger.ts` `log()` helper, which is a no-op when the env flag is unset.

Three new log events:

- **`sse_event`** — one per parsed SSE frame. Compact fields: `t` (event type), `i` (index, when present), `cb` (`content_block.type` for `content_block_start`), `d` (`delta.type` for `content_block_delta`), `sr` (`stop_reason` for `message_delta`).
- **`sse_event_error`** — logs the raw `data` of any `event: error` frame **before** the parser's existing silent fall-through. This is the single highest-signal line: if it appears in a captured opus-4-8 session, it immediately confirms hypothesis (B) — parser-side silent data loss — over hypothesis (A) (model produces a planning-only turn).
- **`sse_stream_end`** — terminal summary emitted exactly once immediately before `parseSSEStream` returns: `contentLen`, `toolCalls`, `stopReason`, and `sawMessageStop` (observation only — never asserted).

## Scope discipline

Per #2048, this is **logging-only**. Explicitly NOT in this PR:

- No new `error` arm in the switch that throws on `event: error`.
- No `message_stop` assertion (`sawMessageStop` is observed, not asserted).
- No `redacted_thinking` content-block handler.

Those are remediations gated on what the captured stream actually shows. Bundling them here would obscure whether the diagnostic or the fix unblocked the symptom; they will be filed separately if and when the captured stream confirms (B).

## Tests

Three new unit tests in `stream.test.ts` using the existing `initLogger({ stream })` convention:

- "emits zero log lines when the logger is disabled (env-flag unset default)" — proves the default path is a no-op, both in logged bytes and in parse output.
- "emits per-event, error, and terminal-summary log lines with compact field shapes when enabled" — asserts every per-event log carries the documented compact fields, the `sse_event_error` fires for a mid-stream `event: error` frame, the terminal summary is unique and last in the log, and no message text (`"hi"`) or raw usage fields leak.
- "terminal summary reports sawMessageStop=false when the stream ends without one" — proves the missing-`message_stop` signal is observable.

## Verification

- `tsx --test` from `modules/programs/prism/pi/extensions/anthropic-oauth/`: **69 / 69 pass** (27 in `stream.test.ts` incl. 3 new).
- `nix build .#prism`: **success**.
- **Manual smoke test** of the file-mode logger (driving `parseSSEStream` with `PI_ANTHROPIC_OAUTH_DEBUG` set to a temp file path, healthy transcript with one text block + `message_stop`):

  ```
  {"ts":"...","event":"sse_event","t":"message_start"}
  {"ts":"...","event":"sse_event","t":"content_block_start","i":0,"cb":"text"}
  {"ts":"...","event":"sse_event","t":"content_block_delta","i":0,"d":"text_delta"}
  {"ts":"...","event":"sse_event","t":"content_block_stop","i":0}
  {"ts":"...","event":"sse_event","t":"message_delta","sr":"end_turn"}
  {"ts":"...","event":"sse_event","t":"message_stop"}
  {"ts":"...","event":"sse_stream_end","contentLen":1,"toolCalls":0,"stopReason":"stop","sawMessageStop":true}
  ```

  Note what is **not** there: the assistant's text content (the transcript contained `"hello"`), token counts, or any payload from `usage`. Frame metadata only.

## Files changed

- `modules/programs/prism/pi/extensions/anthropic-oauth/stream.ts` — +60 lines (import `log`, three log call sites, one local `sawMessageStop` bool, one new `message_stop` arm that **only** flips that bool).
- `modules/programs/prism/pi/extensions/anthropic-oauth/stream.test.ts` — +275 lines (three new tests + helpers).

## How this will be used

1. Switch a worker session to opus-4-8.
2. Set `PI_ANTHROPIC_OAUTH_DEBUG=1` (writes to `~/.pi/agent/pi-anthropic-oauth-debug.log` by default).
3. Spawn a worker we've previously seen plan-without-acting on 4-8.
4. Inspect the log: did the API emit a mid-stream `event: error` we swallowed (B)? Did the stream end without `message_stop` (B)? Or did it just end after thinking + text with no `tool_use` blocks (A)?
5. File the follow-up: parser hardening (B) or 4-8 prompt-template adjustment (A).