### PR TITLE
anthropic-oauth: propagate thinkingLevelMap through getAnthropicModels (#2053)

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/index.ts
@@ -42,11 +42,28 @@ function getAnthropicModels(): NonNullable<ProviderConfig["models"]> {
       name: model.name,
       api: model.api ?? "anthropic-messages",
       reasoning: model.reasoning,
+      // thinkingLevelMap drives request-body.ts::mapThinkingLevelToEffort —
+      // without it, opus-4-6/4-7/4-8 silently fall through to the default
+      // mapping (e.g. xhigh → "high" instead of "max"/"xhigh"). Issue #2053;
+      // same bug shape as leohenon/pi-anthropic-oauth#7. Pi's
+      // ProviderModelConfig schema explicitly accepts this field
+      // (`dist/core/model-registry.js` ~line 114 / 505).
+      thinkingLevelMap: model.thinkingLevelMap,
       input: model.input,
       cost: model.cost,
       contextWindow: model.contextWindow,
       maxTokens: model.maxTokens,
       compat: model.compat,
+      // Deliberately NOT propagated:
+      //   - provider: fixed at "anthropic" by registerProvider() below.
+      //   - baseUrl: set at the provider level in registerProvider(); no
+      //     anthropic-provider registry entry overrides it per-model.
+      //   - headers: this extension builds the Anthropic request headers
+      //     itself in streamSimple (Bearer token, anthropic-version,
+      //     anthropic-beta, x-app, user-agent, x-client-request-id) — pi's
+      //     per-model headers would be additive and risk colliding with the
+      //     OAuth-mode auth header. No anthropic registry model currently
+      //     declares per-model headers, so this is also a no-op today.
     }))
 
   return models

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/request-body.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/request-body.test.ts
@@ -110,7 +110,12 @@ describe("buildRequestBody — adaptive thinking (forceAdaptiveThinking)", () =>
     assert.deepEqual(body.output_config, { effort: "low" })
   })
 
-  it("honours the model's thinkingLevelMap (xhigh → 'xhigh' for opus-4-7/4-8)", () => {
+  it("honours the model's thinkingLevelMap (xhigh → 'xhigh' for opus-4-8)", () => {
+    // Issue #2053: the registry ships opus-4-8 with
+    // thinkingLevelMap: {"xhigh":"xhigh"}. Before the projection in
+    // index.ts::getAnthropicModels propagated thinkingLevelMap, this fell
+    // through to the default mapping ("high"). After the fix the resolved
+    // effort matches the registry.
     const body = buildRequestBody(
       makeAdaptiveModel(), // thinkingLevelMap: { xhigh: "xhigh" }
       makeContext(),
@@ -120,7 +125,27 @@ describe("buildRequestBody — adaptive thinking (forceAdaptiveThinking)", () =>
     assert.deepEqual(body.output_config, { effort: "xhigh" })
   })
 
+  it("honours the model's thinkingLevelMap (xhigh → 'xhigh' for opus-4-7)", () => {
+    // Mirrors the opus-4-8 case — the registry ships opus-4-7 with the
+    // same {"xhigh":"xhigh"} entry. Explicit assertion per AC in #2053.
+    const model = makeAdaptiveModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      thinkingLevelMap: { xhigh: "xhigh" },
+    } as Partial<Model<"anthropic-messages">>)
+    const body = buildRequestBody(
+      model,
+      makeContext(),
+      { reasoning: "xhigh", maxTokens: 1024 },
+      false,
+    )
+    assert.deepEqual(body.output_config, { effort: "xhigh" })
+  })
+
   it("honours the model's thinkingLevelMap (xhigh → 'max' for opus-4-6)", () => {
+    // Registry ships opus-4-6 with thinkingLevelMap: {"xhigh":"max"} —
+    // a distinct value from opus-4-7/4-8, so this assertion also proves the
+    // map is being read per-model and not coincidentally matching a default.
     const model = makeAdaptiveModel({
       id: "claude-opus-4-6",
       thinkingLevelMap: { xhigh: "max" },
@@ -132,6 +157,25 @@ describe("buildRequestBody — adaptive thinking (forceAdaptiveThinking)", () =>
       false,
     )
     assert.deepEqual(body.output_config, { effort: "max" })
+  })
+
+  it("falls through to default mapping when thinkingLevelMap is absent (no regression)", () => {
+    // Adaptive model with no thinkingLevelMap (hypothetical / legacy /
+    // corporate-proxy registry entry that opts into adaptive thinking but
+    // omits the map). Without thinkingLevelMap, mapThinkingLevelToEffort
+    // falls back to its default switch — xhigh hits the `default` arm and
+    // resolves to "high". This is the pre-fix behaviour for opus-4-6/4-7/4-8
+    // (#2053) and the contract we preserve for models that never had a map.
+    const model = makeAdaptiveModel({
+      thinkingLevelMap: undefined,
+    } as Partial<Model<"anthropic-messages">>)
+    const body = buildRequestBody(
+      model,
+      makeContext(),
+      { reasoning: "xhigh", maxTokens: 1024 },
+      false,
+    )
+    assert.deepEqual(body.output_config, { effort: "high" })
   })
 
   it("does NOT set body.temperature when thinking is enabled (pi-ai parity)", () => {


### PR DESCRIPTION
Closes #2053.

## Summary

`getAnthropicModels()` in `index.ts:38-50` projects registry models into pi's `ProviderConfig.models` shape but silently drops `thinkingLevelMap`. The consumer `request-body.ts::mapThinkingLevelToEffort` reads it via a structural cast and falls through to the default switch when the field is missing — so worker-selected `reasoning` levels land at the wrong `output_config.effort` on the wire for every adaptive opus model:

| Model    | Registry `thinkingLevelMap` | Pre-fix wire `effort` (xhigh) | Post-fix |
|----------|------------------------------|--------------------------------|----------|
| opus-4-6 | `{xhigh:"max"}`              | `"high"` (default fallback)    | `"max"`  |
| opus-4-7 | `{xhigh:"xhigh"}`            | `"high"` (default fallback)    | `"xhigh"`|
| opus-4-8 | `{xhigh:"xhigh"}`            | `"high"` (default fallback)    | `"xhigh"`|

Pi's `ProviderModelConfig` schema explicitly accepts `thinkingLevelMap` (see `dist/core/model-registry.js` ~line 114 / 505 of the bundled `pi-coding-agent` package) — pi itself reads and forwards it. The bug was purely the projection dropping the field on its way through our extension.

Same bug shape as [`leohenon/pi-anthropic-oauth#7`](https://github.com/leohenon/pi-anthropic-oauth/issues/7) (unfixed upstream).

## Audit of related fields on `Model<"anthropic-messages">`

The full field set on the registry model type is:

`id, name, api, provider, baseUrl, reasoning, thinkingLevelMap, input, cost, contextWindow, maxTokens, headers, compat`.

**Propagated** (now including the new field): `id, name, api, reasoning, thinkingLevelMap` *(NEW)*, `input, cost, contextWindow, maxTokens, compat`.

**Deliberately not propagated** — documented inline with rationale:

- `provider` — fixed at `"anthropic"` by `registerProvider()` below.
- `baseUrl` — set at the provider level in `registerProvider({ baseUrl: ... })`; no anthropic-provider registry entry overrides it per-model, so propagating would be a no-op today.
- `headers` — this extension builds the full Anthropic request header set itself in `streamSimple` (Bearer token, `anthropic-version`, `anthropic-beta`, `x-app`, `user-agent`, `x-client-request-id`). Pi's per-model `headers` would be additive and risk colliding with the OAuth-mode auth header. No anthropic registry model currently declares per-model `headers`, so this is also a no-op today — and the comment flags the risk if a future registry entry does.

## Tests

Extended `request-body.test.ts`:

- Renamed the existing opus-4-8 case to be model-specific and added a comment cross-referencing this fix.
- Added an explicit opus-4-7 case (`xhigh → "xhigh"`) for AC coverage.
- Added a no-regression test: an adaptive model with `thinkingLevelMap: undefined` falls through to the default switch and resolves `xhigh → "high"` (the pre-fix behaviour, preserved for models that never had a map).

Result: **71/71 tests pass** under `tsx --test` (full extension suite).

## Verification

- `tsx --test *.test.ts` — 71/71 pass.
- `nix build .#prism` — succeeds.

## Scope

Out of scope (separate PRs):

- #2054 — fine-grained-tool-streaming gate for opus≥4.8.
- #2049 — multi-turn thinking-block re-injection.
- Any change to `request-body.ts::mapThinkingLevelToEffort` itself — the consumer is already correct.
- Any change to the SSE parser / response handling.

## Noticed but not propagated (flagged for future)

None at this time — the audit above covers every field on the `Model<"anthropic-messages">` interface. If a future pi-ai release adds new fields with runtime consequence (e.g. `providerOptions`, `defaultTemperature`), the projection in `index.ts` will need a follow-up audit.