### PR TITLE
prism: sever pi resume linkage on cleanup so re-spawn on reused branch starts fresh (#2035)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -246,6 +246,11 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			}
 			instanceIDForSessions := instanceIDFromStatus(d, m.session)
 			isolationMode := isolationModeFromDB(d, m.session)
+			// Sever the pi resume linkage (issue #2035): remove the on-disk pi
+			// JSONL transcript and null agent_status.harness_session_id so a
+			// re-spawn on the same branch name starts a fresh pi conversation.
+			// Must run before SetEnded so the status read still sees the row.
+			severPiResumeLinkage(d, m.session)
 			_ = d.SetEnded(m.session)
 			if instanceIDForSessions != "" {
 				if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
@@ -630,6 +635,11 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 		// row's lifecycle fields.
 		instanceIDForSessions := instanceIDFromStatus(d, session)
 		isolationMode := isolationModeFromDB(d, session)
+		// Sever the pi resume linkage (issue #2035): remove the on-disk pi
+		// JSONL transcript and null agent_status.harness_session_id so a
+		// re-spawn on the same branch name starts a fresh pi conversation.
+		// Must run before SetEnded so the status read still sees the row.
+		severPiResumeLinkage(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
@@ -708,6 +718,8 @@ func closeSession(session string) error {
 		}
 		instanceIDForSessions := instanceIDFromStatus(d, session)
 		isolationMode := isolationModeFromDB(d, session)
+		// Sever the pi resume linkage (issue #2035) before marking ended.
+		severPiResumeLinkage(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
@@ -804,6 +816,8 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 		}
 		instanceIDForSessions := instanceIDFromStatus(d, session)
 		isolationMode := isolationModeFromDB(d, session)
+		// Sever the pi resume linkage (issue #2035) before marking ended.
+		severPiResumeLinkage(d, session)
 		_ = d.SetEnded(session)
 		if instanceIDForSessions != "" {
 			if updErr := d.UpdateSessionEnded(instanceIDForSessions, "finished"); updErr != nil {
@@ -1114,6 +1128,63 @@ func init() {
 	cleanupCmd.Flags().String("session", "", "Target session name (default: current session)")
 	cleanupCmd.Flags().Bool("json", false, "Emit a single JSON object describing per-resource outcomes (requires --yes)")
 	rootCmd.AddCommand(cleanupCmd)
+}
+
+// severPiResumeLinkage breaks the pi conversation-resume linkage for
+// sessionName so that a future spawn on the same branch name (and therefore
+// the same agent_status row) does NOT silently resume the now-defunct
+// pi conversation (issue #2035).
+//
+// Two surfaces survive a plain `prism cleanup` otherwise:
+//
+//  1. agent_status.harness_session_id — db.SetEnded only stamps ended_at;
+//     the harness_session_id column persists. cmd/agent_run.go reads it back
+//     on the next spawn and threads it into container.Config, where
+//     PIInvocation appends `--session <id>` to pi when a matching JSONL is
+//     found on disk.
+//
+//  2. ~/.pi/agent/sessions/<encodePiCWD(worktree)>/*_<harness_session_id>.jsonl
+//     — the on-disk JSONL transcript. The encoded-cwd directory is keyed off
+//     cfg.Worktree, which is stable across a reused branch name (the worktree
+//     path is derived deterministically from the branch). For sandbox-exec
+//     the transcript also lives inside the staging HOME that
+//     RemoveSandboxExecStagingHome subsequently wipes, but we delete it
+//     explicitly here for symmetry across modes.
+//
+// Order:
+//
+//   - Capture worktree + harness_session_id from the live agent_status row
+//     BEFORE the DB clear (the clear nulls the latter).
+//   - Remove the on-disk JSONL (FS-side; non-fatal).
+//   - Null the DB column (load-bearing; logged on error but cleanup
+//     continues so the rest of the teardown still runs).
+//
+// Best-effort — no error path aborts cleanup. A failure here is logged and
+// teardown proceeds: the worst case is that the next spawn on this branch
+// name resumes a defunct conversation, which is recoverable by the operator,
+// whereas a half-cleaned worktree/branch is not.
+func severPiResumeLinkage(d *db.DB, sessionName string) {
+	status, err := d.CurrentStatus(sessionName)
+	if err != nil || status == nil {
+		// No row to read — no JSONL to scope to, no DB clear needed.
+		return
+	}
+	if status.HarnessSessionID != nil && *status.HarnessSessionID != "" && status.Worktree != "" {
+		cfg := container.Config{
+			SessionName:      sessionName,
+			Worktree:         status.Worktree,
+			HarnessSessionID: *status.HarnessSessionID,
+		}
+		if status.InstanceID != nil {
+			cfg.InstanceID = *status.InstanceID
+		}
+		if rmErr := container.RemovePiResumeJSONL(cfg); rmErr != nil {
+			proglog.Warnf("[prism] warning: remove pi resume jsonl for %s: %v — continuing cleanup\n", sessionName, rmErr)
+		}
+	}
+	if clearErr := d.ClearHarnessSessionID(sessionName); clearErr != nil {
+		proglog.Errorf("[prism] severPiResumeLinkage: clear harness_session_id for %s: %v\n", sessionName, clearErr)
+	}
 }
 
 // instanceIDFromStatus returns the instance_id from the agent_status row for

--- a/modules/programs/prism/prism/cmd/cleanup_pi_resume_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_pi_resume_test.go
@@ -1,0 +1,307 @@
+package cmd
+
+// cleanup_pi_resume_test.go — regression tests for issue #2035.
+//
+// `prism cleanup` must sever the pi conversation-resume linkage so that a
+// re-spawn on the SAME branch name does not silently resume the cleaned
+// session's pi conversation. Two surfaces:
+//
+//   1. agent_status.harness_session_id (DB) — must be NULL after cleanup.
+//   2. ~/.pi/agent/sessions/<encodePiCWD(worktree)>/*_<id>.jsonl (FS) — must
+//      be removed for the cleaned session's id.
+//
+// These tests exercise headlessCleanup against a temp DB and a temp $HOME so
+// they verify the cleanup-side severance end-to-end without touching the
+// host's real state. ~review-N-* child sessions are also covered.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// piEncodeCWD mirrors internal/container.encodePiCWD / internal/harness/pi.EncodePiCWD.
+// Duplicated here so cmd-package tests do not need to import internal/container.
+func piEncodeCWD(cwd string) string {
+	stripped := strings.TrimLeft(cwd, "/\\")
+	replaced := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(stripped)
+	return "--" + replaced + "--"
+}
+
+// writeFakePiResumeJSONL creates a synthetic pi transcript at the host-mode
+// sessions root and returns its absolute path. The file's content is not
+// inspected by cleanup — only its name suffix is matched.
+func writeFakePiResumeJSONL(t *testing.T, home, worktree, harnessSessionID string) string {
+	t.Helper()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", piEncodeCWD(worktree))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir resume dir: %v", err)
+	}
+	path := filepath.Join(dir, "2026-01-02T03-04-05-000Z_"+harnessSessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{\"type\":\"session\"}\n"), 0o600); err != nil {
+		t.Fatalf("write resume jsonl: %v", err)
+	}
+	return path
+}
+
+// TestHeadlessCleanup_ClearsHarnessSessionID is the regression test for the
+// DB-side half of issue #2035. After headlessCleanup runs against a session
+// row carrying a harness_session_id, the column must be NULL — otherwise the
+// next spawn on the same branch name would read the stale id back and pi
+// would resume the dead conversation.
+func TestHeadlessCleanup_ClearsHarnessSessionID(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	t.Setenv("HOME", t.TempDir())
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	const session = "myrepo@feature"
+	const sid = "019e72d2-446a-712f-baea-7abc9e7ce7df"
+	if err := d.UpsertStatus(session, "myrepo", "", "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(session, sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	if err := headlessCleanup(session, "feature", "", ""); err != nil {
+		t.Fatalf("headlessCleanup: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("row missing after cleanup")
+	}
+	if status.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID = %q after cleanup; want nil (resume linkage must be severed — issue #2035)",
+			*status.HarnessSessionID)
+	}
+	// Sanity: SetEnded still ran.
+	if status.EndedAt == nil {
+		t.Errorf("EndedAt = nil after cleanup; want non-nil")
+	}
+}
+
+// TestHeadlessCleanup_RemovesPiResumeJSONL is the regression test for the
+// FS-side half of issue #2035. After headlessCleanup runs against a session
+// whose pi transcript is on disk, the *_<id>.jsonl file under the worktree's
+// encoded-cwd directory must be removed.
+func TestHeadlessCleanup_RemovesPiResumeJSONL(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	const session = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+	const sid = "019e72d2-446a-712f-baea-7abc9e7ce7df"
+
+	transcript := writeFakePiResumeJSONL(t, home, worktree, sid)
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.UpsertStatus(session, "myrepo", worktree, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(session, sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Pass empty worktreePath to skip the git-worktree-remove branch; the
+	// pi-resume severance happens later in the same flow.
+	if err := headlessCleanup(session, "feature", "", ""); err != nil {
+		t.Fatalf("headlessCleanup: %v", err)
+	}
+
+	if _, err := os.Stat(transcript); !os.IsNotExist(err) {
+		t.Errorf("pi resume transcript %s still exists after cleanup (err=%v); want removed (issue #2035)",
+			transcript, err)
+	}
+}
+
+// TestHeadlessCleanup_ClearsHarnessSessionIDForReviewChildren verifies the
+// LIKE-cascade parity: after cleanup of a parent session, any review-agent
+// child rows (session_name LIKE "<parent>~review-%") must also have their
+// harness_session_id nulled. This mirrors SetEnded's behaviour so that the
+// resume linkage is severed for review children too.
+func TestHeadlessCleanup_ClearsHarnessSessionIDForReviewChildren(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	t.Setenv("HOME", t.TempDir())
+
+	const parent = "myrepo@feature"
+	child1 := parent + "~review-1-architect"
+	child2 := parent + "~review-2-skeptic"
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	for _, name := range []string{parent, child1, child2} {
+		if err := d.UpsertStatus(name, "myrepo", "", "running", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", name, err)
+		}
+	}
+	if err := d.UpdateHarnessSessionID(parent, "019e0000-0000-0000-0000-000000000001"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID parent: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(child1, "019e0000-0000-0000-0000-000000000002"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID child1: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(child2, "019e0000-0000-0000-0000-000000000003"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID child2: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	if err := headlessCleanup(parent, "feature", "", ""); err != nil {
+		t.Fatalf("headlessCleanup: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	for _, name := range []string{parent, child1, child2} {
+		st, err := d2.CurrentStatus(name)
+		if err != nil {
+			t.Fatalf("CurrentStatus %q: %v", name, err)
+		}
+		if st == nil {
+			t.Fatalf("row %q missing after cleanup", name)
+		}
+		if st.HarnessSessionID != nil {
+			t.Errorf("session %q: HarnessSessionID = %q after cleanup; want nil (LIKE-cascade)",
+				name, *st.HarnessSessionID)
+		}
+	}
+}
+
+// TestHeadlessCleanup_PiResumeAbsentSucceeds verifies the edge case where
+// cleanup is invoked on a session whose pi resume JSONL never existed
+// (fresh session, no transcript yet). Cleanup must still succeed and clear
+// the DB column.
+func TestHeadlessCleanup_PiResumeAbsentSucceeds(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	t.Setenv("HOME", t.TempDir())
+
+	const session = "myrepo@brand-new"
+	const worktree = "/home/user/code/myrepo/brand-new"
+	const sid = "019e0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.UpsertStatus(session, "myrepo", worktree, "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(session, sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	if err := headlessCleanup(session, "brand-new", "", ""); err != nil {
+		t.Errorf("headlessCleanup: %v, want nil (must succeed even with no on-disk transcript)", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	st, _ := d2.CurrentStatus(session)
+	if st == nil {
+		t.Fatal("row missing")
+	}
+	if st.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID = %q after cleanup; want nil", *st.HarnessSessionID)
+	}
+}
+
+// TestHeadlessCleanup_LeavesOtherSessionsResumePointersAlone verifies that
+// cleaning up one session does not collaterally clear another session's
+// harness_session_id — the LIKE pattern is anchored to the cleaned session's
+// name and the `~review-%` suffix, not a wildcard.
+func TestHeadlessCleanup_LeavesOtherSessionsResumePointersAlone(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	t.Setenv("HOME", t.TempDir())
+
+	const cleaned = "myrepo@going"
+	const survivor = "myrepo@staying"
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	for _, name := range []string{cleaned, survivor} {
+		if err := d.UpsertStatus(name, "myrepo", "", "running", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus %q: %v", name, err)
+		}
+	}
+	const survivorSID = "019e0000-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	if err := d.UpdateHarnessSessionID(cleaned, "019e0000-cccc-cccc-cccc-cccccccccccc"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID cleaned: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(survivor, survivorSID); err != nil {
+		t.Fatalf("UpdateHarnessSessionID survivor: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	if err := headlessCleanup(cleaned, "going", "", ""); err != nil {
+		t.Fatalf("headlessCleanup: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	stSurvivor, _ := d2.CurrentStatus(survivor)
+	if stSurvivor == nil {
+		t.Fatal("survivor row missing")
+	}
+	if stSurvivor.HarnessSessionID == nil || *stSurvivor.HarnessSessionID != survivorSID {
+		t.Errorf("survivor HarnessSessionID = %v, want %q (cleanup must not touch sibling rows)",
+			stSurvivor.HarnessSessionID, survivorSID)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -237,6 +237,71 @@ func piResumeSessionsRoot(cfg Config) (string, bool) {
 	return filepath.Join(home, ".pi", "agent", "sessions"), true
 }
 
+// RemovePiResumeJSONL deletes any pi session-transcript JSONL file under the
+// resolved sessions root whose basename ends in `_<HarnessSessionID>.jsonl`,
+// for the encoded-cwd subdirectory derived from cfg.Worktree.
+//
+// This is the FS-side companion to db.ClearHarnessSessionID: together they
+// sever the pi resume linkage so that re-spawning a NEW session on the SAME
+// branch name does not resume the cleaned session's pi conversation
+// (issue #2035). DB-side severance alone is sufficient for the bug —
+// PIInvocation only appends `--session <id>` when HarnessSessionID is
+// non-empty AND ResolvePIResumeSession finds a matching JSONL — but
+// removing the on-disk transcript closes the second path explicitly and
+// keeps ~/.pi/agent/sessions/ from accumulating dead conversations across
+// reused branch names.
+//
+// Resolution mirrors piResumeSessionsRoot (sandbox-exec staging home vs.
+// host/bwrap `~/.pi/agent/sessions/`). For sandbox-exec the JSONL also lives
+// inside the staging HOME that RemoveSandboxExecStagingHome subsequently
+// wipes — calling RemovePiResumeJSONL first is therefore redundant for that
+// mode but harmless (the targeted delete is a no-op when the broader wipe
+// has already run, and vice-versa).
+//
+// Best-effort and non-fatal:
+//
+//   - Returns nil silently when HarnessSessionID or Worktree is empty (caller
+//     contract: nothing to scope to).
+//   - Returns nil silently when the sessions root cannot be resolved
+//     (e.g. no home dir on the host) — cleanup must still succeed.
+//   - Returns nil silently when the encoded-cwd directory does not exist
+//     (fresh-session-then-cleanup, sandbox already torn down, etc.).
+//   - An error is returned only when a matching file was found but
+//     os.Remove failed for some reason other than "not exist" — the caller
+//     may log and continue.
+//
+// The function deliberately scopes by `_<HarnessSessionID>.jsonl` suffix
+// rather than wiping the whole encoded-cwd dir: other sibling sessions on
+// the same worktree path (e.g. the legitimate-resume case in #1838 where a
+// still-active session is being restarted) must not be touched.
+func RemovePiResumeJSONL(cfg Config) error {
+	if cfg.HarnessSessionID == "" || cfg.Worktree == "" {
+		return nil
+	}
+	root, ok := piResumeSessionsRoot(cfg)
+	if !ok {
+		return nil
+	}
+	cwdDir := filepath.Join(root, encodePiCWD(cfg.Worktree))
+	entries, err := os.ReadDir(cwdDir)
+	if err != nil {
+		// Missing dir / unreadable — nothing to do. Cleanup is best-effort.
+		return nil
+	}
+	suffix := "_" + cfg.HarnessSessionID + ".jsonl"
+	var firstErr error
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), suffix) {
+			continue
+		}
+		path := filepath.Join(cwdDir, e.Name())
+		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) && firstErr == nil {
+			firstErr = fmt.Errorf("remove pi resume jsonl %s: %w", path, rmErr)
+		}
+	}
+	return firstErr
+}
+
 // encodePiCWD mirrors internal/harness/pi.EncodePiCWD: pi's session-dir naming
 // formula (`--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`).
 //

--- a/modules/programs/prism/prism/internal/container/pi_invocation_remove_resume_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_remove_resume_test.go
@@ -1,0 +1,159 @@
+package container
+
+// pi_invocation_remove_resume_test.go — issue #2035.
+//
+// Verifies RemovePiResumeJSONL: the FS-side companion to
+// db.ClearHarnessSessionID called from `prism cleanup` so that a re-spawn on
+// the same branch name does not resume the cleaned session's pi conversation
+// via a leftover JSONL transcript in ~/.pi/agent/sessions/<encoded-cwd>/.
+//
+// All tests use t.TempDir() + t.Setenv("HOME", ...) so they never touch the
+// host's real ~/.pi/agent/sessions/.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemovePiResumeJSONL_RemovesMatchingFile verifies the positive case:
+// a JSONL file matching `*_<HarnessSessionID>.jsonl` under the worktree's
+// encoded-cwd directory is removed.
+func TestRemovePiResumeJSONL_RemovesMatchingFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+	const harnessSessionID = "019e72d2-446a-712f-baea-7abc9e7ce7df"
+
+	path := writeBwrapResumeSession(t, sessionName, worktree, harnessSessionID)
+
+	// Pre-condition.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("pre-condition: stat %s: %v", path, err)
+	}
+
+	cfg := bwrapResumeCfg(sessionName, worktree, harnessSessionID)
+	if err := RemovePiResumeJSONL(cfg); err != nil {
+		t.Fatalf("RemovePiResumeJSONL: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file %s still exists after RemovePiResumeJSONL (err=%v); want removed", path, err)
+	}
+}
+
+// TestRemovePiResumeJSONL_LeavesSiblingTranscriptsAlone verifies the targeted
+// suffix match: a JSONL belonging to a DIFFERENT harness_session_id under the
+// same encoded-cwd directory must not be touched.
+//
+// This protects the legitimate-resume case (issue #1838) and any other
+// session that happens to share a worktree path: cleanup must only delete
+// the specific transcript bound to the cleaned session's harness_session_id.
+func TestRemovePiResumeJSONL_LeavesSiblingTranscriptsAlone(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+	const cleanedID = "019e0000-1111-1111-1111-111111111111"
+	const survivorID = "019e0000-2222-2222-2222-222222222222"
+
+	cleanedPath := writeBwrapResumeSession(t, sessionName, worktree, cleanedID)
+	survivorPath := writeBwrapResumeSession(t, sessionName, worktree, survivorID)
+
+	cfg := bwrapResumeCfg(sessionName, worktree, cleanedID)
+	if err := RemovePiResumeJSONL(cfg); err != nil {
+		t.Fatalf("RemovePiResumeJSONL: %v", err)
+	}
+
+	if _, err := os.Stat(cleanedPath); !os.IsNotExist(err) {
+		t.Errorf("cleaned file %s still exists; want removed", cleanedPath)
+	}
+	if _, err := os.Stat(survivorPath); err != nil {
+		t.Errorf("survivor file %s missing (err=%v); want preserved", survivorPath, err)
+	}
+}
+
+// TestRemovePiResumeJSONL_MissingDirIsNoOp verifies that calling against a
+// worktree whose encoded-cwd directory does not exist (fresh-session-then-cleanup
+// scenario) returns nil — cleanup must remain best-effort.
+func TestRemovePiResumeJSONL_MissingDirIsNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := bwrapResumeCfg(
+		"myrepo@never-ran",
+		"/home/user/code/myrepo/never-ran",
+		"019e0000-3333-3333-3333-333333333333",
+	)
+	if err := RemovePiResumeJSONL(cfg); err != nil {
+		t.Errorf("RemovePiResumeJSONL on missing dir: %v, want nil", err)
+	}
+}
+
+// TestRemovePiResumeJSONL_EmptyHarnessSessionIDIsNoOp verifies the caller-
+// contract guard: when HarnessSessionID is empty there is nothing to scope
+// to, and the function returns nil without scanning the filesystem.
+func TestRemovePiResumeJSONL_EmptyHarnessSessionIDIsNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const sessionName = "myrepo@feature"
+	const worktree = "/home/user/code/myrepo/feature"
+
+	// Plant a decoy file that would match if the suffix matching were lax.
+	decoyPath := writeBwrapResumeSession(t, sessionName, worktree, "019e0000-dddd-dddd-dddd-dddddddddddd")
+
+	cfg := bwrapResumeCfg(sessionName, worktree, "")
+	if err := RemovePiResumeJSONL(cfg); err != nil {
+		t.Errorf("RemovePiResumeJSONL with empty HarnessSessionID: %v, want nil", err)
+	}
+	if _, err := os.Stat(decoyPath); err != nil {
+		t.Errorf("decoy file %s was removed when HarnessSessionID was empty; the guard failed", decoyPath)
+	}
+}
+
+// TestRemovePiResumeJSONL_EmptyWorktreeIsNoOp verifies that an empty Worktree
+// is also a silent no-op — the function cannot resolve an encoded-cwd dir
+// without a worktree path.
+func TestRemovePiResumeJSONL_EmptyWorktreeIsNoOp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := Config{
+		SessionName:             "myrepo@feature",
+		Worktree:                "",
+		HarnessSessionID:        "019e0000-eeee-eeee-eeee-eeeeeeeeeeee",
+		PIAgentConfigHostDir:    "/tmp/host-stage",
+		PIAgentConfigSandboxDir: "/run/prism/pi-agent",
+	}
+	if err := RemovePiResumeJSONL(cfg); err != nil {
+		t.Errorf("RemovePiResumeJSONL with empty Worktree: %v, want nil", err)
+	}
+}
+
+// TestRemovePiResumeJSONL_DoesNotDescendIntoSubdirs verifies that a directory
+// whose name happens to end in `_<HarnessSessionID>.jsonl` is not removed
+// (the suffix match must be restricted to regular files).
+func TestRemovePiResumeJSONL_DoesNotDescendIntoSubdirs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	const worktree = "/home/user/code/myrepo/feature"
+	const harnessSessionID = "019e0000-ffff-ffff-ffff-ffffffffffff"
+
+	home, _ := os.UserHomeDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", encodePiCWD(worktree))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pathological: a directory whose name happens to match the suffix.
+	pathologicalDir := filepath.Join(dir, "trap_"+harnessSessionID+".jsonl")
+	if err := os.MkdirAll(pathologicalDir, 0o700); err != nil {
+		t.Fatalf("mkdir pathological: %v", err)
+	}
+
+	cfg := bwrapResumeCfg("myrepo@feature", worktree, harnessSessionID)
+	if err := RemovePiResumeJSONL(cfg); err != nil {
+		t.Errorf("RemovePiResumeJSONL: %v", err)
+	}
+	if _, err := os.Stat(pathologicalDir); err != nil {
+		t.Errorf("pathological subdir %s was removed; want preserved (must skip non-regular entries)", pathologicalDir)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/clear_harness_session_id_test.go
+++ b/modules/programs/prism/prism/internal/db/clear_harness_session_id_test.go
@@ -1,0 +1,230 @@
+package db_test
+
+// Tests for ClearHarnessSessionID (issue #2035).
+//
+// ClearHarnessSessionID nulls agent_status.harness_session_id for a specific
+// session AND for any ~review-N-* child sessions, mirroring SetEnded's
+// LIKE-escape semantics. It is called from the `prism cleanup` paths so that
+// re-spawning a NEW session on the SAME branch name does not pick up the
+// cleaned session's stale harness_session_id and silently resume the dead
+// pi conversation.
+
+import (
+	"testing"
+)
+
+// TestClearHarnessSessionID_NullsTargetRow verifies the basic positive case:
+// after ClearHarnessSessionID, the named session's harness_session_id is NULL.
+func TestClearHarnessSessionID_NullsTargetRow(t *testing.T) {
+	d := openTestDB(t)
+
+	const name = "repo@branch"
+	_ = insertActiveSession(t, d, name, "repo", "/wt/branch")
+	const sid = "019e72d2-446a-712f-baea-7abc9e7ce7df"
+	if err := d.UpdateHarnessSessionID(name, sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	// Pre-condition.
+	pre, _ := d.CurrentStatus(name)
+	if pre == nil || pre.HarnessSessionID == nil || *pre.HarnessSessionID != sid {
+		t.Fatalf("pre-condition: HarnessSessionID = %v, want %q", pre, sid)
+	}
+
+	if err := d.ClearHarnessSessionID(name); err != nil {
+		t.Fatalf("ClearHarnessSessionID: %v", err)
+	}
+
+	post, err := d.CurrentStatus(name)
+	if err != nil {
+		t.Fatalf("CurrentStatus after: %v", err)
+	}
+	if post == nil {
+		t.Fatalf("CurrentStatus after: row missing")
+	}
+	if post.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID = %q, want nil", *post.HarnessSessionID)
+	}
+}
+
+// TestClearHarnessSessionID_CascadesToReviewChildren verifies the LIKE pattern
+// parity with SetEnded: a session and its `~review-N-<agent>` children must
+// all have their harness_session_id cleared in one call, so cleanup of a
+// worker also forgets the pi resume pointer for any review children that
+// were spawned underneath it.
+func TestClearHarnessSessionID_CascadesToReviewChildren(t *testing.T) {
+	d := openTestDB(t)
+
+	const parent = "repo@feature"
+	child1 := parent + "~review-1-architect"
+	child2 := parent + "~review-2-skeptic"
+
+	_ = insertActiveSession(t, d, parent, "repo", "/wt/feature")
+	_ = insertActiveSession(t, d, child1, "repo", "/wt/feature")
+	_ = insertActiveSession(t, d, child2, "repo", "/wt/feature")
+
+	if err := d.UpdateHarnessSessionID(parent, "019e0000-0000-0000-0000-000000000001"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID parent: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(child1, "019e0000-0000-0000-0000-000000000002"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID child1: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(child2, "019e0000-0000-0000-0000-000000000003"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID child2: %v", err)
+	}
+
+	if err := d.ClearHarnessSessionID(parent); err != nil {
+		t.Fatalf("ClearHarnessSessionID: %v", err)
+	}
+
+	for _, name := range []string{parent, child1, child2} {
+		st, err := d.CurrentStatus(name)
+		if err != nil {
+			t.Fatalf("CurrentStatus %q: %v", name, err)
+		}
+		if st == nil {
+			t.Fatalf("CurrentStatus %q: row missing", name)
+		}
+		if st.HarnessSessionID != nil {
+			t.Errorf("session %q: HarnessSessionID = %q, want nil (LIKE cascade)", name, *st.HarnessSessionID)
+		}
+	}
+}
+
+// TestClearHarnessSessionID_DoesNotTouchSiblings verifies the targeted nature
+// of the clear: other sessions whose names do NOT match the literal name or
+// the `~review-%` pattern must be left alone.
+func TestClearHarnessSessionID_DoesNotTouchSiblings(t *testing.T) {
+	d := openTestDB(t)
+
+	const target = "repo@branch"
+	const other = "repo@other-branch"
+	_ = insertActiveSession(t, d, target, "repo", "/wt/branch")
+	_ = insertActiveSession(t, d, other, "repo", "/wt/other")
+
+	const targetSID = "019e0000-aaaa-aaaa-aaaa-000000000001"
+	const otherSID = "019e0000-bbbb-bbbb-bbbb-000000000002"
+	if err := d.UpdateHarnessSessionID(target, targetSID); err != nil {
+		t.Fatalf("UpdateHarnessSessionID target: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(other, otherSID); err != nil {
+		t.Fatalf("UpdateHarnessSessionID other: %v", err)
+	}
+
+	if err := d.ClearHarnessSessionID(target); err != nil {
+		t.Fatalf("ClearHarnessSessionID: %v", err)
+	}
+
+	stOther, _ := d.CurrentStatus(other)
+	if stOther == nil || stOther.HarnessSessionID == nil || *stOther.HarnessSessionID != otherSID {
+		t.Errorf("sibling session %q HarnessSessionID = %v, want %q (must not be touched)", other, stOther.HarnessSessionID, otherSID)
+	}
+}
+
+// TestClearHarnessSessionID_Idempotent verifies that calling against a row
+// whose harness_session_id is already NULL is a no-op and returns nil.
+func TestClearHarnessSessionID_Idempotent(t *testing.T) {
+	d := openTestDB(t)
+
+	const name = "repo@no-sid"
+	_ = insertActiveSession(t, d, name, "repo", "/wt/no-sid")
+
+	if err := d.ClearHarnessSessionID(name); err != nil {
+		t.Errorf("ClearHarnessSessionID on NULL-already row: %v, want nil", err)
+	}
+	if err := d.ClearHarnessSessionID(name); err != nil {
+		t.Errorf("ClearHarnessSessionID second call: %v, want nil", err)
+	}
+
+	st, _ := d.CurrentStatus(name)
+	if st == nil {
+		t.Fatal("row vanished")
+	}
+	if st.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID = %q, want nil", *st.HarnessSessionID)
+	}
+}
+
+// TestClearHarnessSessionID_MissingSessionIsNoOp verifies that calling
+// against a session that does not exist in the DB returns nil — cleanup must
+// not error out when there is nothing to clear.
+func TestClearHarnessSessionID_MissingSessionIsNoOp(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.ClearHarnessSessionID("repo@does-not-exist"); err != nil {
+		t.Errorf("ClearHarnessSessionID on missing row: %v, want nil", err)
+	}
+}
+
+// TestClearHarnessSessionID_LeavesOtherColumnsAlone verifies the targeted
+// nature of the wipe: state, ended_at, instance_id, last_seen, etc. are all
+// preserved. Only harness_session_id changes.
+func TestClearHarnessSessionID_LeavesOtherColumnsAlone(t *testing.T) {
+	d := openTestDB(t)
+
+	const name = "repo@only-sid"
+	iid := insertActiveSession(t, d, name, "repo", "/wt/only-sid")
+	if err := d.UpdateHarnessSessionID(name, "019e0000-1111-2222-3333-444444444444"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	before, _ := d.CurrentStatus(name)
+	if before == nil {
+		t.Fatalf("CurrentStatus before: row missing")
+	}
+
+	if err := d.ClearHarnessSessionID(name); err != nil {
+		t.Fatalf("ClearHarnessSessionID: %v", err)
+	}
+
+	after, _ := d.CurrentStatus(name)
+	if after == nil {
+		t.Fatalf("CurrentStatus after: row missing")
+	}
+
+	if after.HarnessSessionID != nil {
+		t.Errorf("HarnessSessionID = %q, want nil", *after.HarnessSessionID)
+	}
+	if after.State != before.State {
+		t.Errorf("State changed: before=%q, after=%q", before.State, after.State)
+	}
+	if after.SessionName != before.SessionName {
+		t.Errorf("SessionName changed: before=%q, after=%q", before.SessionName, after.SessionName)
+	}
+	if after.Worktree != before.Worktree {
+		t.Errorf("Worktree changed: before=%q, after=%q", before.Worktree, after.Worktree)
+	}
+	if after.InstanceID == nil || *after.InstanceID != iid {
+		t.Errorf("InstanceID = %v, want %q", after.InstanceID, iid)
+	}
+	if after.EndedAt != nil {
+		t.Errorf("EndedAt = %v, want nil (session was active)", after.EndedAt)
+	}
+}
+
+// TestClearHarnessSessionID_DoesNotTouchEndedAt verifies the orthogonality
+// between SetEnded and ClearHarnessSessionID: the cleanup helper that calls
+// both must see them independent of each other. In particular, calling
+// ClearHarnessSessionID on a row that has not been ended must not stamp
+// ended_at, and vice versa (covered by SetEnded's own tests).
+func TestClearHarnessSessionID_DoesNotTouchEndedAt(t *testing.T) {
+	d := openTestDB(t)
+
+	const name = "repo@orthogonal"
+	_ = insertActiveSession(t, d, name, "repo", "/wt/orth")
+	if err := d.UpdateHarnessSessionID(name, "019e0000-cccc-cccc-cccc-cccccccccccc"); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	if err := d.ClearHarnessSessionID(name); err != nil {
+		t.Fatalf("ClearHarnessSessionID: %v", err)
+	}
+
+	st, _ := d.CurrentStatus(name)
+	if st == nil {
+		t.Fatal("row missing")
+	}
+	if st.EndedAt != nil {
+		t.Errorf("EndedAt = %v, want nil (ClearHarnessSessionID must not stamp ended_at)", st.EndedAt)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -506,6 +506,48 @@ func (d *DB) ClearAllResumePointers() (int64, error) {
 	return n, nil
 }
 
+// ClearHarnessSessionID clears agent_status.harness_session_id for sessionName
+// AND for any review-agent child rows whose session_name matches
+// "<sessionName>~review-%" (mirroring SetEnded's LIKE-escape semantics).
+//
+// This is the per-session counterpart to ClearAllResumePointers (issue #1947).
+// It is called from the `prism cleanup` paths so that re-spawning a NEW
+// session on the SAME branch name does not pick up the cleaned session's
+// stale harness_session_id and unconditionally resume the dead pi conversation
+// (issue #2035).
+//
+// Cleanup must sever the resume linkage on two surfaces:
+//
+//  1. The DB: this method nulls agent_status.harness_session_id so
+//     cmd/agent_run.go's spawn-time read (`status.HarnessSessionID`) returns
+//     a nil pointer on the next spawn — and the in-sandbox PIInvocation
+//     therefore omits `--session <id>` and starts a fresh pi conversation.
+//
+//  2. The filesystem: the JSONL transcript under
+//     <piSessionsRoot>/<encodePiCWD(worktree)>/*_<harness_session_id>.jsonl
+//     — handled by container.RemovePiResumeJSONL on the cleanup side.
+//
+// Fix (1) is load-bearing on its own; fix (2) is defence-in-depth. See the
+// issue body for the full forensics.
+//
+// The session name is escaped for SQL LIKE wildcards before being used as a
+// pattern prefix so that names containing `%`, `_`, or `\` are handled
+// correctly.
+//
+// Returns nil even when no rows matched — the call is idempotent and safe
+// to invoke against a session whose harness_session_id was already NULL.
+func (d *DB) ClearHarnessSessionID(sessionName string) error {
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(sessionName)
+	const q = `
+UPDATE agent_status
+SET    harness_session_id = NULL
+WHERE  session_name = ? OR session_name LIKE ? || '~review-%' ESCAPE '\'`
+	if _, err := d.conn.Exec(q, sessionName, escaped); err != nil {
+		return fmt.Errorf("db: clear harness session id: %w", err)
+	}
+	return nil
+}
+
 // SetMuted sets the muted flag for sessionName to muted (true = 1, false = 0).
 //
 // Returns (false, nil) when no agent_status row exists for sessionName so


### PR DESCRIPTION
Closes #2035

## What

Re-spawning a prism worker on a branch name that was used by a previously cleaned-up session produced a dud: pi resumed the prior (already-finished, often empty) conversation instead of starting fresh. The auto-delivered initial prompt landed on a conversation pi considered complete and the agent finished in ~3s — no PR, empty event log.

Two surfaces survived `prism cleanup` and combined to cause unconditional resume:

1. **`agent_status.harness_session_id` (DB).** `db.SetEnded` only stamps `ended_at` — the harness session UUID persisted. On the next spawn `cmd/agent_run.go` read it back and threaded it into `container.Config.HarnessSessionID`.
2. **`~/.pi/agent/sessions/<encodePiCWD(worktree)>/*_<uuid>.jsonl` (FS).** The on-disk transcript was never touched by cleanup. `piResolveResumeSession`'s scan kept matching, and `PIInvocation` kept appending `--session <uuid>` to pi.

Both keys are stable across a reused branch name (the worktree path is deterministic), so the next spawn unconditionally resumed the dead conversation.

## Fix

- **`internal/db/status.go`** — add `ClearHarnessSessionID(sessionName)` that nulls `agent_status.harness_session_id` for the named session AND for any `~review-N-*` child rows, mirroring `SetEnded`'s LIKE-escape parity. Sibling to the existing `ClearAllResumePointers` (#1947).
- **`internal/container/pi_invocation.go`** — add `RemovePiResumeJSONL(cfg)` that scopes by `*_<HarnessSessionID>.jsonl` under the worktree's encoded-cwd directory, reusing the existing `piResumeSessionsRoot` resolution. Best-effort / non-fatal on missing dir or file.
- **`cmd/cleanup.go`** — add `severPiResumeLinkage(d, session)` helper that captures status, removes the JSONL, then nulls the DB column. Wired into all four cleanup paths immediately before `SetEnded`: `doCleanup` (TUI), `headlessCleanupWithJSON`, `closeSession`, `headlessCloseSessionWithJSON`.

## Design call: load-bearing vs. defence-in-depth

The work item flagged that Fix A (DB clear) is load-bearing on its own and Fix B (FS remove) is defence-in-depth — and that if Fix B turned out tricky to scope, Fix A alone is sufficient to satisfy the ACs. Fix B turned out to be straightforward (the same `piResumeSessionsRoot` + `encodePiCWD` logic already used for resolution suffices, and sandbox-exec is harmlessly redundant with `RemoveSandboxExecStagingHome`), so both ship together. The DB clear is what severs the chain (`cmd/agent_run.go` only threads HarnessSessionID into the Config when the DB row carries one); the FS remove keeps `~/.pi/agent/sessions/` from accumulating dead transcripts across reused branch names.

The fix lives at cleanup time, not at `piResolveResumeSession` time — option (3) from the issue (guard resume against finished conversations) would have added a host-side check on cleanup-survived state, but the cleanup-side severance closes the issue more directly and with less surface area.

## Legitimate-resume (#1838) is unchanged

Resume for the SAME conversation across sandbox restarts (the #1838 path) operates on the **live, active** session's `harness_session_id`. It does NOT go through `prism cleanup` — clearing-on-cleanup therefore cannot break it. Verified by tracing the only `harness_session_id` reader after `SetEnded`: `cmd/agent_run.go`'s spawn-time lookup. No one else reads it post-cleanup.

The existing `pi_invocation_resume_test.go` suite (#1838 ACs) continues to pass.

## Tests

- **`internal/db/clear_harness_session_id_test.go`** — DB unit tests covering positive clear, `~review-N-*` LIKE cascade, sibling-untouched, idempotent, missing-row no-op, leaves-other-columns-alone, and orthogonality with `SetEnded` (no incidental `ended_at` stamp).
- **`internal/container/pi_invocation_remove_resume_test.go`** — FS unit tests covering positive remove, sibling transcript preserved (legitimate-resume protection), missing-dir no-op, empty-HarnessSessionID guard, empty-Worktree guard, and skip-non-regular-entries.
- **`cmd/cleanup_pi_resume_test.go`** — end-to-end regression tests against `headlessCleanup`: DB cleared, JSONL removed, `~review-N-*` children cleared, absent-transcript edge case succeeds, sibling sessions untouched.

## Verification

```
# From modules/programs/prism/prism/
go build ./...     # ✓
go test ./...      # ✓ (one pre-existing race-flake in
                   #   internal/session/stale_zombie_test.go that passes
                   #   in isolation — unrelated to this change)

# From repo root
nix build .#prism  # ✓
```

CI gates (`go-tests`, `nix-build-prism-checked`) will fire on this PR per the prism-touching path policy.

## Acceptance Criteria

- [x] [functional] After `prism cleanup` of a session, re-spawning a NEW session on the SAME branch name starts a FRESH pi conversation (new `harness_session_id`); it does NOT resume the prior conversation.
- [x] [functional] The auto-delivered initial prompt is processed by the re-spawned session (`--session` is no longer appended because both DB and FS surfaces are severed).
- [x] [functional] `prism cleanup` nulls `harness_session_id` for the cleaned session in `agent_status`.
- [x] [functional] `prism cleanup` removes the pi JSONL resume source for the cleaned session's worktree-encoded dir.
- [x] [edge-case] Legitimate resume (#1838) — re-attaching to an EXISTING, still-active session — continues to work; the fix only prevents resuming a CLEANED-UP session.
- [x] [functional] `go build ./...` + `go test ./...` pass; regression tests cover cleanup → re-spawn-same-branch → fresh session.