### PR TITLE
prism: drive pi extension's review guard from sidecar's reviewingInFlight (#2050)

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -3895,3 +3895,284 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
     assert.equal(reads, 1)
   })
 })
+
+// ---------------------------------------------------------------------------
+// #2050: review-guard release fix — sidecar-authoritative reviewing_state
+// ---------------------------------------------------------------------------
+//
+// Background. Before the #2050 fix the extension's pendingReviewCall guard
+// was set whenever a bash tool_call contained the substring "prism review".
+// That false-matched on any bash command that incidentally embedded the
+// literal text (a `gh pr comment` body, a `grep` over docs, an `echo` of a
+// commit message). A false-set after the genuine review-complete prompt had
+// cleared the flag re-latched the guard with no release path, suppressed
+// state_change:finished on the next turn_end, and stranded the worker as
+// `active` indefinitely — the exact incident captured in #2050.
+//
+// The fix drives pendingReviewCall solely from the inbound `reviewing_state`
+// frame the sidecar emits on every transition of its ledger-backed
+// reviewingInFlight flag plus once post-handshake. These tests assert the
+// three sequences called out in the AC:
+//
+//   A. no-review     — turn_end emits state_change:finished as today.
+//   B. mid-review    — turn_end during the reviewing window emits nothing
+//                       (the guard remains armed via reviewing_state{true}).
+//   C. completed-review — after reviewing_state{false} arrives the next
+//                       turn_end emits state_change:finished, even if no
+//                       inbound `prompt` frame followed (the regression
+//                       shape from the incident in #2050).
+
+const REVIEW_GUARD_HELLO_ACK = (sessionRole: string = "worker") =>
+  JSON.stringify({
+    type: "hello_ack",
+    protocol_version: 2,
+    session_name: "test@main",
+    session_role: sessionRole,
+    isolation_mode: "host",
+  }) + "\n"
+
+/**
+ * Spin up a fake sidecar server on a unix socket and the prism extension
+ * factory against a minimal mock pi. Returns the wired-up surface so each
+ * test can drive PI events, push inbound frames, and inspect frames received
+ * from the extension.
+ */
+function setupReviewGuardHarness(): Promise<{
+  trigger: (event: string, eventArg?: unknown, ctx?: unknown) => Promise<void>
+  /** Send an inbound frame from the (fake) sidecar to the extension. */
+  pushInbound: (frame: Record<string, unknown>) => void
+  /** Frames received from the extension on the socket, parsed as objects. */
+  received: () => Record<string, unknown>[]
+  /** Tear down server, restore env, remove tempdir. */
+  cleanup: () => void
+}> {
+  return new Promise((resolve, reject) => {
+    const sockDir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-test-2050-"))
+    const sockPath = path.join(sockDir, "pipe.sock")
+
+    const savedName = process.env.PRISM_SESSION_NAME
+    const savedPipe = process.env.PRISM_HARNESS_PIPE
+    process.env.PRISM_SESSION_NAME = "test@main"
+    process.env.PRISM_HARNESS_PIPE = `unix://${sockPath}`
+
+    const receivedLines: string[] = []
+    let serverConn: net.Socket | null = null
+
+    const cleanup = () => {
+      process.env.PRISM_SESSION_NAME = savedName
+      process.env.PRISM_HARNESS_PIPE = savedPipe
+      try { server.close() } catch {}
+      try { fs.rmSync(sockDir, { recursive: true, force: true }) } catch {}
+    }
+
+    const server = net.createServer((conn) => {
+      serverConn = conn
+      attachJsonlReader(conn, (line) => {
+        if (line.length === 0) return
+        receivedLines.push(line)
+        let f: Record<string, unknown>
+        try { f = JSON.parse(line) as Record<string, unknown> } catch { return }
+        if (f.type === "hello") {
+          conn.write(REVIEW_GUARD_HELLO_ACK())
+        }
+      })
+    })
+
+    const { pi, trigger } = makeMockPI1554()
+    // The doom-loop snapshot path that tool_execution_start calls into
+    // requires an appendEntry no-op.
+    ;(pi as unknown as { appendEntry: () => void }).appendEntry = () => {}
+    prismExtension(pi as never)
+
+    server.listen(sockPath, () => {
+      // Fire session_start to dial the socket and complete the handshake.
+      void trigger("session_start", {}, {}).then(async () => {
+        // Wait for the handshake to round-trip and post-handshake frames
+        // (including the sidecar's reviewing_state{in_flight:false}) to
+        // arrive at the server's read side.
+        await new Promise((r) => setTimeout(r, 50))
+        resolve({
+          trigger,
+          pushInbound: (frame) => {
+            if (!serverConn) throw new Error("server connection not yet established")
+            serverConn.write(JSON.stringify(frame) + "\n")
+          },
+          received: () => receivedLines.map((l) => {
+            try { return JSON.parse(l) as Record<string, unknown> } catch { return {} }
+          }),
+          cleanup,
+        })
+      }).catch((err) => {
+        cleanup()
+        reject(err)
+      })
+    })
+
+    server.on("error", (err) => {
+      cleanup()
+      reject(err)
+    })
+  })
+}
+
+describe("#2050: review-guard — sequence A (no review, turn_end → finished)", () => {
+  it("emits state_change:finished on turn_end when no review has been signalled", async () => {
+    const h = await setupReviewGuardHarness()
+    try {
+      // No reviewing_state{true} has been pushed: the guard is clear.
+      // A clean turn_end (stopReason=stop) must emit state_change:finished.
+      await h.trigger("turn_end", { message: { stopReason: "stop" } }, {
+        isIdle: () => true,
+        hasPendingMessages: () => false,
+      })
+      // Allow the writer to flush across the socket.
+      await new Promise((r) => setTimeout(r, 30))
+
+      const stateChanges = h.received().filter((f) => f.type === "state_change")
+      // First frame should be the initial "active" emitted by before_agent_start
+      // — absent here because we did not fire that hook — so we expect exactly
+      // one state_change frame: the finished signal we are testing.
+      assert.equal(
+        stateChanges.length, 1,
+        `sequence A: expected exactly 1 state_change frame, got ${stateChanges.length}: ${JSON.stringify(stateChanges)}`,
+      )
+      assert.equal(stateChanges[0].state, "finished")
+    } finally {
+      h.cleanup()
+    }
+  })
+})
+
+describe("#2050: review-guard — sequence B (mid-review, turn_end suppressed)", () => {
+  it("suppresses state_change after the sidecar pushes reviewing_state{in_flight:true}", async () => {
+    const h = await setupReviewGuardHarness()
+    try {
+      // Sidecar signals that a review has started. The extension MUST set
+      // pendingReviewCall from this frame (replacing the bash-substring
+      // detection that #2050 removed).
+      h.pushInbound({ type: "reviewing_state", in_flight: true })
+      // Let the inbound frame dispatch.
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Now turn_end fires (e.g. the worker took a brief idle turn while
+      // the review monitor pollled). state_change must NOT be emitted.
+      await h.trigger("turn_end", { message: { stopReason: "stop" } }, {
+        isIdle: () => true,
+        hasPendingMessages: () => false,
+      })
+      await new Promise((r) => setTimeout(r, 30))
+
+      const stateChanges = h.received().filter((f) => f.type === "state_change")
+      assert.equal(
+        stateChanges.length, 0,
+        `sequence B (mid-review): expected 0 state_change frames, got ${stateChanges.length}: ${JSON.stringify(stateChanges)}`,
+      )
+    } finally {
+      h.cleanup()
+    }
+  })
+})
+
+describe("#2050: review-guard — sequence C (completed-review, turn_end → finished)", () => {
+  it("releases the guard via reviewing_state{in_flight:false} and emits finished on the next turn_end", async () => {
+    const h = await setupReviewGuardHarness()
+    try {
+      // Mid-review: guard is armed.
+      h.pushInbound({ type: "reviewing_state", in_flight: true })
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Confirm a turn_end during this window emits nothing.
+      await h.trigger("turn_end", { message: { stopReason: "stop" } }, {
+        isIdle: () => true,
+        hasPendingMessages: () => false,
+      })
+      await new Promise((r) => setTimeout(r, 30))
+      const midReviewSC = h.received().filter((f) => f.type === "state_change")
+      assert.equal(
+        midReviewSC.length, 0,
+        `pre-clear turn_end leaked a state_change frame: ${JSON.stringify(midReviewSC)}`,
+      )
+
+      // Review monitor completes the round. The sidecar emits the cleared
+      // signal. Crucially, NO `prompt` inbound frame is pushed in this
+      // test — we want to prove the reviewing_state release path on its
+      // own, since the incident in #2050 showed that the prompt-frame
+      // clear can be lost while the bash-substring set-trigger
+      // (now removed) re-latched the guard.
+      h.pushInbound({ type: "reviewing_state", in_flight: false })
+      await new Promise((r) => setTimeout(r, 20))
+
+      // The worker takes its final handing-off turn. turn_end must emit
+      // state_change:finished so the sidecar starts the finished debounce
+      // and the coordinator is notified.
+      await h.trigger("turn_end", { message: { stopReason: "stop" } }, {
+        isIdle: () => true,
+        hasPendingMessages: () => false,
+      })
+      await new Promise((r) => setTimeout(r, 30))
+
+      const postClearSC = h.received().filter((f) => f.type === "state_change")
+      assert.equal(
+        postClearSC.length, 1,
+        `sequence C: expected exactly 1 state_change frame after reviewing_state{false}, got ${postClearSC.length}: ${JSON.stringify(postClearSC)}`,
+      )
+      assert.equal(postClearSC[0].state, "finished")
+    } finally {
+      h.cleanup()
+    }
+  })
+
+  it("also releases the guard via the prompt inbound frame (belt-and-braces clear path)", async () => {
+    const h = await setupReviewGuardHarness()
+    try {
+      h.pushInbound({ type: "reviewing_state", in_flight: true })
+      await new Promise((r) => setTimeout(r, 20))
+
+      // Simulate the review-complete prompt arriving (the other release
+      // path the extension keeps as defence in depth).
+      h.pushInbound({ type: "prompt", text: "review complete!", deliver_as: "nextTurn" })
+      await new Promise((r) => setTimeout(r, 20))
+
+      await h.trigger("turn_end", { message: { stopReason: "stop" } }, {
+        isIdle: () => true,
+        hasPendingMessages: () => false,
+      })
+      await new Promise((r) => setTimeout(r, 30))
+
+      const stateChanges = h.received().filter((f) => f.type === "state_change")
+      assert.equal(
+        stateChanges.length, 1,
+        `prompt-clear path: expected 1 state_change frame, got ${stateChanges.length}: ${JSON.stringify(stateChanges)}`,
+      )
+      assert.equal(stateChanges[0].state, "finished")
+    } finally {
+      h.cleanup()
+    }
+  })
+})
+
+describe("#2050: bash-substring set-trigger has been removed from prism.ts", () => {
+  it("prism.ts source no longer contains the /\\bprism\\s+review\\b/ set-trigger for pendingReviewCall", () => {
+    // Source-level guard: the bash-substring detection was the root cause
+    // of the #2050 incident. If it is reintroduced anywhere that sets
+    // pendingReviewCall = true, the substring false-match returns and the
+    // stuck-active class is re-enabled.
+    const src = fs.readFileSync(path.join(__dirname, "prism.ts"), "utf8")
+    // Strip line-comments and the // halves of inline comments so that
+    // historical narrative inside comment blocks does not trip the guard.
+    // Block comments (/* ... */) are stripped first via a non-greedy match.
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .split("\n")
+      .map((line) => line.replace(/\/\/.*$/, ""))
+    for (let i = 0; i < stripped.length; i++) {
+      const line = stripped[i]
+      if (/pendingReviewCall\s*=\s*true\b/.test(line)) {
+        const ctx = src.split("\n").slice(Math.max(0, i - 3), i + 4).join("\n")
+        assert.fail(
+          `prism.ts line ${i + 1}: pendingReviewCall is assigned true; the #2050 fix removed this set path entirely (sidecar is now authoritative via reviewing_state).\n\nContext:\n${ctx}`,
+        )
+      }
+    }
+  })
+})

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1417,6 +1417,15 @@ export async function dispatchInboundFrame(
         break
       }
 
+      case "reviewing_state": {
+        // Handled directly in the attachJsonlReader callback above (the
+        // closure that owns pendingReviewCall). The case exists here so
+        // the forward-compat "unknown inbound frame type" warning at the
+        // bottom of the switch does not fire and clutter logs every time
+        // the sidecar pushes a reviewing-state transition (issue #2050).
+        break
+      }
+
       case "error": {
         // Sidecar-side error; log and disconnect is handled by the caller.
         // Per wire spec §7.4 the extension does not retry the handshake.
@@ -2079,9 +2088,27 @@ export default function prismExtension(pi: ExtensionAPI): void {
 
       // A prompt frame signals that the sidecar is delivering a message
       // (e.g. review-complete). Clear the reviewing-state guard so subsequent
-      // turns can emit state_change:idle normally.
+      // turns can emit state_change:idle normally. Belt-and-braces with the
+      // reviewing_state frame handler below: either clearing path is
+      // sufficient on its own; both are defence in depth.
       if (f.type === "prompt") {
         pendingReviewCall = false
+      }
+
+      // Authoritative reviewing-state signal from the sidecar (issue #2050).
+      // The sidecar tracks reviewingInFlight against its session-ledger and
+      // emits this frame on every transition plus immediately after
+      // handshake. We mirror it directly into pendingReviewCall, which is
+      // now driven solely from this signal — the previous bash-substring
+      // set-trigger ("/\bprism\s+review\b/") was removed because it false-
+      // matched on any bash command that incidentally contained the literal
+      // "prism review" (e.g. a `gh pr comment` body, a grep, an echo of a
+      // commit message). That re-latched the guard after the genuine
+      // review-complete prompt had cleared it, and the worker's next
+      // turn_end then suppressed state_change:finished forever — the exact
+      // shape of the stuck-active incident in #2050.
+      if (f.type === "reviewing_state") {
+        pendingReviewCall = f.in_flight === true
       }
 
       void dispatchInboundFrame(f, apiAdapter, sendError)
@@ -2395,15 +2422,22 @@ export default function prismExtension(pi: ExtensionAPI): void {
           pendingGitPushReminder = true
         }
 
-        // Reviewing-state guard: set flag when `prism review` is called so
-        // that the turn_end idle emission is suppressed until the
-        // review-complete prompt arrives. NOTE: this is intentionally a
-        // separate flag from cycle counting (the latter moved to the Go
-        // monitor in #1512). The reviewing-state flag's substring-detection
-        // class is tracked in #1519 and is out of scope here.
-        if (/\bprism\s+review\b/.test(command)) {
-          pendingReviewCall = true
-        }
+        // Reviewing-state guard set-path REMOVED in #2050. The previous
+        // implementation set pendingReviewCall = true whenever a bash
+        // command matched /\bprism\s+review\b/, which false-positived on
+        // any bash invocation that incidentally contained the literal
+        // "prism review" (gh pr comment bodies, grep over docs, echo of
+        // a commit message, etc.). A false-set after the genuine review-
+        // complete prompt had cleared the flag re-latched the guard with
+        // no release path, suppressing state_change:finished on the next
+        // turn_end and stranding the session as `active` indefinitely.
+        //
+        // The guard is now driven authoritatively by the sidecar via the
+        // `reviewing_state` inbound frame (see the attachJsonlReader
+        // callback above). The sidecar emits one on every transition of
+        // its ledger-backed `reviewingInFlight` flag plus once post-
+        // handshake, so the extension's pendingReviewCall is a faithful
+        // mirror of the sidecar's authoritative state.
       }
 
       // Persist guard state after each tool call so session resume can

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -781,6 +781,64 @@ The extension calls PI's abort path. The state transition that follows
 ordinary `state_change` frames; `abort` itself produces no acknowledgement
 on this protocol.
 
+### 6.7 `reviewing_state`
+
+Authoritative push of the sidecar's `reviewingInFlight` flag to the
+extension. The extension uses this as the canonical source of truth for
+its `pendingReviewCall` guard, which suppresses `state_change:finished` on
+turn boundaries while a `prism review` is in flight.
+
+```json
+{"type":"reviewing_state","in_flight":true}
+```
+
+- `in_flight` (bool, required) — `true` while the sidecar is awaiting a
+  review-complete prompt for an in-flight review group; `false` once the
+  review has been delivered (or never started).
+
+**Emission sites (sidecar side).**
+
+- Immediately after handshake completion, so a freshly-connected (or
+  reconnecting) extension initialises with the sidecar's current value
+  rather than relying on a per-session-restart guess.
+- Whenever the in-memory `reviewingInFlight` flag transitions to a new
+  value:
+  - The `/review` HTTP handler setting it to `true` after a successful
+    pre-emptive DB write.
+  - The `/prompt` handler clearing it to `false` after a successful
+    synchronous `source: "review-complete"` delivery.
+  - `flushPendingReplay` clearing it to `false` after a buffered
+    review-complete delivery has been re-enqueued post-reconnect.
+
+**Extension side.** On receipt the extension sets
+`pendingReviewCall = (in_flight === true)`. The strict triple-equals
+defaults any malformed / unexpected payload to `false` (release, not
+latch), which is the secure-by-default direction — a missed `in_flight:
+true` produces an extra notification at worst, while a missed `in_flight:
+false` would strand the session as `active` (the #2050 failure shape).
+
+**Why this frame exists (#2050).** Before this frame, the extension set
+`pendingReviewCall` itself by substring-matching `\bprism\s+review\b`
+against every bash `tool_call`. That false-matched on any bash command
+that incidentally contained the literal string (a `gh pr comment` body,
+a `grep` over docs, an `echo` of a commit message), re-latching the
+guard after the genuine review-complete prompt had cleared it. The next
+`turn_end` then suppressed `state_change:finished` forever and the
+worker was stuck `active`. Moving the source of truth to the sidecar
+(which tracks `reviewingInFlight` against its session ledger) eliminates
+the substring class at the root.
+
+**Belt-and-braces.** The `prompt` frame's `source: "review-complete"`
+release path (§6.2) is retained in the extension as defence in depth:
+either clearing path is sufficient on its own.
+
+**Forward-compat note.** This frame was added without a `protocol_version`
+bump, in line with §8.2's additive-frame contract: older extensions skip
+unknown frame types via the default branch in the dispatcher. Sidecar
+and extension ship together via the same Nix package, so the version-skew
+window exists only on a paused/resumed session that crosses a prism
+upgrade boundary.
+
 ## 7. Failure modes
 
 ### 7.1 Sidecar binds before PI starts; extension's first frame is the readiness signal

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -896,6 +896,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 					s.mu.Lock()
 					s.reviewingInFlight = false
 					s.mu.Unlock()
+					// Push the reviewing-cleared signal to the PI extension so
+					// its pendingReviewCall guard is released even if the
+					// inbound prompt frame is missed by the extension's own
+					// clearing path (issue #2050). Belt-and-braces: the
+					// prompt-frame clear at extensions/prism.ts still applies.
+					s.writeReviewingState(false)
 				}
 				writeJSON(w, http.StatusOK, map[string]string{})
 				return
@@ -1360,6 +1366,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			s.mu.Lock()
 			s.reviewingInFlight = true
 			s.mu.Unlock()
+			// Push the authoritative reviewing-state transition to the PI
+			// extension so its pendingReviewCall guard is set in lock-step with
+			// the sidecar's ledger-backed flag (issue #2050). A dropped frame
+			// here is non-fatal: the handshake-time emission and any subsequent
+			// transition will re-assert the correct state.
+			s.writeReviewingState(true)
 		}
 
 		var req struct {

--- a/modules/programs/prism/prism/internal/sidecar/monitor_recovery_race_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/monitor_recovery_race_test.go
@@ -253,22 +253,30 @@ func TestMonitorAndRecovery_ExactlyOneDelivery(t *testing.T) {
 	// Give the goroutines a brief settling window.
 	time.Sleep(50 * time.Millisecond)
 
-	// Count frames forwarded to PI.
-	var frames [][]byte
+	// Count frames forwarded to PI. We only care about the prompt-frame
+	// delivery here; the sidecar may legitimately emit other control frames
+	// (e.g. reviewing_state on the in-memory flag flip after delivery, #2050)
+	// alongside the prompt, which are unrelated to the dedup behaviour under
+	// test. Filter to prompt frames only so the assertion remains stable.
+	var promptFrames [][]byte
+	var allFrames [][]byte
 	drainLoop:
 	for {
 		select {
 		case f := <-pipeCh:
-			frames = append(frames, f)
+			allFrames = append(allFrames, f)
+			if strings.Contains(string(f), "\"type\":\"prompt\"") {
+				promptFrames = append(promptFrames, f)
+			}
 		default:
 			break drainLoop
 		}
 	}
 
-	if len(frames) != 1 {
-		t.Errorf("monitor + recovery race: got %d frame(s) forwarded to PI, want exactly 1\n"+
+	if len(promptFrames) != 1 {
+		t.Errorf("monitor + recovery race: got %d prompt frame(s) forwarded to PI, want exactly 1 (all frames: %d)\n"+
 			"Before the F2 fix this would be 2 (different delivery_ids).\n"+
 			"After the F2 fix both paths use RecoveryDeliveryID(%s) and the sidecar dedup drops the second.",
-			len(frames), groupID)
+			len(promptFrames), len(allFrames), groupID)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/prompt_dedup_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/prompt_dedup_test.go
@@ -450,10 +450,20 @@ func TestFlushPendingReplay_DuplicateDeliveryIDDropsSecond(t *testing.T) {
 	sc.flushPendingReplay()
 	time.Sleep(10 * time.Millisecond)
 
-	frames := drainFrames(pipeCh)
+	allFrames := drainFrames(pipeCh)
+	// Filter to prompt frames only. The post-#2050 sidecar may also emit a
+	// reviewing_state frame on the reviewingInFlight flip after the
+	// review-complete entry is enqueued; that is orthogonal to the dedup
+	// behaviour under test.
+	var frames [][]byte
+	for _, f := range allFrames {
+		if strings.Contains(string(f), "\"type\":\"prompt\"") {
+			frames = append(frames, f)
+		}
+	}
 	if len(frames) != 1 {
-		t.Fatalf("flushPendingReplay with duplicate delivery_id: want 1 frame (first forwarded, second dropped), got %d: %v",
-			len(frames), framesForLog(frames))
+		t.Fatalf("flushPendingReplay with duplicate delivery_id: want 1 prompt frame (first forwarded, second dropped), got %d (all frames: %v)",
+			len(frames), framesForLog(allFrames))
 	}
 	if !strings.Contains(string(frames[0]), "monitor delivery") {
 		t.Errorf("first frame = %q, want it to contain first entry's text", frames[0])

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -2193,6 +2193,18 @@ func (s *Sidecar) runStartupSocketPipe(ctx context.Context) error {
 		// goroutine so a slow drain cannot block the reader loop.
 		go s.flushPendingReplay()
 
+		// Push the authoritative reviewingInFlight value to the freshly-
+		// connected extension so its pendingReviewCall guard is initialised
+		// from the sidecar's ledger-backed state rather than relying on the
+		// fragile bash-substring detection that was the root cause of #2050.
+		// On a fresh session this is always false; on resume after PI restart
+		// it may legitimately be true (a review group was started before the
+		// restart and has not yet delivered review-complete).
+		s.mu.Lock()
+		reviewingInFlight := s.reviewingInFlight
+		s.mu.Unlock()
+		s.writeReviewingState(reviewingInFlight)
+
 		// --- Inbound frame loop -------------------------------------------
 		cleanShutdown := false
 		for {
@@ -2698,6 +2710,10 @@ func (s *Sidecar) flushPendingReplay() {
 			s.reviewingInFlight = false
 			s.mu.Unlock()
 			s.logger().Printf("sidecar: flushPendingReplay: cleared reviewingInFlight after replayed review-complete enqueue (delivery_id=%s)", d.DeliveryID)
+			// Mirror the in-memory transition on the wire so the PI extension's
+			// pendingReviewCall guard releases in lock-step with the sidecar.
+			// See writeReviewingState's doc comment for #2050 context.
+			s.writeReviewingState(false)
 		}
 	}
 	if len(requeue) > 0 {
@@ -2854,6 +2870,36 @@ func (s *Sidecar) Abort() bool {
 	frame := struct {
 		Type string `json:"type"`
 	}{Type: "abort"}
+	b, _ := json.Marshal(frame)
+	b = append(b, '\n')
+	return s.enqueueHarnessPipeFrame(b)
+}
+
+// writeReviewingState enqueues a reviewing_state frame to the PI extension,
+// telling it the sidecar's authoritative reviewingInFlight value. The extension
+// uses this as the canonical source of truth for its own pendingReviewCall
+// guard, replacing the fragile bash-substring detection that previously set
+// the guard on any tool call containing "prism review" (issue #2050).
+//
+// Emission sites:
+//   - Immediately after handshake completion (so a freshly-connected
+//     extension starts with the correct state, including post-resume).
+//   - Whenever s.reviewingInFlight is mutated to a new value (the /review
+//     handler sets true; the /prompt review-complete handler clears false;
+//     flushPendingReplay clears false after a replayed review-complete frame).
+//
+// MUST be called with s.mu NOT held — enqueueHarnessPipeFrame acquires it
+// internally. A false return is logged-and-dropped; the next transition or
+// handshake will re-assert the correct state, so an isolated drop does not
+// wedge the guard.
+func (s *Sidecar) writeReviewingState(inFlight bool) bool {
+	frame := struct {
+		Type     string `json:"type"`
+		InFlight bool   `json:"in_flight"`
+	}{
+		Type:     "reviewing_state",
+		InFlight: inFlight,
+	}
 	b, _ := json.Marshal(frame)
 	b = append(b, '\n')
 	return s.enqueueHarnessPipeFrame(b)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_reviewing_state_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_reviewing_state_test.go
@@ -1,0 +1,173 @@
+package sidecar
+
+// sidecar_reviewing_state_test.go — issue #2050.
+//
+// Verifies that the sidecar emits a `reviewing_state` frame to the PI
+// extension on every transition of reviewingInFlight plus once immediately
+// after handshake completion. This is the authoritative-from-sidecar signal
+// that replaces the extension's fragile bash-substring set-trigger for
+// pendingReviewCall.
+//
+// See modules/programs/prism/pi/extensions/prism.ts for the consumer side.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReviewingState_EmittedOnHandshake verifies the sidecar emits a
+// reviewing_state{in_flight: false} frame immediately after hello_ack on
+// a fresh session (no review in flight).
+func TestReviewingState_EmittedOnHandshake(t *testing.T) {
+	sockPath := shortSockPath(t)
+	d := openTestDB(t)
+	_ = d
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	wait := runSocketPipeSidecar(sc)
+
+	// dialAndHandshake itself now consumes and asserts the reviewing_state
+	// frame; success here means the frame was emitted and parsed correctly.
+	conn, ack := dialAndHandshake(t, sockPath)
+	if ack["type"] != "hello_ack" {
+		t.Fatalf("ack type = %v, want hello_ack", ack["type"])
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestReviewingState_EmittedOnSetTrue verifies that when the /review handler
+// sets reviewingInFlight=true, the sidecar pushes a reviewing_state{in_flight:
+// true} frame to the connected PI extension. The frame is what drives the
+// extension's pendingReviewCall guard ON, replacing the prior bash-substring
+// set-trigger that false-matched on any bash command containing "prism review"
+// (the #2050 root cause).
+func TestReviewingState_EmittedOnSetTrue(t *testing.T) {
+	sockPath := shortSockPath(t)
+	d := openTestDB(t)
+	_ = d
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	defer conn.Close()
+
+	// Flip reviewingInFlight in-memory the way the /review handler does and
+	// also drive the in-test transition via writeReviewingState directly.
+	// We exercise the wire emission separately from the /review HTTP path
+	// because /review's full path needs DB rows, agents, and a subprocess
+	// spawn — out of scope for this guard-frame test.
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+	sc.writeReviewingState(true)
+
+	frame := readJSON(t, conn)
+	if frame["type"] != "reviewing_state" {
+		t.Fatalf("frame type = %v, want reviewing_state", frame["type"])
+	}
+	if got, _ := frame["in_flight"].(bool); !got {
+		t.Errorf("frame in_flight = %v, want true", frame["in_flight"])
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	_ = wait()
+}
+
+// TestReviewingState_EmittedOnClear verifies that when the /prompt
+// review-complete handler clears reviewingInFlight=false (or
+// flushPendingReplay does so after a buffered review-complete enqueue), the
+// sidecar pushes a reviewing_state{in_flight: false} frame so the extension
+// can release its pendingReviewCall guard even if the inbound prompt frame
+// itself is lost or processed in an unexpected order.
+func TestReviewingState_EmittedOnClear(t *testing.T) {
+	sockPath := shortSockPath(t)
+	d := openTestDB(t)
+	_ = d
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	defer conn.Close()
+
+	// Pre-state: simulate that a review is in flight.
+	sc.mu.Lock()
+	sc.reviewingInFlight = true
+	sc.mu.Unlock()
+	sc.writeReviewingState(true)
+
+	// Drain the in_flight=true frame so the next read sees the clear.
+	first := readJSON(t, conn)
+	if first["type"] != "reviewing_state" {
+		t.Fatalf("first frame type = %v, want reviewing_state", first["type"])
+	}
+
+	// Clear the flag and emit the cleared frame as the host_api.go and
+	// flushPendingReplay paths now do.
+	sc.mu.Lock()
+	sc.reviewingInFlight = false
+	sc.mu.Unlock()
+	sc.writeReviewingState(false)
+
+	cleared := readJSON(t, conn)
+	if cleared["type"] != "reviewing_state" {
+		t.Fatalf("cleared frame type = %v, want reviewing_state", cleared["type"])
+	}
+	if got, ok := cleared["in_flight"].(bool); !ok || got {
+		t.Errorf("cleared frame in_flight = %v, want false", cleared["in_flight"])
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	_ = wait()
+}
+
+// TestReviewingState_FrameShape locks the on-the-wire JSON shape so an
+// accidental rename of either field is caught by tests rather than by a
+// stuck-active worker in production. The shape is asserted by direct call
+// into writeReviewingState plus an inspection of the bytes enqueued on the
+// outbound pipe channel.
+func TestReviewingState_FrameShape(t *testing.T) {
+	d := openTestDB(t)
+	sc := newDedupTestSidecar(t, "prism-test@reviewing-state-shape", d)
+
+	pipeCh := make(chan []byte, 4)
+	sc.mu.Lock()
+	sc.harnessPipeOutCh = pipeCh
+	sc.mu.Unlock()
+
+	if !sc.writeReviewingState(false) {
+		t.Fatalf("writeReviewingState(false) returned false")
+	}
+	if !sc.writeReviewingState(true) {
+		t.Fatalf("writeReviewingState(true) returned false")
+	}
+
+	select {
+	case frame := <-pipeCh:
+		if !strings.Contains(string(frame), `"type":"reviewing_state"`) {
+			t.Errorf("first frame missing type:reviewing_state — got %q", frame)
+		}
+		if !strings.Contains(string(frame), `"in_flight":false`) {
+			t.Errorf("first frame missing in_flight:false — got %q", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for first frame on pipe channel")
+	}
+
+	select {
+	case frame := <-pipeCh:
+		if !strings.Contains(string(frame), `"type":"reviewing_state"`) {
+			t.Errorf("second frame missing type:reviewing_state — got %q", frame)
+		}
+		if !strings.Contains(string(frame), `"in_flight":true`) {
+			t.Errorf("second frame missing in_flight:true — got %q", frame)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for second frame on pipe channel")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_socketpipe_test.go
@@ -108,10 +108,49 @@ func dialAndHandshake(t *testing.T, sockPath string) (net.Conn, map[string]any) 
 	}
 	sendJSON(t, conn, hello)
 
-	// Read hello_ack.
-	ack := readJSON(t, conn)
+	// Read hello_ack and post-handshake reviewing_state through a single
+	// shared buffered reader to avoid the multi-bufio data-loss footgun
+	// (if both frames arrive in one syscall, a fresh bufio per readJSON call
+	// would discard the second frame). The post-handshake reviewing_state
+	// frame initialises the extension's pendingReviewCall guard from the
+	// authoritative sidecar-side flag (issue #2050).
+	rd := bufio.NewReader(conn)
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck
+
+	ackLine, ackErr := rd.ReadBytes('\n')
+	if ackErr != nil {
+		t.Fatalf("hello_ack read: %v", ackErr)
+	}
+	var ack map[string]any
+	if err := json.Unmarshal(ackLine, &ack); err != nil {
+		t.Fatalf("hello_ack unmarshal: %v", err)
+	}
 	if ack["type"] != "hello_ack" {
 		t.Fatalf("expected hello_ack, got %q", ack["type"])
+	}
+
+	rsLine, rsErr := rd.ReadBytes('\n')
+	if rsErr != nil {
+		t.Fatalf("reviewing_state read: %v", rsErr)
+	}
+	var rs map[string]any
+	if err := json.Unmarshal(rsLine, &rs); err != nil {
+		t.Fatalf("reviewing_state unmarshal: %v", err)
+	}
+	if rs["type"] != "reviewing_state" {
+		t.Fatalf("expected reviewing_state after hello_ack, got %q", rs["type"])
+	}
+
+	// Push any extra buffered bytes back onto the connection so the caller's
+	// own reader sees the next frame intact. bufio.Reader.Buffered() returns
+	// data we read into the bufio buffer but did not consume; if non-zero we
+	// must surface it to the caller. The simplest correct path is to refuse
+	// to leak buffered bytes: assert they are zero. Test-side writers feed
+	// frames synchronously after the handshake, so in practice there is
+	// nothing left in the bufio buffer beyond the two frames we read.
+	if rd.Buffered() != 0 {
+		t.Fatalf("dialAndHandshake: %d unconsumed bytes in bufio buffer after handshake — caller would lose data", rd.Buffered())
 	}
 	return conn, ack
 }


### PR DESCRIPTION
Closes #2050

## Diagnosis

AC #1 — root cause. **(a)** The review-guard latches and does not reliably release. The set side, not the release side, is the bug.

The PI extension's `pendingReviewCall` guard is set on every bash `tool_call` whose command matches `/\bprism\s+review\b/`. That regex false-positives on **any** bash command containing the literal substring `prism review` — a `gh pr comment` body, a `grep` over docs, an `echo` of a commit message, a heredoc, etc. The extension's only release path was an inbound `prompt` frame (review-complete delivery). Once a false-set happened **after** the genuine review-complete prompt had already arrived, the guard was latched true with no release path. The next `turn_end` resolved to `"none"` via `resolveTurnEndSignal`, no `state_change:finished` frame reached the sidecar, the finished-debounce never started, and the worker was stuck `active` indefinitely — the exact shape reported in #2050.

The known-fragile bash-substring class is acknowledged in the extension source itself (line ~2402 references #1519: *"The reviewing-state flag's substring-detection class is tracked in #1519"*).

## Fix

Make the guard sidecar-authoritative. The sidecar already tracks `reviewingInFlight` against its session-ledger; the extension now mirrors that single source of truth.

### Wire

New outbound frame, sidecar → extension:

```json
{"type": "reviewing_state", "in_flight": <bool>}
```

No protocol-version bump: a new frame type is forward-compatible (older receivers log-and-skip via the existing default branch in `dispatchInboundFrame`). Sidecar and extension ship together via this flake, so version skew is not a concern in practice.

### Sidecar (Go)

- New `writeReviewingState(inFlight bool)` in `sidecar.go`.
- Emitted on every transition of the in-memory `reviewingInFlight` flag:
  - `/review` HTTP handler — set true (`host_api.go:1361`)
  - `/prompt` review-complete handler — synchronous-success clear (`host_api.go:897`)
  - `flushPendingReplay` — clear after a replayed review-complete enqueue (`sidecar.go:2698`)
- Plus once immediately after handshake completion, so a freshly-connected (or reconnecting) extension initialises with the correct state.

### Extension (TypeScript)

- New inbound handler in `attachJsonlReader`: `pendingReviewCall = f.in_flight === true`.
- **Removed** the bash-substring set-trigger entirely.
- Kept the existing `prompt`-frame clear as belt-and-braces (either release path is sufficient on its own).
- Added an explicit no-op case in `dispatchInboundFrame` so the forward-compat "unknown inbound frame type" log does not fire on every transition.

## ACs

- [x] AC #1 — root cause identified with source evidence (substring set-trigger over-matches; see commit message and the extension comments at lines ~2401-2402).
- [x] AC #2 — completed-review path: worker emits `state_change:finished` on its final `turn_end` after a `prism review` has completed. Asserted by sequence C tests in `prism.test.ts`.
- [x] AC #3 — no-review path: no regression. Asserted by sequence A tests plus the existing `resolveTurnEndSignal` suite.
- [x] AC #4 — mid-review path: `state_change` still correctly suppressed during the reviewing window. Asserted by sequence B tests, the existing `pendingReviewCall=true still suppresses finished` test, and the new sidecar tests for `reviewing_state{in_flight: true}` emission.
- [x] AC #5 — extension unit tests for all three sequences. `tsx --test --test-force-exit prism.test.ts` → 299 pass, 0 fail.
- [x] AC #6 — `nix build .#prism` succeeds (also confirmed with `runChecks = true` for the homeless-shelter sandbox).

## Verification

```
# From modules/programs/prism/prism/
go build ./...
go test ./...                          # all green
go test ./internal/sidecar/ -race       # green

# From modules/programs/prism/pi/extensions/
tsx --test --test-force-exit prism.test.ts
# tests 299, pass 299, fail 0

# From repo root
nix build .#prism                       # green
nix build --impure --no-link --expr     # green (runChecks = true)
  '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
```

## Out of scope

- The `reviewingInFlight` flag is in-memory; if the sidecar process restarts mid-review the flag is lost. That is existing behaviour and not in scope for #2050.
- The review-monitor's verdict-aggregation logic is unchanged (kept observing-only as the work-item required).
- No `protocol_version` bump.