### PR TITLE
Update prism profile to anthropic-opus-medium and downgrade Claude model

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -23,7 +23,7 @@
     };
     programs = {
       prism = {
-        profile.default = "anthropic";
+        profile.default = "anthropic-opus-medium";
         agent.isolation.default = "bwrap";
       };
       anki.enable = false; # build broken as of 2025-08-30

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -97,7 +97,7 @@
             anthropic = profileFromSlots {
               coordinator = slot "coordinator" {
                 provider = "anthropic";
-                model = "anthropic/claude-opus-4-8";
+                model = "anthropic/claude-opus-4-7";
                 thinking = "medium";
               };
               _default = slot "worker" {
@@ -110,12 +110,12 @@
             anthropic-opus-medium = profileFromSlots {
               _default = slot "worker" {
                 provider = "anthropic";
-                model = "anthropic/claude-opus-4-8";
+                model = "anthropic/claude-opus-4-7";
                 thinking = "medium";
               };
               coordinator = slot "coordinator" {
                 provider = "anthropic";
-                model = "anthropic/claude-opus-4-8";
+                model = "anthropic/claude-opus-4-7";
                 thinking = "medium";
               };
             };
@@ -123,12 +123,12 @@
             anthropic-opus = profileFromSlots {
               coordinator = slot "coordinator" {
                 provider = "anthropic";
-                model = "anthropic/claude-opus-4-8";
+                model = "anthropic/claude-opus-4-7";
                 thinking = "medium";
               };
               _default = slot "worker" {
                 provider = "anthropic";
-                model = "anthropic/claude-opus-4-8";
+                model = "anthropic/claude-opus-4-7";
               };
             };
 


### PR DESCRIPTION
This change updates the default prism profile for the navi machine to use anthropic-opus-medium. Additionally, all Claude opus model references are downgraded from 4-8 to 4-7 to ensure stability.