### PR TITLE
prism: fix role system-prompt injection on bwrap sessions (#2064, #2065)

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -57,12 +57,6 @@
       envPrefix = config.nx.programs.prism._internal.agentEnvPrefix;
       clipboardCmd = if pkgs.stdenv.isDarwin then "pbcopy" else "wl-copy";
 
-      # System prompts sourced directly from the agent files so there
-      # is one authoritative copy — updates to those files flow through here
-      # automatically.
-      workerSystemPrompt = builtins.readFile ./agents/worker.md;
-      coordinatorSystemPrompt = builtins.readFile ./agents/coordinator.md;
-
       # AWS skill with clipboard command substituted at eval time.
       awsSkillFile = pkgs.replaceVars ./skills/aws/SKILL.md {
         inherit clipboardCmd;
@@ -124,13 +118,30 @@
           anthropicExtraUsage = false;
         };
 
-        # Vendored extension: replaces the previous npm:pi-anthropic-oauth@0.1.9
-        # package. The extension is stored in the nix store as plain TypeScript
-        # files and loaded by pi's jiti-based extension loader at runtime.
+        # Vendored extensions registered in settings.json. The prism PI
+        # extension is included here as defence-in-depth alongside the
+        # `--extension` CLI flag that prism passes per session (issue #2064
+        # Phase 3) — if a future code path forgets to pass the flag, the
+        # extension still loads from settings, so the role-prompt injection
+        # surface degrades gracefully instead of silently disappearing.
+        #
+        # The first entry (anthropic-oauth) replaces the previous
+        # npm:pi-anthropic-oauth@0.1.9 package. All extensions are stored
+        # in the nix store as plain TypeScript files and loaded by pi's
+        # jiti-based extension loader at runtime.
         # To port a future upstream fix, see:
         #   modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md
         extensions = [
           "${piExtensionsDir}/anthropic-oauth/index.ts"
+          # prism PI extension — sidecar bridge, status bar, doom-loop
+          # guard, role system-prompt injection (issue #2032 / #2064).
+          # The same file is also passed via --extension at spawn time by
+          # internal/container/pi_invocation.go (container modes) and
+          # internal/session/session.go::buildDirectAgentCmd (host mode,
+          # #2065). Registering it here too means pi loads it exactly
+          # once (the loader de-dupes by resolved path) but neither call
+          # path is load-bearing on its own.
+          "${prismExtensionDir}/prism.ts"
         ]
         ++
           lib.optional config.nx.programs.prism.pi.atlassian.enable
@@ -243,8 +254,16 @@
         xdg.configFile."prism/skills".source = skillsDir;
 
         home.file.".pi/agent/settings.json".text = builtins.toJSON piSettings;
-        home.file.".pi/agent/system-prompt.md".text = workerSystemPrompt;
-        home.file.".pi/agent/coordinator-system-prompt.md".text = coordinatorSystemPrompt;
+        # Note: ~/.pi/agent/system-prompt.md and coordinator-system-prompt.md
+        # were removed in the #2064 cleanup. They were staged by the pre-#2031
+        # mechanism (when prism wrote a per-session APPEND_SYSTEM.md staging
+        # file), but pi 0.77 has no native loader for either filename — it
+        # only auto-discovers SYSTEM.md / APPEND_SYSTEM.md per dist/core/
+        # resource-loader.js. Confirmed inert from #2038 onwards (when the
+        # APPEND_SYSTEM.md staging path was removed); role-prompt injection
+        # now flows through the prism PI extension's pi.registerFlag("agent")
+        # path (extension reads ~/.config/prism/agents/<role>.md at
+        # before_agent_start).
         home.file.".pi/agent/AGENTS.md".text = builtins.readFile ./agents/global-instructions.md;
         # Custom theme derived from config.theme, deployed so pi picks it up
         # from ~/.pi/agent/themes/ at runtime. The theme name matches

--- a/modules/programs/prism/pi/extensions/prism.role-prompt.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.role-prompt.test.ts
@@ -1,0 +1,402 @@
+// Regression test for issue #2064 — role system-prompt injection over the
+// pi.registerFlag("agent") path.
+//
+// History. The pre-#2064 design sourced the agent role from the async
+// hello_ack handshake (sidecar → extension). On a fresh bwrap session the
+// handshake races BEHIND the agent-start hook: pi fires before_agent_start
+// inline on the agent side, while the hello_ack frame travels over a Unix
+// socket and arrives a moment later. The first turn therefore lost the role
+// prompt every time. Multi-turn sessions resolved correctly on turn 2+, but
+// the user-visible pi-session export — captured at the first turn — showed
+// pi's default system prompt with no role append.
+//
+// The fix sources the role from pi.getFlag("agent") instead. pi binds
+// extension-registered flags during applyExtensionFlagValues (see pi 0.77
+// dist/core/agent-session-services.js) which runs after resourceLoader.reload()
+// completes — i.e. after every extension factory has returned — and BEFORE
+// the AgentSession is constructed. pi.getFlag("agent") therefore returns
+// synchronously on the very first before_agent_start fire, with no
+// dependency on any async sidecar handshake.
+//
+// This test exercises the end-to-end behaviour the user actually cares
+// about: "a worker session's first-turn system prompt contains the contents
+// of worker.md". It fails on main pre-#2064 because the handshake gate in
+// resolveRolePromptForTurn forces undefined on the first call. It passes on
+// the fix because the flag-sourced role is available synchronously.
+//
+// Run with: tsx --test prism.role-prompt.test.ts
+//        or node --test --import tsx prism.role-prompt.test.ts
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+
+import prismExtension from "./prism.ts"
+
+// A minimal pi mock with the registerFlag / getFlag surface, plus an event
+// dispatcher so the test can fire before_agent_start and inspect the result.
+// Modelled on makeMockPI1554 in prism.test.ts but kept local here so this
+// file does not collide with the in-flight handle-leak fixes there (#2060
+// has landed but route-around discipline keeps the two test surfaces tidy).
+interface MockPI {
+  on: (event: string, handler: (...args: unknown[]) => unknown) => void
+  registerFlag: (
+    name: string,
+    options: { description?: string; type: "boolean" | "string"; default?: boolean | string },
+  ) => void
+  getFlag: (name: string) => string | boolean | undefined
+  sendUserMessage: (...args: unknown[]) => void
+  setModel: (...args: unknown[]) => void
+  setThinkingLevel: (...args: unknown[]) => void
+  registerProvider: (...args: unknown[]) => void
+  setActiveTools: (...args: unknown[]) => void
+}
+
+interface MockHarness {
+  pi: MockPI
+  trigger: (event: string, arg?: unknown, ctx?: unknown) => Promise<unknown>
+  registeredFlags: Map<string, { type: "boolean" | "string"; description?: string }>
+}
+
+function makeMockPI(flagValues: Record<string, string> = {}): MockHarness {
+  const handlers: Record<string, ((...args: unknown[]) => unknown)[]> = {}
+  const registeredFlags = new Map<string, { type: "boolean" | "string"; description?: string }>()
+  const bound = new Map<string, string | boolean>(Object.entries(flagValues))
+  const pi: MockPI = {
+    on: (event, handler) => {
+      if (!handlers[event]) handlers[event] = []
+      handlers[event].push(handler)
+    },
+    registerFlag: (name, options) => {
+      registeredFlags.set(name, { type: options.type, description: options.description })
+    },
+    getFlag: (name) => bound.get(name),
+    sendUserMessage: () => {},
+    setModel: () => {},
+    setThinkingLevel: () => {},
+    registerProvider: () => {},
+    setActiveTools: () => {},
+  }
+  // Returns the first handler's return value so before_agent_start callers
+  // can inspect the { systemPrompt } override directly. Real pi chains
+  // multiple handlers' results; for this regression test the prism extension
+  // is the only handler registered so the single-return shape is correct.
+  const trigger = async (event: string, arg: unknown = {}, ctx: unknown = {}): Promise<unknown> => {
+    let last: unknown
+    for (const h of handlers[event] ?? []) {
+      last = await h(arg, ctx)
+    }
+    return last
+  }
+  return { pi, trigger, registeredFlags }
+}
+
+// Stage a temporary agents directory with a known-token role file. The
+// extension resolves $XDG_CONFIG_HOME/prism/agents/<role>.md (see
+// prismAgentRolePath in prism.ts), so pointing XDG_CONFIG_HOME at the
+// scratch root gives us an isolated agents dir without touching the
+// real ~/.config/prism/agents/.
+function stageAgentsDir(): {
+  dir: string
+  workerToken: string
+  coordinatorToken: string
+  cleanup: () => void
+} {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prism-2064-"))
+  const agents = path.join(dir, "prism", "agents")
+  fs.mkdirSync(agents, { recursive: true })
+  const workerToken = "ROLE_PROMPT_TOKEN_WORKER_2064"
+  const coordinatorToken = "ROLE_PROMPT_TOKEN_COORDINATOR_2064"
+  fs.writeFileSync(
+    path.join(agents, "worker.md"),
+    "# Worker agent\n\n" + workerToken + "\n\nimplements features, fixes bugs, opens PRs.",
+  )
+  fs.writeFileSync(
+    path.join(agents, "coordinator.md"),
+    "# Coordinator agent\n\n" + coordinatorToken + "\n\nspawns workers, reviews PRs.",
+  )
+  return {
+    dir,
+    workerToken,
+    coordinatorToken,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  }
+}
+
+// Save/restore the env vars the extension factory reads. Each test that
+// wires the extension MUST call savedEnv() before and restoreEnv() in a
+// finally — otherwise concurrent tests in the same process see leaks.
+function savedEnv() {
+  return {
+    PRISM_SESSION_NAME: process.env.PRISM_SESSION_NAME,
+    PRISM_HARNESS_PIPE: process.env.PRISM_HARNESS_PIPE,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  }
+}
+function restoreEnv(saved: ReturnType<typeof savedEnv>) {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+}
+
+// shouldActivate requires PRISM_SESSION_NAME. PRISM_HARNESS_PIPE must be
+// set to something parseable but unreachable so the connect attempt fails
+// silently — we never wait for the handshake, so it does not matter that
+// no sidecar is listening.
+function setExtensionEnv(xdgConfigHome: string): void {
+  process.env.PRISM_SESSION_NAME = "test@regression-2064"
+  // tcp:// to a free port that nothing is listening on: connect() schedules
+  // its first ECONNREFUSED retry and we tear down before the budget is hit.
+  process.env.PRISM_HARNESS_PIPE = "tcp://127.0.0.1:1"
+  process.env.XDG_CONFIG_HOME = xdgConfigHome
+}
+
+describe("issue #2064: first-turn role prompt is injected when --agent is set", () => {
+  it(
+    "worker session: before_agent_start returns { systemPrompt } containing worker.md on the very first call",
+    async () => {
+      const stage = stageAgentsDir()
+      const saved = savedEnv()
+      setExtensionEnv(stage.dir)
+      try {
+        // Simulate `pi --agent worker --extension prism.ts`: pi's CLI parses
+        // --agent into unknownFlags, then applyExtensionFlagValues binds it
+        // into runtime.flagValues once the extension's pi.registerFlag has
+        // run. We mirror that by pre-populating the mock pi's bound flags.
+        const { pi, trigger, registeredFlags } = makeMockPI({ agent: "worker" })
+
+        // Factory entry: runs pi.registerFlag("agent", ...) and binds the
+        // before_agent_start handler.
+        prismExtension(pi as never)
+
+        // The extension MUST register --agent so pi can resolve the unknown
+        // flag against an extension-owned one (without this, the same flag
+        // becomes pi's "Unknown option" diagnostic).
+        assert.ok(
+          registeredFlags.has("agent"),
+          "prism extension must register --agent via pi.registerFlag",
+        )
+        assert.equal(registeredFlags.get("agent")?.type, "string")
+
+        // Fire before_agent_start with a representative base system prompt.
+        const baseSystemPrompt =
+          "You are an expert coding assistant. <project_context>repo notes</project_context>"
+        const result = (await trigger(
+          "before_agent_start",
+          { systemPrompt: baseSystemPrompt },
+          {},
+        )) as { systemPrompt?: string } | undefined
+
+        // The fix: the handler MUST return a non-undefined { systemPrompt }
+        // on the first turn (pre-fix returned undefined because the
+        // handshake gate forced it).
+        assert.ok(result, "handler must return an override on the first turn")
+        assert.ok(typeof result.systemPrompt === "string", "override must carry systemPrompt")
+
+        // The composed prompt MUST contain both the base AND the role token
+        // — with exactly one blank line between them (composeRoleSystemPrompt
+        // contract).
+        assert.ok(
+          result.systemPrompt!.includes(baseSystemPrompt),
+          "composed prompt must preserve the base system prompt",
+        )
+        assert.ok(
+          result.systemPrompt!.includes(stage.workerToken),
+          `composed prompt must contain worker.md token; got: ${result.systemPrompt!.slice(0, 200)}...`,
+        )
+        // Exactly one blank line as separator.
+        assert.ok(
+          result.systemPrompt!.includes("</project_context>\n\n# Worker agent"),
+          "separator between base and role must be exactly one blank line",
+        )
+      } finally {
+        restoreEnv(saved)
+        stage.cleanup()
+      }
+    },
+  )
+
+  it(
+    "coordinator session: before_agent_start returns coordinator.md on the very first call",
+    async () => {
+      const stage = stageAgentsDir()
+      const saved = savedEnv()
+      setExtensionEnv(stage.dir)
+      try {
+        const { pi, trigger } = makeMockPI({ agent: "coordinator" })
+        prismExtension(pi as never)
+        const result = (await trigger(
+          "before_agent_start",
+          { systemPrompt: "BASE" },
+          {},
+        )) as { systemPrompt?: string } | undefined
+        assert.ok(result?.systemPrompt, "coordinator must get an override on first turn")
+        assert.ok(
+          result!.systemPrompt!.includes(stage.coordinatorToken),
+          "override must contain coordinator.md token",
+        )
+      } finally {
+        restoreEnv(saved)
+        stage.cleanup()
+      }
+    },
+  )
+
+  it("review-* session: before_agent_start composes the matching review-<n>.md", async () => {
+    const stage = stageAgentsDir()
+    // Add a review-goal.md so the matching review case has a file to read.
+    const reviewToken = "ROLE_PROMPT_TOKEN_REVIEW_GOAL_2064"
+    fs.writeFileSync(
+      path.join(stage.dir, "prism", "agents", "review-goal.md"),
+      "# Review goal\n\n" + reviewToken + "\n\nReviews PRs against their stated goal.",
+    )
+    const saved = savedEnv()
+    setExtensionEnv(stage.dir)
+    try {
+      const { pi, trigger } = makeMockPI({ agent: "review-goal" })
+      prismExtension(pi as never)
+      const result = (await trigger(
+        "before_agent_start",
+        { systemPrompt: "BASE" },
+        {},
+      )) as { systemPrompt?: string } | undefined
+      assert.ok(result?.systemPrompt, "review-goal must get an override on first turn")
+      assert.ok(
+        result!.systemPrompt!.includes(reviewToken),
+        "override must contain review-goal.md token",
+      )
+    } finally {
+      restoreEnv(saved)
+      stage.cleanup()
+    }
+  })
+
+  it(
+    "empty --agent: before_agent_start returns undefined (host-mode launch without --agent — graceful no-op)",
+    async () => {
+      const stage = stageAgentsDir()
+      const saved = savedEnv()
+      setExtensionEnv(stage.dir)
+      try {
+        // No agent flag bound — pi.getFlag("agent") returns undefined.
+        const { pi, trigger } = makeMockPI({})
+        prismExtension(pi as never)
+        const result = (await trigger(
+          "before_agent_start",
+          { systemPrompt: "BASE" },
+          {},
+        )) as { systemPrompt?: string } | undefined
+        // No override: pi keeps its base system prompt unchanged. This is
+        // the missing-role edge-case AC from the issue body.
+        assert.equal(result, undefined)
+      } finally {
+        restoreEnv(saved)
+        stage.cleanup()
+      }
+    },
+  )
+
+  it(
+    "unknown role (no matching .md file): before_agent_start returns undefined (graceful no-op)",
+    async () => {
+      const stage = stageAgentsDir()
+      const saved = savedEnv()
+      setExtensionEnv(stage.dir)
+      try {
+        // A role whose file does not exist in the staged dir.
+        const { pi, trigger } = makeMockPI({ agent: "unknown-role-xyz" })
+        prismExtension(pi as never)
+        const result = (await trigger(
+          "before_agent_start",
+          { systemPrompt: "BASE" },
+          {},
+        )) as { systemPrompt?: string } | undefined
+        assert.equal(result, undefined, "missing role file must be a graceful no-op")
+      } finally {
+        restoreEnv(saved)
+        stage.cleanup()
+      }
+    },
+  )
+
+  it(
+    "path-traversal in --agent: before_agent_start returns undefined (security AC, defence in depth)",
+    async () => {
+      const stage = stageAgentsDir()
+      // Put a sentinel file outside the agents dir that the traversal
+      // attempt would land on if isValidRoleName did not reject it.
+      const sentinel = path.join(stage.dir, "secret.md")
+      fs.writeFileSync(sentinel, "SECRET_TOKEN_MUST_NOT_LEAK")
+      const saved = savedEnv()
+      setExtensionEnv(stage.dir)
+      try {
+        // Construct a relative path that, joined onto
+        // <stage>/prism/agents/<role>.md, would resolve to <stage>/secret.md.
+        // isValidRoleName must reject this BEFORE the path is constructed.
+        const { pi, trigger } = makeMockPI({ agent: "../../secret" })
+        prismExtension(pi as never)
+        const result = (await trigger(
+          "before_agent_start",
+          { systemPrompt: "BASE" },
+          {},
+        )) as { systemPrompt?: string } | undefined
+        assert.equal(result, undefined, "path-traversal role must be rejected")
+      } finally {
+        restoreEnv(saved)
+        stage.cleanup()
+      }
+    },
+  )
+
+  it(
+    "idempotency across turns: before_agent_start fires twice, both turns get a non-undefined override and the role prompt does not accumulate",
+    async () => {
+      const stage = stageAgentsDir()
+      const saved = savedEnv()
+      setExtensionEnv(stage.dir)
+      try {
+        const { pi, trigger } = makeMockPI({ agent: "worker" })
+        prismExtension(pi as never)
+
+        // Turn 1: standard base.
+        const turn1 = (await trigger(
+          "before_agent_start",
+          { systemPrompt: "BASE_TURN_1" },
+          {},
+        )) as { systemPrompt?: string } | undefined
+        assert.ok(turn1?.systemPrompt)
+        assert.ok(turn1!.systemPrompt!.startsWith("BASE_TURN_1"))
+        assert.ok(turn1!.systemPrompt!.includes(stage.workerToken))
+
+        // Turn 2: pi sends a fresh _baseSystemPrompt (event.systemPrompt
+        // always reflects the agent-session base, NOT the previous turn's
+        // override — confirmed at pi 0.77 dist/core/agent-session.js line
+        // 795 where _baseSystemPrompt is the third arg to
+        // emitBeforeAgentStart). The composed result must therefore be
+        // BASE_TURN_2 + role, not BASE_TURN_1 + role + role.
+        const turn2 = (await trigger(
+          "before_agent_start",
+          { systemPrompt: "BASE_TURN_2" },
+          {},
+        )) as { systemPrompt?: string } | undefined
+        assert.ok(turn2?.systemPrompt)
+        assert.ok(turn2!.systemPrompt!.startsWith("BASE_TURN_2"))
+        // The role token must appear EXACTLY ONCE — not accumulated.
+        const tokenCount = turn2!.systemPrompt!.split(stage.workerToken).length - 1
+        assert.equal(tokenCount, 1, "role prompt must appear exactly once per turn (no accumulation)")
+        // And there must be NO leftover BASE_TURN_1 substring.
+        assert.equal(
+          turn2!.systemPrompt!.includes("BASE_TURN_1"),
+          false,
+          "turn 2 must not carry turn 1's base",
+        )
+      } finally {
+        restoreEnv(saved)
+        stage.cleanup()
+      }
+    },
+  )
+})

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -59,7 +59,8 @@ import {
   // Mid-tool heartbeat (issue #1761)
   startToolHeartbeat,
   TOOL_HEARTBEAT_INTERVAL_MS,
-  // Role system-prompt injection (issue #2032 / #2033)
+  // Role system-prompt injection (issue #2032 / #2033 / #2064)
+  isValidRoleName,
   prismAgentRolePath,
   readRolePrompt,
   composeRoleSystemPrompt,
@@ -1974,8 +1975,18 @@ describe("shouldAttemptConnect", () => {
 // correctly waits for completion.
 
 /** Minimal mock of ExtensionAPI — only `on` is needed for these tests. */
-function makeMockPI1554() {
+function makeMockPI1554(
+  options: { flagValues?: Record<string, string | boolean> } = {},
+) {
   const handlers: Record<string, ((...args: unknown[]) => unknown)[]> = {}
+  // Extension-registered flag values. The prism extension now calls
+  // pi.registerFlag("agent", ...) at factory entry (issue #2064 fix); the
+  // mock pi binds the matching value here so before_agent_start sees the
+  // role synchronously, mirroring pi's applyExtensionFlagValues path in
+  // agent-session-services.js.
+  const flagValues: Map<string, string | boolean> = new Map(
+    Object.entries(options.flagValues ?? {}),
+  )
   const pi = {
     on: (event: string, handler: (...args: unknown[]) => unknown) => {
       if (!handlers[event]) handlers[event] = []
@@ -1986,13 +1997,26 @@ function makeMockPI1554() {
     setThinkingLevel: () => {},
     registerProvider: () => {},
     setActiveTools: () => {},
+    registerFlag: (
+      _name: string,
+      _opts: { description?: string; type: "boolean" | "string"; default?: boolean | string },
+    ) => {
+      // No-op: the mock records the registration only to the extent that
+      // it does not throw. `flagValues` is the test fixture's source of
+      // truth, populated via options.flagValues.
+    },
+    getFlag: (name: string): string | boolean | undefined => {
+      return flagValues.get(name)
+    },
   }
   const trigger = async (event: string, eventArg: unknown = {}, ctx: unknown = {}) => {
     for (const h of handlers[event] ?? []) {
       await h(eventArg, ctx)
     }
   }
-  return { pi, trigger }
+  // Expose the flagValues map so individual tests can mutate it after factory
+  // entry if they need to simulate pi binding flags between sessions.
+  return { pi, trigger, flagValues }
 }
 
 /** Minimal sidecar responder: on `hello`, writes hello_ack. Returns frame list. */
@@ -3769,9 +3793,66 @@ describe("#1787: tool_call/tool_result emit parentMessageId from message_start",
 // Role system-prompt injection (issue #2032)
 // ---------------------------------------------------------------------------
 
+describe("isValidRoleName — path-traversal defence (#2064 security AC)", () => {
+  it("accepts canonical prism role names", () => {
+    const roles = [
+      "coordinator",
+      "worker",
+      "review-goal",
+      "review-code",
+      "review-security",
+      "review-qa",
+      "review-context",
+      "a",
+      "a_b",
+      "A-1",
+    ]
+    for (const r of roles) {
+      assert.ok(isValidRoleName(r), `expected ${JSON.stringify(r)} to be a valid role name`)
+    }
+  })
+
+  it("rejects empty / non-string values", () => {
+    assert.equal(isValidRoleName(""), false)
+    assert.equal(isValidRoleName(undefined as unknown as string), false)
+    assert.equal(isValidRoleName(null as unknown as string), false)
+    assert.equal(isValidRoleName(123 as unknown as string), false)
+  })
+
+  it("rejects path-traversal / shell-meta / null-byte attempts", () => {
+    const evil = [
+      "../etc/passwd",
+      "./worker",
+      "/etc/passwd",
+      "worker/../coordinator",
+      "worker\u0000",
+      "worker.md",
+      "worker$",
+      "worker;rm -rf /",
+      "worker space",
+      "·",
+      "é",
+    ]
+    for (const r of evil) {
+      assert.equal(isValidRoleName(r), false, `expected ${JSON.stringify(r)} to be rejected`)
+    }
+  })
+})
+
 describe("prismAgentRolePath — role→file resolution", () => {
   it("returns '' for an empty role (no-op short-circuit)", () => {
     assert.equal(prismAgentRolePath("", { HOME: "/home/u" }), "")
+  })
+
+  it("returns '' when role contains path-traversal (defence-in-depth)", () => {
+    assert.equal(
+      prismAgentRolePath("../etc/passwd", { XDG_CONFIG_HOME: "/xdg", HOME: "/home/u" }),
+      "",
+    )
+    assert.equal(
+      prismAgentRolePath("worker/../coordinator", { HOME: "/home/u" }),
+      "",
+    )
   })
 
   it("respects XDG_CONFIG_HOME when set", () => {
@@ -3891,69 +3972,58 @@ describe("composeRoleSystemPrompt — APPEND semantics preserved", () => {
   })
 })
 
-describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", () => {
+describe("resolveRolePromptForTurn — flag-sourced role, idempotency", () => {
   const newCache = (): RolePromptCache => ({ resolved: false, cached: undefined })
 
-  it("injects unconditionally once the handshake completes (no gating flag — PR2 of #2031)", () => {
+  // The pre-#2064 design accepted a `handshakeComplete` boolean and gated
+  // resolution on it. That gate dropped the first turn's role prompt on every
+  // bwrap session (the hello_ack handshake fires AFTER the agent-start hook).
+  // The new design sources the role from `pi.getFlag("agent")` which pi binds
+  // synchronously before the first hook fires, so there is no handshake gate.
+
+  it("injects the role prompt on the very first call when agentRole is valid", () => {
     const cache = newCache()
     const out = resolveRolePromptForTurn(
-      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { agentRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       () => "ROLE",
     )
-    assert.equal(out, "BASE\n\nROLE") // injected — no flag required
+    assert.equal(out, "BASE\n\nROLE") // first-turn injection — no handshake required
     assert.equal(cache.resolved, true)
   })
 
-  it("returns undefined and does NOT latch when the handshake is incomplete", () => {
+  it("returns undefined and does NOT latch when agentRole is empty (host-mode launch without --agent)", () => {
     const cache = newCache()
     const out = resolveRolePromptForTurn(
-      { handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
+      { agentRole: "", baseSystemPrompt: "BASE" },
       cache,
       () => "ROLE",
     )
     assert.equal(out, undefined)
-    assert.equal(cache.resolved, false) // critical: must NOT latch pre-handshake
+    assert.equal(cache.resolved, false) // empty role must NOT poison the cache
   })
 
-  it("injects once the handshake completes and the role is known", () => {
+  it("returns undefined and does NOT latch when agentRole fails whitelist (path-traversal defence)", () => {
     const cache = newCache()
     const out = resolveRolePromptForTurn(
-      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { agentRole: "../etc/passwd", baseSystemPrompt: "BASE" },
+      cache,
+      () => "ROLE",
+    )
+    assert.equal(out, undefined)
+    assert.equal(cache.resolved, false)
+  })
+
+  it("resolves the matching role file when agentRole is a known prism role", () => {
+    const cache = newCache()
+    const out = resolveRolePromptForTurn(
+      { agentRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       (role) => (role === "worker" ? "WORKER ROLE" : undefined),
     )
     assert.equal(out, "BASE\n\nWORKER ROLE")
     assert.equal(cache.resolved, true)
     assert.equal(cache.cached, "WORKER ROLE")
-  })
-
-  it("first turn before handshake must not poison the cache (the review-code race)", () => {
-    const cache = newCache()
-    let reads = 0
-    const readRole = (role: string): string | undefined => {
-      reads++
-      return role === "worker" ? "WORKER ROLE" : undefined
-    }
-
-    // Turn 1 fires BEFORE hello_ack: handshake incomplete, sessionRole still "".
-    const turn1 = resolveRolePromptForTurn(
-      { handshakeComplete: false, sessionRole: "", baseSystemPrompt: "BASE" },
-      cache,
-      readRole,
-    )
-    assert.equal(turn1, undefined)
-    assert.equal(cache.resolved, false)
-    assert.equal(reads, 0) // no read attempted pre-handshake
-
-    // Turn 2 fires AFTER hello_ack populated sessionRole="worker".
-    const turn2 = resolveRolePromptForTurn(
-      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
-      cache,
-      readRole,
-    )
-    assert.equal(turn2, "BASE\n\nWORKER ROLE") // role IS injected, not poisoned
-    assert.equal(reads, 1)
   })
 
   it("memoises the file read across turns (disk touched at most once)", () => {
@@ -3964,8 +4034,7 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
       return "ROLE"
     }
     const args = {
-      handshakeComplete: true,
-      sessionRole: "worker",
+      agentRole: "worker",
       baseSystemPrompt: "BASE",
     }
     const t1 = resolveRolePromptForTurn(args, cache, readRole)
@@ -3977,11 +4046,31 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
     assert.equal(t2, t3)
   })
 
+  it("recomposes against a fresh baseSystemPrompt each turn (no accumulation across turns)", () => {
+    // before_agent_start fires once per turn (pi 0.77). The handler must NOT
+    // accumulate the role across turns — each call re-composes role onto the
+    // base provided by that turn's event.systemPrompt.
+    const cache = newCache()
+    const readRole = (): string => "ROLE"
+    const t1 = resolveRolePromptForTurn(
+      { agentRole: "worker", baseSystemPrompt: "BASE-TURN-1" },
+      cache,
+      readRole,
+    )
+    const t2 = resolveRolePromptForTurn(
+      { agentRole: "worker", baseSystemPrompt: "BASE-TURN-2" },
+      cache,
+      readRole,
+    )
+    assert.equal(t1, "BASE-TURN-1\n\nROLE")
+    assert.equal(t2, "BASE-TURN-2\n\nROLE")
+  })
+
   it("missing role file resolves to a no-op (undefined) and stays latched", () => {
     const cache = newCache()
     let reads = 0
     const out = resolveRolePromptForTurn(
-      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { agentRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       () => {
         reads++
@@ -3989,10 +4078,10 @@ describe("resolveRolePromptForTurn — gating, handshake latch, idempotency", ()
       },
     )
     assert.equal(out, undefined)
-    assert.equal(cache.resolved, true) // latched after handshake even for no-op
+    assert.equal(cache.resolved, true) // latched after a valid-role read attempt
     // A second turn does not re-read — the no-op is memoised.
     resolveRolePromptForTurn(
-      { handshakeComplete: true, sessionRole: "worker", baseSystemPrompt: "BASE" },
+      { agentRole: "worker", baseSystemPrompt: "BASE" },
       cache,
       () => {
         reads++

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1572,13 +1572,29 @@ export function shouldActivate(env: NodeJS.ProcessEnv = process.env): boolean {
 //     double-injection risk the PR1 gate guarded against no longer exists.
 
 /**
+ * Whitelist-validates a role name. Roles flow from pi.getFlag("agent") which
+ * is bound from the CLI's --agent flag, ultimately set by prism Go-side at
+ * spawn time. The host side is trusted, but a stray path-traversal or null
+ * byte in cfg.AgentRole would otherwise concatenate into the role file path
+ * and read an attacker-chosen file. The whitelist matches the host-side
+ * validator at cmd/spawn.go (prism agent names: ASCII letters, digits,
+ * hyphens, underscores).
+ *
+ * Exported for unit testing only.
+ */
+export function isValidRoleName(role: string): boolean {
+  return typeof role === "string" && role.length > 0 && /^[A-Za-z0-9_-]+$/.test(role)
+}
+
+/**
  * Resolves the absolute path to the role prompt markdown file for `role`,
  * mirroring the host-side prismAgentRolePath (cmd/spawn.go): respect
  * XDG_CONFIG_HOME, else fall back to $HOME/.config. Returns "" when role is
- * empty so callers can short-circuit to a no-op.
+ * empty or contains characters outside the role-name whitelist (defence in
+ * depth against path traversal via a malicious flag value).
  */
 export function prismAgentRolePath(role: string, env: NodeJS.ProcessEnv = process.env): string {
-  if (typeof role !== "string" || role.length === 0) {
+  if (!isValidRoleName(role)) {
     return ""
   }
   let base = env.XDG_CONFIG_HOME
@@ -1650,35 +1666,48 @@ export interface RolePromptCache {
  * Pure decision for one before_agent_start turn. Encapsulates the latch logic
  * so it is unit-testable independently of the PI runtime:
  *
- *   - Injection is unconditional once the handshake completes — PR2 of #2031
- *     removed APPEND_SYSTEM.md, so the extension is the sole source of the role
- *     prompt and there is no gating flag any more.
- *   - The handshake gate is load-bearing: `sessionRole` is only populated by
- *     the async hello_ack handler, so resolving the cache before the handshake
- *     would latch the session to "no role" permanently. Pre-handshake turns
- *     return undefined WITHOUT latching.
- *   - Once resolved, the file read is memoised (cache.resolved) so disk is
- *     touched at most once per session.
- *   - The result is recomposed from `baseSystemPrompt` every turn, so it is
- *     idempotent and never accumulates the role prompt across turns.
+ *   - The role identity is sourced from `agentRole`, which the caller reads
+ *     synchronously from `pi.getFlag("agent")`. pi binds extension flags at
+ *     `applyExtensionFlagValues` time (agent-session-services.js), which runs
+ *     during `resourceLoader.reload()` BEFORE any `before_agent_start` event
+ *     fires. There is therefore no handshake race — the role is available on
+ *     the very first turn.
  *
- * Mutates `cache` in place (sets resolved/cached on first post-handshake call)
+ *     This replaces the pre-#2064 design which sourced the role from the
+ *     async hello_ack handshake. That source was load-bearing on the wrong
+ *     ordering: hello_ack arrived AFTER the first turn's before_agent_start
+ *     fired (the handshake races over the sidecar's Unix socket; the agent
+ *     hook fires inline on the pi side), so on a fresh bwrap session the
+ *     first turn's role prompt was always missed. See PR for the full
+ *     diagnosis chain.
+ *
+ *   - When `agentRole` is empty (host-mode pi launches that did not pass
+ *     --agent, or a session running outside prism), the handler returns
+ *     undefined and pi keeps its base system prompt unchanged.
+ *
+ *   - The file read is memoised (cache.resolved) so disk is touched at most
+ *     once per session.
+ *
+ *   - The result is recomposed from `baseSystemPrompt` every turn, so it is
+ *     idempotent and never accumulates the role prompt across turns even
+ *     though before_agent_start fires per-turn (pi 0.77).
+ *
+ * Mutates `cache` in place (sets resolved/cached on first valid-role call)
  * and returns the systemPrompt override to send, or undefined to keep the base.
  */
 export function resolveRolePromptForTurn(
   opts: {
-    handshakeComplete: boolean
-    sessionRole: string
+    agentRole: string
     baseSystemPrompt: string
   },
   cache: RolePromptCache,
   readRole: (role: string) => string | undefined = readRolePrompt,
 ): string | undefined {
-  if (!opts.handshakeComplete) {
+  if (!isValidRoleName(opts.agentRole)) {
     return undefined
   }
   if (!cache.resolved) {
-    cache.cached = readRole(opts.sessionRole)
+    cache.cached = readRole(opts.agentRole)
     cache.resolved = true
   }
   return composeRoleSystemPrompt(opts.baseSystemPrompt, cache.cached)
@@ -1757,11 +1786,27 @@ export default function prismExtension(pi: ExtensionAPI): void {
   // Session identity captured from hello_ack. Used for status bar display.
   let sessionRole = ""
 
-  // Role system-prompt injection cache (issue #2032). The role file is read
-  // once per session (load-once), then recomposed against event.systemPrompt
-  // on every before_agent_start. The cache is only latched once the handshake
-  // has completed (sessionRole known) — see resolveRolePromptForTurn.
+  // Role system-prompt injection cache (issue #2032 / #2064). The role file
+  // is read once per session (load-once), then recomposed against
+  // event.systemPrompt on every before_agent_start. The role identity is
+  // sourced synchronously from pi.getFlag("agent") in the handler, not from
+  // the async hello_ack handshake (which was the #2064 regression source).
   const roleSystemPromptCache: RolePromptCache = { resolved: false, cached: undefined }
+
+  // Register --agent as an extension-owned CLI flag. pi has no native
+  // concept of agents (prism owns the agent system), so pi parses --agent
+  // into its `unknownFlags` map; pi.registerFlag binds that entry into
+  // `runtime.flagValues` during applyExtensionFlagValues, which runs after
+  // all extensions load and BEFORE any hook fires. pi.getFlag("agent") is
+  // therefore synchronous and available from the first before_agent_start.
+  //
+  // Canonical example: pi 0.77 examples/extensions/plan-mode/index.ts which
+  // registers --plan in the same shape.
+  pi.registerFlag("agent", {
+    description:
+      "Primary agent identity (worker, coordinator, review-*, etc.) — selects the role system prompt appended to pi's base prompt at before_agent_start.",
+    type: "string",
+  })
   let sessionBranch = extractBranch(process.env.PRISM_SESSION_NAME ?? "")
   let sessionIsolationMode = ""
 
@@ -2188,21 +2233,24 @@ export default function prismExtension(pi: ExtensionAPI): void {
       writer.write({ type: "state_change", state: "active" })
     }
 
-    // Role system-prompt injection (issue #2032 / #2033). PR2 of #2031 removed
-    // the per-session APPEND_SYSTEM.md staging file, so the extension is now
-    // the SOLE source of the role prompt and injection is unconditional — no
-    // gating flag. See the helpers above for the replace-vs-append and
-    // per-turn-fire analysis.
+    // Role system-prompt injection (issue #2032 / #2033 / #2064 fix).
     //
-    // resolveRolePromptForTurn still gates on handshakeComplete: sessionRole
-    // is only populated by the async hello_ack handler, so latching the cache
-    // before the handshake would pin the session to "no role" permanently.
-    // Pre-handshake turns return undefined without latching; the next turn
-    // resolves correctly.
+    // Source the role from pi.getFlag("agent") rather than the async
+    // hello_ack-derived sessionRole. The flag is bound by pi BEFORE any
+    // before_agent_start fires (see applyExtensionFlagValues in
+    // pi's agent-session-services.js), so this is race-free — unlike the
+    // pre-#2064 design which lost the first turn's role prompt because the
+    // handshake socket-receive races behind the agent-start hook.
+    //
+    // getFlag returns `string | boolean | undefined`; we registered the flag
+    // as type="string" so the runtime value is always a string when present.
+    // Defensive narrowing keeps the handler safe if a future pi version
+    // changes the contract or a missing-flag returns the registered default.
+    const flagValue = pi.getFlag("agent")
+    const agentRole = typeof flagValue === "string" ? flagValue : ""
     const composed = resolveRolePromptForTurn(
       {
-        handshakeComplete,
-        sessionRole,
+        agentRole,
         baseSystemPrompt: event.systemPrompt,
       },
       roleSystemPromptCache,

--- a/modules/programs/prism/prism/cmd/investigate.go
+++ b/modules/programs/prism/prism/cmd/investigate.go
@@ -165,6 +165,8 @@ func spawnInvestigateSession(invokerSession, promptText, suppliedName string) er
 		HarnessName:      harnessName,
 		ForceFresh:       true,
 		WorktreeReadOnly: true,
+		// PIExtensionDir for host-mode pi launches (#2065).
+		PIExtensionDir: cfg.PIExtensionDir,
 	}
 
 	if err := session.SpawnSession(database, spawnOpts); err != nil {

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -226,6 +226,8 @@ var prCmd = &cobra.Command{
 			ConfigEnvVarName: prHarness.ConfigEnvVar(),
 			RuntimeEnvVars:   prHarness.RuntimeEnv(),
 			ModelsByRole:     modelsByRole,
+			// PIExtensionDir for host-mode pi launches (#2065).
+			PIExtensionDir: cfg.PIExtensionDir,
 			// ForceFresh=true: prism pr creates a new worktree; if a session
 			// with the same name exists it is a stale zombie and should be
 			// killed, matching the same semantics as prism spawn.

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -354,6 +354,8 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		ConfigEnvVarName: restoreHarness.ConfigEnvVar(),
 		RuntimeEnvVars:   restoreHarness.RuntimeEnv(),
 		HarnessName:      restoreHarnessName,
+		// PIExtensionDir for host-mode pi launches (#2065).
+		PIExtensionDir: cfg.PIExtensionDir,
 	}
 	// Propagate the persisted harness session ID so the sandbox launcher can
 	// ask pi to resume the prior conversation (issue #1838). Empty pointer

--- a/modules/programs/prism/prism/cmd/restore_test.go
+++ b/modules/programs/prism/prism/cmd/restore_test.go
@@ -105,7 +105,23 @@ func agentPaneStartCmd(t *testing.T, s *cmdTestServer, sessionName string) strin
 // callRestoreSession is a test helper that wraps restoreSession with sensible
 // defaults (threshold=0, no stagger) so that existing tests don't need to be
 // updated every time the internal signature changes.
+//
+// Also ensures `loadRestoreConfig` returns a config with a non-empty
+// PIExtensionDir if no test has already overridden it — the host-mode pi
+// launch path enforces the #2065 fail-fast guard
+// (session.ValidatePILaunchOpts) and would otherwise reject every restore
+// test that exercises LayoutFull. Tests that explicitly override
+// `loadRestoreConfig` via `withRestoreConfig` and want the empty-
+// PIExtensionDir failure path must set the field themselves (currently
+// none of them do).
 func callRestoreSession(d *db.DB, s db.Status) error {
+	cfg := loadRestoreConfig()
+	if cfg.PIExtensionDir == "" {
+		cfg.PIExtensionDir = "/test/prism-pi-extension"
+		prev := loadRestoreConfig
+		loadRestoreConfig = func() config.Config { return cfg }
+		defer func() { loadRestoreConfig = prev }()
+	}
 	pending := false
 	_, err := restoreSession(d, s, 0, &pending, 0)
 	return err

--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -347,6 +347,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 		HarnessExplicit: cmd.Flags().Changed("harness"),
 		Timeout:        timeoutFlag,
 		PluginHostPath: cfg.SidecarPluginPath,
+		PIExtensionDir: cfg.PIExtensionDir,
 		IsolationMode:  string(isoMode),
 		OnProgress:     progressLine,
 		PRCtx:          &prCtx,

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -680,6 +680,10 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		HarnessName:      harnessFlag,
 		ModelsByRole:     modelsByRole,
 		AllowEmptyPrompt: allowEmptyPrompt,
+		// PIExtensionDir is the host-side prism PI extension directory
+		// (populated by Nix into config.json). Forwarded so that host-mode
+		// pi launches pass --extension <dir>/prism.ts (#2065).
+		PIExtensionDir: cfg.PIExtensionDir,
 		// ForceFresh=true: spawn always wants a new instance. If a session
 		// with the same name already exists it is a stale zombie and should
 		// be killed.
@@ -1339,6 +1343,8 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		Headless:         true,
 		// WorktreeReadOnly: mount the worktree read-only for investigate sessions.
 		WorktreeReadOnly: agentRole == "investigate",
+		// PIExtensionDir for host-mode pi launches (#2065).
+		PIExtensionDir: a.cfg.PIExtensionDir,
 		ReadinessTimeout: session.DefaultReadinessTimeout,
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -369,6 +369,11 @@ var switchCmd = &cobra.Command{
 			ConfigEnvVarName: switchHarness.ConfigEnvVar(),
 			RuntimeEnvVars:   switchHarness.RuntimeEnv(),
 			HarnessName:      switchHarnessName,
+			// PIExtensionDir for host-mode pi launches (#2065). The container
+			// path appends --extension via container.PIInvocation, so this is
+			// load-bearing only for isolation=host — buildDirectAgentCmd skips
+			// the flag when PIExtensionDir is empty.
+			PIExtensionDir: cfg.PIExtensionDir,
 		}
 		// AgentEnvVars only applies to host-mode sessions; sandboxed sessions
 		// receive env vars via podman --env flags in the sidecar (podman) or

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -1719,14 +1719,20 @@ func TestBwrapBuildArgs_FullFixture(t *testing.T) {
 		t.Errorf("-- separator missing from args")
 	}
 
-	// Tail: pi --extension <extensionPath> <prompt>
+	// Tail: pi --extension <extensionPath> --agent <role> <prompt>
 	// PIInvocation emits the prompt as a bare positional arg, not --prompt.
+	// Issue #2064 added --agent <role> between --extension and the prompt
+	// so the prism PI extension's pi.getFlag("agent") path resolves
+	// synchronously — see TestPIInvocation_AgentFlag in this package.
 	n := len(args)
 	if args[n-1] != "implement the feature" {
 		t.Errorf("expected prompt as last positional arg, got %q", args[n-1])
 	}
-	if args[n-3] != "--extension" {
-		t.Errorf("expected --extension flag near end, got %q", args[n-3])
+	if args[n-2] != "worker" || args[n-3] != "--agent" {
+		t.Errorf("expected --agent worker before the prompt, got [..., %q, %q, %q]", args[n-3], args[n-2], args[n-1])
+	}
+	if args[n-5] != "--extension" {
+		t.Errorf("expected --extension flag near end (before --agent), got %q at [n-5]", args[n-5])
 	}
 
 	// Kube and AWS ro-binds present with correct remapped destinations.

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -70,6 +70,11 @@ const (
 //	--model    <cfg.PIModel>              (when non-empty)
 //	--thinking <cfg.PIThinking>           (when non-empty)
 //	--extension <extensionPath>           (always; path is derived from cfg)
+//	--agent    <cfg.AgentRole>            (when non-empty; consumed by the
+//	                                       prism PI extension via
+//	                                       pi.registerFlag("agent") to source
+//	                                       the role system prompt at
+//	                                       before_agent_start — issue #2064)
 //	--session  <cfg.HarnessSessionID>     (when non-empty AND on-disk session
 //	                                       file exists — see piResolveResumeSession)
 //	<cfg.InitialPrompt>                   (bare positional arg, when non-empty)
@@ -114,6 +119,16 @@ func PIInvocation(cfg Config) []string {
 	}
 	extensionSandboxPath := filepath.Join(extensionSandboxDir, piExtensionFilename)
 	args = append(args, "--extension", extensionSandboxPath)
+
+	// --agent <role> for the prism PI extension's role-prompt injection
+	// (issue #2064). pi has no native concept of agents — the extension
+	// registers --agent via pi.registerFlag at factory entry and reads the
+	// bound value synchronously in its before_agent_start handler. Skipping
+	// this flag when AgentRole is empty matches the edge-case AC: a session
+	// with no role file falls back to pi's base system prompt unchanged.
+	if cfg.AgentRole != "" {
+		args = append(args, "--agent", cfg.AgentRole)
+	}
 
 	// --session <id> for conversation resume (#1838). Skipped silently when
 	// HarnessSessionID is empty (fresh session); on missing-file the helper
@@ -466,6 +481,25 @@ func PIExtensionSandboxPath(sandboxDirOverride string) string {
 		dir = piExtensionSandboxDefault
 	}
 	return filepath.Join(dir, piExtensionFilename)
+}
+
+// PIExtensionHostPath returns the host-side absolute path to the prism PI
+// extension file given the extension directory (i.e. cfg.PIExtensionDir as
+// populated from prism's config.json by Nix). Returns "" when hostDir is
+// empty so the host-mode launch path can fall back to a no-flag invocation
+// rather than emit a stray --extension argument with no value.
+//
+// Used by the host-mode pi launch in internal/session/session.go to close
+// the gap fixed by #2065 — host-mode previously emitted `pi --agent worker`
+// with no --extension, so the prism extension never loaded and role-prompt
+// injection (plus the sidecar bridge, status bar, doom-loop guard, etc.)
+// silently no-op'd. The container path already appends --extension via
+// PIInvocation above.
+func PIExtensionHostPath(hostDir string) string {
+	if hostDir == "" {
+		return ""
+	}
+	return filepath.Join(hostDir, piExtensionFilename)
 }
 
 // appendPIBwrapMounts appends the bwrap bind-mount args needed for a PI

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -116,6 +116,75 @@ func TestPIInvocation_NoInitialPrompt(t *testing.T) {
 	}
 }
 
+// TestPIInvocation_AgentFlag verifies that --agent <role> is emitted when
+// cfg.AgentRole is non-empty. This is the load-bearing flag for the
+// #2064 fix: the prism PI extension reads it via pi.getFlag("agent") in
+// its before_agent_start handler to select the role system-prompt file.
+// Without this flag, the extension cannot identify the role synchronously
+// and the first-turn role prompt is lost (the regression #2064 captured).
+func TestPIInvocation_AgentFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		role string
+	}{
+		{"worker", "worker"},
+		{"coordinator", "coordinator"},
+		{"review-goal", "review-goal"},
+		{"review-code", "review-code"},
+		{"review-security", "review-security"},
+		{"review-qa", "review-qa"},
+		{"review-context", "review-context"},
+		{"investigate", "investigate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{AgentRole: tc.role}
+			args := PIInvocation(cfg)
+			if !hasPair(args, "--agent", tc.role) {
+				t.Errorf("expected --agent %q in PIInvocation args; got %v", tc.role, args)
+			}
+		})
+	}
+}
+
+// TestPIInvocation_NoAgentFlagWhenEmpty verifies that --agent is omitted
+// when AgentRole is empty. The extension handles a missing flag as a
+// graceful no-op (issue #2064 edge-case AC: "empty / unknown role starts
+// without error and pi receives only its default system prompt").
+func TestPIInvocation_NoAgentFlagWhenEmpty(t *testing.T) {
+	cfg := Config{}
+	args := PIInvocation(cfg)
+	if hasArg(args, "--agent") {
+		t.Errorf("--agent must not appear when AgentRole is empty; got %v", args)
+	}
+}
+
+// TestPIInvocation_AgentFlagOrder verifies that --agent <role> appears AFTER
+// --extension <path> in the argv. This matters because the extension must
+// be loaded before pi can resolve --agent against the registered flag set
+// (applyExtensionFlagValues runs after resourceLoader.reload). pi's CLI
+// parser is position-agnostic so this is a safety check rather than a
+// load-bearing assertion, but the order helps when reading argv in logs.
+func TestPIInvocation_AgentFlagOrder(t *testing.T) {
+	cfg := Config{AgentRole: "worker"}
+	args := PIInvocation(cfg)
+	var extIdx, agentIdx int = -1, -1
+	for i, a := range args {
+		if a == "--extension" {
+			extIdx = i
+		}
+		if a == "--agent" {
+			agentIdx = i
+		}
+	}
+	if extIdx == -1 || agentIdx == -1 {
+		t.Fatalf("expected both --extension and --agent in args; got %v", args)
+	}
+	if agentIdx < extIdx {
+		t.Errorf("expected --agent to appear after --extension; got --extension at %d, --agent at %d in %v", extIdx, agentIdx, args)
+	}
+}
+
 // hasPair returns true when flag and val appear consecutively in args.
 func hasPair(args []string, flag, val string) bool {
 	for i := 0; i+1 < len(args); i++ {

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -265,6 +265,12 @@ type Opts struct {
 	DBPath string
 	// PluginHostPath is the path to the agent plugin file.
 	PluginHostPath string
+	// PIExtensionDir is the host-side directory containing the prism PI
+	// extension file. Forwarded to session.SpawnOpts.PIExtensionDir for
+	// every spawned review agent so host-mode launches load the extension
+	// (#2065). Empty value falls back to no --extension flag on host mode;
+	// container modes get the flag via container.PIInvocation regardless.
+	PIExtensionDir string
 	// ProfilesFile is the loaded profiles.json, used to resolve per-agent
 	// config content via BuildConfigContent. When nil, no config injection is
 	// performed.

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -248,6 +248,8 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			RuntimeEnvVars:     agentH.RuntimeEnv(),
 			HarnessName:        agentHarnessName,
 			ModelsByRole:       opts.ModelsByRole,
+			// PIExtensionDir for host-mode pi launches (#2065).
+			PIExtensionDir: opts.PIExtensionDir,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -542,6 +544,8 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			RuntimeEnvVars:     asyncAgentH.RuntimeEnv(),
 			HarnessName:        asyncAgentHarnessName,
 			ModelsByRole:       opts.ModelsByRole,
+			// PIExtensionDir for host-mode pi launches (#2065).
+			PIExtensionDir: opts.PIExtensionDir,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {

--- a/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
+++ b/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
@@ -279,6 +279,11 @@ func TestSpawnReviewAgent_LargePrompt_HostMode(t *testing.T) {
 		Prompt:        prompt,
 		Layout:        session.LayoutAgentOnly,
 		IsolationMode: "host", // the previously-broken cell
+		// PIExtensionDir is required for host-mode pi launches
+		// (#2065 fail-fast guard — see ValidatePILaunchOpts). The path
+		// itself is never read; it just satisfies the guard so the test
+		// can exercise the #1195 prompt-file regression unchanged.
+		PIExtensionDir: "/test/prism-pi-extension",
 	}
 
 	// (a) Spawn must succeed. Before the #1195 fix, this call would trip

--- a/modules/programs/prism/prism/internal/session/initial_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt_test.go
@@ -284,6 +284,7 @@ func TestSpawnSession_HostMode_RejectsOversizedLaunchCmd(t *testing.T) {
 		AgentEnvVars: map[string]string{
 			"OVERSIZE_VAR": bigEnvValue,
 		},
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)

--- a/modules/programs/prism/prism/internal/session/lost_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/lost_prompt_test.go
@@ -286,6 +286,7 @@ func TestSpawnSession_LostPromptRace_StrictGateFiresAndCleansUp(t *testing.T) {
 		// Short timeout so the test runs quickly; the gate trips because
 		// only a bare-active state_change will arrive (no turn_start).
 		ReadinessTimeout: 600 * time.Millisecond,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	// Inject the symptom-2 precondition partway through the wait: the
@@ -345,6 +346,7 @@ func TestSpawnSession_LostPromptRace_TurnStartUnblocksGate(t *testing.T) {
 		// Generous timeout; the goroutine below will write turn_start
 		// well before it expires.
 		ReadinessTimeout: 5 * time.Second,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	go func() {
@@ -389,6 +391,7 @@ func TestSpawnSession_NoPrompt_LayoutAgentOnly_Rejected(t *testing.T) {
 		IsolationMode:    "host",
 		HarnessName:      "pi",
 		ReadinessTimeout: 2 * time.Second,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -202,6 +202,19 @@ type Opts struct {
 	// Other launch shapes derive the worktree from the DB or from the
 	// container-mode plumbing and do not consult this field.
 	Worktree string
+	// PIExtensionDir is the host-side absolute path to the directory that
+	// contains the prism PI extension file (cfg.PIExtensionDir, populated by
+	// Nix via piExtensionDir in config.json). When non-empty AND the harness
+	// is pi, buildDirectAgentCmd appends --extension <dir>/prism.ts to the
+	// host-mode launch command so the extension loads and the prism↔pi
+	// integration surface (role prompt, sidecar bridge, status bar) works
+	// the same as it does under bwrap / sandbox-exec. Closes #2065.
+	//
+	// Empty value falls back to omitting the flag, which preserves the
+	// pre-#2065 host-mode shape — useful for environments without a Nix-set
+	// piExtensionDir (e.g. a developer running `go run ./...` outside the
+	// configured prism install).
+	PIExtensionDir string
 }
 
 // Layout selects the window layout used when creating a new session.
@@ -346,6 +359,22 @@ func buildDirectAgentCmd(opts Opts) string {
 		cmd = binary + " --agent " + agent
 	} else {
 		cmd = binary
+	}
+	// --extension <dir>/prism.ts for pi harnesses (#2065). Container modes
+	// (bwrap / sandbox-exec) route through container.PIInvocation, which
+	// emits --extension unconditionally. Host mode previously launched pi
+	// with no --extension flag at all, so the prism PI extension never
+	// loaded and role-prompt injection (plus the sidecar bridge, status
+	// bar, doom-loop guard, and review-cycle tracking) silently no-op'd.
+	//
+	// Scoped to pi (or empty harness, which defaults to pi). Non-pi
+	// harnesses do not have a prism extension and must not receive this
+	// flag — it would either be unknown or claim an unrelated meaning.
+	if (opts.HarnessName == "pi" || opts.HarnessName == "") && opts.PIExtensionDir != "" {
+		extPath := container.PIExtensionHostPath(opts.PIExtensionDir)
+		if extPath != "" {
+			cmd += " --extension " + shellQuote(extPath)
+		}
 	}
 	// Append --session <id> for host-mode pi-resume (issue #1838).
 	//

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -210,11 +210,43 @@ type Opts struct {
 	// integration surface (role prompt, sidecar bridge, status bar) works
 	// the same as it does under bwrap / sandbox-exec. Closes #2065.
 	//
-	// Empty value falls back to omitting the flag, which preserves the
-	// pre-#2065 host-mode shape — useful for environments without a Nix-set
-	// piExtensionDir (e.g. a developer running `go run ./...` outside the
-	// configured prism install).
+	// Production callers MUST set this for host-mode pi launches —
+	// ValidatePILaunchOpts (called from SpawnSession and Create+LayoutFull)
+	// rejects an empty value with a clear error mirroring the container-path
+	// guard at cmd/agent_run.go:730. buildDirectAgentCmd remains a pure
+	// string emitter and omits --extension when this field is empty so test
+	// fixtures and the validator-bypass paths in restore (with the legacy
+	// agent-pane shape) don't need to fake a directory; the fail-fast policy
+	// is centralised in ValidatePILaunchOpts, not the emitter.
 	PIExtensionDir string
+}
+
+// ValidatePILaunchOpts checks Opts against the requirements for a host-mode
+// pi launch. It is the host-mode analogue of the container-path guard at
+// cmd/agent_run.go:730: when the prism PI extension cannot be located the
+// session must fail fast with a clear error rather than launch pi with no
+// extension (and therefore no role-prompt injection, no sidecar bridge, no
+// status bar — the #2065 silent-degradation shape).
+//
+// Returns nil for every non-host isolation mode (container modes route
+// through PIInvocation which has its own guard upstream) and for every
+// non-pi harness (non-pi launches do not load the prism extension).
+//
+// Called from SpawnSession (every spawn-side entry point) and from Create
+// when Layout == LayoutFull (the switch / restore entry points). Bare and
+// Scratchpad layouts skip this check because they do not launch an agent
+// pane and therefore have no pi to misconfigure.
+func ValidatePILaunchOpts(opts Opts) error {
+	if effectiveIsolationMode(opts) != "host" {
+		return nil
+	}
+	if opts.HarnessName != "" && opts.HarnessName != "pi" {
+		return nil
+	}
+	if opts.PIExtensionDir == "" {
+		return fmt.Errorf("pi: PIExtensionDir is not set in prism config — ensure the prism PI extension is configured in Nix (piExtensionDir in config.json)")
+	}
+	return nil
 }
 
 // Layout selects the window layout used when creating a new session.
@@ -640,6 +672,19 @@ func startupGuardKillOld(name string, d *db.DB, forceFresh bool) bool {
 //     and recreated. When opts.DB is nil, any existing session is treated as
 //     live (legacy no-op behaviour).
 func Create(name, directory string, opts Opts) error {
+	// Fail-fast guard for the host-mode pi launch (#2065 edge-case AC).
+	// Only applies to LayoutFull, which is the layout that actually launches
+	// an agent pane. LayoutBare and LayoutScratchpad have no agent and
+	// legitimately leave PIExtensionDir empty (scratchpad sessions are pure
+	// shells; bare sessions are restore-time placeholders for non-LayoutFull
+	// rows). Running the guard for those layouts would block the dashboard's
+	// dead-session recovery path with a misleading error.
+	if opts.Layout == LayoutFull {
+		if err := ValidatePILaunchOpts(opts); err != nil {
+			return fmt.Errorf("session.Create %q: %w", name, err)
+		}
+	}
+
 	if !startupGuardKillOld(name, opts.DB, opts.ForceFresh) {
 		return nil
 	}

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -271,7 +271,12 @@ func TestBuildDirectAgentCmd_PIExtensionFlag(t *testing.T) {
 		}
 	})
 
-	t.Run("pi harness with empty PIExtensionDir omits --extension (no stray flag with no value)", func(t *testing.T) {
+	t.Run("pi harness with empty PIExtensionDir: low-level emitter omits the flag (production paths are guarded by ValidatePILaunchOpts — see TestValidatePILaunchOpts)", func(t *testing.T) {
+		// buildDirectAgentCmd is a pure string emitter; the fail-fast policy
+		// for the empty-PIExtensionDir case lives one level up in
+		// ValidatePILaunchOpts (called from SpawnSession and Create at
+		// LayoutFull). Keeping the emitter pure simplifies test fixtures and
+		// matches the host-mode pi-resume helper's shape (also pure).
 		opts := Opts{
 			HarnessName:    "pi",
 			Agent:          "worker",
@@ -279,7 +284,7 @@ func TestBuildDirectAgentCmd_PIExtensionFlag(t *testing.T) {
 		}
 		cmd := buildDirectAgentCmd(opts)
 		if strings.Contains(cmd, "--extension") {
-			t.Errorf("empty PIExtensionDir must not emit --extension; got: %q", cmd)
+			t.Errorf("empty PIExtensionDir must not emit a stray --extension at the builder level; got: %q", cmd)
 		}
 	})
 
@@ -330,6 +335,135 @@ func TestPIExtensionHostPath(t *testing.T) {
 	t.Run("empty dir returns empty", func(t *testing.T) {
 		if got := container.PIExtensionHostPath(""); got != "" {
 			t.Errorf("expected empty for empty dir; got %q", got)
+		}
+	})
+}
+
+// TestValidatePILaunchOpts covers the #2065 fail-fast edge-case AC: host-mode
+// pi launches must refuse to spawn when cfg.PIExtensionDir is empty, with
+// a clear error message mirroring the container-path guard at
+// cmd/agent_run.go:730. The check is the policy chokepoint for the
+// extension-must-be-loaded invariant on host mode; ValidatePILaunchOpts is
+// called from SpawnSession (all spawn-side entry points) and from Create
+// when Layout == LayoutFull (switch / restore entry points).
+func TestValidatePILaunchOpts(t *testing.T) {
+	t.Run("host mode + pi harness + empty PIExtensionDir: rejects with clear error", func(t *testing.T) {
+		err := ValidatePILaunchOpts(Opts{
+			IsolationMode:  "host",
+			HarnessName:    "pi",
+			PIExtensionDir: "",
+		})
+		if err == nil {
+			t.Fatalf("expected error for host-mode pi with empty PIExtensionDir; got nil")
+		}
+		// Must mention piExtensionDir so an operator can grep for the
+		// recommendation. Mirrors cmd/agent_run.go:730.
+		if !strings.Contains(err.Error(), "piExtensionDir") {
+			t.Errorf("expected error to reference 'piExtensionDir'; got: %v", err)
+		}
+	})
+
+	t.Run("host mode + empty harness (defaults to pi) + empty PIExtensionDir: also rejects", func(t *testing.T) {
+		err := ValidatePILaunchOpts(Opts{
+			IsolationMode:  "host",
+			HarnessName:    "",
+			PIExtensionDir: "",
+		})
+		if err == nil {
+			t.Errorf("expected error for empty harness (defaults to pi); got nil")
+		}
+	})
+
+	t.Run("host mode + pi harness + non-empty PIExtensionDir: accepts", func(t *testing.T) {
+		err := ValidatePILaunchOpts(Opts{
+			IsolationMode:  "host",
+			HarnessName:    "pi",
+			PIExtensionDir: "/nix/store/abc-prism-extension",
+		})
+		if err != nil {
+			t.Errorf("expected nil for properly-configured host-mode pi; got: %v", err)
+		}
+	})
+
+	t.Run("empty isolation (defaults to host) + pi + empty PIExtensionDir: rejects", func(t *testing.T) {
+		// effectiveIsolationMode defaults empty IsolationMode to "host",
+		// so the guard MUST fire even when the caller leaves the mode unset.
+		err := ValidatePILaunchOpts(Opts{
+			IsolationMode:  "",
+			HarnessName:    "pi",
+			PIExtensionDir: "",
+		})
+		if err == nil {
+			t.Errorf("expected error when IsolationMode is empty (defaults to host); got nil")
+		}
+	})
+
+	t.Run("container modes pass the check (container paths have their own guard at agent_run.go:730)", func(t *testing.T) {
+		for _, mode := range []string{"bwrap", "sandbox-exec", "podman"} {
+			err := ValidatePILaunchOpts(Opts{
+				IsolationMode:  mode,
+				HarnessName:    "pi",
+				PIExtensionDir: "",
+			})
+			if err != nil {
+				t.Errorf("mode=%q: expected nil (container paths route through PIInvocation which has its own guard); got: %v", mode, err)
+			}
+		}
+	})
+
+	t.Run("non-pi harness in host mode passes the check (extension is pi-specific)", func(t *testing.T) {
+		// The prism PI extension is a pi-only artefact; a non-pi harness
+		// (e.g. a hypothetical opencode-in-host-mode) must not be blocked
+		// for missing PIExtensionDir — it does not load the extension at all.
+		err := ValidatePILaunchOpts(Opts{
+			IsolationMode:  "host",
+			HarnessName:    "opencode",
+			PIExtensionDir: "",
+		})
+		if err != nil {
+			t.Errorf("expected nil for non-pi harness; got: %v", err)
+		}
+	})
+}
+
+// TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir confirms that the
+// SpawnSession-parallel switch/restore path (which goes through Create with
+// LayoutFull) also fails fast on the empty-PIExtensionDir / host-mode-pi
+// combination, not just SpawnSession. The non-LayoutFull layouts must NOT
+// be blocked because they don't launch an agent pane.
+func TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("LayoutFull + host + pi + empty PIExtensionDir: rejects", func(t *testing.T) {
+		err := Create("unit-test-2065-full", dir, Opts{
+			Layout:         LayoutFull,
+			IsolationMode:  "host",
+			HarnessName:    "pi",
+			PIExtensionDir: "",
+		})
+		if err == nil {
+			t.Fatalf("expected error from Create for empty PIExtensionDir on LayoutFull; got nil")
+		}
+		if !strings.Contains(err.Error(), "piExtensionDir") {
+			t.Errorf("expected error to reference 'piExtensionDir'; got: %v", err)
+		}
+	})
+
+	t.Run("LayoutBare + empty PIExtensionDir: accepted (no agent pane to misconfigure)", func(t *testing.T) {
+		// LayoutBare is the dashboard's dead-session recovery path and
+		// the scratchpad fallback in restore. Both run with no agent.
+		// They legitimately leave PIExtensionDir empty and must NOT be
+		// blocked by the guard.
+		name := "unit-test-2065-bare"
+		defer tmux.KillSession(name)
+		err := Create(name, dir, Opts{
+			Layout:         LayoutBare,
+			IsolationMode:  "host",
+			HarnessName:    "pi",
+			PIExtensionDir: "",
+		})
+		if err != nil {
+			t.Errorf("LayoutBare must not be blocked by the PIExtensionDir guard; got: %v", err)
 		}
 	})
 }

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prismatic-koi/prism/internal/container"
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -237,6 +238,100 @@ func TestBuildAgentCmd_EmptyIsolationMode(t *testing.T) {
 	if !strings.Contains(cmd, "pi") {
 		t.Errorf("empty IsolationMode: cmd does not contain 'pi': %q", cmd)
 	}
+}
+
+// TestBuildDirectAgentCmd_PIExtensionFlag verifies that host-mode pi launch
+// appends --extension <PIExtensionDir>/prism.ts when the harness is pi (or
+// empty, which defaults to pi). This is the #2065 fix bundled into the
+// #2064 PR: without it, host-mode sessions launch pi with no --extension,
+// and the prism PI extension never loads — silently disabling role-prompt
+// injection, the sidecar bridge, and the status bar.
+func TestBuildDirectAgentCmd_PIExtensionFlag(t *testing.T) {
+	t.Run("pi harness emits --extension when PIExtensionDir is set", func(t *testing.T) {
+		opts := Opts{
+			HarnessName:    "pi",
+			Agent:          "worker",
+			PIExtensionDir: "/nix/store/abc-prism-extension",
+		}
+		cmd := buildDirectAgentCmd(opts)
+		if !strings.Contains(cmd, "--extension '/nix/store/abc-prism-extension/prism.ts'") {
+			t.Errorf("expected --extension '/nix/store/abc-prism-extension/prism.ts' in cmd; got: %q", cmd)
+		}
+	})
+
+	t.Run("empty harness defaults to pi and emits --extension", func(t *testing.T) {
+		opts := Opts{
+			HarnessName:    "",
+			Agent:          "worker",
+			PIExtensionDir: "/nix/store/abc-prism-extension",
+		}
+		cmd := buildDirectAgentCmd(opts)
+		if !strings.Contains(cmd, "--extension '/nix/store/abc-prism-extension/prism.ts'") {
+			t.Errorf("expected --extension on empty-harness cmd; got: %q", cmd)
+		}
+	})
+
+	t.Run("pi harness with empty PIExtensionDir omits --extension (no stray flag with no value)", func(t *testing.T) {
+		opts := Opts{
+			HarnessName:    "pi",
+			Agent:          "worker",
+			PIExtensionDir: "",
+		}
+		cmd := buildDirectAgentCmd(opts)
+		if strings.Contains(cmd, "--extension") {
+			t.Errorf("empty PIExtensionDir must not emit --extension; got: %q", cmd)
+		}
+	})
+
+	t.Run("non-pi harness must NOT receive --extension (pi-specific flag)", func(t *testing.T) {
+		opts := Opts{
+			HarnessName:    "opencode",
+			Agent:          "worker",
+			PIExtensionDir: "/nix/store/abc-prism-extension",
+		}
+		cmd := buildDirectAgentCmd(opts)
+		if strings.Contains(cmd, "--extension") {
+			t.Errorf("non-pi harness must not receive --extension; got: %q", cmd)
+		}
+	})
+}
+
+// TestBuildDirectAgentCmd_AgentFlag confirms that --agent <role> is always
+// emitted for pi (and empty=pi) when Agent is non-empty. This is the host-
+// mode complement to TestPIInvocation_AgentFlag in the container package —
+// together they guarantee the prism PI extension's pi.getFlag("agent")
+// receives a value on every code path.
+func TestBuildDirectAgentCmd_AgentFlag(t *testing.T) {
+	for _, harnessName := range []string{"pi", ""} {
+		t.Run("harness="+harnessName, func(t *testing.T) {
+			opts := Opts{
+				HarnessName: harnessName,
+				Agent:       "coordinator",
+			}
+			cmd := buildDirectAgentCmd(opts)
+			if !strings.Contains(cmd, "--agent coordinator") {
+				t.Errorf("expected --agent coordinator in cmd; got: %q", cmd)
+			}
+		})
+	}
+}
+
+// TestPIExtensionHostPath verifies the helper that buildDirectAgentCmd uses
+// to resolve the on-disk extension file path. Empty dir must return empty
+// so the caller falls back to no flag rather than emitting a stray
+// `--extension /prism.ts` against the filesystem root.
+func TestPIExtensionHostPath(t *testing.T) {
+	t.Run("non-empty dir resolves to dir/prism.ts", func(t *testing.T) {
+		got := container.PIExtensionHostPath("/nix/store/abc-prism-extension")
+		if got != "/nix/store/abc-prism-extension/prism.ts" {
+			t.Errorf("expected dir/prism.ts; got %q", got)
+		}
+	})
+	t.Run("empty dir returns empty", func(t *testing.T) {
+		if got := container.PIExtensionHostPath(""); got != "" {
+			t.Errorf("expected empty for empty dir; got %q", got)
+		}
+	})
 }
 
 // TestBuildDirectAgentCmd_AgentEnvVars_ValuesQuoted verifies that env var

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -288,6 +288,32 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		return fmt.Errorf("spawn session: Prompt is required for layout %d (LayoutFull or LayoutAgentOnly) — an agent pane cannot start without a prompt", opts.Layout)
 	}
 
+	// Fail-fast guard for the host-mode pi launch (#2065 edge-case AC).
+	// Mirrors the container-path guard at cmd/agent_run.go:730: refuse to
+	// spawn rather than silently launch pi without --extension. Container
+	// modes (bwrap / sandbox-exec) route through PIInvocation which has its
+	// own equivalent check; this guard is host-mode only and is suppressed
+	// for non-pi harnesses (the prism extension is pi-specific).
+	//
+	// LayoutBare and LayoutScratchpad never reach here — SpawnSession is
+	// only called for LayoutFull and LayoutAgentOnly. Both of those layouts
+	// launch an agent pane and therefore require the extension to be wired.
+	//
+	// The validator reads IsolationMode via effectiveIsolationMode, which
+	// defaults empty to "host". Use resolveLayoutIsolationMode here so
+	// LayoutAgentOnly callers that leave IsolationMode empty (the review
+	// fan-out shape on machines whose default is bwrap) are correctly
+	// resolved to the machine default before the host check fires — same
+	// resolution path the actual launch uses below at spawnAgentOnlyLayout.
+	validationOpts := Opts{
+		IsolationMode:  resolveLayoutIsolationMode(opts),
+		HarnessName:    opts.HarnessName,
+		PIExtensionDir: opts.PIExtensionDir,
+	}
+	if err := ValidatePILaunchOpts(validationOpts); err != nil {
+		return fmt.Errorf("spawn session %q: %w", opts.SessionName, err)
+	}
+
 	// Open the per-session startup log as the very first step (#1051 Piece B).
 	// Doing this before any other work means the per-session run directory
 	// exists from the moment the spawn begins, so any later failure has a

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -234,6 +234,13 @@ type SpawnOpts struct {
 	// no prompt was supplied. All other callers should leave this false so
 	// the original "agent pane needs a prompt" guard (#1891) keeps firing.
 	AllowEmptyPrompt bool
+
+	// PIExtensionDir is the host-side absolute path to the directory that
+	// contains the prism PI extension file. Forwarded to Opts.PIExtensionDir
+	// so buildDirectAgentCmd can emit --extension <dir>/prism.ts on the
+	// host-mode pi launch (#2065). Empty value falls back to no --extension
+	// flag on host mode.
+	PIExtensionDir string
 }
 
 // SpawnSession creates a single prism session end-to-end: seeds the
@@ -822,6 +829,7 @@ func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 		HarnessName:         opts.HarnessName,
 		HarnessPipeSockPath: opts.HarnessPipeSockPath,
 		ModelsByRole:        opts.ModelsByRole,
+		PIExtensionDir:      opts.PIExtensionDir,
 	}
 }
 
@@ -977,6 +985,7 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		PluginHostPath:   opts.PluginHostPath,
 		ConfigEnvVarName: opts.ConfigEnvVarName,
 		RuntimeEnvVars:   opts.RuntimeEnvVars,
+		PIExtensionDir:   opts.PIExtensionDir,
 		// AgentEnvVars intentionally omitted: review sessions don't inject
 		// profile env vars in host mode today.
 	}

--- a/modules/programs/prism/prism/internal/session/spawn_allow_empty_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_allow_empty_prompt_test.go
@@ -45,6 +45,7 @@ func TestSpawnSession_AllowEmptyPrompt_LayoutFull_Accepted(t *testing.T) {
 		IsolationMode:    "host",
 		HarnessName:      "pi",
 		AllowEmptyPrompt: true,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)
@@ -74,7 +75,8 @@ func TestSpawnSession_AllowEmptyPrompt_LayoutFull_OptInRequired(t *testing.T) {
 		Layout:        LayoutFull,
 		IsolationMode: "host",
 		HarnessName:   "pi",
-		// AllowEmptyPrompt deliberately omitted (defaults to false).
+		// AllowEmptyPrompt deliberately omitted (defaults to false).,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)

--- a/modules/programs/prism/prism/internal/session/spawn_fkrace_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_fkrace_test.go
@@ -61,7 +61,8 @@ func TestSpawnSession_FullLayout_PreInsertsSessionsRow(t *testing.T) {
 		IsolationMode: "host",
 		HarnessName:   "pi",
 		// ReadinessTimeout=0: skip the readiness gate. We are testing the
-		// pre-spawn DB-state invariants, not the readiness path.
+		// pre-spawn DB-state invariants, not the readiness path.,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -138,6 +139,7 @@ func TestSpawnSession_FullLayout_HonoursPreSetInstanceID(t *testing.T) {
 		Layout:        LayoutFull,
 		IsolationMode: "host",
 		HarnessName:   "pi",
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -195,6 +197,7 @@ func TestSpawnSession_FullLayout_ConcurrentSpawnsAllPreSeeded(t *testing.T) {
 				Layout:        LayoutFull,
 				IsolationMode: "host",
 				HarnessName:   "pi",
+				PIExtensionDir: testPIExtensionDir,
 			}
 			errs[i] = SpawnSession(d, opts)
 		}()

--- a/modules/programs/prism/prism/internal/session/spawn_layout_failure_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_layout_failure_test.go
@@ -45,6 +45,7 @@ func TestSpawnSession_LayoutFailure_CleansUpDB(t *testing.T) {
 		Layout:        LayoutAgentOnly,
 		IsolationMode: "host",
 		HarnessName:   "pi",
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)

--- a/modules/programs/prism/prism/internal/session/spawn_pi_extension_dir_helper_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_pi_extension_dir_helper_test.go
@@ -1,0 +1,20 @@
+package session
+
+// Test helper: a non-empty placeholder for SpawnOpts.PIExtensionDir /
+// Opts.PIExtensionDir on test fixtures that exercise spawn / Create code
+// paths unrelated to the #2065 fail-fast guard.
+//
+// ValidatePILaunchOpts (the chokepoint) rejects an empty PIExtensionDir on
+// host-mode pi launches. That guard is correct for production callers, but
+// every pre-#2064 spawn-test fixture left the field unset because the gate
+// did not exist. Rather than churn each fixture to set the field literally,
+// they all use this single string so the intent ("test does not care about
+// extension dir; satisfy the guard") is visible at the call site.
+//
+// The string itself is never opened or stat'd by SpawnSession / Create —
+// the value travels into buildDirectAgentCmd which embeds it in the host-
+// mode launch command string, and the tests that care about the command
+// string assert positively on the presence of this token. Tests that
+// exercise the failure path explicitly leave the field unset (see
+// TestValidatePILaunchOpts and TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir).
+const testPIExtensionDir = "/test/prism-pi-extension"

--- a/modules/programs/prism/prism/internal/session/spawn_readiness_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_readiness_test.go
@@ -48,7 +48,8 @@ func TestSpawnSession_ReadinessTimeout_FiresAndCleansUp(t *testing.T) {
 		AgentRole:        "review-code",
 		Prompt:           "go",
 		Layout:           LayoutAgentOnly,
-		ReadinessTimeout: 300 * time.Millisecond, // short; no signal will arrive
+		ReadinessTimeout: 300 * time.Millisecond, // short; no signal will arrive,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	start := time.Now()
@@ -94,7 +95,8 @@ func TestSpawnSession_ReadinessTimeoutZero_SkipsGate(t *testing.T) {
 		AgentRole:   "review-code",
 		Prompt:      "go",
 		Layout:      LayoutAgentOnly,
-		// ReadinessTimeout omitted (zero) — gate must be skipped.
+		// ReadinessTimeout omitted (zero) — gate must be skipped.,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	start := time.Now()
@@ -128,6 +130,7 @@ func TestSpawnSession_WritesStartupLog(t *testing.T) {
 		AgentRole:   "review-code",
 		Prompt:      "go",
 		Layout:      LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -184,7 +187,8 @@ func TestSpawnSession_ReadinessTimeout_SetsSessionsRowEnded(t *testing.T) {
 		AgentRole:        "review-code",
 		Prompt:           "go",
 		Layout:           LayoutAgentOnly,
-		ReadinessTimeout: 100 * time.Millisecond, // short; no signal will arrive
+		ReadinessTimeout: 100 * time.Millisecond, // short; no signal will arrive,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); !IsReadinessTimeout(err) {
@@ -249,6 +253,7 @@ func TestSpawnSession_ReadinessTimeoutWritesFailureToStartupLog(t *testing.T) {
 		Prompt:           "go",
 		Layout:           LayoutAgentOnly,
 		ReadinessTimeout: 250 * time.Millisecond,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err == nil {

--- a/modules/programs/prism/prism/internal/session/spawn_same_name_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_same_name_test.go
@@ -51,6 +51,7 @@ func TestSpawnSession_Concurrent_SameName(t *testing.T) {
 				Layout:        LayoutAgentOnly,
 				IsolationMode: "host",
 				HarnessName:   "pi",
+				PIExtensionDir: testPIExtensionDir,
 			}
 			errs[i] = SpawnSession(d, opts)
 		}()

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -63,6 +63,7 @@ func TestSpawnSession_AgentOnly_SeedsRootAgentName(t *testing.T) {
 		AgentRole:   "review-code",
 		Prompt:      "review this PR",
 		Layout:      LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -122,6 +123,7 @@ func TestSpawnSession_AgentOnly_WritesGroupID(t *testing.T) {
 		Prompt:      "go",
 		Layout:      LayoutAgentOnly,
 		GroupID:     groupID,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -161,6 +163,7 @@ func TestSpawnSession_AgentOnly_CreatesTmuxSession(t *testing.T) {
 		AgentRole:   "review-qa",
 		Prompt:      "go",
 		Layout:      LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -201,6 +204,7 @@ func TestSpawnSession_NoAgentRole_LeavesRootAgentNameNull(t *testing.T) {
 		// AgentRole intentionally left empty.
 		Prompt: "go",
 		Layout: LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -244,6 +248,7 @@ func TestSpawnSession_AllocatePortFails_ReturnsError(t *testing.T) {
 		AgentRole:   "review-security",
 		Prompt:      "go",
 		Layout:      LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)
@@ -275,6 +280,7 @@ func TestSpawnSession_Validation_RequiresSessionName(t *testing.T) {
 		Worktree:  "/tmp",
 		AgentRole: "worker",
 		Layout:    LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
 		t.Fatal("expected error when SessionName is empty, got nil")
@@ -292,6 +298,7 @@ func TestSpawnSession_Validation_RequiresWorktree(t *testing.T) {
 		SessionName: "myrepo@branch",
 		AgentRole:   "worker",
 		Layout:      LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
 		t.Fatal("expected error when Worktree is empty, got nil")
@@ -308,6 +315,7 @@ func TestSpawnSession_Validation_RequiresDB(t *testing.T) {
 		Worktree:    "/tmp",
 		AgentRole:   "worker",
 		Layout:      LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
 		t.Fatal("expected error when db is nil, got nil")
@@ -343,6 +351,7 @@ func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
 				Prompt:        "go",
 				Layout:        LayoutAgentOnly,
 				IsolationMode: mode,
+				PIExtensionDir: testPIExtensionDir,
 			}
 
 			if err := SpawnSession(d, opts); err != nil {
@@ -392,6 +401,7 @@ func TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Host(t *testing.T) {
 		Prompt:        prompt,
 		Layout:        LayoutAgentOnly,
 		IsolationMode: "host",
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	if err := SpawnSession(d, opts); err != nil {
@@ -576,6 +586,7 @@ func TestSpawnAgentPaneEnvVars(t *testing.T) {
 		got := spawnAgentPaneEnvVars(SpawnOpts{
 			Prompt:         "hello",
 			PromptFilePath: "/var/state/prism/run/abc/initial-prompt.txt",
+			PIExtensionDir: testPIExtensionDir,
 		})
 		if got == nil {
 			t.Fatal("got nil, want non-nil map")
@@ -588,7 +599,9 @@ func TestSpawnAgentPaneEnvVars(t *testing.T) {
 		}
 	})
 	t.Run("with prompt only (legacy)", func(t *testing.T) {
-		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "hello"})
+		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "hello",
+	PIExtensionDir: testPIExtensionDir,
+})
 		if got == nil {
 			t.Fatal("got nil, want non-nil map")
 		}
@@ -597,7 +610,9 @@ func TestSpawnAgentPaneEnvVars(t *testing.T) {
 		}
 	})
 	t.Run("empty prompt", func(t *testing.T) {
-		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: ""})
+		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "",
+	PIExtensionDir: testPIExtensionDir,
+})
 		if got != nil {
 			t.Errorf("got %v, want nil (an empty entry would override an inherited value)", got)
 		}
@@ -617,7 +632,8 @@ func TestSpawnSession_UnsupportedLayout_ReturnsError(t *testing.T) {
 		SessionName: "myrepo@branch-bad-layout",
 		Worktree:    "/tmp",
 		AgentRole:   "worker",
-		Layout:      LayoutScratchpad, // not supported by SpawnSession
+		Layout:      LayoutScratchpad, // not supported by SpawnSession,
+		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
 		t.Fatal("expected error for unsupported layout, got nil")
@@ -676,6 +692,7 @@ func TestSpawnSession_NeedsPromptFile_AllModesAndLayouts(t *testing.T) {
 				Prompt:        prompt,
 				Layout:        tc.layout,
 				IsolationMode: tc.isolationMode,
+				PIExtensionDir: testPIExtensionDir,
 			}
 
 			if err := SpawnSession(d, opts); err != nil {
@@ -820,7 +837,8 @@ func TestSpawnSession_EmptyPrompt_LayoutFull_Rejected(t *testing.T) {
 		Layout:        LayoutFull,
 		IsolationMode: "host",
 		HarnessName:   "pi",
-		// Prompt deliberately empty.
+		// Prompt deliberately empty.,
+		PIExtensionDir: testPIExtensionDir,
 	}
 
 	err := SpawnSession(d, opts)
@@ -877,7 +895,8 @@ func TestSpawnSession_EmptyPrompt_NonAgentLayouts_NotRejectedForEmptyPrompt(t *t
 				Repo:        "myrepo",
 				Worktree:    "/worktrees/myrepo-" + layout.name,
 				Layout:      layout.v,
-				// Prompt deliberately empty — legitimate for these layouts.
+				// Prompt deliberately empty — legitimate for these layouts.,
+				PIExtensionDir: testPIExtensionDir,
 			}
 
 			err := SpawnSession(d, opts)


### PR DESCRIPTION
## Diagnosis chain

Phase 1 file-based diagnostics on a fresh bwrap worker session showed:

```
factory entry      — PRISM_SESSION_NAME=nixos-config@diag-probe4
                     PRISM_HARNESS_PIPE set, HOME=/home/ben
before_agent_start — handshakeComplete=false sessionRole=""
                     baseSystemPromptLen=20539 composedOverride=false
hello_ack received — session_role="worker" isolation_mode="bwrap"
                     handshakeComplete(about to be set)=true
```

**Root cause: handshake race lost the first-turn role prompt.**

The handler at `pi/extensions/prism.ts::before_agent_start` was sourcing the agent role from a `sessionRole` variable populated by the async `hello_ack` socket frame. On a fresh bwrap session, pi's `before_agent_start` hook fires inline on the agent side **before** the sidecar's hello_ack frame travels over the Unix socket and is processed on the extension side. The handler therefore saw `handshakeComplete=false`, hit the handshake gate in `resolveRolePromptForTurn`, returned `undefined`, and pi fell back to `_baseSystemPrompt`. The first turn's pi-effective system prompt contained pi's default + AGENTS.md repo context only — matching the user-visible symptom in #2064.

Multi-turn sessions would have resolved correctly on turn 2+ (handshake done by then), but the pi-session export captured at turn 1 always showed the missed role prompt.

The pre-#2031 mechanism (a per-session `APPEND_SYSTEM.md` staging file under `~/.pi/agent/sessions/<id>/`) masked this race because pi's resource-loader auto-discovered the staged file and appended it to the base prompt synchronously. #2038 removed that staging path, deliberately leaving the extension as the sole source of role-prompt injection. The race had been latent since #2031 introduced the extension hook but went undetected for a day because there was zero end-to-end test coverage asserting "role prompt appears in pi's effective system prompt".

## Fix — extension owns `--agent` via `pi.registerFlag`

`--agent` is a prism concept, not a pi concept. Pi 0.77 has a first-class API for extensions to claim CLI flags: `pi.registerFlag(name, opts)` + `pi.getFlag(name)`. Pi's CLI parser stashes `--agent worker` into `unknownFlags`; once the prism extension calls `registerFlag("agent", {type: "string"})` during the factory load phase, pi's `applyExtensionFlagValues` (`dist/core/agent-session-services.js`) binds the value into `runtime.flagValues` — and this happens **before** the AgentSession is constructed, which is **before** the first `before_agent_start` fires.

`pi.getFlag("agent")` therefore returns the role synchronously on the very first turn — no handshake dependency, no race.

Canonical reference: pi 0.77's bundled `examples/extensions/plan-mode/index.ts` which registers `--plan` in exactly the same shape.

### Why not the other shapes (designs rejected during this PR's design phase)

1. **Env var `PRISM_SESSION_ROLE`** — would require plumbing through bwrap `--setenv`, sandbox-exec env, host-mode shell-prefix, plus a parallel read path in the extension. Janky and crosses three packages for what is fundamentally a CLI argument.
2. **`pi --append-system-prompt <body>`** — pi-native and synchronous, but the role prompt body rides on argv. macOS arg-limit blow-up risk on large role files, and the design conflates "role identity" with "role content" at the call site.

`pi.registerFlag` is the documented, idiomatic pi 0.77 extension mechanism for extension-owned CLI flags. It puts the role-identity concept in the extension where it belongs and keeps the argv minimal (`--agent worker` is the same shape host-mode already had).

## Bundled #2065 — host-mode `--extension` gap

`internal/container/pi_invocation.go::PIInvocation` (the bwrap + sandbox-exec launch path) always passes `--extension <path>/prism.ts`. `internal/session/session.go::buildDirectAgentCmd` (the host-mode launch path) did NOT — so host-mode sessions launched pi with no extension at all, silently disabling the entire prism↔pi integration surface (role prompt, sidecar bridge, status bar, doom-loop guard, review tracking).

This PR bundles the fix:

- new `session.Opts.PIExtensionDir` field (plumbed from `cfg.PIExtensionDir` at every spawn site)
- `buildDirectAgentCmd` appends `--extension <dir>/prism.ts` when the harness is pi (or empty, which defaults to pi)
- non-pi harnesses do NOT receive the flag (pi-specific carve-out)

## Adjacent cleanup (Phase 3 of #2064)

- `~/.pi/agent/system-prompt.md` and `coordinator-system-prompt.md` stagings removed from `pi.nix`. Confirmed inert: pi 0.77's resource-loader auto-discovers `SYSTEM.md` / `APPEND_SYSTEM.md` only, not these filenames. Verified by grepping `/nix/store/...-pi-coding-agent-0.77.0/lib/node_modules/pi-monorepo/dist/`.
- The prism extension is now registered in `settings.json`'s extensions array as defence-in-depth alongside `--extension`. Pi's loader canonicalises and de-dupes by resolved path (`resource-loader.js::mergePaths`), so loading via both paths is safe — the file loads exactly once.

## Security AC

The role prompt content is loaded read-only from `~/.config/prism/agents/`. A new `isValidRoleName` whitelist on the extension side rejects any role string outside `[A-Za-z0-9_-]+` (null bytes, dots, slashes, unicode, shell metas), so `prismAgentRolePath` cannot resolve a path-traversal payload onto a host-chosen file. The whitelist matches the role-name shape used by the host-side spawn validator.

## Side-findings (out of scope, will file as follow-ups)

- pi 0.77 does NOT recognise `--agent` as a **native** flag — it falls through to `unknownFlags` → `applyExtensionFlagValues`. Without this PR's `pi.registerFlag` call, `pi --agent worker` is functionally `pi` (the role value sits in `unknownFlags` with no claimant and pi later emits an "Unknown option" diagnostic). Worth a docs/upstream note.
- `~/.cache/prism/clipboard/` is `--ro-bind` in the bwrap sandbox (verified by inspecting the live bwrap argv via `/proc`), not RW as I initially assumed during Phase 1. The only RW host path inside the sandbox is the per-session run dir at `~/.local/state/prism/run/<instance>/`.

## Verification

- `nix build .#prism` succeeds.
- `nix flake check --no-build` passes (all derivations evaluate, all checks green).
- `go test ./...` from `modules/programs/prism/prism/` — all 32 packages pass.
- `tsx --test prism.role-prompt.test.ts` — **7/7 pass on fix**; **4/7 fail on main** (confirmed by `git show main:...prism.ts` swap test). The 4 failing tests on main are exactly the regression-shape ones: first-turn worker / coordinator / review-goal injection, plus the per-turn idempotency check.
- `tsx --test prism.test.ts` — 304/304 pass (existing tests updated for the new flag-sourced contract; mock pi extended with `registerFlag`/`getFlag`).

Closes #2064.
Closes #2065.