### PR TITLE
pi: bump 0.77.0 → 0.78.0

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -257,7 +257,7 @@
         # Note: ~/.pi/agent/system-prompt.md and coordinator-system-prompt.md
         # were removed in the #2064 cleanup. They were staged by the pre-#2031
         # mechanism (when prism wrote a per-session APPEND_SYSTEM.md staging
-        # file), but pi 0.77 has no native loader for either filename — it
+        # file), but pi 0.78 has no native loader for either filename — it
         # only auto-discovers SYSTEM.md / APPEND_SYSTEM.md per dist/core/
         # resource-loader.js. Confirmed inert from #2038 onwards (when the
         # APPEND_SYSTEM.md staging path was removed); role-prompt injection

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -89,17 +89,17 @@ rec {
           newSrc = prev.fetchFromGitHub {
             owner = "earendil-works";
             repo = "pi";
-            tag = "v0.77.0";
-            hash = "sha256-PJyhLWfqoPjHoYl4pKJVD3uMD5YjQB5YIk5mBZvGi8E=";
+            tag = "v0.78.0";
+            hash = "sha256-Cw+W5w6yuL+cH+JfgCbEwiyeXloMb7yFd46TXJPZGTg=";
           };
         in
         prev.pi-coding-agent.overrideAttrs (old: {
-          version = "0.77.0";
+          version = "0.78.0";
           src = newSrc;
           npmDeps = prev.fetchNpmDeps {
             inherit (old) npmWorkspace;
             src = newSrc;
-            hash = "sha256-X0qMLqAi5pgrtTw5+DfSPsgIEngUnHwGxqYE6PL8NJU=";
+            hash = "sha256-TxMiT7nJqLZRXKFoxb4FpsETGe3I99qU7olTgNsoQd4=";
           };
           # Upstream nixpkgs' postInstall hard-codes the old
           # @mariozechner/* workspace names; in v0.75.0 the monorepo


### PR DESCRIPTION
Bumps `pi-coding-agent` from 0.77.0 to 0.78.0.

Release notes: https://github.com/earendil-works/pi/releases/tag/v0.78.0

Per upstream, this is an additive release: a new `--name`/`-n` flag for naming sessions, OSC 8 terminal hyperlinks, exported `parseArgs`/`Args`/`convertToPng` symbols for extension authors, plus assorted fixes. No documented breaking changes to the extension API surface (`pi.registerFlag`, `pi.getFlag`, `before_agent_start`, etc.) — which matters here because the role-prompt injection that landed yesterday in #2068 rides directly on those APIs.

## Verification

Empirical, because the #2068 role-prompt path is exactly the shape we don't want to silently regress:

- `nix build .#prism` — clean.
- Direct build of the overridden `pi-coding-agent-0.78.0` derivation — clean.
- `go test ./...` from `modules/programs/prism/prism/` — all packages pass.
- `tsx --test pi/extensions/prism.test.ts` — 304/304 pass (this is the #2050 / extension regression suite).
- `tsx --test pi/extensions/prism.role-prompt.test.ts` — 7/7 pass (this is the #2064 / #2068 role-prompt regression suite).

## `pi --help` diff (0.77.0 → 0.78.0)

```diff
29a30
>   --name, -n <name>              Set session display name
77a79,81
> 
>   # Start a named session
>   pi --name "Refactor auth module"
```

Exactly the additive change the release notes call out — the new `--name`/`-n` flag and an example for it. Nothing relevant disappears.

## Files changed

- `overlays/default.nix` — `pi-coding-agent` overrideAttrs: tag `v0.78.0`, version `0.78.0`, refreshed source + npmDeps hashes.
- `modules/programs/prism/pi.nix` — comment bumped from "pi 0.77" to "pi 0.78" in the SYSTEM.md loader-discovery note.