### PR TITLE
prism: propagate keybind carve-out through proxySpawn (#2063)

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -1433,6 +1433,9 @@ func TestProxySpawn_EmptyPromptFile_Rejected(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+	// Clear PRISM_SPAWN_PATH so the keybind carve-out (#2063) does not fire —
+	// this test exercises the non-keybind empty-prompt rejection.
+	t.Setenv("PRISM_SPAWN_PATH", "")
 
 	// Write an empty prompt file.
 	dir := t.TempDir()
@@ -1479,6 +1482,9 @@ func TestProxySpawn_EmptyPromptLiteral_Rejected(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+	// Clear PRISM_SPAWN_PATH so the keybind carve-out (#2063) does not fire —
+	// this test exercises the non-keybind empty-prompt rejection.
+	t.Setenv("PRISM_SPAWN_PATH", "")
 
 	cmd := &cobra.Command{Use: "spawn"}
 	cmd.Flags().String("branch", "", "")
@@ -1514,6 +1520,9 @@ func TestProxySpawn_EmptyPromptStdin_Rejected(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+	// Clear PRISM_SPAWN_PATH so the keybind carve-out (#2063) does not fire —
+	// this test exercises the non-keybind empty-prompt rejection.
+	t.Setenv("PRISM_SPAWN_PATH", "")
 
 	// Redirect os.Stdin to an empty file for the duration of the test.
 	empty, err := os.CreateTemp(t.TempDir(), "empty-stdin")

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -131,15 +131,29 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	// Keybind carve-out (issue #2063 — parity with the host-side carve-out
 	// added for issue #2012). The tmux Prefix+a keybind invokes `prism spawn
 	// --attach` with no --prompt because the operator types the initial
-	// prompt to the live agent after the popup attaches. The keybind sets
-	// PRISM_SPAWN_PATH (the `fromKeybind` discriminator), so an empty prompt
-	// on that path is legitimate and must be allowed through the proxy too.
+	// prompt to the live agent after the popup attaches.
 	//
-	// Without this, every Prefix+a popup launched from a tmux server whose
-	// environment contains PRISM_HOST_API hits proxySpawn and flash-closes
-	// on the empty-prompt reject below — exactly the symptom #2012 reported
-	// and #2016 fixed only on the host-side runSpawn path.
-	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""
+	// The host-side runSpawn uses `PRISM_SPAWN_PATH != ""` as the keybind
+	// discriminator, but inside a container PRISM_SPAWN_PATH is set
+	// UNCONDITIONALLY by every sandbox (bwrap.go:496-503,
+	// agent_run_sandbox_exec_darwin.go:284) — it is documented as a
+	// working-directory hint, not a sandbox sentinel
+	// (internal/sandboxenv/sandboxenv.go). Using it as the sole discriminator
+	// here would fire on every container-originated `prism spawn`, not just
+	// keybind spawns, and the resulting `from_keybind: true` would flip the
+	// host-side child's `headless := !fromKeybind && !attachFlag` from true
+	// to false on every container worker-spawn flow — causing the host child
+	// to call session.Attach against whatever tmux client the sidecar
+	// inherited.
+	//
+	// Narrow the carve-out to the only case where it materially matters: an
+	// EMPTY prompt. That is the exact symptom #2012/#2063 set out to fix
+	// (Prefix+a popup flash-close from an unconditional empty-prompt reject),
+	// and it cannot break a non-empty-prompt invocation because the
+	// non-empty path is byte-identical to today. A coordinator/worker that
+	// passes `--prompt "X"` from inside a container hits the same code path
+	// it did pre-PR.
+	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != "" && promptFlag == ""
 	// Reject an empty prompt at the operator boundary (layers 1+2 of issue
 	// #1891). Without this, an empty --prompt-file, --prompt "", or empty
 	// stdin produces a session that is created successfully on every

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -128,13 +128,25 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	// Keybind carve-out (issue #2063 — parity with the host-side carve-out
+	// added for issue #2012). The tmux Prefix+a keybind invokes `prism spawn
+	// --attach` with no --prompt because the operator types the initial
+	// prompt to the live agent after the popup attaches. The keybind sets
+	// PRISM_SPAWN_PATH (the `fromKeybind` discriminator), so an empty prompt
+	// on that path is legitimate and must be allowed through the proxy too.
+	//
+	// Without this, every Prefix+a popup launched from a tmux server whose
+	// environment contains PRISM_HOST_API hits proxySpawn and flash-closes
+	// on the empty-prompt reject below — exactly the symptom #2012 reported
+	// and #2016 fixed only on the host-side runSpawn path.
+	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""
 	// Reject an empty prompt at the operator boundary (layers 1+2 of issue
 	// #1891). Without this, an empty --prompt-file, --prompt "", or empty
 	// stdin produces a session that is created successfully on every
 	// observable surface but never receives a prompt and sits idle forever.
 	// The host-API /spawn handler has a defence-in-depth check too (layer 3);
 	// this surfaces the error in the caller's stderr instead of an HTTP 400.
-	if promptFlag == "" {
+	if promptFlag == "" && !fromKeybind {
 		return emptyPromptError(cmd, "prism spawn")
 	}
 
@@ -153,6 +165,13 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 			"variant":                variantFlag,
 			"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 			"abtest":                 abtestFlag,
+		}
+		// Forward the keybind discriminator so the host-side /spawn handler
+		// permits an empty prompt on this request. The layer-3 handler still
+		// rejects empty prompts from arbitrary HTTP callers that omit this
+		// field — see issue #2063.
+		if fromKeybind {
+			body["from_keybind"] = true
 		}
 		// Only forward "harness" when explicitly set. When absent, the host-side
 		// spawn derives the harness from the profile slot as designed (#1421).
@@ -200,6 +219,13 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		"variant":                variantFlag,
 		"ignore_concurrency_cap": ignoreConcurrencyCapFlag,
 		"reuse":                  reuseFlag,
+	}
+	// Forward the keybind discriminator so the host-side /spawn handler
+	// permits an empty prompt on this request. The layer-3 handler still
+	// rejects empty prompts from arbitrary HTTP callers that omit this
+	// field — see issue #2063.
+	if fromKeybind {
+		body["from_keybind"] = true
 	}
 	if len(modelOverrideFlag) > 0 {
 		modelsByRole, parseErr := parseModelOverrides(modelOverrideFlag)
@@ -513,7 +539,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 					if broken {
 						return fmt.Errorf(
 							"prism spawn --reuse: existing session %q is in a broken state (%s)\n"+
-							"run: prism cleanup --yes --session %s",
+								"run: prism cleanup --yes --session %s",
 							existing.SessionName, existing.State, existing.SessionName)
 					}
 					// Healthy session — emit its details and exit 0.
@@ -532,8 +558,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 				// No --reuse: refuse with a structured error.
 				return fmt.Errorf(
 					"prism spawn: branch %q already has an active session %q\n"+
-					"to clean it up: prism cleanup --yes --session %s\n"+
-					"to reuse it: prism spawn --branch %s --reuse",
+						"to clean it up: prism cleanup --yes --session %s\n"+
+						"to reuse it: prism spawn --branch %s --reuse",
 					branch, existing.SessionName, existing.SessionName, branch)
 			}
 		}
@@ -687,8 +713,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		// ForceFresh=true: spawn always wants a new instance. If a session
 		// with the same name already exists it is a stale zombie and should
 		// be killed.
-		ForceFresh:       true,
-		Headless:         headless,
+		ForceFresh: true,
+		Headless:   headless,
 		// WorktreeReadOnly: mount the worktree read-only for investigate sessions
 		// (defence in depth — denylist prevents writes at the bash level;
 		// read-only mount ensures even a denylist gap cannot modify the repo).
@@ -1344,7 +1370,7 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		// WorktreeReadOnly: mount the worktree read-only for investigate sessions.
 		WorktreeReadOnly: agentRole == "investigate",
 		// PIExtensionDir for host-mode pi launches (#2065).
-		PIExtensionDir: a.cfg.PIExtensionDir,
+		PIExtensionDir:   a.cfg.PIExtensionDir,
 		ReadinessTimeout: session.DefaultReadinessTimeout,
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {

--- a/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
@@ -13,8 +13,11 @@ package cmd
 // is gated on the discriminator only.
 
 import (
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -105,6 +108,153 @@ func TestRunSpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	// (stdin), or --prompt-file <path>".
 	if !strings.Contains(err.Error(), "a prompt is required") {
 		t.Errorf("error %q does not contain 'a prompt is required'", err.Error())
+	}
+}
+
+// TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded verifies the issue
+// #2063 parity gap: when proxySpawn is invoked with PRISM_HOST_API set,
+// PRISM_SPAWN_PATH set (the keybind discriminator), and no prompt, the
+// proxy must NOT return emptyPromptError before the round-trip. Instead
+// it must POST the request to the host API with from_keybind=true so the
+// host-side handler honours the carve-out.
+//
+// Without the fix from #2063, this test fails at the layer-1+2 guard in
+// proxySpawn ("a prompt is required") before the HTTP request is ever made,
+// which is exactly the tmux Prefix+a flash-close symptom.
+func TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch      string `json:"branch"`
+		Prompt      string `json:"prompt"`
+		FromKeybind bool   `json:"from_keybind"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spawn" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@20260101T1200"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	// PRISM_SPAWN_PATH is the keybind discriminator. With it set and no
+	// --prompt, the proxy must forward from_keybind=true rather than
+	// rejecting at the layer-1+2 guard.
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	// No --prompt set; no --branch set — mirrors the tmux Prefix+a invocation.
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		// The error must NOT be the empty-prompt rejection — anything else
+		// (e.g. an HTTP-level oddity) would be a separate failure, but a
+		// successful HTTP round-trip is what the AC requires.
+		if strings.Contains(err.Error(), "a prompt is required") ||
+			strings.Contains(err.Error(), "empty string — supply a non-empty prompt") {
+			t.Fatalf("proxySpawn returned empty-prompt error despite PRISM_SPAWN_PATH set: %v", err)
+		}
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Prompt != "" {
+			t.Errorf("prompt = %q, want empty (keybind path forwards empty prompt)", req.Prompt)
+		}
+		if !req.FromKeybind {
+			t.Errorf("from_keybind = false, want true (keybind discriminator must be forwarded)")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for /spawn request — proxySpawn likely errored before the round-trip")
+	}
+}
+
+// TestProxySpawn_NoKeybind_EmptyPromptStillRejected verifies the security AC:
+// when PRISM_HOST_API is set but PRISM_SPAWN_PATH is NOT set, an empty prompt
+// must still be rejected at the proxy boundary (layer 1+2) — the carve-out
+// fires only on the keybind discriminator. The host-API request must never
+// be made.
+func TestProxySpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
+	reqCh := make(chan struct{}, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		reqCh <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"should-not-happen"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	// PRISM_SPAWN_PATH explicitly unset — not a keybind invocation.
+	t.Setenv("PRISM_SPAWN_PATH", "")
+
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	// No --prompt set.
+
+	err := proxySpawn(srv.apiURL(), cmd)
+	if err == nil {
+		t.Fatal("proxySpawn returned nil; expected empty-prompt rejection")
+	}
+	if !strings.Contains(err.Error(), "a prompt is required") {
+		t.Errorf("error %q does not contain 'a prompt is required'", err.Error())
+	}
+
+	select {
+	case <-reqCh:
+		t.Fatal("host-API was contacted; layer-1+2 guard must reject before the round-trip")
+	case <-time.After(100 * time.Millisecond):
+		// expected — no request reached the server
+	}
+}
+
+// TestProxySpawn_KeybindCarveOut_SuppliedPromptForwarded verifies the
+// edge-case AC: when BOTH PRISM_SPAWN_PATH and --prompt are set, the
+// supplied prompt is forwarded verbatim (the carve-out does not swallow
+// it). from_keybind is still set true so the host knows the call origin.
+func TestProxySpawn_KeybindCarveOut_SuppliedPromptForwarded(t *testing.T) {
+	type spawnReq struct {
+		Prompt      string `json:"prompt"`
+		FromKeybind bool   `json:"from_keybind"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@x"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	_ = cmd.Flags().Set("prompt", "explicit prompt from keybind")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Prompt != "explicit prompt from keybind" {
+			t.Errorf("prompt = %q, want %q (carve-out must not swallow a supplied prompt)",
+				req.Prompt, "explicit prompt from keybind")
+		}
+		if !req.FromKeybind {
+			t.Errorf("from_keybind = false, want true (discriminator forwarded whenever PRISM_SPAWN_PATH set)")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for /spawn request")
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
@@ -213,11 +213,24 @@ func TestProxySpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	}
 }
 
-// TestProxySpawn_KeybindCarveOut_SuppliedPromptForwarded verifies the
-// edge-case AC: when BOTH PRISM_SPAWN_PATH and --prompt are set, the
-// supplied prompt is forwarded verbatim (the carve-out does not swallow
-// it). from_keybind is still set true so the host knows the call origin.
-func TestProxySpawn_KeybindCarveOut_SuppliedPromptForwarded(t *testing.T) {
+// TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind verifies
+// the missed-context regression flagged on the first review round of #2063:
+// PRISM_SPAWN_PATH is set UNCONDITIONALLY inside every bwrap / sandbox-exec
+// sandbox (internal/container/bwrap.go:496-503, documented in
+// internal/sandboxenv/sandboxenv.go as a working-directory hint, not a
+// sandbox sentinel). If the proxy treated `PRISM_SPAWN_PATH != ""` as the
+// sole keybind discriminator, every ordinary container worker-spawn flow
+// (… e.g. a coordinator calling `prism spawn --prompt "X"` from inside its
+// container) would forward `from_keybind: true`, and the host-API handler
+// would then set PRISM_SPAWN_PATH on the host-side prism spawn child —
+// flipping its `headless := !fromKeybind && !attachFlag` from true to
+// false and causing it to call session.Attach against whatever tmux
+// client the sidecar inherited.
+//
+// The narrowing fix gates the carve-out on `PRISM_SPAWN_PATH != "" &&
+// promptFlag == ""`. This test pins that down: a container spawn with a
+// supplied prompt must NOT carry `from_keybind: true`.
+func TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind(t *testing.T) {
 	type spawnReq struct {
 		Prompt      string `json:"prompt"`
 		FromKeybind bool   `json:"from_keybind"`
@@ -235,10 +248,12 @@ func TestProxySpawn_KeybindCarveOut_SuppliedPromptForwarded(t *testing.T) {
 	})
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	// Simulate the bwrap-sandbox state: PRISM_SPAWN_PATH set to the
+	// container's worktree path even though this is NOT a keybind spawn.
 	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
 
 	cmd := buildSpawnCmdForEmptyPromptTest(t)
-	_ = cmd.Flags().Set("prompt", "explicit prompt from keybind")
+	_ = cmd.Flags().Set("prompt", "explicit prompt from container worker")
 
 	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
 		t.Fatalf("proxySpawn: %v", err)
@@ -246,12 +261,12 @@ func TestProxySpawn_KeybindCarveOut_SuppliedPromptForwarded(t *testing.T) {
 
 	select {
 	case req := <-reqCh:
-		if req.Prompt != "explicit prompt from keybind" {
-			t.Errorf("prompt = %q, want %q (carve-out must not swallow a supplied prompt)",
-				req.Prompt, "explicit prompt from keybind")
+		if req.Prompt != "explicit prompt from container worker" {
+			t.Errorf("prompt = %q, want %q (supplied prompt must be forwarded verbatim)",
+				req.Prompt, "explicit prompt from container worker")
 		}
-		if !req.FromKeybind {
-			t.Errorf("from_keybind = false, want true (discriminator forwarded whenever PRISM_SPAWN_PATH set)")
+		if req.FromKeybind {
+			t.Errorf("from_keybind = true; want false — a container spawn with a supplied prompt must NOT trigger the keybind carve-out (would flip the host-side child's headless flag and side-effect session.Attach)")
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for /spawn request")

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -57,6 +57,22 @@ func contextErrStatus(ctx context.Context) (int, bool) {
 	return statusClientClosedRequest, true
 }
 
+// filterEnv returns a copy of env with any entry whose key matches name
+// removed. Used to control specific environment variables passed to a child
+// process (e.g. unsetting PRISM_SPAWN_PATH so the child does not inherit the
+// sidecar process's own value — see the /spawn handler and issue #2063).
+func filterEnv(env []string, name string) []string {
+	prefix := name + "="
+	out := env[:0:0]
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
 // hostAPIServeLogsTail writes the last n lines of the log file to w.
 // When n == 0, the response body is empty.
 func hostAPIServeLogsTail(w http.ResponseWriter, logPath string, n int) {
@@ -1241,29 +1257,46 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		defer cancel()
 		cmd := exec.CommandContext(ctx, prismBinary(), args...)
 		// Issue #2063: when the request was initiated by the tmux Prefix+a
-		// keybind, propagate the discriminator to the host-side prism spawn
-		// via PRISM_SPAWN_PATH. The host-side runSpawn already reads that
-		// env var to recognise a keybind spawn (`fromKeybind`) and skip the
-		// empty-prompt guard — reusing it here keeps a single discriminator
-		// across both code paths instead of inventing a parallel CLI flag.
-		// The value itself is informational only; runSpawn just checks for
-		// non-empty. We derive it from the sidecar's own worktree so any
-		// downstream code that resolves the path lands on the coordinator's
-		// repo, but the empty-prompt carve-out is the only behaviour it
-		// gates on the host side.
-		if req.FromKeybind {
-			// runSpawn only checks `os.Getenv("PRISM_SPAWN_PATH") != ""`, so
-			// any non-empty value enables the carve-out. Prefer the sidecar's
-			// own worktree path when populated so any downstream consumer that
-			// resolves the path lands on a real directory; fall back to a
-			// sentinel marker if it is unset (defence in depth — production
-			// sidecars always have Worktree populated).
+		// keybind AND no prompt was supplied, propagate the discriminator to
+		// the host-side prism spawn via PRISM_SPAWN_PATH. The host-side
+		// runSpawn already reads that env var to recognise a keybind spawn
+		// (`fromKeybind`) and skip the empty-prompt guard — reusing it here
+		// keeps a single discriminator across both code paths instead of
+		// inventing a parallel CLI flag.
+		//
+		// Narrow the propagation to `req.Prompt == ""` to match the proxy
+		// side. fromKeybind on the host also flips runSpawn's
+		// `headless := !fromKeybind && !attachFlag` from true to false, which
+		// for a NON-empty-prompt invocation would make the child call
+		// session.Attach against whatever tmux client this sidecar inherited
+		// — a behavioural change the empty-prompt carve-out does not need.
+		// Restricting to the empty-prompt case keeps the supplied-prompt path
+		// byte-identical to the pre-PR behaviour.
+		//
+		// IMPORTANT: control the env value explicitly in BOTH branches.
+		// Without an explicit unset, the child inherits the sidecar process's
+		// own PRISM_SPAWN_PATH — which can happen if this sidecar itself was
+		// launched from a shell with PRISM_SPAWN_PATH already set (e.g. a
+		// developer running prism manually for testing). Always overwriting
+		// PRISM_SPAWN_PATH (either to the keybind value or to empty) makes the
+		// child's view of the discriminator a pure function of the request,
+		// independent of the sidecar's launch environment.
+		//
+		// runSpawn only checks `os.Getenv("PRISM_SPAWN_PATH") != ""`, so any
+		// non-empty value enables the carve-out. Prefer the sidecar's own
+		// worktree path when populated so any downstream consumer that
+		// resolves the path lands on a real directory; fall back to a
+		// sentinel marker if it is unset (defence in depth — production
+		// sidecars always have Worktree populated).
+		spawnPathEnv := "PRISM_SPAWN_PATH="
+		if req.FromKeybind && req.Prompt == "" {
 			spawnPath := s.cfg.Worktree
 			if spawnPath == "" {
 				spawnPath = "keybind"
 			}
-			cmd.Env = append(os.Environ(), "PRISM_SPAWN_PATH="+spawnPath)
+			spawnPathEnv = "PRISM_SPAWN_PATH=" + spawnPath
 		}
+		cmd.Env = append(filterEnv(os.Environ(), "PRISM_SPAWN_PATH"), spawnPathEnv)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			if status, ok := contextErrStatus(ctx); ok {

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1032,6 +1032,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Reuse                 bool     `json:"reuse"`
 			ModelVariantOverrides string   `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
 			Abtest                []string `json:"abtest"`                  // two-element array of profile names; see #1330
+			// FromKeybind discriminates a tmux Prefix+a (keybind) spawn from
+			// an arbitrary HTTP caller. When true, an empty prompt is
+			// permitted — the operator types the initial prompt to the live
+			// agent after the popup attaches. The proxySpawn CLI path sets
+			// this when PRISM_SPAWN_PATH is set in its own environment. See
+			// issues #2012 (host-side carve-out) and #2063 (proxy parity).
+			FromKeybind bool `json:"from_keybind"`
 		}
 		// /spawn body cap: default 1 MiB (issue #1848). DisallowUnknownFields
 		// is applied via decodeRequestJSON — already strict on this endpoint.
@@ -1060,7 +1067,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// a malformed or alternate client that POSTs {"prompt":""} would otherwise
 		// produce a session that comes up successfully but sits idle forever
 		// because no --prompt argument is forwarded to the host-side prism spawn.
-		if req.Prompt == "" {
+		//
+		// Keybind carve-out (issue #2063): when the request carries
+		// from_keybind=true the empty prompt is intentional and the spawn
+		// proceeds. The carve-out fires only on this explicit discriminator,
+		// so arbitrary HTTP callers that omit the field still hit this guard.
+		if req.Prompt == "" && !req.FromKeybind {
 			writeError(w, http.StatusBadRequest, "prompt is required — the request body must include a non-empty \"prompt\" field")
 			return
 		}
@@ -1228,6 +1240,30 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, prismBinary(), args...)
+		// Issue #2063: when the request was initiated by the tmux Prefix+a
+		// keybind, propagate the discriminator to the host-side prism spawn
+		// via PRISM_SPAWN_PATH. The host-side runSpawn already reads that
+		// env var to recognise a keybind spawn (`fromKeybind`) and skip the
+		// empty-prompt guard — reusing it here keeps a single discriminator
+		// across both code paths instead of inventing a parallel CLI flag.
+		// The value itself is informational only; runSpawn just checks for
+		// non-empty. We derive it from the sidecar's own worktree so any
+		// downstream code that resolves the path lands on the coordinator's
+		// repo, but the empty-prompt carve-out is the only behaviour it
+		// gates on the host side.
+		if req.FromKeybind {
+			// runSpawn only checks `os.Getenv("PRISM_SPAWN_PATH") != ""`, so
+			// any non-empty value enables the carve-out. Prefer the sidecar's
+			// own worktree path when populated so any downstream consumer that
+			// resolves the path lands on a real directory; fall back to a
+			// sentinel marker if it is unset (defence in depth — production
+			// sidecars always have Worktree populated).
+			spawnPath := s.cfg.Worktree
+			if spawnPath == "" {
+				spawnPath = "keybind"
+			}
+			cmd.Env = append(os.Environ(), "PRISM_SPAWN_PATH="+spawnPath)
+		}
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			if status, ok := contextErrStatus(ctx); ok {
@@ -2150,14 +2186,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		var req struct {
-			Prompt      string `json:"prompt"`
-			To          string `json:"to,omitempty"`
-			From        string `json:"from,omitempty"`
+			Prompt string `json:"prompt"`
+			To     string `json:"to,omitempty"`
+			From   string `json:"from,omitempty"`
 			// JSON forwards the --json flag to the host-side `prism escalate`
 			// child so its stdout carries the JSON envelope (and stderr the
 			// human mirror). The proxy on the container side then writes the
 			// captured streams verbatim to its own stdout/stderr. See #2018.
-			JSON        bool   `json:"json,omitempty"`
+			JSON bool `json:"json,omitempty"`
 			// DedupWindow forwards the hidden --dedup-window flag for tests
 			// and operator overrides. Empty string falls back to the default.
 			DedupWindow string `json:"dedup_window,omitempty"`
@@ -2961,8 +2997,6 @@ func isPipeConnected(s *Sidecar) bool {
 	s.mu.Unlock()
 	return ch != nil
 }
-
-
 
 // resolveRoleForSession returns the root_agent_name (role) for targetSess, or
 // a non-empty skipStatus string when the session should be skipped.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5572,6 +5572,93 @@ func TestHostAPI_Spawn_EmptyPromptReturns400(t *testing.T) {
 	}
 }
 
+// TestHostAPI_Spawn_FromKeybind_EmptyPromptAccepted verifies the issue
+// #2063 carve-out: when the request carries {"from_keybind":true}, an
+// empty prompt must NOT be rejected at layer 3 — the proxy has signalled
+// that this is a tmux Prefix+a invocation and the operator will type the
+// initial prompt to the live agent after the popup attaches.
+//
+// The stub records its env so we can assert that PRISM_SPAWN_PATH is
+// propagated to the host-side prism spawn child. That env var is the
+// discriminator runSpawn uses for its own carve-out — if the sidecar
+// failed to set it, the host-side child would still reject the empty
+// prompt and the popup would flash-close.
+func TestHostAPI_Spawn_FromKeybind_EmptyPromptAccepted(t *testing.T) {
+	d := openTestDB(t)
+
+	envFile := filepath.Join(t.TempDir(), "captured-env")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	// The stub writes its PRISM_SPAWN_PATH env to a file then prints the
+	// canonical session-created line so the handler's parse succeeds.
+	stubScript := `#!/bin/sh
+echo "PRISM_SPAWN_PATH=${PRISM_SPAWN_PATH}" > ` + envFile + `
+echo "session \"test-repo@keybind-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	sc := New(cfg)
+
+	// Empty prompt + from_keybind:true — must be accepted (200) instead of 400.
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"keybind-branch","prompt":"","from_keybind":true}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for empty prompt + from_keybind:true; body = %s",
+			rr.Code, rr.Body.String())
+	}
+
+	// Verify PRISM_SPAWN_PATH was propagated to the host-side child.
+	capturedEnv, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read captured env: %v", err)
+	}
+	envLine := strings.TrimSpace(string(capturedEnv))
+	if envLine == "PRISM_SPAWN_PATH=" || envLine == "" {
+		t.Errorf("captured env %q: PRISM_SPAWN_PATH was not set on the child; host-side runSpawn will still reject the empty prompt",
+			envLine)
+	}
+}
+
+// TestHostAPI_Spawn_NoFromKeybind_EmptyPromptStillRejected verifies the
+// security AC for issue #2063: the layer-3 empty-prompt guard still fires
+// for arbitrary HTTP callers that do NOT carry from_keybind:true. The
+// relaxation lives in the prism CLI proxy path only — not in the public
+// /spawn handler for everyone else.
+func TestHostAPI_Spawn_NoFromKeybind_EmptyPromptStillRejected(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+
+	// Empty prompt, from_keybind absent (or explicit false) — must still 400.
+	for _, body := range []string{
+		`{"branch":"feature","prompt":""}`,
+		`{"branch":"feature","prompt":"","from_keybind":false}`,
+	} {
+		rr := doHostAPI(t, sc, http.MethodPost, "/spawn", body)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("body %q: status = %d, want 400 (carve-out must fire only on from_keybind:true)",
+				body, rr.Code)
+			continue
+		}
+		var errResp map[string]string
+		decodeJSONBody(t, rr, &errResp)
+		if !strings.Contains(errResp["error"], "prompt is required") {
+			t.Errorf("body %q: error %q should mention 'prompt is required'", body, errResp["error"])
+		}
+	}
+}
+
 // TestHostAPI_Spawn_SidecarNoAtSign_Returns500 verifies AC edge case: if the
 // sidecar's own session name contains no "@", /spawn returns 500 with a
 // message indicating the repo cannot be derived, and no spawn is attempted.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5619,14 +5619,79 @@ echo "session \"test-repo@keybind-branch\" created"
 			rr.Code, rr.Body.String())
 	}
 
-	// Verify PRISM_SPAWN_PATH was propagated to the host-side child.
+	// Verify PRISM_SPAWN_PATH was propagated to the host-side child with the
+	// sidecar's own worktree path — not whatever the sidecar process
+	// happened to inherit at launch. The handler explicitly filters and
+	// overwrites PRISM_SPAWN_PATH so the child's view is a pure function of
+	// the request, independent of the sidecar's environment.
 	capturedEnv, err := os.ReadFile(envFile)
 	if err != nil {
 		t.Fatalf("read captured env: %v", err)
 	}
 	envLine := strings.TrimSpace(string(capturedEnv))
-	if envLine == "PRISM_SPAWN_PATH=" || envLine == "" {
-		t.Errorf("captured env %q: PRISM_SPAWN_PATH was not set on the child; host-side runSpawn will still reject the empty prompt",
+	wantLine := "PRISM_SPAWN_PATH=" + cfg.Worktree
+	if envLine != wantLine {
+		t.Errorf("captured env %q, want %q (host-side child must see the sidecar's worktree, not whatever PRISM_SPAWN_PATH this sidecar process inherited)",
+			envLine, wantLine)
+	}
+}
+
+// TestHostAPI_Spawn_FromKeybind_NonEmptyPrompt_DoesNotSetEnv verifies the
+// narrowing fix surfaced by review-context on the first review round: when
+// from_keybind:true arrives alongside a NON-empty prompt, the sidecar must
+// NOT set PRISM_SPAWN_PATH on the host-side prism spawn child. Doing so
+// would flip the child's `headless := !fromKeybind && !attachFlag` from
+// true to false and cause it to call session.Attach against whatever tmux
+// client the sidecar inherited — a behavioural change for ordinary
+// container worker-spawn flows that the empty-prompt carve-out does not
+// need to enable.
+//
+// In practice the narrowed proxy will not send from_keybind:true alongside
+// a non-empty prompt, but the layer-3 handler's behaviour must be safe
+// even if a malformed client does.
+func TestHostAPI_Spawn_FromKeybind_NonEmptyPrompt_DoesNotSetEnv(t *testing.T) {
+	d := openTestDB(t)
+
+	envFile := filepath.Join(t.TempDir(), "captured-env")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "PRISM_SPAWN_PATH=${PRISM_SPAWN_PATH}" > ` + envFile + `
+echo "session \"test-repo@some-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"some-branch","prompt":"hello","from_keybind":true}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedEnv, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("read captured env: %v", err)
+	}
+	envLine := strings.TrimSpace(string(capturedEnv))
+	// The harness MUST NOT have inherited PRISM_SPAWN_PATH from this sidecar.
+	// The stub captures `PRISM_SPAWN_PATH=<value>`; for a clean child the
+	// value half is empty. We accept either "PRISM_SPAWN_PATH=" or no line at
+	// all in case the stub never wrote the file for any reason.
+	if envLine != "PRISM_SPAWN_PATH=" && envLine != "" {
+		t.Errorf("captured env %q: PRISM_SPAWN_PATH must NOT be set on the child when from_keybind:true arrives with a non-empty prompt (would flip headless and side-effect session.Attach)",
 			envLine)
 	}
 }


### PR DESCRIPTION
Closes #2063.

## Symptom

Pressing tmux **Prefix+a** opens the spawn popup, which then flash-closes
too fast to read — identical to the original #2012 symptom. PR #2016
landed and the host has been switched many times since, so the binary
contains the host-side fix.

## Root cause

PR #2016 added the `fromKeybind` empty-prompt carve-out to the **host**
`runSpawn` in \`cmd/spawn.go\`, but did **not** add the same carve-out to
`proxySpawn` (the proxy path taken whenever `PRISM_HOST_API` is set in
the caller's environment).

`runSpawn` dispatches to `proxySpawn` whenever `PRISM_HOST_API` is set —
and `display-popup -E` inherits the **tmux server's** environment (not
the current pane's). If the tmux server was started from a shell that
had `PRISM_HOST_API` exported, every Prefix+a popup routes through
`proxySpawn` and hits the unfixed empty-prompt reject, flash-closing
the popup exactly as #2012 described.

## Fix

Three coordinated changes close the parity gap end-to-end:

1. **`cmd/spawn.go`** — `proxySpawn` now reads `PRISM_SPAWN_PATH` and skips
   the layer-1+2 empty-prompt reject when it is set, mirroring the
   host-side carve-out. It then forwards a `from_keybind: true` field in
   the JSON request body so the layer-3 handler knows the empty prompt
   is intentional.

2. **`internal/sidecar/host_api.go`** — the `/spawn` handler accepts the
   new `from_keybind` field, relaxes its own empty-prompt guard when set,
   and propagates `PRISM_SPAWN_PATH` to the host-side `prism spawn` child
   process so the host-side `runSpawn` carve-out fires too. Arbitrary HTTP
   callers that omit `from_keybind` still hit the original 400 — the
   relaxation lives in the prism CLI proxy path, not in the public handler.

3. **Tests** — new coverage in `cmd/spawn_empty_prompt_test.go` for the
   proxy carve-out (forwards empty prompt + `from_keybind=true`; still
   rejects empty prompt without the discriminator; does not swallow a
   supplied prompt) and in `internal/sidecar/sidecar_test.go` for the
   host-API handler (accepts `from_keybind=true`; propagates
   `PRISM_SPAWN_PATH`; still rejects empty prompts from non-keybind
   callers).

## Discriminator choice

The issue suggested two shapes: (a) forward `PRISM_SPAWN_PATH` to the
host so its own `fromKeybind` check fires, or (b) add a request-body
field analogous to `prompt-source: proxy-spawn`. This PR takes **both**:

- **Wire format**: a new `from_keybind` boolean on the request body.
  Explicit, self-documenting, and the layer-3 handler can gate the
  empty-prompt relaxation on it specifically — instead of allowing any
  HTTP caller that happens to know to set a magic env var to bypass the
  guard. Mirrors the existing `prompt-source: proxy-spawn` precedent.

- **Host-side propagation**: when `from_keybind=true`, the handler sets
  `PRISM_SPAWN_PATH` in the env of the spawned `prism spawn` child so
  the host-side `runSpawn`'s existing `fromKeybind` check fires too.
  This avoids inventing a parallel CLI flag.

Forwarding `PRISM_SPAWN_PATH` from the client directly was rejected
because (i) the container-side path is meaningless to the host and
(ii) it would conflate \"keybind\" with \"has a path\" — the host
already derives `bareRoot` from the session name independently.

## Side fix

A handful of pre-existing `TestProxySpawn_EmptyPrompt_*` tests needed
`t.Setenv(\"PRISM_SPAWN_PATH\", \"\")` added — they were silently relying
on the developer shell not having `PRISM_SPAWN_PATH` set, which is
false when run inside a prism-spawned worker session. The new keybind
carve-out exposed this latent assumption.

## Verification

- \`go build ./...\` ✓
- \`go test ./...\` ✓ (full suite)
- \`nix build .#prism\` ✓

## ACs

- [x] [functional] \`PRISM_SPAWN_PATH=<path> prism spawn --attach\` from inside a container with \`PRISM_HOST_API\` set succeeds.
- [x] [functional] tmux Prefix+a with \`PRISM_HOST_API\` in tmux server env opens the popup and attaches (no flash-close).
- [x] [functional] tmux Prefix+a without \`PRISM_HOST_API\` in tmux server env works as before (host-side carve-out unchanged).
- [x] [edge-case] \`prism spawn\` with \`PRISM_HOST_API\` set + no \`PRISM_SPAWN_PATH\` + empty prompt still rejects.
- [x] [edge-case] \`prism spawn --prompt \"real\"\` with \`PRISM_HOST_API\` set continues to work with or without \`PRISM_SPAWN_PATH\`.
- [x] [security] Layer-3 \`/spawn\` handler still rejects empty prompts from HTTP callers that omit \`from_keybind\`.
- [x] [functional] New tests in \`cmd/spawn_empty_prompt_test.go\` cover the proxySpawn carve-out (plus matching host-API handler tests).
- [x] [functional] \`nix build .#prism\` succeeds.