### PR TITLE
tmux: fix Prefix+a flash-close by resolving pane_current_path in shell

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -261,21 +261,25 @@ in
               # spawn new timestamped worktree from current repo (prefix+a)
               # prism spawn infers the repo from the current pane path, creates
               # a zettelkasten-timestamped branch+worktree, and switches to it.
-              # -d sets the popup's start directory to the caller's pane path
-              # (#{pane_current_path} is expanded by tmux for -d). The popup
-              # pane then reports that same path via pane_current_path, so
-              # prism's CurrentPanePath() fallback works without PRISM_SPAWN_PATH.
               #
-              # PRISM_SPAWN_PATH is also set explicitly so the spawn command
-              # can discriminate keybind-initiated spawns from shell/agent
+              # Wrapped in run-shell so we can resolve #{pane_current_path}
+              # via `tmux display-message -p` at trigger time and substitute
+              # the resolved string into both `-d` and `-e`. On tmux 3.6a,
+              # `display-popup -e VAR=#{format}` does NOT run the value
+              # through tmux format-expansion — PRISM_SPAWN_PATH arrives
+              # inside the popup as the literal string "#{pane_current_path}",
+              # which causes prism spawn to misroute and flash-close the
+              # popup with an unreadable error (issue #2072). Doing the
+              # substitution in the shell sidesteps the bug entirely.
+              #
+              # PRISM_SPAWN_PATH is set explicitly so the spawn command can
+              # discriminate keybind-initiated spawns from shell/agent
               # callers. The empty-prompt guard (issue #1891) is relaxed for
               # the keybind path — the operator types the initial prompt to
               # the live agent after the popup attaches, so requiring
               # --prompt at invocation time would flash-close the popup with
               # an unreadable error (issue #2012).
-              bind a display-popup -E -d "#{pane_current_path}" -w 60% -h 20% -b single \
-                -e "PRISM_SPAWN_PATH=#{pane_current_path}" \
-                "${prism} spawn --attach"
+              bind a run-shell 'path=$(${pkgs.tmux}/bin/tmux display-message -p "#{pane_current_path}"); ${pkgs.tmux}/bin/tmux display-popup -E -d "$path" -w 60% -h 20% -b single -e "PRISM_SPAWN_PATH=$path" "${prism} spawn --attach"'
 
               # agent scrolling keybinds — active when the pane is a prism agent
               # running under either supported isolation mode (podman or bwrap),


### PR DESCRIPTION
Closes #2072

## Problem

Pressing tmux **Prefix+a** opens the spawn popup, which flash-closes too fast to read. Same user-visible symptom as #2012 and #2063, different root cause.

On tmux **3.6a**, `display-popup -e VAR=value` does **not** run `value` through tmux format-expansion at trigger time. The previous bind:

```
bind a display-popup -E -d "#{pane_current_path}" -w 60% -h 20% -b single \
  -e "PRISM_SPAWN_PATH=#{pane_current_path}" \
  "${prism} spawn --attach"
```

…delivered `PRISM_SPAWN_PATH` to the popup as the **literal string** `#{pane_current_path}`. `prism spawn` then walked `resolveBareRoot` → `IsInsideRegularRepo` against that nonsense path, emitted `"this repo isn't using the worktree layout yet"`, and exited non-zero — popup closed instantly.

`-d` IS format-expanded by tmux (the popup's cwd was correct), so the original comment on that score was accurate — the bug is specific to `-e`.

## Fix

Wrap the bind in `run-shell`, resolve `pane_current_path` via `tmux display-message -p` at trigger time, and substitute the resolved string into both `-d` and `-e`. This is the exact pattern already used by the C-Space and C-e binds in the same file (~lines 255, 259) and sidesteps the tmux `-e` expansion bug entirely — the shell does the substitution.

```nix
bind a run-shell 'path=$(${pkgs.tmux}/bin/tmux display-message -p "#{pane_current_path}"); ${pkgs.tmux}/bin/tmux display-popup -E -d "$path" -w 60% -h 20% -b single -e "PRISM_SPAWN_PATH=$path" "${prism} spawn --attach"'
```

## Verification

- `nix build .#prism` passes (no Go changes).
- `nix eval` of the emitted `programs.tmux.extraConfig` shows the bind with both store paths and `"#{pane_current_path}"` correctly surviving inside the single-quoted run-shell body.
- Running tmux against the isolated bind and `list-keys -T prefix` confirms tmux parses the keybind cleanly and binds `a` to the intended run-shell command.

## Scope

- `modules/programs/prism/tmux.nix` only — no `prism/**` Go changes.
- The broader cleanup that decouples `PRISM_SPAWN_PATH` from the keybind discriminator is tracked in #2073 and depends on this PR.