### PR TITLE
prism: decouple keybind discriminator from PRISM_SPAWN_PATH (#2073)

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -1437,6 +1437,11 @@ func TestProxySpawn_EmptyPromptFile_Rejected(t *testing.T) {
 	// this test exercises the non-keybind empty-prompt rejection.
 	t.Setenv("PRISM_SPAWN_PATH", "")
 
+	// Post-#2073 the keybind carve-out is gated on PRISM_KEYBIND_SPAWN, a
+	// dedicated sentinel that no sandbox injects — the defensive
+	// `t.Setenv("PRISM_SPAWN_PATH", "")` shim that pre-#2073 tests carried
+	// is no longer required.
+
 	// Write an empty prompt file.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "prompt.txt")
@@ -1482,9 +1487,9 @@ func TestProxySpawn_EmptyPromptLiteral_Rejected(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
-	// Clear PRISM_SPAWN_PATH so the keybind carve-out (#2063) does not fire —
-	// this test exercises the non-keybind empty-prompt rejection.
-	t.Setenv("PRISM_SPAWN_PATH", "")
+	// Post-#2073 the keybind carve-out is gated on PRISM_KEYBIND_SPAWN, a
+	// dedicated sentinel that no sandbox injects — the defensive
+	// `t.Setenv("PRISM_SPAWN_PATH", "")` shim is no longer required.
 
 	cmd := &cobra.Command{Use: "spawn"}
 	cmd.Flags().String("branch", "", "")
@@ -1520,9 +1525,9 @@ func TestProxySpawn_EmptyPromptStdin_Rejected(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
-	// Clear PRISM_SPAWN_PATH so the keybind carve-out (#2063) does not fire —
-	// this test exercises the non-keybind empty-prompt rejection.
-	t.Setenv("PRISM_SPAWN_PATH", "")
+	// Post-#2073 the keybind carve-out is gated on PRISM_KEYBIND_SPAWN, a
+	// dedicated sentinel that no sandbox injects — the defensive
+	// `t.Setenv("PRISM_SPAWN_PATH", "")` shim is no longer required.
 
 	// Redirect os.Stdin to an empty file for the duration of the test.
 	empty, err := os.CreateTemp(t.TempDir(), "empty-stdin")

--- a/modules/programs/prism/prism/cmd/hostapi_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_test.go
@@ -1433,10 +1433,6 @@ func TestProxySpawn_EmptyPromptFile_Rejected(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
-	// Clear PRISM_SPAWN_PATH so the keybind carve-out (#2063) does not fire —
-	// this test exercises the non-keybind empty-prompt rejection.
-	t.Setenv("PRISM_SPAWN_PATH", "")
-
 	// Post-#2073 the keybind carve-out is gated on PRISM_KEYBIND_SPAWN, a
 	// dedicated sentinel that no sandbox injects — the defensive
 	// `t.Setenv("PRISM_SPAWN_PATH", "")` shim that pre-#2073 tests carried

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -128,32 +128,25 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	// Keybind carve-out (issue #2063 — parity with the host-side carve-out
-	// added for issue #2012). The tmux Prefix+a keybind invokes `prism spawn
-	// --attach` with no --prompt because the operator types the initial
-	// prompt to the live agent after the popup attaches.
+	// Keybind carve-out (issues #2063, #2073). The tmux Prefix+a keybind
+	// invokes `prism spawn --attach` with no --prompt because the operator
+	// types the initial prompt to the live agent after the popup attaches.
 	//
-	// The host-side runSpawn uses `PRISM_SPAWN_PATH != ""` as the keybind
-	// discriminator, but inside a container PRISM_SPAWN_PATH is set
-	// UNCONDITIONALLY by every sandbox (bwrap.go:496-503,
-	// agent_run_sandbox_exec_darwin.go:284) — it is documented as a
-	// working-directory hint, not a sandbox sentinel
-	// (internal/sandboxenv/sandboxenv.go). Using it as the sole discriminator
-	// here would fire on every container-originated `prism spawn`, not just
-	// keybind spawns, and the resulting `from_keybind: true` would flip the
-	// host-side child's `headless := !fromKeybind && !attachFlag` from true
-	// to false on every container worker-spawn flow — causing the host child
-	// to call session.Attach against whatever tmux client the sidecar
-	// inherited.
-	//
-	// Narrow the carve-out to the only case where it materially matters: an
-	// EMPTY prompt. That is the exact symptom #2012/#2063 set out to fix
-	// (Prefix+a popup flash-close from an unconditional empty-prompt reject),
-	// and it cannot break a non-empty-prompt invocation because the
-	// non-empty path is byte-identical to today. A coordinator/worker that
-	// passes `--prompt "X"` from inside a container hits the same code path
-	// it did pre-PR.
-	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != "" && promptFlag == ""
+	// History: the original carve-out (#2063) reused PRISM_SPAWN_PATH as the
+	// discriminator, but that env var is set UNCONDITIONALLY by every
+	// sandbox (bwrap.go:~500, cmd/agent_run_sandbox_exec_darwin.go:~284) as
+	// a working-directory hint (see internal/sandboxenv/sandboxenv.go). To
+	// stop ordinary container worker-spawn flows from being misclassified
+	// as keybind spawns, the proxy check had to be narrowed to
+	// `PRISM_SPAWN_PATH != "" && promptFlag == ""`, with an extra layer of
+	// narrowing in the sidecar's /spawn handler. That conflation is finally
+	// retired by #2073: the keybind sets a dedicated sentinel
+	// PRISM_KEYBIND_SPAWN=1 that no sandbox injects, so the discriminator
+	// can be a single env-var check on both the host and proxy paths — no
+	// `promptFlag == ""` narrowing needed, no risk of leakage from sandbox
+	// env-injection. PRISM_SPAWN_PATH keeps its working-directory-hint job
+	// and nothing else.
+	fromKeybind := os.Getenv("PRISM_KEYBIND_SPAWN") != ""
 	// Reject an empty prompt at the operator boundary (layers 1+2 of issue
 	// #1891). Without this, an empty --prompt-file, --prompt "", or empty
 	// stdin produces a session that is created successfully on every
@@ -420,19 +413,20 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	}
 	attachFlag, _ := cmd.Flags().GetBool("attach")
 	// headless when invoked from a shell/agent rather than the tmux keybinding.
-	// The keybinding sets PRISM_SPAWN_PATH; --attach overrides to force a switch.
-	fromKeybind := os.Getenv("PRISM_SPAWN_PATH") != ""
+	// The keybinding sets PRISM_KEYBIND_SPAWN=1; --attach overrides to force a switch.
+	fromKeybind := os.Getenv("PRISM_KEYBIND_SPAWN") != ""
 	// Reject an empty prompt at the operator boundary (issue #1891). When the
 	// hidden --prompt-source flag is set we are running as the child of the
 	// host-API /spawn handler, which has already validated that req.Prompt is
 	// non-empty (layer 3); skipping the check there keeps the proxy's own
 	// 400 surface as the source of truth for that path.
 	//
-	// Keybind carve-out (issue #2012): the tmux Prefix+a keybind invokes
-	// `prism spawn --attach` with no --prompt because the operator types the
-	// initial prompt to the live agent after the popup attaches. The keybind
-	// sets PRISM_SPAWN_PATH (the `fromKeybind` discriminator), so an empty
-	// prompt on that path is legitimate and must be allowed through.
+	// Keybind carve-out (issues #2012, #2073): the tmux Prefix+a keybind
+	// invokes `prism spawn --attach` with no --prompt because the operator
+	// types the initial prompt to the live agent after the popup attaches.
+	// The keybind sets PRISM_KEYBIND_SPAWN=1 (the `fromKeybind`
+	// discriminator — a dedicated sentinel that no sandbox injects), so an
+	// empty prompt on that path is legitimate and must be allowed through.
 	if promptText == "" && promptSource != "proxy-spawn" && !fromKeybind {
 		return emptyPromptError(cmd, "prism spawn")
 	}

--- a/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_empty_prompt_test.go
@@ -1,16 +1,21 @@
 package cmd
 
 // Tests for the keybind carve-out of the layer-1+2 empty-prompt guard
-// (issue #2012). The tmux Prefix+a keybind invokes `prism spawn --attach`
-// with no --prompt — the operator types the initial prompt to the live
-// agent after the popup attaches. The keybind discriminator is the
-// PRISM_SPAWN_PATH environment variable; when that is set and no prompt
-// was supplied, runSpawn must skip the empty-prompt rejection so the
-// popup does not flash-close with an unreadable error.
+// (issues #2012, #2063, #2073). The tmux Prefix+a keybind invokes
+// `prism spawn --attach` with no --prompt — the operator types the
+// initial prompt to the live agent after the popup attaches. The keybind
+// discriminator is the PRISM_KEYBIND_SPAWN environment variable
+// (introduced in #2073 to replace the overloaded PRISM_SPAWN_PATH); when
+// that is set and no prompt was supplied, runSpawn must skip the
+// empty-prompt rejection so the popup does not flash-close with an
+// unreadable error.
 //
-// Without PRISM_SPAWN_PATH set, the existing emptyPromptError must still
-// fire — protecting the shell-invocation path and proving the relaxation
-// is gated on the discriminator only.
+// Without PRISM_KEYBIND_SPAWN set, the existing emptyPromptError must
+// still fire — protecting the shell-invocation path and proving the
+// relaxation is gated on the dedicated sentinel only. Crucially,
+// PRISM_SPAWN_PATH alone (which every sandbox injects unconditionally)
+// must NOT trip the carve-out — that conflation was the reason #2073
+// existed.
 
 import (
 	"encoding/json"
@@ -46,23 +51,29 @@ func buildSpawnCmdForEmptyPromptTest(t *testing.T) *cobra.Command {
 }
 
 // TestRunSpawn_KeybindCarveOut_EmptyPromptAccepted verifies that runSpawn
-// with PRISM_SPAWN_PATH set and no prompt does NOT return emptyPromptError.
+// with PRISM_KEYBIND_SPAWN set and no prompt does NOT return
+// emptyPromptError.
 //
-// Because the test environment has no real git repo at PRISM_SPAWN_PATH and
-// no live tmux server is available, runSpawn will still fail downstream of
-// the layer-1+2 guard — typically on resolveBareRoot ("not inside a git
-// repo") or another pre-flight check. The assertion is therefore negative:
-// the error must NOT contain the empty-prompt message. That is sufficient
-// evidence that the layer-1+2 guard let the call through, which is the
-// exact behaviour the issue #2012 fix promises.
+// Because the test environment has no real git repo and no live tmux
+// server is available, runSpawn will still fail downstream of the
+// layer-1+2 guard — typically on resolveBareRoot ("not inside a git
+// repo") or another pre-flight check. The assertion is therefore
+// negative: the error must NOT contain the empty-prompt message. That
+// is sufficient evidence that the layer-1+2 guard let the call through,
+// which is the exact behaviour the issue #2012/#2073 fix promises.
 func TestRunSpawn_KeybindCarveOut_EmptyPromptAccepted(t *testing.T) {
 	cmd := buildSpawnCmdForEmptyPromptTest(t)
 	// No --prompt / --prompt-file flags set — promptText resolves to "".
 
 	t.Setenv("PRISM_HOST_API", "")
-	// PRISM_SPAWN_PATH is the keybind discriminator. Set it to a non-git
-	// temp dir so resolveBareRoot returns "not inside a git repo" without
-	// hitting the live tmux pane path (#1180 isolation pattern).
+	// PRISM_KEYBIND_SPAWN is the dedicated keybind discriminator (#2073).
+	t.Setenv("PRISM_KEYBIND_SPAWN", "1")
+	// PRISM_SPAWN_PATH is now purely a working-directory hint. Set it to a
+	// non-git temp dir so resolveBareRoot fails with "not inside a git repo"
+	// without falling back to tmux.CurrentPanePath() (which would resolve
+	// against the real test cwd — the nixos-config repo — and leak a
+	// timestamped worktree directory). The leak guard in killsidecar_test.go
+	// will fail loudly if this isolation breaks.
 	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
 	t.Setenv("PRISM_BARE_ROOT", "")
 	withNoopTmux(t)
@@ -78,30 +89,29 @@ func TestRunSpawn_KeybindCarveOut_EmptyPromptAccepted(t *testing.T) {
 		strings.Contains(err.Error(), "empty string — supply a non-empty prompt") ||
 		strings.Contains(err.Error(), "empty stdin — supply a non-empty prompt") ||
 		strings.Contains(err.Error(), "file is empty — supply a non-empty prompt") {
-		t.Errorf("runSpawn returned empty-prompt error despite PRISM_SPAWN_PATH being set: %v", err)
+		t.Errorf("runSpawn returned empty-prompt error despite PRISM_KEYBIND_SPAWN being set: %v", err)
 	}
 }
 
 // TestRunSpawn_NoKeybind_EmptyPromptStillRejected verifies that runSpawn
-// with PRISM_SPAWN_PATH unset (i.e. invoked from a normal shell) and no
-// prompt still returns the existing emptyPromptError shape. This guards
-// the existing layer-1+2 behaviour for the non-keybind path.
+// without PRISM_KEYBIND_SPAWN set (i.e. invoked from a normal shell) and
+// no prompt still returns the existing emptyPromptError shape. This
+// guards the existing layer-1+2 behaviour for the non-keybind path.
 func TestRunSpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	cmd := buildSpawnCmdForEmptyPromptTest(t)
 	// No --prompt flags set.
 
 	t.Setenv("PRISM_HOST_API", "")
-	// IMPORTANT: PRISM_SPAWN_PATH explicitly unset (not just empty in the
-	// caller's environment — t.Setenv guarantees the env var is "" for
-	// the duration of the test, which os.Getenv treats identically to
-	// unset for the fromKeybind check).
-	t.Setenv("PRISM_SPAWN_PATH", "")
+	// PRISM_KEYBIND_SPAWN unset — not a keybind invocation. Post-#2073
+	// the sentinel is dedicated, so no sandbox injects it; we do not
+	// need the `t.Setenv("PRISM_SPAWN_PATH", "")` defensive shim that
+	// the pre-#2073 tests carried.
 	t.Setenv("PRISM_BARE_ROOT", "")
 	withNoopTmux(t)
 
 	err := runSpawn(cmd, nil)
 	if err == nil {
-		t.Fatal("runSpawn with empty prompt and no PRISM_SPAWN_PATH: expected non-nil error, got nil")
+		t.Fatal("runSpawn with empty prompt and no PRISM_KEYBIND_SPAWN: expected non-nil error, got nil")
 	}
 	// The default branch of emptyPromptError fires when no prompt flag was
 	// set at all: "a prompt is required — supply --prompt <text>, --prompt -
@@ -111,16 +121,41 @@ func TestRunSpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	}
 }
 
-// TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded verifies the issue
-// #2063 parity gap: when proxySpawn is invoked with PRISM_HOST_API set,
-// PRISM_SPAWN_PATH set (the keybind discriminator), and no prompt, the
-// proxy must NOT return emptyPromptError before the round-trip. Instead
-// it must POST the request to the host API with from_keybind=true so the
-// host-side handler honours the carve-out.
-//
-// Without the fix from #2063, this test fails at the layer-1+2 guard in
-// proxySpawn ("a prompt is required") before the HTTP request is ever made,
-// which is exactly the tmux Prefix+a flash-close symptom.
+// TestRunSpawn_SandboxEnvAlone_DoesNotTriggerKeybindCarveOut verifies the
+// #2073 AC edge case: a container-style invocation with PRISM_SPAWN_PATH
+// set (every sandbox sets this unconditionally as a cwd hint) and
+// PRISM_KEYBIND_SPAWN UNSET must still hit the empty-prompt guard. The
+// dedicated sentinel cannot be tripped by the sandbox env-injection
+// surface that PRISM_SPAWN_PATH belongs to.
+func TestRunSpawn_SandboxEnvAlone_DoesNotTriggerKeybindCarveOut(t *testing.T) {
+	cmd := buildSpawnCmdForEmptyPromptTest(t)
+	// No --prompt flags set.
+
+	t.Setenv("PRISM_HOST_API", "")
+	// Simulate the bwrap/sandbox-exec state: PRISM_SPAWN_PATH set to the
+	// container's worktree path, but PRISM_KEYBIND_SPAWN unset.
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_KEYBIND_SPAWN", "")
+	t.Setenv("PRISM_BARE_ROOT", "")
+	withNoopTmux(t)
+
+	err := runSpawn(cmd, nil)
+	if err == nil {
+		t.Fatal("runSpawn returned nil; expected empty-prompt rejection")
+	}
+	if !strings.Contains(err.Error(), "a prompt is required") {
+		t.Errorf("error %q must be the empty-prompt rejection — PRISM_SPAWN_PATH alone must NOT trigger the keybind carve-out post-#2073",
+			err.Error())
+	}
+}
+
+// TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded verifies the parity
+// gap from #2063 carried forward by #2073: when proxySpawn is invoked
+// with PRISM_HOST_API set, PRISM_KEYBIND_SPAWN set (the keybind
+// discriminator), and no prompt, the proxy must NOT return
+// emptyPromptError before the round-trip. Instead it must POST the
+// request to the host API with from_keybind=true so the host-side
+// handler honours the carve-out.
 func TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded(t *testing.T) {
 	type spawnReq struct {
 		Branch      string `json:"branch"`
@@ -144,10 +179,8 @@ func TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded(t *testing.T) {
 	})
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
-	// PRISM_SPAWN_PATH is the keybind discriminator. With it set and no
-	// --prompt, the proxy must forward from_keybind=true rather than
-	// rejecting at the layer-1+2 guard.
-	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	// PRISM_KEYBIND_SPAWN is the dedicated keybind discriminator (#2073).
+	t.Setenv("PRISM_KEYBIND_SPAWN", "1")
 
 	cmd := buildSpawnCmdForEmptyPromptTest(t)
 	// No --prompt set; no --branch set — mirrors the tmux Prefix+a invocation.
@@ -158,7 +191,7 @@ func TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded(t *testing.T) {
 		// successful HTTP round-trip is what the AC requires.
 		if strings.Contains(err.Error(), "a prompt is required") ||
 			strings.Contains(err.Error(), "empty string — supply a non-empty prompt") {
-			t.Fatalf("proxySpawn returned empty-prompt error despite PRISM_SPAWN_PATH set: %v", err)
+			t.Fatalf("proxySpawn returned empty-prompt error despite PRISM_KEYBIND_SPAWN set: %v", err)
 		}
 		t.Fatalf("proxySpawn: %v", err)
 	}
@@ -176,11 +209,11 @@ func TestProxySpawn_KeybindCarveOut_EmptyPromptForwarded(t *testing.T) {
 	}
 }
 
-// TestProxySpawn_NoKeybind_EmptyPromptStillRejected verifies the security AC:
-// when PRISM_HOST_API is set but PRISM_SPAWN_PATH is NOT set, an empty prompt
-// must still be rejected at the proxy boundary (layer 1+2) — the carve-out
-// fires only on the keybind discriminator. The host-API request must never
-// be made.
+// TestProxySpawn_NoKeybind_EmptyPromptStillRejected verifies the security
+// AC: when PRISM_HOST_API is set but PRISM_KEYBIND_SPAWN is NOT set, an
+// empty prompt must still be rejected at the proxy boundary (layer 1+2)
+// — the carve-out fires only on the keybind sentinel. The host-API
+// request must never be made.
 func TestProxySpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	reqCh := make(chan struct{}, 1)
 
@@ -191,8 +224,7 @@ func TestProxySpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	})
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
-	// PRISM_SPAWN_PATH explicitly unset — not a keybind invocation.
-	t.Setenv("PRISM_SPAWN_PATH", "")
+	// PRISM_KEYBIND_SPAWN unset — not a keybind invocation.
 
 	cmd := buildSpawnCmdForEmptyPromptTest(t)
 	// No --prompt set.
@@ -213,24 +245,19 @@ func TestProxySpawn_NoKeybind_EmptyPromptStillRejected(t *testing.T) {
 	}
 }
 
-// TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind verifies
-// the missed-context regression flagged on the first review round of #2063:
-// PRISM_SPAWN_PATH is set UNCONDITIONALLY inside every bwrap / sandbox-exec
-// sandbox (internal/container/bwrap.go:496-503, documented in
-// internal/sandboxenv/sandboxenv.go as a working-directory hint, not a
-// sandbox sentinel). If the proxy treated `PRISM_SPAWN_PATH != ""` as the
-// sole keybind discriminator, every ordinary container worker-spawn flow
-// (… e.g. a coordinator calling `prism spawn --prompt "X"` from inside its
-// container) would forward `from_keybind: true`, and the host-API handler
-// would then set PRISM_SPAWN_PATH on the host-side prism spawn child —
-// flipping its `headless := !fromKeybind && !attachFlag` from true to
-// false and causing it to call session.Attach against whatever tmux
-// client the sidecar inherited.
+// TestProxySpawn_ContainerSandboxEnv_DoesNotSetFromKeybind verifies the
+// #2073 AC edge case at the proxy layer: a container worker-spawn (where
+// PRISM_SPAWN_PATH is set unconditionally by the sandbox but
+// PRISM_KEYBIND_SPAWN is NOT set) MUST NOT forward from_keybind=true,
+// even when the spawn happens to carry no --prompt (the proxy no longer
+// narrows on `promptFlag == ""` — the dedicated sentinel makes that
+// narrowing unnecessary).
 //
-// The narrowing fix gates the carve-out on `PRISM_SPAWN_PATH != "" &&
-// promptFlag == ""`. This test pins that down: a container spawn with a
-// supplied prompt must NOT carry `from_keybind: true`.
-func TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind(t *testing.T) {
+// This case wraps an unusual but legitimate flow: a container caller
+// proxy-spawning with an explicit empty prompt should hit the
+// empty-prompt rejection at the host, not be misclassified as a keybind
+// spawn.
+func TestProxySpawn_ContainerSandboxEnv_DoesNotSetFromKeybind(t *testing.T) {
 	type spawnReq struct {
 		Prompt      string `json:"prompt"`
 		FromKeybind bool   `json:"from_keybind"`
@@ -249,8 +276,9 @@ func TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind(t *testing.T)
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 	// Simulate the bwrap-sandbox state: PRISM_SPAWN_PATH set to the
-	// container's worktree path even though this is NOT a keybind spawn.
+	// container's worktree path, PRISM_KEYBIND_SPAWN unset.
 	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_KEYBIND_SPAWN", "")
 
 	cmd := buildSpawnCmdForEmptyPromptTest(t)
 	_ = cmd.Flags().Set("prompt", "explicit prompt from container worker")
@@ -266,7 +294,7 @@ func TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind(t *testing.T)
 				req.Prompt, "explicit prompt from container worker")
 		}
 		if req.FromKeybind {
-			t.Errorf("from_keybind = true; want false — a container spawn with a supplied prompt must NOT trigger the keybind carve-out (would flip the host-side child's headless flag and side-effect session.Attach)")
+			t.Errorf("from_keybind = true; want false — a container spawn (PRISM_SPAWN_PATH set, PRISM_KEYBIND_SPAWN unset) must NOT trigger the keybind carve-out post-#2073")
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for /spawn request")
@@ -274,10 +302,11 @@ func TestProxySpawn_ContainerSpawnWithPrompt_DoesNotSetFromKeybind(t *testing.T)
 }
 
 // TestRunSpawn_KeybindCarveOut_DoesNotSwallowSuppliedPrompt verifies the
-// AC edge-case: when PRISM_SPAWN_PATH is set AND a non-empty --prompt is
-// also supplied, the carve-out does not swallow the prompt. We assert this
-// by checking the error is NOT an empty-prompt error (proving the guard
-// is bypassed cleanly without erasing the prompt the caller supplied).
+// AC edge-case: when PRISM_KEYBIND_SPAWN is set AND a non-empty --prompt
+// is also supplied, the carve-out does not swallow the prompt. We assert
+// this by checking the error is NOT an empty-prompt error (proving the
+// guard is bypassed cleanly without erasing the prompt the caller
+// supplied).
 //
 // The downstream failure here is the same as the empty-prompt-accepted
 // test: "not inside a git repo" from resolveBareRoot. We only care that
@@ -287,6 +316,11 @@ func TestRunSpawn_KeybindCarveOut_DoesNotSwallowSuppliedPrompt(t *testing.T) {
 	_ = cmd.Flags().Set("prompt", "hello from the keybind path")
 
 	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("PRISM_KEYBIND_SPAWN", "1")
+	// PRISM_SPAWN_PATH is now purely a working-directory hint. Set it to a
+	// non-git temp dir so resolveBareRoot fails with "not inside a git repo"
+	// rather than falling back to the real test cwd. See the equivalent
+	// comment in TestRunSpawn_KeybindCarveOut_EmptyPromptAccepted.
 	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
 	t.Setenv("PRISM_BARE_ROOT", "")
 	withNoopTmux(t)

--- a/modules/programs/prism/prism/internal/sandboxenv/sandboxenv.go
+++ b/modules/programs/prism/prism/internal/sandboxenv/sandboxenv.go
@@ -11,8 +11,10 @@
 //   - PRISM_HOST_API is set exclusively by the prism sidecar when launching a
 //     sandboxed session (bwrap, sandbox-exec, or podman container).
 //   - PRISM_SPAWN_PATH is also set in sandboxed sessions but serves as a
-//     working-directory hint, not a sandbox sentinel — using it would be a
-//     semantic stretch.
+//     working-directory hint only — it is NOT a sandbox sentinel and NOT a
+//     keybind discriminator. The dedicated tmux-keybind sentinel is
+//     PRISM_KEYBIND_SPAWN (introduced in #2073 to retire the old overload),
+//     which the sidecar never injects into a sandboxed session.
 //
 // Future callers that need to know "am I sandboxed?" should use
 // IsInsideSandbox() rather than repeating the inline os.Getenv check.

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -227,12 +227,14 @@ type SpawnOpts struct {
 	ReadinessTimeout time.Duration
 
 	// AllowEmptyPrompt opts the caller out of the layer-4 empty-prompt guard
-	// for LayoutFull / LayoutAgentOnly (issue #2012). The tmux Prefix+a
-	// keybind invokes `prism spawn --attach` with no --prompt so the operator
-	// can type the initial prompt to the live agent after the popup attaches;
-	// `cmd/spawn.go` sets this field when `PRISM_SPAWN_PATH` is present and
-	// no prompt was supplied. All other callers should leave this false so
-	// the original "agent pane needs a prompt" guard (#1891) keeps firing.
+	// for LayoutFull / LayoutAgentOnly (issues #2012, #2073). The tmux
+	// Prefix+a keybind invokes `prism spawn --attach` with no --prompt so
+	// the operator can type the initial prompt to the live agent after the
+	// popup attaches; `cmd/spawn.go` sets this field when
+	// `PRISM_KEYBIND_SPAWN` is present (the dedicated keybind sentinel
+	// introduced in #2073 to replace the overloaded PRISM_SPAWN_PATH). All
+	// other callers should leave this false so the original "agent pane
+	// needs a prompt" guard (#1891) keeps firing.
 	AllowEmptyPrompt bool
 
 	// PIExtensionDir is the host-side absolute path to the directory that

--- a/modules/programs/prism/prism/internal/session/spawn_allow_empty_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_allow_empty_prompt_test.go
@@ -7,7 +7,8 @@ package session
 // initial prompt because the operator types it to the live agent after
 // the popup attaches. The new opts.AllowEmptyPrompt field opts the
 // caller out of the layer-4 guard; cmd/spawn.go sets it when
-// PRISM_SPAWN_PATH is present and no prompt was supplied.
+// PRISM_KEYBIND_SPAWN is present (the dedicated keybind sentinel
+// introduced in #2073 to replace the overloaded PRISM_SPAWN_PATH).
 //
 // These tests are package-internal (`package session`, not session_test)
 // so they can use spyTmuxBin / openSpawnTestDB from spawn_test.go — the

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -59,8 +59,9 @@ func contextErrStatus(ctx context.Context) (int, bool) {
 
 // filterEnv returns a copy of env with any entry whose key matches name
 // removed. Used to control specific environment variables passed to a child
-// process (e.g. unsetting PRISM_SPAWN_PATH so the child does not inherit the
-// sidecar process's own value — see the /spawn handler and issue #2063).
+// process (e.g. unsetting PRISM_SPAWN_PATH / PRISM_KEYBIND_SPAWN so the
+// child does not inherit the sidecar process's own value — see the
+// /spawn handler and issues #2063, #2073).
 func filterEnv(env []string, name string) []string {
 	prefix := name + "="
 	out := env[:0:0]
@@ -1052,8 +1053,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// an arbitrary HTTP caller. When true, an empty prompt is
 			// permitted — the operator types the initial prompt to the live
 			// agent after the popup attaches. The proxySpawn CLI path sets
-			// this when PRISM_SPAWN_PATH is set in its own environment. See
-			// issues #2012 (host-side carve-out) and #2063 (proxy parity).
+			// this when PRISM_KEYBIND_SPAWN is set in its own environment
+			// (the dedicated keybind sentinel introduced in #2073 to replace
+			// the overloaded PRISM_SPAWN_PATH). See issues #2012 (host-side
+			// carve-out), #2063 (proxy parity), and #2073 (sentinel decoupling).
 			FromKeybind bool `json:"from_keybind"`
 		}
 		// /spawn body cap: default 1 MiB (issue #1848). DisallowUnknownFields
@@ -1256,47 +1259,59 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
 		defer cancel()
 		cmd := exec.CommandContext(ctx, prismBinary(), args...)
-		// Issue #2063: when the request was initiated by the tmux Prefix+a
-		// keybind AND no prompt was supplied, propagate the discriminator to
-		// the host-side prism spawn via PRISM_SPAWN_PATH. The host-side
-		// runSpawn already reads that env var to recognise a keybind spawn
-		// (`fromKeybind`) and skip the empty-prompt guard — reusing it here
-		// keeps a single discriminator across both code paths instead of
-		// inventing a parallel CLI flag.
+		// Issues #2063, #2073: when the request was initiated by the tmux
+		// Prefix+a keybind, propagate the keybind discriminator to the
+		// host-side `prism spawn` child so runSpawn's own carve-out fires and
+		// the empty-prompt guard is skipped.
 		//
-		// Narrow the propagation to `req.Prompt == ""` to match the proxy
-		// side. fromKeybind on the host also flips runSpawn's
+		// Two env vars are involved, with two separate jobs:
+		//
+		//   - PRISM_KEYBIND_SPAWN=1 — the dedicated keybind sentinel
+		//     introduced in #2073. This is the SOLE discriminator runSpawn
+		//     uses. No sandbox injects this var, so propagating it on
+		//     from_keybind cannot leak into ordinary container worker-spawn
+		//     flows.
+		//   - PRISM_SPAWN_PATH — a working-directory hint (see
+		//     internal/sandboxenv/sandboxenv.go). Propagated here so the
+		//     host-side child has a real path to resolve the bare repo from
+		//     when it falls back through `resolveBareRoot`. NOT a
+		//     discriminator post-#2073.
+		//
+		// IMPORTANT: control both env values explicitly in BOTH branches.
+		// Without an explicit unset, the child inherits the sidecar process's
+		// own values — which can happen if this sidecar itself was launched
+		// from a shell with those vars already set (e.g. a developer running
+		// prism manually for testing). Always overwriting both (either to
+		// the keybind values or to empty) makes the child's view a pure
+		// function of the request, independent of the sidecar's launch
+		// environment.
+		//
+		// Prefer the sidecar's own worktree path when populated so any
+		// downstream consumer that resolves the path lands on a real
+		// directory; fall back to a sentinel marker if it is unset (defence
+		// in depth — production sidecars always have Worktree populated).
+		//
+		// Narrow propagation to `req.Prompt == ""`. fromKeybind on the
+		// host-side child also flips runSpawn's
 		// `headless := !fromKeybind && !attachFlag` from true to false, which
 		// for a NON-empty-prompt invocation would make the child call
-		// session.Attach against whatever tmux client this sidecar inherited
-		// — a behavioural change the empty-prompt carve-out does not need.
-		// Restricting to the empty-prompt case keeps the supplied-prompt path
-		// byte-identical to the pre-PR behaviour.
-		//
-		// IMPORTANT: control the env value explicitly in BOTH branches.
-		// Without an explicit unset, the child inherits the sidecar process's
-		// own PRISM_SPAWN_PATH — which can happen if this sidecar itself was
-		// launched from a shell with PRISM_SPAWN_PATH already set (e.g. a
-		// developer running prism manually for testing). Always overwriting
-		// PRISM_SPAWN_PATH (either to the keybind value or to empty) makes the
-		// child's view of the discriminator a pure function of the request,
-		// independent of the sidecar's launch environment.
-		//
-		// runSpawn only checks `os.Getenv("PRISM_SPAWN_PATH") != ""`, so any
-		// non-empty value enables the carve-out. Prefer the sidecar's own
-		// worktree path when populated so any downstream consumer that
-		// resolves the path lands on a real directory; fall back to a
-		// sentinel marker if it is unset (defence in depth — production
-		// sidecars always have Worktree populated).
+		// session.Attach against whatever tmux client this sidecar inherited.
+		// Restricting propagation to the empty-prompt case keeps the
+		// supplied-prompt path byte-identical to the pre-PR behaviour even
+		// if a malformed client posts from_keybind:true alongside a
+		// non-empty prompt.
 		spawnPathEnv := "PRISM_SPAWN_PATH="
+		keybindEnv := "PRISM_KEYBIND_SPAWN="
 		if req.FromKeybind && req.Prompt == "" {
 			spawnPath := s.cfg.Worktree
 			if spawnPath == "" {
 				spawnPath = "keybind"
 			}
 			spawnPathEnv = "PRISM_SPAWN_PATH=" + spawnPath
+			keybindEnv = "PRISM_KEYBIND_SPAWN=1"
 		}
-		cmd.Env = append(filterEnv(os.Environ(), "PRISM_SPAWN_PATH"), spawnPathEnv)
+		cleanedEnv := filterEnv(filterEnv(os.Environ(), "PRISM_SPAWN_PATH"), "PRISM_KEYBIND_SPAWN")
+		cmd.Env = append(cleanedEnv, spawnPathEnv, keybindEnv)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			if status, ok := contextErrStatus(ctx); ok {

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5572,26 +5572,31 @@ func TestHostAPI_Spawn_EmptyPromptReturns400(t *testing.T) {
 	}
 }
 
-// TestHostAPI_Spawn_FromKeybind_EmptyPromptAccepted verifies the issue
-// #2063 carve-out: when the request carries {"from_keybind":true}, an
-// empty prompt must NOT be rejected at layer 3 — the proxy has signalled
-// that this is a tmux Prefix+a invocation and the operator will type the
-// initial prompt to the live agent after the popup attaches.
+// TestHostAPI_Spawn_FromKeybind_EmptyPromptAccepted verifies the
+// #2063/#2073 carve-out: when the request carries
+// {"from_keybind":true}, an empty prompt must NOT be rejected at layer
+// 3 — the proxy has signalled that this is a tmux Prefix+a invocation
+// and the operator will type the initial prompt to the live agent
+// after the popup attaches.
 //
-// The stub records its env so we can assert that PRISM_SPAWN_PATH is
-// propagated to the host-side prism spawn child. That env var is the
-// discriminator runSpawn uses for its own carve-out — if the sidecar
-// failed to set it, the host-side child would still reject the empty
-// prompt and the popup would flash-close.
+// The stub records its env so we can assert that both PRISM_KEYBIND_SPAWN
+// (the dedicated discriminator post-#2073) AND PRISM_SPAWN_PATH (the
+// cwd hint) are propagated to the host-side prism spawn child. The
+// sentinel is what runSpawn checks for its own carve-out — if the
+// sidecar failed to set it, the host-side child would still reject the
+// empty prompt and the popup would flash-close.
 func TestHostAPI_Spawn_FromKeybind_EmptyPromptAccepted(t *testing.T) {
 	d := openTestDB(t)
 
 	envFile := filepath.Join(t.TempDir(), "captured-env")
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
-	// The stub writes its PRISM_SPAWN_PATH env to a file then prints the
-	// canonical session-created line so the handler's parse succeeds.
+	// The stub writes both env vars to a file then prints the canonical
+	// session-created line so the handler's parse succeeds.
 	stubScript := `#!/bin/sh
-echo "PRISM_SPAWN_PATH=${PRISM_SPAWN_PATH}" > ` + envFile + `
+{
+  echo "PRISM_SPAWN_PATH=${PRISM_SPAWN_PATH}"
+  echo "PRISM_KEYBIND_SPAWN=${PRISM_KEYBIND_SPAWN}"
+} > ` + envFile + `
 echo "session \"test-repo@keybind-branch\" created"
 `
 	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
@@ -5619,43 +5624,49 @@ echo "session \"test-repo@keybind-branch\" created"
 			rr.Code, rr.Body.String())
 	}
 
-	// Verify PRISM_SPAWN_PATH was propagated to the host-side child with the
-	// sidecar's own worktree path — not whatever the sidecar process
-	// happened to inherit at launch. The handler explicitly filters and
-	// overwrites PRISM_SPAWN_PATH so the child's view is a pure function of
-	// the request, independent of the sidecar's environment.
+	// Verify both env vars were propagated to the host-side child:
+	//   - PRISM_KEYBIND_SPAWN=1 — the dedicated discriminator runSpawn checks.
+	//   - PRISM_SPAWN_PATH=<sidecar.Worktree> — the cwd hint, set to the
+	//     sidecar's own worktree path so any downstream consumer that
+	//     resolves the path lands on a real directory (not whatever the
+	//     sidecar process happened to inherit at launch).
 	capturedEnv, err := os.ReadFile(envFile)
 	if err != nil {
 		t.Fatalf("read captured env: %v", err)
 	}
-	envLine := strings.TrimSpace(string(capturedEnv))
-	wantLine := "PRISM_SPAWN_PATH=" + cfg.Worktree
-	if envLine != wantLine {
-		t.Errorf("captured env %q, want %q (host-side child must see the sidecar's worktree, not whatever PRISM_SPAWN_PATH this sidecar process inherited)",
-			envLine, wantLine)
+	got := strings.TrimSpace(string(capturedEnv))
+	want := "PRISM_SPAWN_PATH=" + cfg.Worktree + "\nPRISM_KEYBIND_SPAWN=1"
+	if got != want {
+		t.Errorf("captured env %q, want %q (host-side child must see both the keybind sentinel and the sidecar's worktree path, not whatever this sidecar process inherited)",
+			got, want)
 	}
 }
 
 // TestHostAPI_Spawn_FromKeybind_NonEmptyPrompt_DoesNotSetEnv verifies the
-// narrowing fix surfaced by review-context on the first review round: when
-// from_keybind:true arrives alongside a NON-empty prompt, the sidecar must
-// NOT set PRISM_SPAWN_PATH on the host-side prism spawn child. Doing so
-// would flip the child's `headless := !fromKeybind && !attachFlag` from
-// true to false and cause it to call session.Attach against whatever tmux
-// client the sidecar inherited — a behavioural change for ordinary
-// container worker-spawn flows that the empty-prompt carve-out does not
-// need to enable.
+// narrowing fix surfaced by review-context on the first review round of
+// #2063, preserved post-#2073: when from_keybind:true arrives alongside
+// a NON-empty prompt, the sidecar must NOT set PRISM_KEYBIND_SPAWN (or
+// PRISM_SPAWN_PATH) on the host-side prism spawn child. Setting the
+// keybind sentinel would flip the child's
+// `headless := !fromKeybind && !attachFlag` from true to false and
+// cause it to call session.Attach against whatever tmux client the
+// sidecar inherited — a behavioural change for ordinary worker-spawn
+// flows that the empty-prompt carve-out does not need to enable.
 //
-// In practice the narrowed proxy will not send from_keybind:true alongside
-// a non-empty prompt, but the layer-3 handler's behaviour must be safe
-// even if a malformed client does.
+// In practice the proxy will only ever send from_keybind:true alongside
+// an empty prompt (the keybind path has no --prompt), but the layer-3
+// handler's behaviour must be safe even if a malformed client posts
+// from_keybind:true with a non-empty prompt.
 func TestHostAPI_Spawn_FromKeybind_NonEmptyPrompt_DoesNotSetEnv(t *testing.T) {
 	d := openTestDB(t)
 
 	envFile := filepath.Join(t.TempDir(), "captured-env")
 	stubPath := filepath.Join(t.TempDir(), "prism-stub")
 	stubScript := `#!/bin/sh
-echo "PRISM_SPAWN_PATH=${PRISM_SPAWN_PATH}" > ` + envFile + `
+{
+  echo "PRISM_SPAWN_PATH=${PRISM_SPAWN_PATH}"
+  echo "PRISM_KEYBIND_SPAWN=${PRISM_KEYBIND_SPAWN}"
+} > ` + envFile + `
 echo "session \"test-repo@some-branch\" created"
 `
 	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
@@ -5685,14 +5696,15 @@ echo "session \"test-repo@some-branch\" created"
 	if err != nil {
 		t.Fatalf("read captured env: %v", err)
 	}
-	envLine := strings.TrimSpace(string(capturedEnv))
-	// The harness MUST NOT have inherited PRISM_SPAWN_PATH from this sidecar.
-	// The stub captures `PRISM_SPAWN_PATH=<value>`; for a clean child the
-	// value half is empty. We accept either "PRISM_SPAWN_PATH=" or no line at
-	// all in case the stub never wrote the file for any reason.
-	if envLine != "PRISM_SPAWN_PATH=" && envLine != "" {
-		t.Errorf("captured env %q: PRISM_SPAWN_PATH must NOT be set on the child when from_keybind:true arrives with a non-empty prompt (would flip headless and side-effect session.Attach)",
-			envLine)
+	got := strings.TrimSpace(string(capturedEnv))
+	// Both env vars must be cleared on the child when from_keybind:true
+	// arrives with a non-empty prompt. The stub captures
+	// `<KEY>=<value>`; for a clean child the value half is empty on
+	// both lines.
+	want := "PRISM_SPAWN_PATH=\nPRISM_KEYBIND_SPAWN="
+	if got != want {
+		t.Errorf("captured env %q, want %q: neither PRISM_SPAWN_PATH nor PRISM_KEYBIND_SPAWN may be set on the child when from_keybind:true arrives with a non-empty prompt (setting PRISM_KEYBIND_SPAWN would flip headless and side-effect session.Attach)",
+			got, want)
 	}
 }
 

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -264,22 +264,27 @@ in
               #
               # Wrapped in run-shell so we can resolve #{pane_current_path}
               # via `tmux display-message -p` at trigger time and substitute
-              # the resolved string into both `-d` and `-e`. On tmux 3.6a,
+              # the resolved string into `-d`. On tmux 3.6a,
               # `display-popup -e VAR=#{format}` does NOT run the value
-              # through tmux format-expansion — PRISM_SPAWN_PATH arrives
-              # inside the popup as the literal string "#{pane_current_path}",
-              # which causes prism spawn to misroute and flash-close the
-              # popup with an unreadable error (issue #2072). Doing the
-              # substitution in the shell sidesteps the bug entirely.
+              # through tmux format-expansion — a format like
+              # `#{pane_current_path}` arrives inside the popup as the
+              # literal string, not the resolved path (issue #2072). The
+              # run-shell pattern resolves the path in the shell and feeds
+              # it to `-d` directly, sidestepping the bug entirely. The
+              # popup's cwd is enough context for `prism spawn` — its
+              # `resolveBareRoot` falls back to `tmux.CurrentPanePath()`
+              # for the bare-repo lookup, no env transport needed.
               #
-              # PRISM_SPAWN_PATH is set explicitly so the spawn command can
-              # discriminate keybind-initiated spawns from shell/agent
-              # callers. The empty-prompt guard (issue #1891) is relaxed for
-              # the keybind path — the operator types the initial prompt to
-              # the live agent after the popup attaches, so requiring
-              # --prompt at invocation time would flash-close the popup with
-              # an unreadable error (issue #2012).
-              bind a run-shell 'path=$(${pkgs.tmux}/bin/tmux display-message -p "#{pane_current_path}"); ${pkgs.tmux}/bin/tmux display-popup -E -d "$path" -w 60% -h 20% -b single -e "PRISM_SPAWN_PATH=$path" "${prism} spawn --attach"'
+              # PRISM_KEYBIND_SPAWN=1 is the dedicated keybind discriminator
+              # (issue #2073). The empty-prompt guard (issue #1891) is
+              # relaxed for the keybind path — the operator types the
+              # initial prompt to the live agent after the popup attaches,
+              # so requiring --prompt at invocation time would flash-close
+              # the popup with an unreadable error (issue #2012). Using a
+              # dedicated sentinel (rather than reusing PRISM_SPAWN_PATH)
+              # ensures sandbox-injected env vars cannot accidentally trip
+              # the carve-out from inside a container.
+              bind a run-shell 'path=$(${pkgs.tmux}/bin/tmux display-message -p "#{pane_current_path}"); ${pkgs.tmux}/bin/tmux display-popup -E -d "$path" -w 60% -h 20% -b single -e "PRISM_KEYBIND_SPAWN=1" "${prism} spawn --attach"'
 
               # agent scrolling keybinds — active when the pane is a prism agent
               # running under either supported isolation mode (podman or bwrap),


### PR DESCRIPTION
Closes #2073.

## Summary

Introduces a dedicated `PRISM_KEYBIND_SPAWN=1` sentinel for the tmux Prefix+a keybind, replacing the overload of `PRISM_SPAWN_PATH` that previously did double-duty as both a working-directory hint AND the keybind discriminator.

The conflation was fragile: every sandbox sets `PRISM_SPAWN_PATH` unconditionally as a cwd hint (`internal/container/bwrap.go`, `cmd/agent_run_sandbox_exec_darwin.go`), which forced the proxy-side carve-out in #2063 to be narrowed to `PRISM_SPAWN_PATH != "" && promptFlag == ""` to avoid misclassifying ordinary container worker-spawn flows as keybind spawns. With a dedicated sentinel that no sandbox injects, the narrowing is no longer needed and the discriminator becomes a single env-var check on both the host and proxy paths.

## Code changes

| File | Change |
|---|---|
| `modules/programs/prism/tmux.nix` | Prefix+a bind sets `-e PRISM_KEYBIND_SPAWN=1` (dropped `-e PRISM_SPAWN_PATH`). Keeps the #2074 `run-shell` pattern. |
| `cmd/spawn.go` | `runSpawn` and `proxySpawn` discriminator is now `os.Getenv("PRISM_KEYBIND_SPAWN") != ""`. Removed the `&& promptFlag == ""` narrowing in `proxySpawn`. History comment block rewritten. |
| `internal/sidecar/host_api.go` | `/spawn` handler propagates BOTH `PRISM_KEYBIND_SPAWN=1` (discriminator) AND `PRISM_SPAWN_PATH=<sidecar.Worktree>` (cwd hint) when `from_keybind=true && req.Prompt == ""`. The narrowing on `req.Prompt == ""` is preserved here to keep the headless-safety guarantee from #2063 review-context. |
| `internal/sandboxenv/sandboxenv.go` | Doc explicitly states `PRISM_SPAWN_PATH` is a working-directory hint only; points to `PRISM_KEYBIND_SPAWN` as the keybind sentinel. |
| `internal/session/spawn.go` | `AllowEmptyPrompt` doc updated to reference `PRISM_KEYBIND_SPAWN`. |

## Test changes

- `cmd/spawn_empty_prompt_test.go`: all assertions updated to the new sentinel. New `TestRunSpawn_SandboxEnvAlone_DoesNotTriggerKeybindCarveOut` pins the AC edge-case: `PRISM_SPAWN_PATH` set, `PRISM_KEYBIND_SPAWN` unset, empty prompt → still rejected.
- `internal/sidecar/sidecar_test.go`: `TestHostAPI_Spawn_FromKeybind_EmptyPromptAccepted` now asserts the child sees both env vars; `TestHostAPI_Spawn_FromKeybind_NonEmptyPrompt_DoesNotSetEnv` asserts both are cleared on the non-empty-prompt malformed-client path; `TestHostAPI_Spawn_NoFromKeybind_EmptyPromptStillRejected` unchanged (it never set env vars).
- `cmd/hostapi_test.go`: defensive `t.Setenv("PRISM_SPAWN_PATH", "")` shims removed in the three empty-prompt-rejection tests (no longer required post-#2073).

## Verification

- `go build ./...` ✅
- `go test ./...` ✅
- `nix build .#prism` ✅
- `nix build .#prism.override { runChecks = true; }` (homeless-shelter gate) ✅

## ACs

All ACs from #2073 are addressed:

- [x] tmux bind updated to set `PRISM_KEYBIND_SPAWN=1`
- [x] `runSpawn` uses `PRISM_KEYBIND_SPAWN` as sole discriminator
- [x] `proxySpawn` uses `PRISM_KEYBIND_SPAWN` as sole discriminator; `&& promptFlag == ""` narrowing removed
- [x] `/spawn` handler propagates `PRISM_KEYBIND_SPAWN=1` alongside `PRISM_SPAWN_PATH`
- [x] Container-style invocation (`PRISM_SPAWN_PATH` set, `PRISM_KEYBIND_SPAWN` unset, empty prompt) does NOT trigger the carve-out (new test)
- [x] Empty-prompt rejection still fires on host, proxy, and `/spawn` HTTP paths without the sentinel
- [x] HTTP `/spawn` still rejects empty-prompt requests when `from_keybind=false`
- [x] Defensive `PRISM_SPAWN_PATH=""` shims removed from tests
- [x] `go build ./...` / `go test ./...` pass
- [x] `nix build .#prism` passes
- [x] Homeless-shelter gate (`nix-build-prism-checked`) passes locally; CI will re-run