### PR TITLE
qutebrowser: spoof Chrome UA on farmers.co.nz

### DIFF
--- a/modules/programs/qutebrowser/default.nix
+++ b/modules/programs/qutebrowser/default.nix
@@ -304,6 +304,9 @@
                 config.set("content.geolocation", True, "https://www.metlink.org.nz")
                 config.set("content.geolocation", True, "https://www.newworld.co.nz")
                 config.set("content.geolocation", True, "https://www.pbtech.co.nz")
+                # farmers.co.nz rejects qutebrowser's default UA and serves a "temporarily down"
+                # error page; spoof a recent Chrome desktop UA on that origin only.
+                config.set("content.headers.user_agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36", "https://www.farmers.co.nz/*")
                 # tab padding
                 c.tabs.padding = {
                     "bottom": 5,


### PR DESCRIPTION
## Symptom

farmers.co.nz consistently shows a "temporarily down" error page when loaded in qutebrowser. The site is fine in other browsers — its origin detects qutebrowser's default `User-Agent` (which contains the string `QtWebEngine`) and rejects the request.

## Fix

Add a per-URL `content.headers.user_agent` override scoped to `https://www.farmers.co.nz/*` that presents a recent Chrome-on-Linux UA. The override sits alongside the existing per-URL `config.set` overrides (geolocation block) for consistency.

```python
config.set("content.headers.user_agent",
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
           "https://www.farmers.co.nz/*")
```

Only the farmers.co.nz origin is affected — all other sites continue to use qutebrowser's default UA.

## Verification

- `nixfmt .` clean.
- `nix eval .#nixosConfigurations.navi.config.system.build.toplevel.drvPath` evaluates successfully (qutebrowser module evaluates as part of the host config).
- `nix build .#prism` succeeds (unaffected, as expected).