### PR TITLE
Add --force-cleanup to homebrew configuration

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -147,6 +147,9 @@ in
       autoUpdate = true;
       cleanup = "uninstall";
       upgrade = true;
+      extraFlags = [
+        "--force-cleanup"
+      ];
     };
     brews = [
       "node"


### PR DESCRIPTION
This change updates the homebrew configuration on m4mac to include the --force-cleanup flag. Enabling this option ensures that outdated versions are removed effectively during the automatic upgrade process.