### PR TITLE
agents: clarify user identity is prismatic-koi

### DIFF
--- a/modules/programs/prism/agents/global-instructions.md
+++ b/modules/programs/prism/agents/global-instructions.md
@@ -1,5 +1,13 @@
 # Global Agent Instructions
 
+## Identity
+
+Ben Sherman is the user. When an agent is operating in his environment:
+
+- His GitHub handle is **prismatic-koi** — that is the account agents commit and push as, and the only Ben in any of his orgs that should be tagged, requested as a reviewer, or otherwise referenced.
+- Do NOT pick a "Ben" by name-matching against org membership — handles like `b-h-mck`, `ben-*`, etc. are other people and must not be substituted in.
+- Whenever an instruction or notification says "request review from Ben", "tag Ben", or similar, that always means **prismatic-koi**.
+
 ## Skills
 
 When working in environments with domain-specific skills available (via the `skill` tool), err on the side of loading them. If a conversation touches a domain that has a skill, load it – even if you think you know the conventions from other context sources.


### PR DESCRIPTION
Add a short `## Identity` section to `modules/programs/prism/agents/global-instructions.md` clarifying who the user is when an agent is operating in Ben's environment.

## Motivation

An agent recently picked a random Ben-named org member as a PR reviewer by name-matching against org membership. This makes the user's identity (and the correct GitHub handle, `prismatic-koi`) explicit so agents stop substituting in other Ben-named accounts.

## Changes

- New `## Identity` section placed after the intro, before `## Skills`.
- Three bullets: the canonical handle is `prismatic-koi`; no name-matching against handles like `b-h-mck` or `ben-*`; "tag Ben" / "request review from Ben" always means `prismatic-koi`.

Docs-only change \u2014 no Nix or Go touched.