### PR TITLE
bitwarden-desktop: pin electron_39-bin + allow EOL electron

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,12 @@
           pkgs = import nixpkgs {
             inherit system;
             config = lib.mkMerge [
-              { allowUnfree = true; }
+              {
+                allowUnfree = true;
+                # See overlays/default.nix (bitwarden-desktop block) for
+                # context + removal condition.
+                permittedInsecurePackages = [ "electron-39.8.10" ];
+              }
               extraConfig
             ];
             overlays = [ self.overlays.modifications ];

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -84,6 +84,29 @@ rec {
       # remains our most-vetted package source.
       # See: https://github.com/prismatic-koi/nixos-config/issues/1894
       bitwarden-cli = stablePkgs.bitwarden-cli;
+
+      # bitwarden-desktop: swap the source-built `electron_39` for the
+      # prebuilt `electron_39-bin` so we don't compile EOL electron from
+      # source. Electron 39 is past end-of-life and has been marked
+      # insecure in nixpkgs; the matching `permittedInsecurePackages =
+      # [ "electron-39.8.10" ];` entry lives in `flake.nix`'s base
+      # config block (module-level `nixpkgs.config` is bypassed because
+      # we pass a pre-built `pkgs` into `nixosSystem`).
+      #
+      # nixpkgs tracking issue (Electron 39 EOL, most dependents bumped):
+      #   https://github.com/NixOS/nixpkgs/issues/521305
+      # nixpkgs issue for bitwarden-desktop specifically:
+      #   https://github.com/NixOS/nixpkgs/issues/526914
+      # Upstream electron bump PR (open, not yet merged):
+      #   https://github.com/bitwarden/clients/pull/20448
+      #
+      # REMOVAL CONDITION: delete this block (and the matching
+      # `permittedInsecurePackages` entry in `flake.nix`) once
+      # bitwarden/clients#20448 lands and nixpkgs bumps
+      # `bitwarden-desktop` to a build on electron >= 40.
+      bitwarden-desktop = prev.bitwarden-desktop.override {
+        electron_39 = final.electron_39-bin;
+      };
       pi-coding-agent =
         let
           newSrc = prev.fetchFromGitHub {


### PR DESCRIPTION
## Summary

The unstable channel pointer advanced past the cutover where `electron-39.8.10` was marked insecure (EOL) in nixpkgs, breaking `build-configs (tui)` on the scheduled `update-flakes` workflow. `bitwarden-desktop` still depends on electron 39 and is enabled by default on Linux hosts via `modules/programs/bitwarden.nix`, so both `tui` and `navi` pull it.

## Changes

Two-piece local workaround (per nixpkgs maintainer @amarshall's recommendation in nixpkgs#526914):

1. **`overlays/default.nix`** — override `bitwarden-desktop` to use the prebuilt `electron_39-bin` instead of the source-built `electron_39`, so we don't compile EOL electron from source. Comment block matches the existing `bitwarden-cli` / `openrazer` style with rationale, upstream links, and a `REMOVAL CONDITION` line.
2. **`flake.nix`** — add `permittedInsecurePackages = [ \"electron-39.8.10\" ];` to the Linux base `config` block in `mkSystem` (next to `allowUnfree = true;`), with a short comment pointing back at the overlay. Module-level `nixpkgs.config` would be ignored here because `flake.nix` passes a pre-built `pkgs` into `nixosSystem` — the entry must live at the flake-level `import nixpkgs { config = ...; }` call site.

Linux-only. Darwin (`m4mac`) sets `nx.programs.bitwarden.enable = false`, so `bitwarden-desktop` is not in the Darwin closure.

## Upstream state

- nixpkgs tracking issue: [NixOS/nixpkgs#521305](https://github.com/NixOS/nixpkgs/issues/521305) (Electron 39 EOL)
- nixpkgs bitwarden-desktop issue: [NixOS/nixpkgs#526914](https://github.com/NixOS/nixpkgs/issues/526914) (labelled \`9.needs: upstream fix\`)
- Upstream electron bump PR (open): [bitwarden/clients#20448](https://github.com/bitwarden/clients/pull/20448)

## Verification

- ✅ \`nix build .#nixosConfigurations.tui.config.system.build.toplevel\` — succeeds
- ✅ \`nix build .#nixosConfigurations.navi.config.system.build.toplevel\` — succeeds
- ✅ \`nix flake check\` — \`all checks passed!\`
- ✅ \`nixfmt .\` — clean

## Removal

When `bitwarden/clients#20448` lands and nixpkgs bumps `bitwarden-desktop` to a build on electron >= 40, delete both the overlay block and the `permittedInsecurePackages` entry in the same PR. Both carry matching `REMOVAL CONDITION` comments pointing at the upstream PR.

Closes #2084