### PR TITLE
Upgrade default Prism profile to anthropic-opus-max

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -23,7 +23,7 @@
     };
     programs = {
       prism = {
-        profile.default = "anthropic-opus-medium";
+        profile.default = "anthropic-opus-max";
         agent.isolation.default = "bwrap";
       };
       anki.enable = false; # build broken as of 2025-08-30

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -120,6 +120,19 @@
               };
             };
 
+            anthropic-opus-max = profileFromSlots {
+              _default = slot "worker" {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-7";
+                thinking = "xhigh";
+              };
+              coordinator = slot "coordinator" {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-7";
+                thinking = "xhigh";
+              };
+            };
+
             anthropic-opus = profileFromSlots {
               coordinator = slot "coordinator" {
                 provider = "anthropic";


### PR DESCRIPTION
Added the anthropic-opus-max profile definition to the Prism module, which utilizes the anthropic/claude-opus-4-7 model with xhigh thinking enabled. Updated the navi machine configuration to set this as the new default profile.