### PR TITLE
prism: thread --model / --variant overrides through agent-run (#2086)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -41,6 +41,10 @@ package cmd
 // Flags:
 //
 //	--session <name>   prism session name (e.g. "nixos-config@feature")
+//	--model <id>       model identifier override (overrides profile slot's model;
+//	                    sourced from `prism spawn --model`, issue #2086)
+//	--variant <name>   variant/thinking-level override (overrides profile slot's
+//	                    thinking; sourced from `prism spawn --variant`, issue #2086)
 
 import (
 	"context"
@@ -94,6 +98,12 @@ is tee'd to both the tmux pane and ~/.local/state/prism/run/<session>/agent-run.
 func init() {
 	agentRunCmd.Flags().String("session", "", "Prism session name (e.g. nixos-config@main)")
 	_ = agentRunCmd.MarkFlagRequired("session")
+	// --model / --variant: CLI overrides forwarded from `prism spawn` via the
+	// tmux pane command (issue #2086). When set, populatePIConfig uses these
+	// values in place of the active profile slot's Model / Thinking. Empty
+	// values fall back to the slot, matching the pre-#2086 behaviour.
+	agentRunCmd.Flags().String("model", "", "Model identifier override (overrides profile slot's model; sourced from prism spawn --model)")
+	agentRunCmd.Flags().String("variant", "", "Variant/thinking-level override (overrides profile slot's thinking; sourced from prism spawn --variant)")
 	rootCmd.AddCommand(agentRunCmd)
 
 	// Register the per-mode AgentRun handlers with the container package
@@ -124,6 +134,8 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	agentRunStart := time.Now()
 
 	sessionName, _ := cmd.Flags().GetString("session")
+	modelOverride, _ := cmd.Flags().GetString("model")
+	variantOverride, _ := cmd.Flags().GetString("variant")
 
 	// Open the agent-run log file as early as possible so that pre-exec
 	// `[timing]` markers can be written to it and the failure point is
@@ -185,6 +197,12 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	// cleared by the handler when it is done.
 	storeAgentRunStatus(sessionName, status)
 	defer clearAgentRunStatus(sessionName)
+
+	// Stash CLI overrides (--model / --variant) so per-mode handlers can
+	// read them without re-parsing argv. Cleared by clearAgentRunStatus.
+	// Empty fields mean "no override" — the active profile slot's value
+	// is used unchanged (issue #2086).
+	storeAgentRunOverrides(sessionName, piOverrides{Model: modelOverride, Variant: variantOverride})
 
 	return iso.AgentRun(cmd.Context(), container.AgentRunOpts{
 		SessionName: sessionName,
@@ -309,7 +327,7 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 
 	// PI-harness: populate PI-specific config fields from the active profile slot.
 	if harnessName == "pi" {
-		if piErr := populatePIConfig(&ctrCfg, sessionName, agentRole, cfg); piErr != nil {
+		if piErr := populatePIConfig(&ctrCfg, sessionName, agentRole, cfg, loadAgentRunOverrides(sessionName)); piErr != nil {
 			return fmt.Errorf("agent-run: %w", piErr)
 		}
 	}
@@ -661,6 +679,16 @@ func logTimingTo(logFile *os.File, phase string, d time.Duration) {
 	}
 }
 
+// piOverrides bundles the CLI override values that `prism agent-run` accepts
+// for the pi harness (issue #2086). Empty fields mean "no override" and the
+// active profile slot's value is used unchanged. A non-empty Model wins over
+// slot.Model; a non-empty Variant wins over slot.Thinking (pi consumes both
+// via --model and --thinking on its argv in PIInvocation).
+type piOverrides struct {
+	Model   string
+	Variant string
+}
+
 // populatePIConfig fills the PI-specific fields on ctrCfg for harness=pi sessions.
 //
 // It:
@@ -676,8 +704,13 @@ func logTimingTo(logFile *os.File, phase string, d time.Duration) {
 //     The role system-prompt is injected at runtime by the prism PI extension,
 //     not staged here.
 //  4. Populates PIExtensionHostDir from cfg.PIExtensionDir (set by Nix).
-//  5. Copies PIProvider, PIModel, PIThinking from the profile slot.
-func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, cfg config.Config) error {
+//  5. Copies PIProvider, PIModel, PIThinking from the profile slot, then
+//     applies any CLI overrides from `prism agent-run --model` /
+//     `--variant` (issue #2086). A non-empty Model override wins over
+//     slot.Model; a non-empty Variant override wins over slot.Thinking.
+//     Empty override fields leave the slot value unchanged so the
+//     pre-#2086 default path is preserved.
+func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, cfg config.Config, overrides piOverrides) error {
 	// Load profiles.json.
 	pf, pfErr := config.LoadProfiles()
 	if pfErr != nil {
@@ -731,10 +764,22 @@ func populatePIConfig(ctrCfg *container.Config, sessionName, agentRole string, c
 	}
 	ctrCfg.PIExtensionHostDir = cfg.PIExtensionDir
 
-	// Model/provider/thinking from the profile slot.
+	// Model/provider/thinking from the profile slot, then CLI overrides win.
+	//
+	// Issue #2086: `prism spawn --model` / `--variant` flow through to
+	// `prism agent-run` as explicit flags (threaded via AgentPaneOpts in the
+	// tmux pane command). When non-empty they replace the slot's value here,
+	// before PIInvocation reads PIModel / PIThinking. Empty override fields
+	// fall through to the slot value unchanged.
 	ctrCfg.PIProvider = slot.Provider
 	ctrCfg.PIModel = slot.Model
 	ctrCfg.PIThinking = slot.Thinking
+	if overrides.Model != "" {
+		ctrCfg.PIModel = overrides.Model
+	}
+	if overrides.Variant != "" {
+		ctrCfg.PIThinking = overrides.Variant
+	}
 
 	// Resolve the pi binary path. This must be the absolute store
 	// path (or profile path) so that bwrap can bind-mount it into the sandbox.

--- a/modules/programs/prism/prism/cmd/agent_run_handlers.go
+++ b/modules/programs/prism/prism/cmd/agent_run_handlers.go
@@ -26,6 +26,12 @@ var (
 	// process); the map shape lets us key cleanly without a global pointer
 	// race.
 	agentRunStatusCache = map[string]*db.Status{}
+
+	// agentRunOverridesCache caches the CLI override flag values
+	// (--model / --variant) for the session being dispatched, so the
+	// sandbox-exec handler can read them without re-parsing argv. Same
+	// single-entry contract as agentRunStatusCache (issue #2086).
+	agentRunOverridesCache = map[string]piOverrides{}
 )
 
 // storeAgentRunStatus stashes the looked-up DB status for sessionName so the
@@ -53,6 +59,26 @@ func clearAgentRunStatus(sessionName string) {
 	agentRunStatusMu.Lock()
 	defer agentRunStatusMu.Unlock()
 	delete(agentRunStatusCache, sessionName)
+	delete(agentRunOverridesCache, sessionName)
+}
+
+// storeAgentRunOverrides stashes the CLI overrides parsed by runAgentRun so
+// the registered per-mode handler can read them via loadAgentRunOverrides.
+// Empty fields mean "no override" and the active profile slot's value is
+// used unchanged (issue #2086).
+func storeAgentRunOverrides(sessionName string, overrides piOverrides) {
+	agentRunStatusMu.Lock()
+	defer agentRunStatusMu.Unlock()
+	agentRunOverridesCache[sessionName] = overrides
+}
+
+// loadAgentRunOverrides returns the cached CLI overrides for sessionName, or
+// a zero piOverrides when no entry has been stored. Zero value means
+// "no overrides" — the slot value is used unchanged.
+func loadAgentRunOverrides(sessionName string) piOverrides {
+	agentRunStatusMu.Lock()
+	defer agentRunStatusMu.Unlock()
+	return agentRunOverridesCache[sessionName]
 }
 
 // runAgentRunSandboxExecHandler is the registered AgentRun handler for the

--- a/modules/programs/prism/prism/cmd/agent_run_overrides_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_overrides_test.go
@@ -1,0 +1,276 @@
+package cmd
+
+// agent_run_overrides_test.go — issue #2086 regression tests.
+//
+// Covers the CLI override path that threads `prism spawn --model` /
+// `--variant` through `prism agent-run` and into `populatePIConfig`, where
+// the override wins over the active profile slot's Model/Thinking before
+// PIInvocation builds the final pi argv.
+//
+// The end-to-end picture:
+//
+//   1. cmd/spawn.go reads --model / --variant flags, puts them on
+//      session.SpawnOpts.{Model,Variant}.
+//   2. internal/session threads them into the AgentPaneCmd built for bwrap/
+//      sandbox-exec, producing a tmux pane command like
+//      `prism agent-run --session <X> --model <M> --variant <V>`.
+//   3. cmd/agent_run.go parses --model / --variant, stashes them on the
+//      per-session cache, then `populatePIConfig` reads the cache and
+//      replaces slot.Model / slot.Thinking with the override values when
+//      non-empty.
+//   4. internal/container/pi_invocation.go reads PIModel / PIThinking from
+//      the container.Config and emits --model / --thinking on pi's argv.
+//
+// The unit tests below pin steps 3 and 4 explicitly so that a regression
+// at either layer is caught without depending on the spawn driver.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// writeProfiles writes a profiles.json under $XDG_CONFIG_HOME/prism/ with a
+// single profile named "test" defining a worker slot. The caller supplies the
+// slot values so multiple scenarios can share the helper.
+func writeProfiles(t *testing.T, configHome, profileName, model, thinking string) {
+	t.Helper()
+	prismDir := filepath.Join(configHome, "prism")
+	if err := os.MkdirAll(prismDir, 0o700); err != nil {
+		t.Fatalf("mkdir prism config dir: %v", err)
+	}
+	pf := config.ProfilesFile{
+		Default: profileName,
+		Profiles: map[string]config.ProfileEntry{
+			profileName: {
+				"worker": config.RoleSlot{
+					Provider: "anthropic",
+					Model:    model,
+					Thinking: thinking,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(&pf)
+	if err != nil {
+		t.Fatalf("marshal profiles: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(prismDir, "profiles.json"), b, 0o600); err != nil {
+		t.Fatalf("write profiles.json: %v", err)
+	}
+}
+
+// writeFakePiBinary writes a non-executable-fast shim named `pi` into binDir
+// and returns the path. populatePIConfig calls `exec.LookPath("pi")` so the
+// shim just needs to be discoverable on PATH and have the executable bit set
+// — its contents are never run by the code under test.
+func writeFakePiBinary(t *testing.T, binDir string) string {
+	t.Helper()
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	piPath := filepath.Join(binDir, "pi")
+	if err := os.WriteFile(piPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	return piPath
+}
+
+// isolateForPopulatePIConfig sets up an isolated HOME, XDG_CONFIG_HOME,
+// XDG_STATE_HOME, and PATH so that populatePIConfig's calls to
+// LoadProfiles, ResolveActiveProfile, EnsurePIAgentConfigDir, and
+// exec.LookPath all resolve against the tmp directory rather than touching
+// the developer's real environment. Returns the configHome and the fake pi
+// binary path so test cases can assert against them if needed.
+func isolateForPopulatePIConfig(t *testing.T) (configHome, piBinary string) {
+	t.Helper()
+	tmp := t.TempDir()
+	configHome = filepath.Join(tmp, "config")
+	stateHome := filepath.Join(tmp, "state")
+	binDir := filepath.Join(tmp, "bin")
+	if err := os.MkdirAll(configHome, 0o700); err != nil {
+		t.Fatalf("mkdir config home: %v", err)
+	}
+	if err := os.MkdirAll(stateHome, 0o700); err != nil {
+		t.Fatalf("mkdir state home: %v", err)
+	}
+	piBinary = writeFakePiBinary(t, binDir)
+
+	// HOME governs both EnsurePIAgentConfigDir (creates $HOME/.pi/agent)
+	// and the fallback for XDG_STATE_HOME / XDG_CONFIG_HOME.
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	// Restrict PATH to only the bin dir so exec.LookPath("pi") resolves to
+	// our shim deterministically and cannot accidentally pick up a real pi
+	// from /etc/profiles/per-user/<u>/bin or /run/current-system/sw/bin.
+	t.Setenv("PATH", binDir)
+	return configHome, piBinary
+}
+
+// TestPopulatePIConfig_SlotOnly is the no-regression baseline: with no CLI
+// overrides set, ctrCfg.PIModel and ctrCfg.PIThinking must come from the
+// active profile slot exactly as they did before issue #2086.
+func TestPopulatePIConfig_SlotOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("populatePIConfig depends on POSIX exec semantics")
+	}
+	configHome, _ := isolateForPopulatePIConfig(t)
+	writeProfiles(t, configHome, "test", "anthropic/claude-opus-4-7", "medium")
+
+	ctrCfg := container.Config{}
+	cfg := config.Config{PIExtensionDir: "/nix/store/fake-ext"}
+	err := populatePIConfig(&ctrCfg, "prism-test@session", "worker", cfg, piOverrides{})
+	if err != nil {
+		t.Fatalf("populatePIConfig: %v", err)
+	}
+
+	if ctrCfg.PIModel != "anthropic/claude-opus-4-7" {
+		t.Errorf("PIModel = %q, want slot value %q", ctrCfg.PIModel, "anthropic/claude-opus-4-7")
+	}
+	if ctrCfg.PIThinking != "medium" {
+		t.Errorf("PIThinking = %q, want slot value %q", ctrCfg.PIThinking, "medium")
+	}
+	if ctrCfg.PIProvider != "anthropic" {
+		t.Errorf("PIProvider = %q, want slot value %q", ctrCfg.PIProvider, "anthropic")
+	}
+}
+
+// TestPopulatePIConfig_CLIOverrideWins is the core #2086 regression guard:
+// when a non-empty Model / Variant override is supplied alongside a profile
+// that defines a different slot value, the override wins on ctrCfg.PIModel
+// and ctrCfg.PIThinking — i.e. on the final pi argv that PIInvocation
+// produces from the container.Config.
+func TestPopulatePIConfig_CLIOverrideWins(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("populatePIConfig depends on POSIX exec semantics")
+	}
+	configHome, _ := isolateForPopulatePIConfig(t)
+	// Profile slot says opus-4-7 / medium. Override says opus-4-8 / high.
+	// Post-fix the override must reach ctrCfg.
+	writeProfiles(t, configHome, "test", "anthropic/claude-opus-4-7", "medium")
+
+	ctrCfg := container.Config{}
+	cfg := config.Config{PIExtensionDir: "/nix/store/fake-ext"}
+	overrides := piOverrides{
+		Model:   "anthropic/claude-opus-4-8",
+		Variant: "high",
+	}
+	err := populatePIConfig(&ctrCfg, "prism-test@session", "worker", cfg, overrides)
+	if err != nil {
+		t.Fatalf("populatePIConfig: %v", err)
+	}
+
+	if ctrCfg.PIModel != "anthropic/claude-opus-4-8" {
+		t.Errorf("PIModel = %q, want override value %q", ctrCfg.PIModel, "anthropic/claude-opus-4-8")
+	}
+	if ctrCfg.PIThinking != "high" {
+		t.Errorf("PIThinking = %q, want override value %q", ctrCfg.PIThinking, "high")
+	}
+	// Provider is not overridable today and must still come from the slot.
+	if ctrCfg.PIProvider != "anthropic" {
+		t.Errorf("PIProvider = %q, want slot value %q", ctrCfg.PIProvider, "anthropic")
+	}
+
+	// End-to-end: feed the populated ctrCfg into PIInvocation and assert the
+	// override pair lands on the final pi argv. This is the same shape the
+	// bwrap and sandbox-exec entry points produce just before exec.
+	args := container.PIInvocation(ctrCfg)
+	if !argvHasPair(args, "--model", "anthropic/claude-opus-4-8") {
+		t.Errorf("pi argv missing --model override: %v", args)
+	}
+	if !argvHasPair(args, "--thinking", "high") {
+		t.Errorf("pi argv missing --thinking override: %v", args)
+	}
+	// Negative: the pre-override slot values must not leak onto the argv.
+	if argvHasPair(args, "--model", "anthropic/claude-opus-4-7") {
+		t.Errorf("slot model leaked into argv after override: %v", args)
+	}
+	if argvHasPair(args, "--thinking", "medium") {
+		t.Errorf("slot thinking leaked into argv after override: %v", args)
+	}
+}
+
+// TestPopulatePIConfig_PartialOverride_ModelOnly verifies that supplying
+// only --model (no --variant) overrides the model but leaves Thinking on
+// the slot value. Mirrors the operator workflow where one axis is varied
+// for an A/B test while the rest of the slot is preserved.
+func TestPopulatePIConfig_PartialOverride_ModelOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("populatePIConfig depends on POSIX exec semantics")
+	}
+	configHome, _ := isolateForPopulatePIConfig(t)
+	writeProfiles(t, configHome, "test", "anthropic/claude-opus-4-7", "medium")
+
+	ctrCfg := container.Config{}
+	cfg := config.Config{PIExtensionDir: "/nix/store/fake-ext"}
+	overrides := piOverrides{Model: "anthropic/claude-opus-4-8"}
+	if err := populatePIConfig(&ctrCfg, "prism-test@session", "worker", cfg, overrides); err != nil {
+		t.Fatalf("populatePIConfig: %v", err)
+	}
+
+	if ctrCfg.PIModel != "anthropic/claude-opus-4-8" {
+		t.Errorf("PIModel = %q, want override %q", ctrCfg.PIModel, "anthropic/claude-opus-4-8")
+	}
+	if ctrCfg.PIThinking != "medium" {
+		t.Errorf("PIThinking = %q, want slot %q (no variant override)", ctrCfg.PIThinking, "medium")
+	}
+}
+
+// TestAgentRunCmd_FlagsRegistered asserts the help surface promised by the
+// AC: `prism agent-run --help` lists --model and --variant. Cobra's flag
+// lookup is the closest verifiable analogue to "appears in --help" without
+// re-exec'ing the binary.
+func TestAgentRunCmd_FlagsRegistered(t *testing.T) {
+	for _, name := range []string{"session", "model", "variant"} {
+		if f := agentRunCmd.Flags().Lookup(name); f == nil {
+			t.Errorf("expected agentRunCmd to define flag --%s", name)
+		}
+	}
+}
+
+// TestStoreLoadAgentRunOverrides_Roundtrip asserts the in-process cache
+// shape used to ferry CLI overrides from runAgentRun (which parses argv)
+// into the registered per-mode handlers (which receive only
+// AgentRunOpts). A regression here would silently drop the overrides for
+// sandbox-exec.
+func TestStoreLoadAgentRunOverrides_Roundtrip(t *testing.T) {
+	const session = "prism-test@cache-roundtrip"
+	storeAgentRunOverrides(session, piOverrides{Model: "M", Variant: "V"})
+	t.Cleanup(func() { clearAgentRunStatus(session) })
+
+	got := loadAgentRunOverrides(session)
+	if got.Model != "M" || got.Variant != "V" {
+		t.Errorf("loadAgentRunOverrides = %+v, want {Model:M Variant:V}", got)
+	}
+
+	// Empty zero value when nothing stored.
+	if zero := loadAgentRunOverrides("prism-test@no-such-entry"); zero.Model != "" || zero.Variant != "" {
+		t.Errorf("expected zero piOverrides for unknown key; got %+v", zero)
+	}
+
+	// clearAgentRunStatus must also purge the overrides entry (single-
+	// session-per-process contract).
+	clearAgentRunStatus(session)
+	if got := loadAgentRunOverrides(session); got.Model != "" || got.Variant != "" {
+		t.Errorf("expected overrides to be cleared; got %+v", got)
+	}
+}
+
+// argvHasPair returns true when flag and val appear consecutively in args.
+// Local helper to avoid coupling to the internal/container test helper of
+// the same name.
+func argvHasPair(args []string, flag, val string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
+}
+

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -160,7 +160,7 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	// On Darwin sandbox-exec there are no bind-mounts, so the "sandbox paths"
 	// are the same as the host paths — sandbox-exec shares the host filesystem.
 	if sandboxHarnessName == "pi" {
-		if piErr := populatePIConfig(&ctrCfg, sessionName, agentRole, cfg); piErr != nil {
+		if piErr := populatePIConfig(&ctrCfg, sessionName, agentRole, cfg, loadAgentRunOverrides(sessionName)); piErr != nil {
 			return fmt.Errorf("agent-run: %w", piErr)
 		}
 		// sandbox-exec shares the host filesystem, so the in-sandbox paths for

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -228,6 +228,14 @@ var prCmd = &cobra.Command{
 			ModelsByRole:     modelsByRole,
 			// PIExtensionDir for host-mode pi launches (#2065).
 			PIExtensionDir: cfg.PIExtensionDir,
+			// CLI overrides (issue #2086) flow through to the tmux pane
+			// command so `prism agent-run` (bwrap / sandbox-exec) and direct
+			// pi (host) receive --model / --variant on the final argv.
+			// `prism pr` is a sibling front door to `prism spawn` and
+			// already accepts these flags (see the flag registration below),
+			// so the same wire-through is required here.
+			Model:   modelFlag,
+			Variant: variantFlag,
 			// ForceFresh=true: prism pr creates a new worktree; if a session
 			// with the same name exists it is a stale zombie and should be
 			// killed, matching the same semantics as prism spawn.

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -714,6 +714,11 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		HarnessName:      harnessFlag,
 		ModelsByRole:     modelsByRole,
 		AllowEmptyPrompt: allowEmptyPrompt,
+		// CLI overrides (issue #2086) flow through to the tmux pane command
+		// so `prism agent-run` (bwrap / sandbox-exec) and direct pi (host)
+		// receive --model / --variant on the final argv.
+		Model:   modelFlag,
+		Variant: variantFlag,
 		// PIExtensionDir is the host-side prism PI extension directory
 		// (populated by Nix into config.json). Forwarded so that host-mode
 		// pi launches pass --extension <dir>/prism.ts (#2065).
@@ -1373,8 +1378,11 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		RuntimeEnvVars:   h.RuntimeEnv(),
 		HarnessName:      a.harnessFlag,
 		ModelsByRole:     a.modelsByRole,
-		ForceFresh:       true,
-		Headless:         true,
+		// CLI overrides flow through to the tmux pane command (issue #2086).
+		Model:      a.modelFlag,
+		Variant:    a.variantFlag,
+		ForceFresh: true,
+		Headless:   true,
 		// WorktreeReadOnly: mount the worktree read-only for investigate sessions.
 		WorktreeReadOnly: agentRole == "investigate",
 		// PIExtensionDir for host-mode pi launches (#2065).

--- a/modules/programs/prism/prism/internal/container/agent_pane_overrides_test.go
+++ b/modules/programs/prism/prism/internal/container/agent_pane_overrides_test.go
@@ -1,0 +1,154 @@
+package container
+
+// agent_pane_overrides_test.go — issue #2086 regression test for the tmux
+// pane command that bwrap and sandbox-exec emit when `prism spawn --model`
+// and/or `--variant` are supplied.
+//
+// The shape under test is the output of `iso.AgentPaneCmd(...)` for the
+// pane-owned modes. The pre-#2086 shape was:
+//
+//	prism agent-run --session '<X>'
+//
+// The post-#2086 shape, when AgentPaneOpts.Model and/or .Variant are set,
+// appends the override flags:
+//
+//	prism agent-run --session '<X>' --model '<M>' --variant '<V>'
+//
+// `prism agent-run` then parses --model / --variant and threads the values
+// into populatePIConfig, where they override the active profile slot's
+// Model / Thinking on the final pi argv (see TestPIInvocation_CLIOverride*
+// and TestPopulatePIConfig_CLIOverrideWins).
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBwrapAgentPaneCmd_OverrideFlagsAppended asserts that --model and
+// --variant land on the tmux pane command when AgentPaneOpts carries them.
+func TestBwrapAgentPaneCmd_OverrideFlagsAppended(t *testing.T) {
+	iso := &bwrapIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+		Model:       "anthropic/claude-opus-4-8",
+		Variant:     "high",
+	})
+
+	// Order is load-bearing for readability of `ps` output but not for
+	// cobra's flag parser. Use substring checks so a reordering inside
+	// appendAgentRunOverrides does not break the test (cobra still parses
+	// the flags correctly regardless of position).
+	for _, want := range []string{
+		"prism agent-run --session 'prism-test@bwrap'",
+		"--model 'anthropic/claude-opus-4-8'",
+		"--variant 'high'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("bwrap AgentPaneCmd missing %q; got %q", want, got)
+		}
+	}
+}
+
+// TestBwrapAgentPaneCmd_NoOverrideFlagsByDefault is the no-regression case:
+// when AgentPaneOpts carries no override fields the pane command is exactly
+// the pre-#2086 shape so existing tests, restore semantics, and operator
+// expectations are preserved.
+func TestBwrapAgentPaneCmd_NoOverrideFlagsByDefault(t *testing.T) {
+	iso := &bwrapIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+	})
+	want := "prism agent-run --session 'prism-test@bwrap'"
+	if got != want {
+		t.Errorf("bwrap AgentPaneCmd = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "--model") || strings.Contains(got, "--variant") {
+		t.Errorf("expected no --model/--variant when overrides empty; got %q", got)
+	}
+}
+
+// TestSandboxExecAgentPaneCmd_OverrideFlagsAppended mirrors the bwrap test
+// for sandbox-exec — both isolators dispatch through the same
+// appendAgentRunOverrides helper so a divergence would be a real bug.
+func TestSandboxExecAgentPaneCmd_OverrideFlagsAppended(t *testing.T) {
+	iso := &sandboxExecIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@sbx",
+		Model:       "anthropic/claude-opus-4-8",
+		Variant:     "high",
+	})
+	for _, want := range []string{
+		"prism agent-run --session 'prism-test@sbx'",
+		"--model 'anthropic/claude-opus-4-8'",
+		"--variant 'high'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("sandbox-exec AgentPaneCmd missing %q; got %q", want, got)
+		}
+	}
+}
+
+// TestSandboxExecAgentPaneCmd_NoOverrideFlagsByDefault — no-regression case.
+func TestSandboxExecAgentPaneCmd_NoOverrideFlagsByDefault(t *testing.T) {
+	iso := &sandboxExecIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@sbx",
+	})
+	want := "prism agent-run --session 'prism-test@sbx'"
+	if got != want {
+		t.Errorf("sandbox-exec AgentPaneCmd = %q, want %q", got, want)
+	}
+}
+
+// TestBwrapAgentPaneCmd_PartialOverride_ModelOnly verifies that supplying
+// only Model (no Variant) emits --model but not --variant. Mirrors the
+// operator workflow where one axis is varied for an A/B test.
+func TestBwrapAgentPaneCmd_PartialOverride_ModelOnly(t *testing.T) {
+	iso := &bwrapIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+		Model:       "anthropic/claude-opus-4-8",
+	})
+	if !strings.Contains(got, "--model 'anthropic/claude-opus-4-8'") {
+		t.Errorf("expected --model in pane cmd; got %q", got)
+	}
+	if strings.Contains(got, "--variant") {
+		t.Errorf("--variant must not appear when Variant is empty; got %q", got)
+	}
+}
+
+// TestBwrapAgentPaneCmd_ShellQuoting_SingleQuotedValues ensures values pass
+// through shellQuotePodman so weird characters in a model name (or in the
+// session name) cannot break out of the shell context. Cobra parses argv
+// regardless, but the tmux pane wraps the command in `sh -c "<cmd>"` so
+// unquoted values are a real injection risk.
+func TestBwrapAgentPaneCmd_ShellQuoting_SingleQuotedValues(t *testing.T) {
+	iso := &bwrapIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+		// A value containing a single quote exercises the escape path in
+		// shellQuotePodman.
+		Model: "danger'name",
+	})
+	want := `--model 'danger'\''name'`
+	if !strings.Contains(got, want) {
+		t.Errorf("expected shell-escaped Model %q in cmd; got %q", want, got)
+	}
+}
+
+// TestBwrapAgentPaneCmd_EmptySessionName_FallsBackToDirect verifies the
+// defensive fallback: when SessionName is empty the pane command is the
+// host-mode DirectCmd unchanged. Pre-#2086 behaviour; the override fields
+// must not be appended onto the DirectCmd fallback (those flags are owned
+// by `prism agent-run`, not by the direct pi launch).
+func TestBwrapAgentPaneCmd_EmptySessionName_FallsBackToDirect(t *testing.T) {
+	iso := &bwrapIsolator{}
+	got := iso.AgentPaneCmd(AgentPaneOpts{
+		DirectCmd: "pi --agent worker",
+		Model:     "anthropic/claude-opus-4-8",
+		Variant:   "high",
+	})
+	if got != "pi --agent worker" {
+		t.Errorf("expected fallback to DirectCmd; got %q", got)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/dispatch.go
+++ b/modules/programs/prism/prism/internal/container/dispatch.go
@@ -209,6 +209,20 @@ type AgentPaneOpts struct {
 	// (defensive fallback) or for the host isolator. Callers construct it
 	// before calling AgentPaneCmd.
 	DirectCmd string
+
+	// Model, when non-empty, is appended to the bwrap/sandbox-exec tmux
+	// pane command as `--model <X>` so that `prism agent-run` overrides the
+	// active profile slot's model on the final pi argv. Sourced from
+	// `prism spawn --model` (issue #2086). Empty value omits the flag and
+	// the slot's model is used unchanged.
+	Model string
+
+	// Variant, when non-empty, is appended to the bwrap/sandbox-exec tmux
+	// pane command as `--variant <Y>` so that `prism agent-run` overrides
+	// the active profile slot's thinking/variant on the final pi argv.
+	// Sourced from `prism spawn --variant` (issue #2086). Empty value omits
+	// the flag and the slot's thinking is used unchanged.
+	Variant string
 }
 
 // ArchivePaths describes the per-mode paths that the archive copy step
@@ -307,7 +321,7 @@ func (b *bwrapIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
 	if opts.SessionName == "" {
 		return opts.DirectCmd
 	}
-	return "prism agent-run --session " + shellQuotePodman(opts.SessionName)
+	return appendAgentRunOverrides("prism agent-run --session "+shellQuotePodman(opts.SessionName), opts)
 }
 
 // SidecarFlags returns the sidecar argv extensions for bwrap: --port and the
@@ -390,7 +404,7 @@ func (s *sandboxExecIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
 	if opts.SessionName == "" {
 		return opts.DirectCmd
 	}
-	return "prism agent-run --session " + shellQuotePodman(opts.SessionName)
+	return appendAgentRunOverrides("prism agent-run --session "+shellQuotePodman(opts.SessionName), opts)
 }
 
 // SidecarFlags returns the sidecar argv extensions for sandbox-exec — same
@@ -476,6 +490,25 @@ func (h *hostIsolator) LogPaths() LogPaths {
 // ----------------------------------------------------------------------------
 // shared helpers
 // ----------------------------------------------------------------------------
+
+// appendAgentRunOverrides appends `--model <X>` and/or `--variant <Y>` to the
+// `prism agent-run` tmux pane command when those overrides are set on opts.
+// Shared between the bwrap and sandbox-exec isolators because both modes
+// dispatch the agent via `prism agent-run` (which then re-reads the session
+// row, populates a container.Config, and launches pi via PIInvocation).
+//
+// Issue #2086: without these flags the `--model` / `--variant` values passed
+// to `prism spawn` are silently dropped — `populatePIConfig` only consults
+// the active profile slot, so the CLI override never reaches pi's argv.
+func appendAgentRunOverrides(cmd string, opts AgentPaneOpts) string {
+	if opts.Model != "" {
+		cmd += " --model " + shellQuotePodman(opts.Model)
+	}
+	if opts.Variant != "" {
+		cmd += " --variant " + shellQuotePodman(opts.Variant)
+	}
+	return cmd
+}
 
 // shellQuotePodman wraps s in single quotes for shell-safe embedding. It is a
 // local copy of internal/session.shellQuote — duplicated here to avoid a

--- a/modules/programs/prism/prism/internal/container/pi_invocation_test.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation_test.go
@@ -185,6 +185,69 @@ func TestPIInvocation_AgentFlagOrder(t *testing.T) {
 	}
 }
 
+// TestPIInvocation_CLIOverrideWinsOverSlot is the issue #2086 regression
+// guard. The end-to-end picture: `prism spawn --model X` is translated by
+// `populatePIConfig` into a PIModel/PIThinking override that wins over the
+// active profile slot's Model/Thinking before `PIInvocation` reads the
+// fields. This test pins the contract at the PIInvocation layer: whatever
+// value ends up in cfg.PIModel / cfg.PIThinking is what appears on the
+// final pi argv.
+//
+// The test is written as a pair: the "slot only" case stands in for the
+// pre-#2086 baseline (slot.Model goes straight onto argv); the "override
+// wins" case stands in for the post-#2086 fix (populatePIConfig replaced
+// the slot value with the CLI override before constructing this Config).
+// Both cases assert against the same argv positions so a future regression
+// that re-introduces the slot value (e.g. by reading the profile inside
+// PIInvocation itself) trips this guard.
+func TestPIInvocation_CLIOverrideWinsOverSlot(t *testing.T) {
+	t.Run("slot only (no override) - baseline", func(t *testing.T) {
+		cfg := Config{
+			PIBinaryPath:          "/nix/store/abc-pi/bin/pi",
+			PIProvider:            "anthropic",
+			PIModel:               "anthropic/claude-opus-4-7",
+			PIThinking:            "medium",
+			PIExtensionSandboxDir: "/etc/prism/pi-extensions",
+		}
+		args := PIInvocation(cfg)
+		if !hasPair(args, "--model", "anthropic/claude-opus-4-7") {
+			t.Errorf("expected --model anthropic/claude-opus-4-7 (slot value); got %v", args)
+		}
+		if !hasPair(args, "--thinking", "medium") {
+			t.Errorf("expected --thinking medium (slot value); got %v", args)
+		}
+	})
+
+	t.Run("CLI override wins on final argv", func(t *testing.T) {
+		// Same shape as above except PIModel/PIThinking carry the post-
+		// override values (claude-opus-4-8 / high) that `populatePIConfig`
+		// produced. The slot's claude-opus-4-7 / medium values are
+		// intentionally absent from the argv — if they appear here the
+		// override path has regressed.
+		cfg := Config{
+			PIBinaryPath:          "/nix/store/abc-pi/bin/pi",
+			PIProvider:            "anthropic",
+			PIModel:               "anthropic/claude-opus-4-8",
+			PIThinking:            "high",
+			PIExtensionSandboxDir: "/etc/prism/pi-extensions",
+		}
+		args := PIInvocation(cfg)
+		if !hasPair(args, "--model", "anthropic/claude-opus-4-8") {
+			t.Errorf("expected --model anthropic/claude-opus-4-8 (override); got %v", args)
+		}
+		if !hasPair(args, "--thinking", "high") {
+			t.Errorf("expected --thinking high (override); got %v", args)
+		}
+		// Negative checks: the pre-override slot values must not appear.
+		if hasPair(args, "--model", "anthropic/claude-opus-4-7") {
+			t.Errorf("slot model leaked into argv after override; got %v", args)
+		}
+		if hasPair(args, "--thinking", "medium") {
+			t.Errorf("slot thinking leaked into argv after override; got %v", args)
+		}
+	})
+}
+
 // hasPair returns true when flag and val appear consecutively in args.
 func hasPair(args []string, flag, val string) bool {
 	for i := 0; i+1 < len(args); i++ {

--- a/modules/programs/prism/prism/internal/session/host_overrides_test.go
+++ b/modules/programs/prism/prism/internal/session/host_overrides_test.go
@@ -1,0 +1,169 @@
+package session
+
+// host_overrides_test.go — issue #2086 regression tests for the host-mode
+// direct pi launch command.
+//
+// In host mode, the tmux pane runs pi directly (not via `prism agent-run`),
+// so the CLI overrides --model and --variant must be appended to pi's argv
+// here in buildDirectAgentCmd. The container modes (bwrap / sandbox-exec)
+// route through AgentPaneCmd; see
+// internal/container/agent_pane_overrides_test.go for those.
+//
+// Mapping reminder: pi's CLI flag for the variant axis is `--thinking`
+// (not `--variant`). The user-facing prism flag is `--variant` to match
+// the on-disk profiles.json key name; internally it lands on Opts.Variant
+// and buildDirectAgentCmd emits it as `--thinking <Y>` so pi parses it.
+// See pi --help: "--thinking <level>  Set thinking level: off, minimal,
+// low, medium, high, xhigh".
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildDirectAgentCmd_HostModeModelOverride asserts that Opts.Model
+// produces `--model <X>` on the direct pi launch command.
+func TestBuildDirectAgentCmd_HostModeModelOverride(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		SessionName: "myrepo@branch",
+		HarnessName: "pi",
+		Model:       "anthropic/claude-opus-4-8",
+	}
+	cmd := buildDirectAgentCmd(opts)
+	if !strings.Contains(cmd, "--model 'anthropic/claude-opus-4-8'") {
+		t.Errorf("expected --model in direct cmd; got %q", cmd)
+	}
+}
+
+// TestBuildDirectAgentCmd_HostModeVariantOverride asserts that Opts.Variant
+// produces `--thinking <Y>` (pi's flag name) on the direct pi launch command.
+func TestBuildDirectAgentCmd_HostModeVariantOverride(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		SessionName: "myrepo@branch",
+		HarnessName: "pi",
+		Variant:     "high",
+	}
+	cmd := buildDirectAgentCmd(opts)
+	if !strings.Contains(cmd, "--thinking 'high'") {
+		t.Errorf("expected --thinking 'high' in direct cmd; got %q", cmd)
+	}
+}
+
+// TestBuildDirectAgentCmd_HostModeBothOverrides asserts the combined case:
+// when both Model and Variant are set, both flag pairs appear, and the
+// pre-#2086 invariants (pi appears, --agent appears) are preserved.
+func TestBuildDirectAgentCmd_HostModeBothOverrides(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		SessionName: "myrepo@branch",
+		HarnessName: "pi",
+		Model:       "anthropic/claude-opus-4-8",
+		Variant:     "high",
+	}
+	cmd := buildDirectAgentCmd(opts)
+
+	for _, want := range []string{
+		"pi ",                              // binary
+		"--agent worker",                   // role flag still emitted
+		"--model 'anthropic/claude-opus-4-8'", // override
+		"--thinking 'high'",                // override
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("expected %q in direct cmd; got %q", want, cmd)
+		}
+	}
+}
+
+// TestBuildDirectAgentCmd_HostModeNoOverrides_NoFlags is the no-regression
+// guard: when Model and Variant are empty, neither --model nor --thinking
+// appears on the host-mode direct command (matching the pre-#2086 shape,
+// where pi's defaults take over — or, in practice today, the profile slot
+// values are baked into a config blob the pi process ignores).
+func TestBuildDirectAgentCmd_HostModeNoOverrides_NoFlags(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		SessionName: "myrepo@branch",
+		HarnessName: "pi",
+	}
+	cmd := buildDirectAgentCmd(opts)
+	if strings.Contains(cmd, "--model") {
+		t.Errorf("--model must not appear when Opts.Model is empty; got %q", cmd)
+	}
+	if strings.Contains(cmd, "--thinking") {
+		t.Errorf("--thinking must not appear when Opts.Variant is empty; got %q", cmd)
+	}
+}
+
+// TestBuildDirectAgentCmd_NonPiHarness_NoOverrideFlags scopes the override
+// emission to the pi harness. Other harnesses do not have --model /
+// --thinking flags in the same shape, so we must not append them blindly.
+func TestBuildDirectAgentCmd_NonPiHarness_NoOverrideFlags(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		SessionName: "myrepo@branch",
+		HarnessName: "opencode", // not pi
+		Model:       "anthropic/claude-opus-4-8",
+		Variant:     "high",
+	}
+	cmd := buildDirectAgentCmd(opts)
+	if strings.Contains(cmd, "--model") {
+		t.Errorf("--model must not appear for non-pi harness; got %q", cmd)
+	}
+	if strings.Contains(cmd, "--thinking") {
+		t.Errorf("--thinking must not appear for non-pi harness; got %q", cmd)
+	}
+}
+
+// TestBuildOptsForLayout_ForwardsModelAndVariant pins the SpawnOpts → Opts
+// forwarding so a future refactor cannot silently drop the override fields
+// between cmd/spawn.go (which sets SpawnOpts) and buildDirectAgentCmd /
+// AgentPaneCmd (which consume Opts.Model / Opts.Variant).
+func TestBuildOptsForLayout_ForwardsModelAndVariant(t *testing.T) {
+	spawnOpts := SpawnOpts{
+		SessionName: "myrepo@branch",
+		Worktree:    "/tmp/wt",
+		AgentRole:   "worker",
+		Prompt:      "do the thing",
+		HarnessName: "pi",
+		Model:       "anthropic/claude-opus-4-8",
+		Variant:     "high",
+	}
+	got := buildOptsForLayout(spawnOpts, 14000, "")
+	if got.Model != "anthropic/claude-opus-4-8" {
+		t.Errorf("Opts.Model = %q, want forwarded value", got.Model)
+	}
+	if got.Variant != "high" {
+		t.Errorf("Opts.Variant = %q, want forwarded value", got.Variant)
+	}
+}
+
+// TestBuildDirectAgentCmd_OverrideFlagsBeforePrompt verifies the flag pair
+// appears before any positional prompt — pi treats a positional argument as
+// the user message and would parse `--model X` as message bytes if it came
+// after the prompt.
+func TestBuildDirectAgentCmd_OverrideFlagsBeforePrompt(t *testing.T) {
+	opts := Opts{
+		Agent:       "worker",
+		SessionName: "myrepo@branch",
+		HarnessName: "pi",
+		Model:       "anthropic/claude-opus-4-8",
+		Variant:     "high",
+		Prompt:      "do the thing",
+	}
+	cmd := buildDirectAgentCmd(opts)
+
+	modelIdx := strings.Index(cmd, "--model")
+	thinkingIdx := strings.Index(cmd, "--thinking")
+	promptIdx := strings.Index(cmd, "--prompt")
+	if modelIdx == -1 || thinkingIdx == -1 || promptIdx == -1 {
+		t.Fatalf("expected --model, --thinking, and --prompt all present; got %q", cmd)
+	}
+	if modelIdx > promptIdx {
+		t.Errorf("--model (at %d) must appear before --prompt (at %d) in %q", modelIdx, promptIdx, cmd)
+	}
+	if thinkingIdx > promptIdx {
+		t.Errorf("--thinking (at %d) must appear before --prompt (at %d) in %q", thinkingIdx, promptIdx, cmd)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -219,6 +219,23 @@ type Opts struct {
 	// agent-pane shape) don't need to fake a directory; the fail-fast policy
 	// is centralised in ValidatePILaunchOpts, not the emitter.
 	PIExtensionDir string
+
+	// Model, when non-empty, is the CLI-supplied model override (`prism spawn
+	// --model <X>`). In host mode, buildDirectAgentCmd appends `--model <X>`
+	// to the pi argv so it wins over the profile slot's model. In bwrap and
+	// sandbox-exec modes the value is threaded into AgentPaneOpts so the
+	// `prism agent-run` tmux pane command carries it forward to the
+	// populatePIConfig override path. Empty value omits the flag and the
+	// profile slot's model is used unchanged. Issue #2086.
+	Model string
+
+	// Variant, when non-empty, is the CLI-supplied variant override (`prism
+	// spawn --variant <Y>`). Semantics mirror Model: in host mode the value
+	// is appended as `--variant <Y>` (pi consumes it as a thinking/reasoning
+	// level via the harness's --thinking mapping at the populatePIConfig
+	// override path); in bwrap and sandbox-exec modes it flows through
+	// AgentPaneOpts. Issue #2086.
+	Variant string
 }
 
 // ValidatePILaunchOpts checks Opts against the requirements for a host-mode
@@ -357,6 +374,14 @@ func BuildAgentCmd(opts Opts) string {
 	return iso.AgentPaneCmd(container.AgentPaneOpts{
 		SessionName: opts.SessionName,
 		DirectCmd:   direct,
+		// Model / Variant overrides (issue #2086) are forwarded into the
+		// tmux pane command for bwrap and sandbox-exec so that `prism
+		// agent-run` receives them as explicit flags and can override the
+		// active profile slot's model/variant on the final pi argv. The
+		// host isolator's AgentPaneCmd returns DirectCmd unchanged, which
+		// already carries the flags via buildDirectAgentCmd above.
+		Model:   opts.Model,
+		Variant: opts.Variant,
 	})
 }
 
@@ -406,6 +431,20 @@ func buildDirectAgentCmd(opts Opts) string {
 		extPath := container.PIExtensionHostPath(opts.PIExtensionDir)
 		if extPath != "" {
 			cmd += " --extension " + shellQuote(extPath)
+		}
+	}
+	// CLI overrides for model and variant (issue #2086). Scoped to the pi
+	// harness (or empty, which defaults to pi). The flag pair must appear
+	// before the positional prompt so pi parses them as named flags rather
+	// than as positional message bytes. Empty values omit the flag and the
+	// profile slot's model/variant is used unchanged (no-regression default
+	// path).
+	if opts.HarnessName == "pi" || opts.HarnessName == "" {
+		if opts.Model != "" {
+			cmd += " --model " + shellQuote(opts.Model)
+		}
+		if opts.Variant != "" {
+			cmd += " --thinking " + shellQuote(opts.Variant)
 		}
 	}
 	// Append --session <id> for host-mode pi-resume (issue #1838).

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -243,6 +243,16 @@ type SpawnOpts struct {
 	// host-mode pi launch (#2065). Empty value falls back to no --extension
 	// flag on host mode.
 	PIExtensionDir string
+
+	// Model, when non-empty, is the CLI-supplied model override from
+	// `prism spawn --model <X>`. Forwarded to Opts.Model and (for bwrap /
+	// sandbox-exec) into the AgentPaneOpts that builds the `prism
+	// agent-run` tmux pane command. Issue #2086.
+	Model string
+
+	// Variant, when non-empty, is the CLI-supplied variant override from
+	// `prism spawn --variant <Y>`. Semantics mirror Model. Issue #2086.
+	Variant string
 }
 
 // SpawnSession creates a single prism session end-to-end: seeds the
@@ -458,6 +468,8 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			Port:             0,
 			IsolationMode:    mode,
 			ConfigEnvVarName: opts.ConfigEnvVarName,
+			Model:            opts.Model,
+			Variant:          opts.Variant,
 		}
 		size += len(BuildAgentCmd(previewOpts))
 		hostLaunchCmdSize = size
@@ -486,6 +498,8 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			Port:             0,
 			IsolationMode:    mode,
 			ConfigEnvVarName: opts.ConfigEnvVarName,
+			Model:            opts.Model,
+			Variant:          opts.Variant,
 		}
 		previewCmd := BuildAgentCmd(previewOpts)
 		// For the env-var preview, route through the same helper used at
@@ -858,6 +872,10 @@ func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 		HarnessPipeSockPath: opts.HarnessPipeSockPath,
 		ModelsByRole:        opts.ModelsByRole,
 		PIExtensionDir:      opts.PIExtensionDir,
+		// CLI overrides (issue #2086) flow into buildDirectAgentCmd (host)
+		// and AgentPaneOpts (bwrap / sandbox-exec) via BuildAgentCmd.
+		Model:   opts.Model,
+		Variant: opts.Variant,
 	}
 }
 
@@ -1014,6 +1032,9 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		ConfigEnvVarName: opts.ConfigEnvVarName,
 		RuntimeEnvVars:   opts.RuntimeEnvVars,
 		PIExtensionDir:   opts.PIExtensionDir,
+		// CLI overrides (issue #2086) for review-style agent-only layouts.
+		Model:   opts.Model,
+		Variant: opts.Variant,
 		// AgentEnvVars intentionally omitted: review sessions don't inject
 		// profile env vars in host mode today.
 	}


### PR DESCRIPTION
## Summary

`prism spawn --model X` and `--variant Y` were silently ignored. Both flags reached `agent-run` only as a `PI_CONFIG_CONTENT` env var that pi v0.78.0 does not consume; `populatePIConfig` only consulted the active profile slot. This meant an operator running an A/B test got both sessions on the same model — the failure described in the issue.

This PR implements **option 2** from the issue: thread the overrides as explicit flags on `prism agent-run`.

## What changed

- `prism agent-run` grows `--model` / `--variant` flags (visible in `--help`).
- `populatePIConfig` now replaces `slot.Model` and `slot.Thinking` with the override values when non-empty, before `PIInvocation` reads them. Empty overrides fall through to the slot (no-regression default path).
- The tmux pane command emitted by the bwrap and sandbox-exec isolators (`AgentPaneCmd`) appends `--model <X> --variant <Y>` when `AgentPaneOpts` carries them. `session.Opts` and `SpawnOpts` grow matching `Model`/`Variant` fields; `cmd/spawn.go` populates them from `modelFlag`/`variantFlag`.
- Host mode's `buildDirectAgentCmd` appends `--model <X>` and `--thinking <Y>` (pi's flag name for the variant axis) to the pi argv when set. Scoped to the pi harness so non-pi launchers do not receive spurious flags.
- Cross-handler plumbing: `runAgentRun` stashes the CLI overrides on a per-session in-process cache (mirrors the existing `agentRunStatusCache` pattern) so the registered sandbox-exec handler can read them without re-parsing argv or expanding `container.AgentRunOpts`.

## Tests

- `internal/container/pi_invocation_test.go` — `TestPIInvocation_CLIOverrideWinsOverSlot` (the AC-mandated case).
- `cmd/agent_run_overrides_test.go` — `populatePIConfig` end-to-end (slot-only baseline + override-wins + partial override), cache round-trip, `--help` flag registration.
- `internal/container/agent_pane_overrides_test.go` — pins the bwrap and sandbox-exec `AgentPaneCmd` output for the override / no-override / partial / shell-escaping / empty-session-name-fallback cases.
- `internal/session/host_overrides_test.go` — pins `buildDirectAgentCmd` host-mode behaviour (override flags emitted, no flags by default, scoped to pi harness, flag order relative to `--prompt`) and `SpawnOpts → Opts` forwarding.

All existing tests pass (`go test ./...` and `go test -race ./internal/{session,container}/... ./cmd/...`). `nix build .#prism` succeeds; the homeless-shelter gate runs in CI.

## Verification

```
$ ./result/bin/prism agent-run --help | grep -E 'model|variant|session'
      --model string     Model identifier override (overrides profile slot's model; sourced from prism spawn --model)
      --session string   Prism session name (e.g. nixos-config@main)
      --variant string   Variant/thinking-level override (overrides profile slot's thinking; sourced from prism spawn --variant)
```

## Notes

- The host-mode AC bullet says append `--variant` to the pi argv; pi's CLI actually exposes the variant axis as `--thinking` (per `pi --help`). I emit `--thinking <Y>` so pi parses the flag — same value, pi's native flag name. The user-facing prism flag stays `--variant` to match the profiles.json key.
- Out of scope per the issue: restart / restore semantics (overrides are spawn-time only), `--model-override role=model` (separate concern that hits sidecar metadata, not pi argv), and the spawn_inputs audit trail (covered by sibling issue #2087).

Closes #2086