### PR TITLE
prism: centralise spawn_inputs writer in SpawnSession (#2087)

### DIFF
--- a/modules/programs/prism/prism/cmd/investigate.go
+++ b/modules/programs/prism/prism/cmd/investigate.go
@@ -151,12 +151,17 @@ func spawnInvestigateSession(invokerSession, promptText, suppliedName string) er
 	h, _ := harness.New(harnessName, "", nil, "", "")
 
 	spawnOpts := session.SpawnOpts{
-		SessionName:      sessionName,
-		Repo:             repo,
-		Worktree:         worktree,
-		AgentRole:        "investigate",
-		Prompt:           promptText,
-		PromptSource:     "cli-positional",
+		SessionName:  sessionName,
+		Repo:         repo,
+		Worktree:     worktree,
+		AgentRole:    "investigate",
+		Prompt:       promptText,
+		PromptSource: "cli-positional",
+		// spawn_inputs audit (#2087): record the agent role on the audit row
+		// so investigate spawns show up in `prism stats` group-by queries
+		// alongside `prism spawn` / `prism pr` rows.
+		AgentFlag:        "investigate",
+		HarnessFlag:      harnessName,
 		Layout:           session.LayoutAgentOnly,
 		IsolationMode:    string(isoMode),
 		PluginHostPath:   cfg.SidecarPluginPath,

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -24,16 +24,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/skills"
 )
 
 var prCmd = &cobra.Command{
@@ -241,8 +245,138 @@ var prCmd = &cobra.Command{
 			// killed, matching the same semantics as prism spawn.
 			ForceFresh: true,
 		}
-		return ensureAndSwitch(worktreePath, bareRoot, opts)
+		if err := ensureAndSwitch(worktreePath, bareRoot, opts); err != nil {
+			return err
+		}
+
+		// Write spawn_inputs (#2087). prism pr does not go through
+		// SpawnSession — it uses ensureAndSwitch → session.Create — so the
+		// audit-row writer fires here, mirroring the centralised writer in
+		// SpawnSession with the same column mapping.
+		writeSpawnInputsForPR(cmd, prSpawnInputsArgs{
+			worktreePath:         worktreePath,
+			bareRoot:             bareRoot,
+			agentRole:            session.DefaultAgent(worktreePath, agentFlag),
+			profileName:          resolvedProfile,
+			modelFlag:            modelFlag,
+			variantFlag:          variantFlag,
+			agentFlag:            agentFlag,
+			harnessFlag:          effectiveHarness,
+			isolationFlag:        isolationFlag,
+			prNumber:             prNumber,
+			ignoreConcurrencyCap: ignoreConcurrencyCapFlag,
+			modelsByRole:         modelsByRole,
+			promptText:           promptFlag,
+			promptSource:         "cli-positional",
+		})
+		return nil
 	},
+}
+
+// prSpawnInputsArgs bundles the fields needed to write spawn_inputs from the
+// `prism pr` path. Kept separate from the centralised SpawnSession write
+// because prism pr does not flow through SpawnSession (it uses
+// ensureAndSwitch → session.Create), and we need to mirror SpawnSession's
+// column mapping without duplicating the SpawnOpts struct.
+type prSpawnInputsArgs struct {
+	worktreePath         string
+	bareRoot             string
+	agentRole            string
+	profileName          string
+	modelFlag            string
+	variantFlag          string
+	agentFlag            string
+	harnessFlag          string
+	isolationFlag        string
+	prNumber             string
+	ignoreConcurrencyCap bool
+	modelsByRole         map[string]string
+	promptText           string
+	promptSource         string
+}
+
+// writeSpawnInputsForPR writes the spawn_inputs row for a `prism pr` spawn.
+// All errors are non-fatal and logged — the session is already live and the
+// row is best-effort telemetry.
+func writeSpawnInputsForPR(cmd *cobra.Command, a prSpawnInputsArgs) {
+	d, dbErr := openDB()
+	if dbErr != nil {
+		proglog.Warnf("[prism pr] warning: could not open DB for spawn_inputs: %v\n", dbErr)
+		return
+	}
+	defer d.Close()
+
+	sessionName := session.NameFor(a.worktreePath, a.bareRoot)
+	st, lookupErr := d.CurrentStatus(sessionName)
+	if lookupErr != nil || st == nil || st.InstanceID == nil || *st.InstanceID == "" {
+		proglog.Warnf("[prism pr] warning: could not resolve instance_id for spawn_inputs (%v)\n", lookupErr)
+		return
+	}
+
+	// Compute skills and agent-role hashes the same way cmd/spawn.go does so
+	// the audit columns line up across the two CLI front doors.
+	skillsDir := prismSkillsDir()
+	skillsManifestHash, hashErr := skills.ComputeManifest(skillsDir)
+	if hashErr != nil {
+		proglog.Warnf("[prism pr] warning: could not compute skills manifest hash: %v\n", hashErr)
+		skillsManifestHash = ""
+	}
+	agentPromptHash, hashErr := skills.ComputeAgentPromptHash(prismAgentRolePath(a.agentRole))
+	if hashErr != nil {
+		proglog.Warnf("[prism pr] warning: could not compute agent prompt hash: %v\n", hashErr)
+		agentPromptHash = ""
+	}
+
+	si := db.SpawnInputs{
+		InstanceID: *st.InstanceID,
+		CreatedAt:  time.Now().UnixMilli(),
+	}
+	if a.profileName != "" {
+		si.ProfileName = &a.profileName
+	}
+	if a.modelFlag != "" {
+		si.ModelFlag = &a.modelFlag
+	}
+	if a.variantFlag != "" {
+		si.VariantFlag = &a.variantFlag
+	}
+	if a.agentFlag != "" {
+		si.AgentFlag = &a.agentFlag
+	}
+	if a.harnessFlag != "" {
+		si.HarnessFlag = &a.harnessFlag
+	}
+	if a.isolationFlag != "" {
+		si.IsolationFlag = &a.isolationFlag
+	}
+	if a.prNumber != "" {
+		if n, convErr := strconv.Atoi(a.prNumber); convErr == nil {
+			si.PRNumber = &n
+		}
+	}
+	si.IgnoreConcurrencyCap = a.ignoreConcurrencyCap
+	if len(a.modelsByRole) > 0 {
+		if encoded, encErr := json.Marshal(a.modelsByRole); encErr == nil {
+			s := string(encoded)
+			si.ModelVariantOverrides = &s
+		}
+	}
+	if skillsManifestHash != "" {
+		si.SkillsManifestHash = &skillsManifestHash
+	}
+	if agentPromptHash != "" {
+		si.AgentPromptHash = &agentPromptHash
+	}
+	if a.promptText != "" {
+		si.PromptText = &a.promptText
+	}
+	if a.promptSource != "" {
+		si.PromptSource = &a.promptSource
+	}
+
+	if err := d.InsertSpawnInputs(si); err != nil {
+		proglog.Warnf("[prism pr] warning: could not write spawn_inputs: %v\n", err)
+	}
 }
 
 func init() {

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -698,6 +698,36 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// (non-keybind, or keybind with an explicit --prompt) keeps the original
 	// #1891 guard active.
 	allowEmptyPrompt := fromKeybind && promptText == ""
+
+	// C4.SK / C4.AP: compute the skills manifest hash and the agent role file
+	// hash before building SpawnOpts so they land on the spawn_inputs row
+	// written by SpawnSession (issue #2087 centralisation). Errors are
+	// non-fatal: a missing or unreadable input produces an empty hash (which
+	// SpawnSession then writes as NULL).
+	skillsDir := prismSkillsDir()
+	skillsManifestHash, skillsHashErr := skills.ComputeManifest(skillsDir)
+	if skillsHashErr != nil {
+		proglog.Warnf("[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
+		skillsManifestHash = ""
+	}
+	agentRoleFilePath := prismAgentRolePath(agentRole)
+	agentPromptHash, agentHashErr := skills.ComputeAgentPromptHash(agentRoleFilePath)
+	if agentHashErr != nil {
+		proglog.Warnf("[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
+		agentPromptHash = ""
+	}
+
+	// spawn_inputs audit fields (issue #2087): collected here, written by
+	// SpawnSession via SpawnOpts. Raw user-passed flag values — isolationMode
+	// above is the *resolved* value; this is the raw --isolation flag.
+	isolationFlagRaw, _ := cmd.Flags().GetString("isolation")
+	prNumber := 0
+	if prFlag != "" {
+		if n, convErr := strconv.Atoi(prFlag); convErr == nil {
+			prNumber = n
+		}
+	}
+
 	spawnOpts := session.SpawnOpts{
 		SessionName:      sessionName,
 		Repo:             deriveRepo(worktreePath),
@@ -719,6 +749,19 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		// receive --model / --variant on the final argv.
 		Model:   modelFlag,
 		Variant: variantFlag,
+		// ── spawn_inputs audit fields (#2087) ─────────────────────────
+		ProfileName:          resolvedProfile,
+		ModelFlag:            modelFlag,
+		VariantFlag:          variantFlag,
+		AgentFlag:            agentFlag,
+		HarnessFlag:          harnessFlag,
+		IsolationFlag:        isolationFlagRaw,
+		PRNumber:             prNumber,
+		BranchFlag:           branchFlag,
+		IgnoreConcurrencyCap: ignoreConcurrencyCapFlagFromCmd(cmd),
+		SkillsManifestHash:   skillsManifestHash,
+		AgentPromptHash:      agentPromptHash,
+		// ────────────────────────────────────────────────────────
 		// PIExtensionDir is the host-side prism PI extension directory
 		// (populated by Nix into config.json). Forwarded so that host-mode
 		// pi launches pass --extension <dir>/prism.ts (#2065).
@@ -764,51 +807,12 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	}
 	defer d.Close()
 
-	// C4.SK: compute skills manifest hash before spawn so it is available for
-	// spawn_inputs. Read skills from XDG_CONFIG_HOME/prism/skills/ (with the
-	// standard ~/.config fallback). Errors are non-fatal: a missing or
-	// unreadable skills directory produces an empty hash (caller writes NULL).
-	skillsDir := prismSkillsDir()
-	skillsManifestHash, skillsHashErr := skills.ComputeManifest(skillsDir)
-	if skillsHashErr != nil {
-		proglog.Warnf("[prism spawn] warning: could not compute skills manifest hash: %v\n", skillsHashErr)
-		skillsManifestHash = ""
-	}
-
-	// C4.AP: compute agent role file hash. The role file is resolved from
-	// XDG_CONFIG_HOME/prism/agents/<role>.md. Errors are non-fatal.
-	agentRoleFilePath := prismAgentRolePath(agentRole)
-	agentPromptHash, agentHashErr := skills.ComputeAgentPromptHash(agentRoleFilePath)
-	if agentHashErr != nil {
-		proglog.Warnf("[prism spawn] warning: could not compute agent prompt hash: %v\n", agentHashErr)
-		agentPromptHash = ""
-	}
-
+	// SpawnSession is the canonical spawn_inputs writer (#2087): it builds
+	// the row from SpawnOpts fields populated above and inserts it after the
+	// sessions row exists. No post-spawn writer is needed here.
 	if err := session.SpawnSession(d, spawnOpts); err != nil {
 		return err
 	}
-
-	// Write spawn_inputs row. This is best-effort: a failure is logged but
-	// does not roll back the session (the session is already live).
-	// We read instance_id back from the DB because the sidecar mints it
-	// at startup and we do not want to thread it back through SpawnOpts just
-	// for this write path.
-	writeSpawnInputs(d, spawnInputsArgs{
-		sessionName:        sessionName,
-		profileName:        resolvedProfile,
-		modelFlag:          modelFlag,
-		variantFlag:        variantFlag,
-		agentFlag:          agentFlag,
-		harnessFlag:        harnessFlag,
-		cmd:                cmd,
-		prFlag:             prFlag,
-		branchFlag:         branchFlag,
-		skillsManifestHash: skillsManifestHash,
-		agentPromptHash:    agentPromptHash,
-		promptText:         promptText,
-		promptSource:       promptSource,
-		modelsByRole:       modelsByRole,
-	})
 
 	waitFlag, _ := cmd.Flags().GetBool("wait")
 	jsonFlag, _ := cmd.Flags().GetBool("json")
@@ -854,101 +858,17 @@ func prismAgentRolePath(role string) string {
 	return filepath.Join(base, "prism", "agents", role+".md")
 }
 
-// spawnInputsArgs bundles the flag values needed to build a db.SpawnInputs row.
-type spawnInputsArgs struct {
-	sessionName        string
-	profileName        string
-	modelFlag          string
-	variantFlag        string
-	agentFlag          string
-	harnessFlag        string
-	cmd                *cobra.Command
-	prFlag             string
-	branchFlag         string
-	skillsManifestHash string
-	agentPromptHash    string
-	promptText         string
-	promptSource       string
-	modelsByRole       map[string]string
-	// abtestPairID is non-empty for sessions spawned via --abtest.
-	abtestPairID string
+// ignoreConcurrencyCapFlagFromCmd reads --ignore-concurrency-cap if present.
+// Safe to call on commands that do not register the flag (returns false).
+// Used to populate SpawnOpts.IgnoreConcurrencyCap for the spawn_inputs audit
+// row written by SpawnSession (issue #2087).
+func ignoreConcurrencyCapFlagFromCmd(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	v, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
+	return v
 }
-
-// writeSpawnInputs looks up the instance_id for sessionName and inserts a row
-// into spawn_inputs. All errors are non-fatal and logged to stderr.
-func writeSpawnInputs(d *db.DB, args spawnInputsArgs) {
-	st, err := d.CurrentStatus(args.sessionName)
-	if err != nil || st == nil || st.InstanceID == nil || *st.InstanceID == "" {
-		proglog.Warnf("[prism spawn] warning: could not read instance_id for spawn_inputs: %v\n", err)
-		return
-	}
-
-	si := db.SpawnInputs{
-		InstanceID: *st.InstanceID,
-		CreatedAt:  time.Now().UnixMilli(),
-	}
-	if args.promptSource != "" {
-		si.PromptSource = spawnStrPtr(args.promptSource)
-	}
-
-	if args.profileName != "" {
-		si.ProfileName = &args.profileName
-	}
-	if args.modelFlag != "" {
-		si.ModelFlag = &args.modelFlag
-	}
-	if args.variantFlag != "" {
-		si.VariantFlag = &args.variantFlag
-	}
-	if args.agentFlag != "" {
-		si.AgentFlag = &args.agentFlag
-	}
-	if args.harnessFlag != "" {
-		si.HarnessFlag = &args.harnessFlag
-	}
-	if isolationFlag, _ := args.cmd.Flags().GetString("isolation"); isolationFlag != "" {
-		si.IsolationFlag = &isolationFlag
-	}
-	if hostModeFlag, _ := args.cmd.Flags().GetBool("host-mode"); hostModeFlag {
-		si.HostModeFlag = true
-	}
-	if args.prFlag != "" {
-		if n, err := strconv.Atoi(args.prFlag); err == nil {
-			si.PRNumber = &n
-		}
-	}
-	if args.branchFlag != "" {
-		si.BranchFlag = &args.branchFlag
-	}
-	if ignoreCap, _ := args.cmd.Flags().GetBool("ignore-concurrency-cap"); ignoreCap {
-		si.IgnoreConcurrencyCap = true
-	}
-	if args.skillsManifestHash != "" {
-		si.SkillsManifestHash = &args.skillsManifestHash
-	}
-	if args.agentPromptHash != "" {
-		si.AgentPromptHash = &args.agentPromptHash
-	}
-	if args.promptText != "" {
-		si.PromptText = &args.promptText
-	}
-	if len(args.modelsByRole) > 0 {
-		if encoded, encErr := json.Marshal(args.modelsByRole); encErr == nil {
-			s := string(encoded)
-			si.ModelVariantOverrides = &s
-		}
-	}
-	if args.abtestPairID != "" {
-		si.AbtestPairID = &args.abtestPairID
-	}
-
-	if err := d.InsertSpawnInputs(si); err != nil {
-		proglog.Warnf("[prism spawn] warning: could not write spawn_inputs: %v\n", err)
-	}
-}
-
-// spawnStrPtr returns a pointer to s, for optional string fields in SpawnInputs.
-func spawnStrPtr(s string) *string { return &s }
 
 // resolveBareRoot returns the bare repo root to operate on.
 // If repoFlag is set, it is resolved as a shorthand name under ~/code or as a
@@ -1363,6 +1283,13 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 	}
 
 	h, _ := harness.New(a.harnessFlag, "", nil, "", "")
+	isolationFlagRaw, _ := cmd.Flags().GetString("isolation")
+	prNumber := 0
+	if a.prFlag != "" {
+		if n, convErr := strconv.Atoi(a.prFlag); convErr == nil {
+			prNumber = n
+		}
+	}
 	spawnOpts := session.SpawnOpts{
 		SessionName:      sessionName,
 		Repo:             deriveRepo(worktreePath),
@@ -1388,6 +1315,20 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		// PIExtensionDir for host-mode pi launches (#2065).
 		PIExtensionDir:   a.cfg.PIExtensionDir,
 		ReadinessTimeout: session.DefaultReadinessTimeout,
+		// ── spawn_inputs audit fields (#2087) ─────────────────────────
+		ProfileName:          a.profileName,
+		ModelFlag:            a.modelFlag,
+		VariantFlag:          a.variantFlag,
+		AgentFlag:            a.agentFlag,
+		HarnessFlag:          a.harnessFlag,
+		IsolationFlag:        isolationFlagRaw,
+		PRNumber:             prNumber,
+		BranchFlag:           a.branchFlag,
+		IgnoreConcurrencyCap: ignoreConcurrencyCapFlagFromCmd(cmd),
+		SkillsManifestHash:   a.skillsManifestHash,
+		AgentPromptHash:      a.agentPromptHash,
+		AbtestPairID:         a.pairID,
+		// ────────────────────────────────────────────────────────
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {
 		spawnOpts.AgentEnvVars = a.pf.AgentEnvVars
@@ -1400,28 +1341,12 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		}
 	}
 
+	// SpawnSession is the canonical spawn_inputs writer (#2087) and includes
+	// the abtest_pair_id from SpawnOpts.AbtestPairID. Both legs of the abtest
+	// pair share the same a.pairID minted by the caller.
 	if err := session.SpawnSession(a.d, spawnOpts); err != nil {
 		return "", worktreePath, err
 	}
-
-	// Write spawn_inputs including abtest_pair_id.
-	writeSpawnInputs(a.d, spawnInputsArgs{
-		sessionName:        sessionName,
-		profileName:        a.profileName,
-		modelFlag:          a.modelFlag,
-		variantFlag:        a.variantFlag,
-		agentFlag:          a.agentFlag,
-		harnessFlag:        a.harnessFlag,
-		cmd:                cmd,
-		prFlag:             a.prFlag,
-		branchFlag:         a.branchFlag,
-		skillsManifestHash: a.skillsManifestHash,
-		agentPromptHash:    a.agentPromptHash,
-		promptText:         a.promptText,
-		promptSource:       a.promptSource,
-		modelsByRole:       a.modelsByRole,
-		abtestPairID:       a.pairID,
-	})
 
 	return sessionName, worktreePath, nil
 }

--- a/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
@@ -1,0 +1,358 @@
+package cmd
+
+// Tests for the centralised spawn_inputs writer introduced in issue #2087.
+//
+// SpawnSession is the single chokepoint that writes spawn_inputs (see
+// internal/session/spawn.go). The writer builds the row from
+// session.SpawnOpts fields via session.SpawnInputsFromOpts. These tests
+// exercise that mapping and the end-to-end insert path against an isolated
+// DB so the schema, flag→column mapping, and abtest-pair propagation all
+// land correctly without spinning up tmux / sidecar / a real agent.
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608):
+//   - sidecartest.NewIsolated redirects $XDG_STATE_HOME to a t.TempDir() and
+//     sets the PRISM_TEST_MODE_RESTRICT_HOSTAPI guard, so no host DB / bus /
+//     tmux state is touched.
+//   - Session names use the "prism-test@" prefix.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// seedSessionForSpawnInputs inserts a minimal sessions row for the given instance + name so
+// the spawn_inputs FK (spawn_inputs.instance_id → sessions.instance_id) is
+// satisfied. Mirrors what SpawnSession does host-side before writing the
+// audit row (#1507).
+func seedSessionForSpawnInputs(t *testing.T, d *db.DB, instanceID, sessionName string) {
+	t.Helper()
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "test-repo",
+		Worktree:    "/tmp/worktree",
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("seedSessionForSpawnInputs: InsertSession: %v", err)
+	}
+}
+
+// TestSpawnInputsFromOpts_FullFlagSet verifies that every flag-mirror field
+// on session.SpawnOpts lands in the corresponding spawn_inputs column when
+// the row is written via InsertSpawnInputs and read back via
+// SpawnInputsByInstanceID.
+//
+// This is the core flag→column mapping test required by issue #2087:
+// after a `prism spawn` with all flags set, the audit row reflects the
+// invocation faithfully.
+func TestSpawnInputsFromOpts_FullFlagSet(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-full-flags"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	modelsByRole := map[string]string{
+		"coordinator":    "anthropic/claude-opus-4",
+		"review-context": "google/gemini-2.5-pro",
+	}
+	opts := session.SpawnOpts{
+		InstanceID:           instanceID,
+		Prompt:               "do the mahi",
+		PromptSource:         "cli-positional",
+		PromptTemplateHash:   "tmpl-sha-abc",
+		ProfileName:          "anthropic",
+		ModelFlag:            "anthropic/claude-opus-4-8",
+		VariantFlag:          "high",
+		AgentFlag:            "worker",
+		HarnessFlag:          "pi",
+		IsolationFlag:        "bwrap",
+		HostModeFlag:         true,
+		PRNumber:             1234,
+		BranchFlag:           "feature/x",
+		IgnoreConcurrencyCap: true,
+		ModelsByRole:         modelsByRole,
+		SkillsManifestHash:   "skills-sha-xyz",
+		AgentPromptHash:      "agent-sha-def",
+		AbtestPairID:         "abtest-pair-uuid-0001",
+	}
+
+	si := session.SpawnInputsFromOpts(opts)
+	if si.InstanceID != instanceID {
+		t.Errorf("InstanceID: got %q, want %q", si.InstanceID, instanceID)
+	}
+	if si.CreatedAt == 0 {
+		t.Error("CreatedAt: got 0, want non-zero (mirrors sessions.started_at)")
+	}
+	// CreatedAt should be within a sensible window of now — guards against
+	// time.Now() being read at the wrong point in the helper.
+	if delta := time.Now().UnixMilli() - si.CreatedAt; delta < 0 || delta > 5_000 {
+		t.Errorf("CreatedAt: %d ms away from now, want within 5s", delta)
+	}
+
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil, want non-nil row")
+	}
+
+	assertStringPtr(t, "ProfileName", got.ProfileName, "anthropic")
+	assertStringPtr(t, "ModelFlag", got.ModelFlag, "anthropic/claude-opus-4-8")
+	assertStringPtr(t, "VariantFlag", got.VariantFlag, "high")
+	assertStringPtr(t, "AgentFlag", got.AgentFlag, "worker")
+	assertStringPtr(t, "HarnessFlag", got.HarnessFlag, "pi")
+	assertStringPtr(t, "IsolationFlag", got.IsolationFlag, "bwrap")
+	if !got.HostModeFlag {
+		t.Error("HostModeFlag: got false, want true")
+	}
+	if got.PRNumber == nil || *got.PRNumber != 1234 {
+		t.Errorf("PRNumber: got %v, want 1234", got.PRNumber)
+	}
+	assertStringPtr(t, "BranchFlag", got.BranchFlag, "feature/x")
+	if !got.IgnoreConcurrencyCap {
+		t.Error("IgnoreConcurrencyCap: got false, want true")
+	}
+	assertStringPtr(t, "SkillsManifestHash", got.SkillsManifestHash, "skills-sha-xyz")
+	assertStringPtr(t, "PromptTemplateHash", got.PromptTemplateHash, "tmpl-sha-abc")
+	assertStringPtr(t, "AgentPromptHash", got.AgentPromptHash, "agent-sha-def")
+	assertStringPtr(t, "PromptText", got.PromptText, "do the mahi")
+	assertStringPtr(t, "PromptSource", got.PromptSource, "cli-positional")
+	assertStringPtr(t, "AbtestPairID", got.AbtestPairID, "abtest-pair-uuid-0001")
+
+	// ModelVariantOverrides is the JSON encoding of ModelsByRole.
+	if got.ModelVariantOverrides == nil {
+		t.Fatal("ModelVariantOverrides: got nil, want JSON of ModelsByRole")
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(*got.ModelVariantOverrides), &decoded); err != nil {
+		t.Fatalf("ModelVariantOverrides: unmarshal: %v (raw: %q)", err, *got.ModelVariantOverrides)
+	}
+	if len(decoded) != len(modelsByRole) {
+		t.Errorf("ModelVariantOverrides: got %d entries, want %d", len(decoded), len(modelsByRole))
+	}
+	for role, model := range modelsByRole {
+		if decoded[role] != model {
+			t.Errorf("ModelVariantOverrides[%q]: got %q, want %q", role, decoded[role], model)
+		}
+	}
+}
+
+// TestSpawnInputsFromOpts_EmptyFlagsRoundTripAsNull verifies that unset
+// flag fields land as NULL (nil pointer) in the DB row — the
+// "minimum-viable spawn" case for `prism spawn` with only a prompt.
+//
+// This case matters because `prism stats --group-by model` queries
+// IS NOT NULL on model_flag; if an unset flag round-tripped as the empty
+// string instead of NULL, the group-by would mis-classify rows.
+func TestSpawnInputsFromOpts_EmptyFlagsRoundTripAsNull(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-empty-flags"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	// Only the bare minimum: instance id + a prompt. Everything else is
+	// the zero value of SpawnOpts.
+	opts := session.SpawnOpts{
+		InstanceID:   instanceID,
+		Prompt:       "minimal prompt",
+		PromptSource: "cli-positional",
+	}
+	si := session.SpawnInputsFromOpts(opts)
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil, want non-nil row")
+	}
+
+	// Unset flag-mirror fields must be nil so downstream IS NULL queries
+	// classify them correctly.
+	for name, field := range map[string]*string{
+		"ProfileName":           got.ProfileName,
+		"ModelFlag":             got.ModelFlag,
+		"VariantFlag":           got.VariantFlag,
+		"AgentFlag":             got.AgentFlag,
+		"HarnessFlag":           got.HarnessFlag,
+		"IsolationFlag":         got.IsolationFlag,
+		"BranchFlag":            got.BranchFlag,
+		"SkillsManifestHash":    got.SkillsManifestHash,
+		"PromptTemplateHash":    got.PromptTemplateHash,
+		"AgentPromptHash":       got.AgentPromptHash,
+		"AbtestPairID":          got.AbtestPairID,
+		"ModelVariantOverrides": got.ModelVariantOverrides,
+	} {
+		if field != nil {
+			t.Errorf("%s: got %q, want nil (flag was not passed)", name, *field)
+		}
+	}
+	if got.PRNumber != nil {
+		t.Errorf("PRNumber: got %d, want nil (flag was not passed)", *got.PRNumber)
+	}
+	if got.HostModeFlag {
+		t.Error("HostModeFlag: got true, want false (default)")
+	}
+	if got.IgnoreConcurrencyCap {
+		t.Error("IgnoreConcurrencyCap: got true, want false (default)")
+	}
+
+	// Prompt-related fields that were set must survive the round trip.
+	assertStringPtr(t, "PromptText", got.PromptText, "minimal prompt")
+	assertStringPtr(t, "PromptSource", got.PromptSource, "cli-positional")
+}
+
+// TestSpawnInputsFromOpts_AbtestPair verifies that both legs of an --abtest
+// pair land with the same abtest_pair_id, matching the front-door contract
+// (cmd/spawn.go's runAbtestSpawn mints one pairID and passes it to both
+// spawnOneAbtest invocations). This is the writer-level contract: given the
+// same SpawnOpts.AbtestPairID on two SpawnOpts, the two rows share the value.
+func TestSpawnInputsFromOpts_AbtestPair(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	pairID := uuid.New().String()
+
+	for _, leg := range []struct{ name, profile string }{
+		{"prism-test@worker-abtest-a", "profileA"},
+		{"prism-test@worker-abtest-b", "profileB"},
+	} {
+		instanceID := uuid.New().String()
+		seedSessionForSpawnInputs(t, d, instanceID, leg.name)
+		si := session.SpawnInputsFromOpts(session.SpawnOpts{
+			InstanceID:   instanceID,
+			Prompt:       "abtest leg prompt",
+			PromptSource: "cli-positional",
+			ProfileName:  leg.profile,
+			AbtestPairID: pairID,
+		})
+		if err := d.InsertSpawnInputs(si); err != nil {
+			t.Fatalf("InsertSpawnInputs leg %q: %v", leg.name, err)
+		}
+		got, err := d.SpawnInputsByInstanceID(instanceID)
+		if err != nil {
+			t.Fatalf("SpawnInputsByInstanceID leg %q: %v", leg.name, err)
+		}
+		if got == nil {
+			t.Fatalf("leg %q: got nil row", leg.name)
+		}
+		assertStringPtr(t, "AbtestPairID/"+leg.name, got.AbtestPairID, pairID)
+		assertStringPtr(t, "ProfileName/"+leg.name, got.ProfileName, leg.profile)
+	}
+}
+
+// TestSpawnInputsFromOpts_ModelOverrideJSON verifies the JSON shape written
+// to model_variant_overrides for --model-override flag repeats. Downstream
+// readers parse this back into a map, so the round trip must be lossless.
+func TestSpawnInputsFromOpts_ModelOverrideJSON(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-model-override"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	overrides := map[string]string{
+		"review-context": "google/gemini-2.5-pro",
+		"review-code":    "anthropic/claude-sonnet-4-7",
+	}
+	si := session.SpawnInputsFromOpts(session.SpawnOpts{
+		InstanceID:   instanceID,
+		Prompt:       "with overrides",
+		PromptSource: "cli-positional",
+		ModelsByRole: overrides,
+	})
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil || got.ModelVariantOverrides == nil {
+		t.Fatalf("ModelVariantOverrides: got nil row or nil column, want JSON")
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(*got.ModelVariantOverrides), &decoded); err != nil {
+		t.Fatalf("decode model_variant_overrides JSON: %v (raw: %q)", err, *got.ModelVariantOverrides)
+	}
+	for role, model := range overrides {
+		if decoded[role] != model {
+			t.Errorf("ModelVariantOverrides[%q]: got %q, want %q", role, decoded[role], model)
+		}
+	}
+}
+
+// TestSpawnInputsFromOpts_InvestigateMinimalRow verifies that the minimum
+// audit row required by the issue ACs lands for an investigate-style spawn:
+// instance_id + created_at + agent role/flag. cmd/investigate.go sets
+// SpawnOpts.AgentFlag = "investigate" so the row classifies under
+// `prism stats --group-by agent` alongside spawn / pr rows.
+func TestSpawnInputsFromOpts_InvestigateMinimalRow(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@coord~investigate-slug"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	si := session.SpawnInputsFromOpts(session.SpawnOpts{
+		InstanceID:   instanceID,
+		Prompt:       "investigation prompt",
+		PromptSource: "cli-positional",
+		AgentFlag:    "investigate",
+		HarnessFlag:  "pi",
+	})
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("got nil, want non-nil row")
+	}
+	if got.InstanceID != instanceID {
+		t.Errorf("InstanceID: got %q, want %q", got.InstanceID, instanceID)
+	}
+	if got.CreatedAt == 0 {
+		t.Error("CreatedAt: got 0, want non-zero")
+	}
+	assertStringPtr(t, "AgentFlag", got.AgentFlag, "investigate")
+	assertStringPtr(t, "HarnessFlag", got.HarnessFlag, "pi")
+}
+
+// assertStringPtr fails the test if got is nil or *got != want. Used to keep
+// the per-field assertions in the tests above concise.
+func assertStringPtr(t *testing.T, name string, got *string, want string) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s: got nil, want %q", name, want)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s: got %q, want %q", name, *got, want)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -250,6 +250,12 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			ModelsByRole:       opts.ModelsByRole,
 			// PIExtensionDir for host-mode pi launches (#2065).
 			PIExtensionDir: opts.PIExtensionDir,
+			// spawn_inputs audit (#2087): record the per-agent role and the
+			// harness so review fan-out rows are queryable alongside other
+			// spawn front doors. PromptSource / PromptTemplateHash above
+			// already feed the centralised SpawnSession writer.
+			AgentFlag:   ag.Name,
+			HarnessFlag: agentHarnessName,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -546,6 +552,9 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			ModelsByRole:       opts.ModelsByRole,
 			// PIExtensionDir for host-mode pi launches (#2065).
 			PIExtensionDir: opts.PIExtensionDir,
+			// spawn_inputs audit (#2087): mirror the sync fan-out block.
+			AgentFlag:   ag.Name,
+			HarnessFlag: asyncAgentHarnessName,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -616,7 +625,7 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 		Agents:        liveAgents,
 		AgentSessions: liveSessions,
 		DBPath:        dbPath,
-		Timeout: opts.Timeout * 2, // 2x per-agent timeout as group monitor limit
+		Timeout:       opts.Timeout * 2, // 2x per-agent timeout as group monitor limit
 	}
 	if startErr := StartMonitorProcess(monitorOpts, prismBinary); startErr != nil {
 		// Monitor failed to start — not fatal for spawning, but warn loudly.

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -23,6 +23,7 @@ package session
 //     review.go once this primitive lands.
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -253,6 +254,75 @@ type SpawnOpts struct {
 	// Variant, when non-empty, is the CLI-supplied variant override from
 	// `prism spawn --variant <Y>`. Semantics mirror Model. Issue #2086.
 	Variant string
+
+	// Note: ModelFlag / VariantFlag below are distinct from Model / Variant
+	// above. Model / Variant feed harness-routing (the agent-run launch argv);
+	// ModelFlag / VariantFlag feed the audit row written to spawn_inputs.
+	// In `prism spawn` they carry the same string — keeping them as separate
+	// fields lets the audit shape evolve independently of launch-time semantics.
+
+	// ── spawn_inputs audit fields (issue #2087) ──────────────────────────
+	//
+	// These mirror the CLI flag values passed at spawn time and are written
+	// to the spawn_inputs table by SpawnSession. Each front door
+	// (`prism spawn`, `prism pr`, `prism investigate`, `prism review`) populates
+	// the fields it knows about; SpawnSession is the single chokepoint that
+	// inserts the row. Pointer fields are nullable in the DB — leave the
+	// matching SpawnOpts field as its zero value when the flag was not passed.
+
+	// ProfileName is the resolved active profile name (e.g. "anthropic").
+	// Mirrors spawn_inputs.profile_name. Empty when no profile is active.
+	ProfileName string
+
+	// ModelFlag is the raw --model flag value (e.g. "anthropic/claude-sonnet-4-7").
+	// Mirrors spawn_inputs.model_flag.
+	ModelFlag string
+
+	// VariantFlag is the raw --variant flag value (e.g. "high").
+	// Mirrors spawn_inputs.variant_flag.
+	VariantFlag string
+
+	// AgentFlag is the raw --agent flag value as the user passed it
+	// (distinct from AgentRole, which is the resolved role written to
+	// agent_status.root_agent_name). Mirrors spawn_inputs.agent_flag.
+	AgentFlag string
+
+	// HarnessFlag is the raw --harness flag value (e.g. "pi").
+	// Mirrors spawn_inputs.harness_flag.
+	HarnessFlag string
+
+	// IsolationFlag is the raw --isolation flag value as the user passed
+	// it (distinct from IsolationMode, which is the resolved mode used at
+	// launch). Mirrors spawn_inputs.isolation_flag.
+	IsolationFlag string
+
+	// HostModeFlag mirrors --host-mode. Mirrors spawn_inputs.host_mode_flag.
+	HostModeFlag bool
+
+	// PRNumber is the parsed --pr flag value. Zero means no --pr was passed.
+	// Mirrors spawn_inputs.pr_number.
+	PRNumber int
+
+	// BranchFlag is the raw --branch flag value.
+	// Mirrors spawn_inputs.branch_flag.
+	BranchFlag string
+
+	// IgnoreConcurrencyCap mirrors --ignore-concurrency-cap.
+	// Mirrors spawn_inputs.ignore_concurrency_cap.
+	IgnoreConcurrencyCap bool
+
+	// SkillsManifestHash is the C4.SK skills directory hash computed at spawn
+	// time. Mirrors spawn_inputs.skills_manifest_hash.
+	SkillsManifestHash string
+
+	// AgentPromptHash is the C4.AP agent role file hash computed at spawn
+	// time. Mirrors spawn_inputs.agent_prompt_hash.
+	AgentPromptHash string
+
+	// AbtestPairID is the shared UUID minted at the spawn-call site when
+	// --abtest is used. Both sibling sessions receive the same value so the
+	// rows pair via spawn_inputs.abtest_pair_id (P4.ABTEST, #1216).
+	AbtestPairID string
 }
 
 // SpawnSession creates a single prism session end-to-end: seeds the
@@ -663,37 +733,23 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		startup.log("spawn-session: sessions row pre-inserted (instance_id=%s)", opts.InstanceID)
 	}
 
-	// Write spawn_inputs row (C.4.SRC / C.4.PT, issue #1148). Non-fatal:
-	// spawn_inputs is best-effort telemetry; a failure here must never block
-	// session creation.
+	// Write spawn_inputs row (C.4.SRC / C.4.PT, issue #1148; centralised in
+	// SpawnSession per issue #2087). SpawnSession is the single chokepoint:
+	// every front door (`prism spawn`, `prism pr`, `prism investigate`,
+	// `prism review`) populates the audit fields on SpawnOpts and the row is
+	// written here, after the sessions row has been pre-inserted (FK target)
+	// and before any layout/sidecar side-effects. Non-fatal: spawn_inputs is
+	// best-effort telemetry; a failure here must never block session creation.
 	//
-	// LayoutFull (CLI) spawns: the richer writeSpawnInputs call in cmd/spawn.go
-	// carries all flag-value columns (profile, model, variant, agent, harness,
-	// branch, skills hash, etc.) and will write the row after SpawnSession
-	// returns. Avoid writing here so INSERT OR IGNORE does not silently drop
-	// that richer payload.
-	//
-	// LayoutAgentOnly (review fan-out) spawns: the caller does not run
-	// writeSpawnInputs afterwards, so SpawnSession owns the only write.
-	if opts.Layout != LayoutFull {
-		si := db.SpawnInputs{
-			InstanceID: opts.InstanceID,
-			CreatedAt:  time.Now().UnixMilli(),
-		}
-		if opts.Prompt != "" {
-			si.PromptText = &opts.Prompt
-		}
-		if opts.PromptSource != "" {
-			si.PromptSource = &opts.PromptSource
-		}
-		if opts.PromptTemplateHash != "" {
-			si.PromptTemplateHash = &opts.PromptTemplateHash
-		}
-		if insertErr := d.InsertSpawnInputs(si); insertErr != nil {
-			fmt.Fprintf(os.Stderr,
-				"warning: could not write spawn_inputs for %q: %v\n",
-				opts.SessionName, insertErr)
-		}
+	// The write happens for every Layout. INSERT OR IGNORE means a duplicate
+	// call (e.g. from a caller that has not yet migrated) is silently dropped
+	// rather than overwriting the row — the first writer wins, and since this
+	// is the canonical writer it always wins.
+	si := spawnInputsFromOpts(opts)
+	if insertErr := d.InsertSpawnInputs(si); insertErr != nil {
+		fmt.Fprintf(os.Stderr,
+			"warning: could not write spawn_inputs for %q: %v\n",
+			opts.SessionName, insertErr)
 	}
 
 	// Step 3: Allocate a port from the configured range. Fails fast if the
@@ -853,21 +909,21 @@ func resolveLayoutIsolationMode(opts SpawnOpts) string {
 // preview and launch in practice.
 func buildOptsForLayout(opts SpawnOpts, port int, promptFilePath string) Opts {
 	return Opts{
-		Prompt:           opts.Prompt,
-		PromptFilePath:   promptFilePath,
-		Agent:            opts.AgentRole,
-		ConfigContent:    opts.ConfigContent,
-		SessionName:      opts.SessionName,
-		Port:             port,
-		IsolationMode:    opts.IsolationMode,
-		PluginHostPath:   opts.PluginHostPath,
-		InstanceID:       opts.InstanceID,
-		AgentEnvVars:     opts.AgentEnvVars,
-		ConfigEnvVarName: opts.ConfigEnvVarName,
-		RuntimeEnvVars:   opts.RuntimeEnvVars,
-		Layout:           LayoutFull,
-		ForceFresh:       opts.ForceFresh,
-		Headless:         opts.Headless,
+		Prompt:              opts.Prompt,
+		PromptFilePath:      promptFilePath,
+		Agent:               opts.AgentRole,
+		ConfigContent:       opts.ConfigContent,
+		SessionName:         opts.SessionName,
+		Port:                port,
+		IsolationMode:       opts.IsolationMode,
+		PluginHostPath:      opts.PluginHostPath,
+		InstanceID:          opts.InstanceID,
+		AgentEnvVars:        opts.AgentEnvVars,
+		ConfigEnvVarName:    opts.ConfigEnvVarName,
+		RuntimeEnvVars:      opts.RuntimeEnvVars,
+		Layout:              LayoutFull,
+		ForceFresh:          opts.ForceFresh,
+		Headless:            opts.Headless,
 		HarnessName:         opts.HarnessName,
 		HarnessPipeSockPath: opts.HarnessPipeSockPath,
 		ModelsByRole:        opts.ModelsByRole,
@@ -1073,4 +1129,97 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	}
 	_ = tmux.SelectWindow(opts.SessionName, 1)
 	return nil
+}
+
+// spawnInputsFromOpts builds the db.SpawnInputs row written by SpawnSession
+// from the audit-field subset of SpawnOpts. Each pointer field is set only
+// when the corresponding flag was passed (non-empty / non-zero) so that
+// genuinely-unset flags remain NULL in the DB — matching the schema's
+// nullability and downstream `prism stats` / abtest queries which test for
+// IS NULL / IS NOT NULL explicitly.
+//
+// Exported test-side via the spawnInputsFromOptsForTest shim in
+// spawn_test.go so cmd/-level tests can assert the flag→column mapping
+// without spinning up a real tmux/sidecar.
+func spawnInputsFromOpts(opts SpawnOpts) db.SpawnInputs {
+	si := db.SpawnInputs{
+		InstanceID: opts.InstanceID,
+		CreatedAt:  time.Now().UnixMilli(),
+	}
+	if opts.ProfileName != "" {
+		s := opts.ProfileName
+		si.ProfileName = &s
+	}
+	if opts.ModelFlag != "" {
+		s := opts.ModelFlag
+		si.ModelFlag = &s
+	}
+	if opts.VariantFlag != "" {
+		s := opts.VariantFlag
+		si.VariantFlag = &s
+	}
+	if opts.AgentFlag != "" {
+		s := opts.AgentFlag
+		si.AgentFlag = &s
+	}
+	if opts.HarnessFlag != "" {
+		s := opts.HarnessFlag
+		si.HarnessFlag = &s
+	}
+	if opts.IsolationFlag != "" {
+		s := opts.IsolationFlag
+		si.IsolationFlag = &s
+	}
+	si.HostModeFlag = opts.HostModeFlag
+	if opts.PRNumber != 0 {
+		n := opts.PRNumber
+		si.PRNumber = &n
+	}
+	if opts.BranchFlag != "" {
+		s := opts.BranchFlag
+		si.BranchFlag = &s
+	}
+	si.IgnoreConcurrencyCap = opts.IgnoreConcurrencyCap
+	if len(opts.ModelsByRole) > 0 {
+		if encoded, err := json.Marshal(opts.ModelsByRole); err == nil {
+			s := string(encoded)
+			si.ModelVariantOverrides = &s
+		}
+	}
+	if opts.SkillsManifestHash != "" {
+		s := opts.SkillsManifestHash
+		si.SkillsManifestHash = &s
+	}
+	if opts.PromptTemplateHash != "" {
+		s := opts.PromptTemplateHash
+		si.PromptTemplateHash = &s
+	}
+	if opts.AgentPromptHash != "" {
+		s := opts.AgentPromptHash
+		si.AgentPromptHash = &s
+	}
+	if opts.Prompt != "" {
+		s := opts.Prompt
+		si.PromptText = &s
+	}
+	if opts.PromptSource != "" {
+		s := opts.PromptSource
+		si.PromptSource = &s
+	}
+	if opts.AbtestPairID != "" {
+		s := opts.AbtestPairID
+		si.AbtestPairID = &s
+	}
+	return si
+}
+
+// SpawnInputsFromOpts is the test-only export of spawnInputsFromOpts. It lets
+// cmd/-level unit tests assert the flag-to-column mapping without spinning up
+// a real tmux/sidecar/DB stack — they build a SpawnOpts, call this, and
+// assert on the returned db.SpawnInputs.
+//
+// Not for production use: production code should go through SpawnSession,
+// which is the single chokepoint that writes the row.
+func SpawnInputsFromOpts(opts SpawnOpts) db.SpawnInputs {
+	return spawnInputsFromOpts(opts)
 }

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -57,12 +57,12 @@ func TestSpawnSession_AgentOnly_SeedsRootAgentName(t *testing.T) {
 
 	const sessionName = "myrepo@branch~review-1-review-code"
 	opts := SpawnOpts{
-		SessionName: sessionName,
-		Repo:        "myrepo",
-		Worktree:    "/worktrees/myrepo-branch",
-		AgentRole:   "review-code",
-		Prompt:      "review this PR",
-		Layout:      LayoutAgentOnly,
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "review-code",
+		Prompt:         "review this PR",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	}
 
@@ -116,13 +116,13 @@ func TestSpawnSession_AgentOnly_WritesGroupID(t *testing.T) {
 
 	const sessionName = "myrepo@branch~review-1-review-goal"
 	opts := SpawnOpts{
-		SessionName: sessionName,
-		Repo:        "myrepo",
-		Worktree:    "/worktrees/myrepo-branch",
-		AgentRole:   "review-goal",
-		Prompt:      "go",
-		Layout:      LayoutAgentOnly,
-		GroupID:     groupID,
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "review-goal",
+		Prompt:         "go",
+		Layout:         LayoutAgentOnly,
+		GroupID:        groupID,
 		PIExtensionDir: testPIExtensionDir,
 	}
 
@@ -157,12 +157,12 @@ func TestSpawnSession_AgentOnly_CreatesTmuxSession(t *testing.T) {
 
 	const sessionName = "myrepo@branch~review-1-review-qa"
 	opts := SpawnOpts{
-		SessionName: sessionName,
-		Repo:        "myrepo",
-		Worktree:    "/worktrees/myrepo-branch",
-		AgentRole:   "review-qa",
-		Prompt:      "go",
-		Layout:      LayoutAgentOnly,
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "review-qa",
+		Prompt:         "go",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	}
 
@@ -202,8 +202,8 @@ func TestSpawnSession_NoAgentRole_LeavesRootAgentNameNull(t *testing.T) {
 		Repo:        "myrepo",
 		Worktree:    "/worktrees/myrepo-branch",
 		// AgentRole intentionally left empty.
-		Prompt: "go",
-		Layout: LayoutAgentOnly,
+		Prompt:         "go",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	}
 
@@ -242,12 +242,12 @@ func TestSpawnSession_AllocatePortFails_ReturnsError(t *testing.T) {
 
 	const sessionName = "myrepo@branch-alloc-fail"
 	opts := SpawnOpts{
-		SessionName: sessionName,
-		Repo:        "myrepo",
-		Worktree:    "/worktrees/myrepo-branch",
-		AgentRole:   "review-security",
-		Prompt:      "go",
-		Layout:      LayoutAgentOnly,
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "review-security",
+		Prompt:         "go",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	}
 
@@ -277,9 +277,9 @@ func TestSpawnSession_Validation_RequiresSessionName(t *testing.T) {
 	d, _ := openSpawnTestDB(t)
 
 	err := SpawnSession(d, SpawnOpts{
-		Worktree:  "/tmp",
-		AgentRole: "worker",
-		Layout:    LayoutAgentOnly,
+		Worktree:       "/tmp",
+		AgentRole:      "worker",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
@@ -295,9 +295,9 @@ func TestSpawnSession_Validation_RequiresWorktree(t *testing.T) {
 	d, _ := openSpawnTestDB(t)
 
 	err := SpawnSession(d, SpawnOpts{
-		SessionName: "myrepo@branch",
-		AgentRole:   "worker",
-		Layout:      LayoutAgentOnly,
+		SessionName:    "myrepo@branch",
+		AgentRole:      "worker",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
@@ -311,10 +311,10 @@ func TestSpawnSession_Validation_RequiresWorktree(t *testing.T) {
 // TestSpawnSession_Validation_RequiresDB verifies the argument guard.
 func TestSpawnSession_Validation_RequiresDB(t *testing.T) {
 	err := SpawnSession(nil, SpawnOpts{
-		SessionName: "myrepo@branch",
-		Worktree:    "/tmp",
-		AgentRole:   "worker",
-		Layout:      LayoutAgentOnly,
+		SessionName:    "myrepo@branch",
+		Worktree:       "/tmp",
+		AgentRole:      "worker",
+		Layout:         LayoutAgentOnly,
 		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
@@ -344,13 +344,13 @@ func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
 
 			sessionName := "myrepo@branch~review-1-review-code-" + mode
 			opts := SpawnOpts{
-				SessionName:   sessionName,
-				Repo:          "myrepo",
-				Worktree:      "/worktrees/myrepo-branch",
-				AgentRole:     "review-code",
-				Prompt:        "go",
-				Layout:        LayoutAgentOnly,
-				IsolationMode: mode,
+				SessionName:    sessionName,
+				Repo:           "myrepo",
+				Worktree:       "/worktrees/myrepo-branch",
+				AgentRole:      "review-code",
+				Prompt:         "go",
+				Layout:         LayoutAgentOnly,
+				IsolationMode:  mode,
 				PIExtensionDir: testPIExtensionDir,
 			}
 
@@ -394,13 +394,13 @@ func TestSpawnSession_AgentOnly_PromptFile_WithPrompt_Host(t *testing.T) {
 	const sessionName = "myrepo@branch~review-1-review-code"
 	const prompt = "review this PR"
 	opts := SpawnOpts{
-		SessionName:   sessionName,
-		Repo:          "myrepo",
-		Worktree:      "/worktrees/myrepo-branch",
-		AgentRole:     "review-code",
-		Prompt:        prompt,
-		Layout:        LayoutAgentOnly,
-		IsolationMode: "host",
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "review-code",
+		Prompt:         prompt,
+		Layout:         LayoutAgentOnly,
+		IsolationMode:  "host",
 		PIExtensionDir: testPIExtensionDir,
 	}
 
@@ -600,8 +600,8 @@ func TestSpawnAgentPaneEnvVars(t *testing.T) {
 	})
 	t.Run("with prompt only (legacy)", func(t *testing.T) {
 		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "hello",
-	PIExtensionDir: testPIExtensionDir,
-})
+			PIExtensionDir: testPIExtensionDir,
+		})
 		if got == nil {
 			t.Fatal("got nil, want non-nil map")
 		}
@@ -611,8 +611,8 @@ func TestSpawnAgentPaneEnvVars(t *testing.T) {
 	})
 	t.Run("empty prompt", func(t *testing.T) {
 		got := spawnAgentPaneEnvVars(SpawnOpts{Prompt: "",
-	PIExtensionDir: testPIExtensionDir,
-})
+			PIExtensionDir: testPIExtensionDir,
+		})
 		if got != nil {
 			t.Errorf("got %v, want nil (an empty entry would override an inherited value)", got)
 		}
@@ -629,10 +629,10 @@ func TestSpawnSession_UnsupportedLayout_ReturnsError(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 
 	err := SpawnSession(d, SpawnOpts{
-		SessionName: "myrepo@branch-bad-layout",
-		Worktree:    "/tmp",
-		AgentRole:   "worker",
-		Layout:      LayoutScratchpad, // not supported by SpawnSession,
+		SessionName:    "myrepo@branch-bad-layout",
+		Worktree:       "/tmp",
+		AgentRole:      "worker",
+		Layout:         LayoutScratchpad, // not supported by SpawnSession,
 		PIExtensionDir: testPIExtensionDir,
 	})
 	if err == nil {
@@ -685,13 +685,13 @@ func TestSpawnSession_NeedsPromptFile_AllModesAndLayouts(t *testing.T) {
 			sessionName := "myrepo@branch~review-1-review-code-" + strings.ReplaceAll(tc.name, "+", "-")
 
 			opts := SpawnOpts{
-				SessionName:   sessionName,
-				Repo:          "myrepo",
-				Worktree:      "/worktrees/myrepo",
-				AgentRole:     "review-code",
-				Prompt:        prompt,
-				Layout:        tc.layout,
-				IsolationMode: tc.isolationMode,
+				SessionName:    sessionName,
+				Repo:           "myrepo",
+				Worktree:       "/worktrees/myrepo",
+				AgentRole:      "review-code",
+				Prompt:         prompt,
+				Layout:         tc.layout,
+				IsolationMode:  tc.isolationMode,
 				PIExtensionDir: testPIExtensionDir,
 			}
 
@@ -904,5 +904,223 @@ func TestSpawnSession_EmptyPrompt_NonAgentLayouts_NotRejectedForEmptyPrompt(t *t
 				t.Errorf("SpawnSession with empty Prompt + %s returned a 'Prompt is required' error: %v — the layer-4 guard must fire only for LayoutFull/LayoutAgentOnly (issue #1891 AC5)", layout.name, err)
 			}
 		})
+	}
+}
+
+// TestSpawnSession_WritesSpawnInputs_AllFields is the end-to-end integration
+// test for the centralised spawn_inputs writer (issue #2087). It verifies
+// that SpawnSession, given a SpawnOpts populated with every audit-mirror
+// field, inserts a single spawn_inputs row keyed by the host-minted
+// instance_id and that every column lands with the expected value.
+//
+// This test exercises the writer path inside SpawnSession itself (rather than
+// the helper SpawnInputsFromOpts in isolation), so a regression that
+// silently drops the InsertSpawnInputs call — the failure mode that
+// motivated #2087 — would be caught here.
+func TestSpawnSession_WritesSpawnInputs_AllFields(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "prism-test@worker-spawn-inputs-end-to-end"
+	overrides := map[string]string{
+		"review-context": "google/gemini-2.5-pro",
+	}
+	opts := SpawnOpts{
+		SessionName:          sessionName,
+		Repo:                 "myrepo",
+		Worktree:             "/worktrees/myrepo-spawn-inputs",
+		AgentRole:            "worker",
+		Prompt:               "ship the audit row",
+		PromptSource:         "cli-positional",
+		PromptTemplateHash:   "tmpl-sha-e2e",
+		Layout:               LayoutAgentOnly,
+		IsolationMode:        "host",
+		HarnessName:          "pi",
+		PIExtensionDir:       testPIExtensionDir,
+		ProfileName:          "anthropic",
+		ModelFlag:            "anthropic/claude-opus-4-7",
+		VariantFlag:          "high",
+		AgentFlag:            "worker",
+		HarnessFlag:          "pi",
+		IsolationFlag:        "host",
+		HostModeFlag:         false,
+		PRNumber:             2087,
+		BranchFlag:           "prism-spawn-inputs-writer",
+		IgnoreConcurrencyCap: true,
+		ModelsByRole:         overrides,
+		SkillsManifestHash:   "skills-e2e",
+		AgentPromptHash:      "agent-e2e",
+		AbtestPairID:         "abtest-e2e",
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil || st.InstanceID == nil || *st.InstanceID == "" {
+		t.Fatal("CurrentStatus: missing instance_id after SpawnSession")
+	}
+
+	si, err := d.SpawnInputsByInstanceID(*st.InstanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si == nil {
+		t.Fatal("spawn_inputs row missing — SpawnSession must write a row for every spawn (#2087)")
+	}
+
+	checkPtr := func(name string, got *string, want string) {
+		t.Helper()
+		if got == nil {
+			t.Errorf("spawn_inputs.%s: got nil, want %q", name, want)
+			return
+		}
+		if *got != want {
+			t.Errorf("spawn_inputs.%s: got %q, want %q", name, *got, want)
+		}
+	}
+	checkPtr("profile_name", si.ProfileName, "anthropic")
+	checkPtr("model_flag", si.ModelFlag, "anthropic/claude-opus-4-7")
+	checkPtr("variant_flag", si.VariantFlag, "high")
+	checkPtr("agent_flag", si.AgentFlag, "worker")
+	checkPtr("harness_flag", si.HarnessFlag, "pi")
+	checkPtr("isolation_flag", si.IsolationFlag, "host")
+	checkPtr("branch_flag", si.BranchFlag, "prism-spawn-inputs-writer")
+	checkPtr("skills_manifest_hash", si.SkillsManifestHash, "skills-e2e")
+	checkPtr("prompt_template_hash", si.PromptTemplateHash, "tmpl-sha-e2e")
+	checkPtr("agent_prompt_hash", si.AgentPromptHash, "agent-e2e")
+	checkPtr("prompt_text", si.PromptText, "ship the audit row")
+	checkPtr("prompt_source", si.PromptSource, "cli-positional")
+	checkPtr("abtest_pair_id", si.AbtestPairID, "abtest-e2e")
+
+	if si.PRNumber == nil || *si.PRNumber != 2087 {
+		t.Errorf("spawn_inputs.pr_number: got %v, want 2087", si.PRNumber)
+	}
+	if !si.IgnoreConcurrencyCap {
+		t.Error("spawn_inputs.ignore_concurrency_cap: got false, want true")
+	}
+	if si.HostModeFlag {
+		t.Error("spawn_inputs.host_mode_flag: got true, want false")
+	}
+	if si.CreatedAt == 0 {
+		t.Error("spawn_inputs.created_at: got 0, want non-zero")
+	}
+	if si.ModelVariantOverrides == nil || *si.ModelVariantOverrides == "" {
+		t.Error("spawn_inputs.model_variant_overrides: got empty, want JSON of ModelsByRole")
+	} else if !strings.Contains(*si.ModelVariantOverrides, "review-context") {
+		t.Errorf("spawn_inputs.model_variant_overrides: got %q, expected to contain %q",
+			*si.ModelVariantOverrides, "review-context")
+	}
+}
+
+// TestSpawnSession_WritesSpawnInputs_MinimalRow verifies the floor of the
+// AC contract for #2087: a SpawnSession invocation with only the required
+// inputs (no audit flags) still produces a spawn_inputs row keyed by
+// instance_id with created_at populated, so downstream JOINs see the row
+// instead of the pre-fix empty-table state.
+func TestSpawnSession_WritesSpawnInputs_MinimalRow(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "prism-test@worker-spawn-inputs-minimal"
+	opts := SpawnOpts{
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-minimal",
+		AgentRole:      "worker",
+		Prompt:         "minimal",
+		Layout:         LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil || st == nil || st.InstanceID == nil {
+		t.Fatalf("CurrentStatus: %v / %v", err, st)
+	}
+
+	si, err := d.SpawnInputsByInstanceID(*st.InstanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si == nil {
+		t.Fatal("spawn_inputs row missing — minimal spawn must still produce an audit row (#2087)")
+	}
+	if si.InstanceID != *st.InstanceID {
+		t.Errorf("spawn_inputs.instance_id = %q, want %q", si.InstanceID, *st.InstanceID)
+	}
+	if si.CreatedAt == 0 {
+		t.Error("spawn_inputs.created_at: got 0, want non-zero")
+	}
+	if si.PromptText == nil || *si.PromptText != "minimal" {
+		t.Errorf("spawn_inputs.prompt_text: got %v, want %q", si.PromptText, "minimal")
+	}
+}
+
+// TestSpawnSession_WritesSpawnInputs_AbtestPairIDShared verifies that two
+// SpawnSession calls carrying the same AbtestPairID land two rows that
+// share the abtest_pair_id column, matching the contract of `prism spawn
+// --abtest` (cmd/spawn.go's runAbtestSpawn mints one pairID and passes it
+// to both legs).
+func TestSpawnSession_WritesSpawnInputs_AbtestPairIDShared(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	pairID := "abtest-pair-shared-uuid"
+
+	legs := []struct{ name, profile string }{
+		{"prism-test@worker-abtest-leg-a", "profileA"},
+		{"prism-test@worker-abtest-leg-b", "profileB"},
+	}
+	instanceIDs := make([]string, len(legs))
+
+	for i, leg := range legs {
+		opts := SpawnOpts{
+			SessionName:    leg.name,
+			Repo:           "myrepo",
+			Worktree:       "/worktrees/myrepo-" + leg.profile,
+			AgentRole:      "worker",
+			Prompt:         "abtest leg",
+			Layout:         LayoutAgentOnly,
+			PIExtensionDir: testPIExtensionDir,
+			ProfileName:    leg.profile,
+			AbtestPairID:   pairID,
+		}
+		if err := SpawnSession(d, opts); err != nil {
+			t.Fatalf("SpawnSession leg %d (%q): %v", i, leg.name, err)
+		}
+		st, _ := d.CurrentStatus(leg.name)
+		if st == nil || st.InstanceID == nil {
+			t.Fatalf("leg %d: missing instance_id after SpawnSession", i)
+		}
+		instanceIDs[i] = *st.InstanceID
+	}
+
+	for i, iid := range instanceIDs {
+		si, err := d.SpawnInputsByInstanceID(iid)
+		if err != nil {
+			t.Fatalf("SpawnInputsByInstanceID leg %d: %v", i, err)
+		}
+		if si == nil {
+			t.Fatalf("leg %d: missing spawn_inputs row", i)
+		}
+		if si.AbtestPairID == nil || *si.AbtestPairID != pairID {
+			t.Errorf("leg %d: abtest_pair_id = %v, want %q", i, si.AbtestPairID, pairID)
+		}
+		if si.ProfileName == nil || *si.ProfileName != legs[i].profile {
+			t.Errorf("leg %d: profile_name = %v, want %q", i, si.ProfileName, legs[i].profile)
+		}
 	}
 }


### PR DESCRIPTION
Closes #2087.

The `spawn_inputs` table was empty on navi despite many `prism spawn` invocations having recorded sessions. The audit trail for "what flags did the user actually pass at spawn time" was unrecoverable after the fact, breaking `prism stats --group-by model` and the `--abtest` pair ledger.

## Root cause

`prism pr` / `prism switch` routed through `ensureAndSwitch` → `session.Create`, which never wrote `spawn_inputs`. Only `prism spawn` / `prism review` / `prism investigate` (which go through `SpawnSession`) ever wrote rows, and even those split the writer logic across two layers — `SpawnSession` for `LayoutAgentOnly` only, `cmd/spawn.go`'s `writeSpawnInputs` helper for `LayoutFull`. The split meant any spawn that bailed before `writeSpawnInputs` (readiness timeout, post-spawn error) left no audit row.

## Fix — centralise in SpawnSession

`SpawnSession` is now the single chokepoint that writes `spawn_inputs`:

- `SpawnOpts` grows a clearly-labelled block of audit-mirror fields (`ProfileName`, `ModelFlag`, `VariantFlag`, `AgentFlag`, `HarnessFlag`, `IsolationFlag`, `HostModeFlag`, `PRNumber`, `BranchFlag`, `IgnoreConcurrencyCap`, `SkillsManifestHash`, `AgentPromptHash`, `AbtestPairID`). Front doors populate the fields they know about and `SpawnSession` inserts the row.
- The write happens for **every** Layout, **after** the sessions row is pre-inserted (FK target) and **before** any layout / sidecar / readiness side-effects. A readiness-timeout failure or a layout-create failure no longer drops the audit row.
- `cmd/spawn.go` drops its post-spawn `writeSpawnInputs` helper and populates `SpawnOpts` instead — both the regular and the `--abtest` paths.
- `cmd/investigate.go` and `internal/review/run.go` pick up the new write path for free; they set `AgentFlag` / `HarnessFlag` so investigate and review-agent rows classify alongside spawn / pr rows in `prism stats` group-by queries.
- `cmd/pr.go` does **not** flow through `SpawnSession` (it uses `ensureAndSwitch` → `session.Create`). It now writes a parallel `spawn_inputs` row via `writeSpawnInputsForPR` after `ensureAndSwitch` returns successfully, mirroring `SpawnSession`'s column mapping.

## `--abtest` pair UUIDs

`runAbtestSpawn` already minted one `pairID` via `generateAbtestPairID` and passed it to both `spawnOneAbtest` invocations. The `pairID` now propagates to both legs via `SpawnOpts.AbtestPairID` so both sibling rows share the same `abtest_pair_id` value. A regression test (`TestSpawnSession_WritesSpawnInputs_AbtestPairIDShared`) locks this in.

## `--model-override` JSON shape

`session.spawnInputsFromOpts` JSON-marshals `SpawnOpts.ModelsByRole` into `spawn_inputs.model_variant_overrides`. Empty map → NULL column. A round-trip test (`TestSpawnInputsFromOpts_ModelOverrideJSON`) verifies the JSON decodes back to the original map shape.

## Tests

Unit tests (`cmd/spawn_inputs_writer_test.go`) cover the `SpawnInputsFromOpts` flag-to-column mapping in isolation via `sidecartest.NewIsolated`:

- Full-flag set round-trips losslessly.
- Empty / unset flags land as NULL (not empty string), so `prism stats` `IS NULL` queries classify correctly.
- `--abtest` pair shares `abtest_pair_id` across both legs.
- `--model-override` JSON encoding round-trips.
- Investigate-style minimal row carries `instance_id` + `created_at` + `agent_flag`.

Integration tests (`internal/session/spawn_test.go`) exercise the real `SpawnSession` write path end-to-end with the spy-tmux harness:

- `TestSpawnSession_WritesSpawnInputs_AllFields` — every column lands.
- `TestSpawnSession_WritesSpawnInputs_MinimalRow` — bare spawn still produces an audit row (the failure mode this PR fixes).
- `TestSpawnSession_WritesSpawnInputs_AbtestPairIDShared` — pair UUID propagates to both legs.

All tests use the `prism-test@` session-name prefix per AGENTS.md isolation contract (#1608).

## Out of scope

`prism switch` is not covered: it opens or attaches to existing sessions rather than creating new ones at the user's request, so it has no "spawn-time CLI flag" semantics to record. The issue ACs list only spawn / pr / review / investigate / quick — and `quick` does not spawn at all (it runs an inline action and exits).