### PR TITLE
Add anthropic-opus-max-4-8 profile to Prism

### DIFF
--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -133,6 +133,19 @@
               };
             };
 
+            anthropic-opus-max-4-8 = profileFromSlots {
+              _default = slot "worker" {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-8";
+                thinking = "xhigh";
+              };
+              coordinator = slot "coordinator" {
+                provider = "anthropic";
+                model = "anthropic/claude-opus-4-8";
+                thinking = "xhigh";
+              };
+            };
+
             anthropic-opus = profileFromSlots {
               coordinator = slot "coordinator" {
                 provider = "anthropic";


### PR DESCRIPTION
This change introduces a new profile configuration utilizing Claude Opus 4.8 with high-intensity thinking parameters. It enables support for this specific model variant across both worker and coordinator slots.