### PR TITLE
sidecar: classify zero-output worker exits as error, not finished

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -309,6 +309,36 @@ func (s *Sidecar) handleSessionFinished() {
 			return
 		}
 
+		// Zero-output guard (#2081): a worker that connects, produces no
+		// assistant output, and disconnects within seconds of the handshake
+		// must not be reported as a clean finish — the coordinator would chase a
+		// PR that never existed. Two corroborating signals from the issue are
+		// combined here:
+		//
+		//   (3) the persisted-state machine rejects the transition to finished —
+		//       the session never reached `active` (no turn_start upserted the
+		//       row out of `idle`), so finishing from here is illegal; and
+		//   (1) the session produced no assistant output this lifetime
+		//       (sawAssistantOutput is still false).
+		//
+		// When BOTH hold this is a zero-output startup exit: route to StateError
+		// (a valid idle → error transition) and deliver the "has errored"
+		// notification instead of "has finished". Requiring both signals keeps
+		// the fix narrow — a session that did real work (sawAssistantOutput) or
+		// that reached a state from which finishing is legal (active/waiting) is
+		// untouched.
+		if !s.sawAssistantOutput && agent.Transition(currentState, agent.StateFinished) != nil {
+			s.logger().Printf("sidecar: transition -> error (cause=zero_output_exit, state=%q, no assistant output)", currentState)
+			s.upsertState(agent.StateError, nil, nil)
+			s.writeStateChange(agent.StateError)
+			s.lastState = agent.StateError
+			s.lastErrorAt = s.cfg.Clock.Now()
+			finalText := s.lastInvestigatorText
+			s.goNotify(func() { s.notifyCoordinatorWithState(agent.StateError) })
+			s.goNotify(func() { s.notifyInvestigatorCompletion(agent.StateError, finalText) })
+			return
+		}
+
 		s.logger().Printf("sidecar: transition -> finished (cause=finished_debounce)")
 		s.upsertState(agent.StateFinished, nil, nil)
 		s.writeStateChange(agent.StateFinished)

--- a/modules/programs/prism/prism/internal/sidecar/notify.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify.go
@@ -172,9 +172,32 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 	}
 }
 
+// coordinatorNotifyText returns the verbatim coordinator notification body for
+// a worker terminal state. The strings are fixed so coordinators can
+// pattern-match on them — see the "Worker terminal-state notifications" table
+// in the prism skill (SKILL.md). StateError uses the "has errored" wording;
+// every other terminal state uses the "has finished" wording.
+func coordinatorNotifyText(sessionName string, state agent.AgentState) string {
+	if state == agent.StateError {
+		return fmt.Sprintf("Agent %s has errored its current task", sessionName)
+	}
+	return fmt.Sprintf("Agent %s has finished its current task", sessionName)
+}
+
 // notifyCoordinator sends a "finished" notification to the coordinator session
-// for this repo. It is called asynchronously (via go) after writing
-// StateFinished, so s.mu must NOT be held when this method runs.
+// for this repo. It is a thin wrapper over notifyCoordinatorWithState that
+// preserves the historical StateFinished ("has finished") behaviour for the
+// clean-exit call sites.
+func (s *Sidecar) notifyCoordinator() {
+	s.notifyCoordinatorWithState(agent.StateFinished)
+}
+
+// notifyCoordinatorWithState sends a terminal-state notification to the
+// coordinator session for this repo. It is called asynchronously (via go)
+// after writing the terminal state, so s.mu must NOT be held when this method
+// runs. The notification body is selected from the terminal state via
+// coordinatorNotifyText: StateError yields "has errored", StateFinished (and
+// any other state) yields "has finished".
 //
 // The coordinator is discovered by looking up "<repo>@main" in the DB.
 // Notification is delivered via the coordinator's host-API Unix socket
@@ -193,7 +216,7 @@ func (s *Sidecar) notifyParentWorkerOnStartupFailure(startupErr error) {
 //
 // Delivery is a single attempt via promptdelivery.DeliverToSession; there is
 // no retry loop or backoff in this function.
-func (s *Sidecar) notifyCoordinator() {
+func (s *Sidecar) notifyCoordinatorWithState(state agent.AgentState) {
 	// Self-notification guard: if this session IS the coordinator, skip.
 	// DB-backed: check root_agent_name == "coordinator" for self.
 	// Fallback to name heuristic for pre-migration rows.
@@ -276,7 +299,7 @@ func (s *Sidecar) notifyCoordinator() {
 
 	coordinatorName := coordStatus.SessionName
 
-	notifyText := fmt.Sprintf("Agent %s has finished its current task", s.cfg.SessionName)
+	notifyText := coordinatorNotifyText(s.cfg.SessionName, state)
 
 	// Capture the coordinator's current instance_id so the message is scoped
 	// to the correct incarnation of the coordinator. If the coordinator has no

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -482,6 +482,18 @@ type Sidecar struct {
 	// Protected by s.mu.
 	lastInvestigatorText string
 
+	// sawAssistantOutput records whether this session has produced any
+	// non-empty assistant turn since the sidecar started. It is set once (to
+	// true) on the first turn_end carrying assistant text and is never reset.
+	//
+	// handleSessionFinished reads it to distinguish a genuine clean finish
+	// from a zero-output startup crash (#2081): a worker that connects,
+	// produces no assistant output, and disconnects within seconds of the
+	// handshake must be classified as StateError ("has errored"), not
+	// StateFinished ("has finished") — otherwise the coordinator chases a PR
+	// that does not exist. Protected by s.mu.
+	sawAssistantOutput bool
+
 	// promptDedup is the bounded in-memory dedup set for /prompt deliveries.
 	// Each /prompt request carries a delivery_id (UUID minted by the sender);
 	// repeats whose ID has been seen recently are dropped before they reach
@@ -2455,9 +2467,12 @@ func (s *Sidecar) handlePipeFrame(line []byte) (cleanShutdown bool) {
 			s.writeEvent("msg_assistant", p, nil)
 		}
 		s.writeEvent(frame.Type, json.RawMessage(line), nil)
-		// Track the most recent turn text for the final completion notification.
+		// Track the most recent turn text for the final completion notification,
+		// and record that this session has produced assistant output at least
+		// once (#2081 zero-output detection in handleSessionFinished).
 		if text != "" {
 			s.lastInvestigatorText = text
+			s.sawAssistantOutput = true
 		}
 
 	case "auto_retry_start":

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_zero_output_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_zero_output_test.go
@@ -1,0 +1,266 @@
+// Tests for the zero-output-exit classification fix (issue #2081).
+//
+// A worker session that connects, produces no assistant output, and
+// disconnects within seconds of the handshake was previously classified as
+// `finished` — the coordinator then chased a PR that never existed. The fix in
+// handleSessionFinished combines two signals from the issue:
+//
+//	(3) the persisted-state machine rejects the transition to finished (the
+//	    session never reached `active`, so it is still `idle`); and
+//	(1) the session produced no assistant output (sawAssistantOutput == false).
+//
+// When both hold, the session is routed to StateError and the coordinator
+// receives the "has errored" notification instead of "has finished".
+//
+// # Isolation contract
+//
+// newZeroOutputWorkerSidecar redirects XDG_STATE_HOME to a t.TempDir(), sets
+// PRISM_TEST_MODE_RESTRICT_HOSTAPI=1, uses an openTestDB temp database, and
+// installs a capturing notifyCoordinatorDeliverFn seam so no notification ever
+// reaches a live host. Session names carry the prism-test@ prefix per AGENTS.md.
+package sidecar
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+)
+
+// coordNotifyTracker records every coordinator notification delivered through
+// the notifyCoordinatorDeliverFn seam. It is safe for concurrent use because
+// the delivery runs on a goNotify goroutine; readers must drain via
+// sc.WaitNotifies() before calling snapshot().
+type coordNotifyTracker struct {
+	mu    sync.Mutex
+	calls []coordNotifyCall
+}
+
+type coordNotifyCall struct {
+	to   string
+	text string
+}
+
+func (c *coordNotifyTracker) record(to, text string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls = append(c.calls, coordNotifyCall{to: to, text: text})
+}
+
+func (c *coordNotifyTracker) snapshot() []coordNotifyCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]coordNotifyCall, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+// newZeroOutputWorkerSidecar builds a socket-pipe worker sidecar against an
+// isolated temp DB, seeds a discoverable coordinator row and the worker's
+// initial `idle` agent_status row (as tmux-session-start does before the
+// sidecar attaches), and installs a capturing coordinator-delivery seam.
+func newZeroOutputWorkerSidecar(t *testing.T, sockPath, worker, coord, repo string) (*Sidecar, *testClock, *coordNotifyTracker) {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")
+	d := openTestDB(t)
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:           worker,
+		Repo:                  repo,
+		Worktree:              t.TempDir(),
+		DB:                    d,
+		Clock:                 clk,
+		AgentRole:             "worker",
+		HarnessName:           "pi",
+		HarnessPipeSockPath:   sockPath,
+		StartupConnectTimeout: 5 * time.Second,
+		PipeReconnectTimeout:  200 * time.Millisecond,
+		Harness:               pih.New("", "", ""),
+	}
+	sc := New(cfg)
+
+	// Seed a discoverable coordinator for this repo so notifyCoordinator can
+	// resolve a delivery target via CoordinatorForRepo.
+	coordAgent := "coordinator"
+	if err := d.UpsertStatusWithRootAgent(coord, repo, "/tmp/coord-"+coord, string(agent.StateActive), nil, nil, &coordAgent, nil); err != nil {
+		t.Fatalf("seed coordinator %q: %v", coord, err)
+	}
+	// Seed the worker's initial idle state — this is the persisted state the
+	// finished debounce sees when the zero-output worker never went active.
+	if err := d.UpsertStatus(worker, repo, "/tmp/worker-"+worker, string(agent.StateIdle), nil, nil); err != nil {
+		t.Fatalf("seed worker %q idle: %v", worker, err)
+	}
+
+	tr := &coordNotifyTracker{}
+	sc.notifyCoordinatorDeliverFn = func(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any, source string, deliverAs string) error {
+		tr.record(sessionName, text)
+		return nil
+	}
+	return sc, clk, tr
+}
+
+// TestSocketPipe_ZeroOutputExit_ClassifiedAsError drives the exact reproducer
+// from issue #2081: a turn_end with NO preceding turn_start and NO assistant
+// text (an empty turn), immediately followed by state_change{finished}. The
+// worker never reached `active` and produced no output, so the finished
+// debounce must route it to StateError and deliver the "has errored"
+// notification, NOT "has finished".
+func TestSocketPipe_ZeroOutputExit_ClassifiedAsError(t *testing.T) {
+	sockPath := shortSockPath(t)
+	worker := "prism-test@zero-output-worker"
+	coord := "prism-test@main"
+	repo := "prism-test"
+	sc, clk, tr := newZeroOutputWorkerSidecar(t, sockPath, worker, coord, repo)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Empty turn: turn_end with no turn_start and no msg_assistant fragments,
+	// then a finish signal. This mirrors the captured production frames where
+	// turn_end was the first inbound frame.
+	sendJSON(t, conn, map[string]any{"type": "turn_end", "agent": "worker"})
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer was created after state_change{finished}")
+	}
+	timer.Fire()
+	sc.WaitNotifies()
+
+	// The session must land in error, not finished.
+	st := waitForState(t, sc.cfg.DB, worker, string(agent.StateError), 2*time.Second)
+	if st != string(agent.StateError) {
+		t.Fatalf("zero-output worker state = %q, want %q", st, agent.StateError)
+	}
+
+	// The coordinator must receive exactly one notification with the "has
+	// errored" wording.
+	calls := tr.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("coordinator notifications = %d, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].to != coord {
+		t.Errorf("notification target = %q, want %q", calls[0].to, coord)
+	}
+	wantText := "Agent " + worker + " has errored its current task"
+	if calls[0].text != wantText {
+		t.Errorf("notification body = %q, want %q", calls[0].text, wantText)
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// TestSocketPipe_NormalExit_StillClassifiedAsFinished is the negative case:
+// a worker that runs a normal turn (turn_start → assistant text → turn_end)
+// and produces output must still classify as StateFinished and deliver the
+// "has finished" notification. This proves the zero-output guard is not
+// over-broad.
+//
+// Note: in the PI socket-pipe path lastAssistantAgent is cleared on the
+// root-agent turn_end, so it is "" at finish time in BOTH the normal and the
+// zero-output case. The load-bearing "did this session produce output" signal
+// is therefore sawAssistantOutput (set by the non-empty turn_end here), not
+// lastAssistantAgent.
+func TestSocketPipe_NormalExit_StillClassifiedAsFinished(t *testing.T) {
+	sockPath := shortSockPath(t)
+	worker := "prism-test@normal-output-worker"
+	coord := "prism-test@main"
+	repo := "prism-test"
+	sc, clk, tr := newZeroOutputWorkerSidecar(t, sockPath, worker, coord, repo)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// A normal turn: go active, stream assistant text, end the turn with that
+	// text, then finish.
+	sendJSON(t, conn, map[string]any{"type": "turn_start"})
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "Opened PR #123 and pushed the branch."})
+	sendJSON(t, conn, map[string]any{
+		"type":  "turn_end",
+		"agent": "worker",
+		"usage": map[string]any{"input": 10, "output": 5},
+	})
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer was created after state_change{finished}")
+	}
+	timer.Fire()
+	sc.WaitNotifies()
+
+	st := waitForState(t, sc.cfg.DB, worker, string(agent.StateFinished), 2*time.Second)
+	if st != string(agent.StateFinished) {
+		t.Fatalf("normal worker state = %q, want %q", st, agent.StateFinished)
+	}
+
+	calls := tr.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("coordinator notifications = %d, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].to != coord {
+		t.Errorf("notification target = %q, want %q", calls[0].to, coord)
+	}
+	wantText := "Agent " + worker + " has finished its current task"
+	if calls[0].text != wantText {
+		t.Errorf("notification body = %q, want %q", calls[0].text, wantText)
+	}
+
+	conn.Close()
+	_ = wait()
+}
+
+// TestSocketPipe_OutputWithoutActive_StillFinishes proves the guard requires
+// BOTH signals: a session that produced assistant output but whose persisted
+// state never advanced past idle (so the state machine would reject
+// idle → finished, signal 3) is NOT routed to error, because it produced
+// output (signal 1 is false). This is the combination boundary that keeps the
+// fix narrow — only genuine zero-output exits are reclassified.
+func TestSocketPipe_OutputWithoutActive_StillFinishes(t *testing.T) {
+	sockPath := shortSockPath(t)
+	worker := "prism-test@output-no-active-worker"
+	coord := "prism-test@main"
+	repo := "prism-test"
+	sc, clk, tr := newZeroOutputWorkerSidecar(t, sockPath, worker, coord, repo)
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+
+	// Produce assistant output WITHOUT a turn_start, so agent_status stays at
+	// the seeded `idle` while sawAssistantOutput becomes true.
+	sendJSON(t, conn, map[string]any{"type": "msg_assistant", "text": "Some real work happened here."})
+	sendJSON(t, conn, map[string]any{"type": "turn_end", "agent": "worker"})
+	sendJSON(t, conn, map[string]any{"type": "state_change", "state": "finished"})
+
+	timer := clk.WaitForTimerCount(1, 5*time.Second)
+	if timer == nil {
+		t.Fatal("no finished debounce timer was created after state_change{finished}")
+	}
+	timer.Fire()
+	sc.WaitNotifies()
+
+	// Signal (1) is false (output was produced), so the guard must NOT fire:
+	// the session finishes despite the idle→finished state-machine rejection.
+	st := waitForState(t, sc.cfg.DB, worker, string(agent.StateFinished), 2*time.Second)
+	if st != string(agent.StateFinished) {
+		t.Fatalf("worker-with-output state = %q, want %q", st, agent.StateFinished)
+	}
+
+	calls := tr.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("coordinator notifications = %d, want 1: %+v", len(calls), calls)
+	}
+	wantText := "Agent " + worker + " has finished its current task"
+	if calls[0].text != wantText {
+		t.Errorf("notification body = %q, want %q", calls[0].text, wantText)
+	}
+
+	conn.Close()
+	_ = wait()
+}

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -805,9 +805,11 @@ When a worker session reaches a terminal state, the coordinator that spawned it 
 | Terminal state | Notification body |
 |---|---|
 | `finished` (clean exit) | `Agent <name> has finished its current task` |
-| `error` (crash / restart-exhausted) | `Agent <name> has errored its current task` |
+| `error` (crash / restart-exhausted / zero-output exit) | `Agent <name> has errored its current task` |
 
 The wording is fixed so coordinators can pattern-match on either string.
+
+- **Zero-output exits classify as `error` (issue #2081).** A worker that connects, produces no assistant output, and disconnects within seconds of the handshake never reached `active` — the persisted-state machine rejects the `idle → finished` transition. The sidecar honours that rejection: such an exit is routed to `error` (the "has errored" wording) rather than firing a false "has finished" signal that would send the coordinator chasing a PR that does not exist.
 
 ### Delivery contract
 


### PR DESCRIPTION
## Summary

A worker session that connects, fails to produce any assistant output, and disconnects within ~3 s of the handshake was classified as `finished`, so the coordinator received the `"Agent <name> has finished its current task"` notification and then chased a PR that doesn't exist.

The persisted-state machine already rejected the `idle → finished` transition for this case (logged as `invalid transition "idle" → "finished"`), but the in-memory sidecar transitioned anyway and fired the finish notification. This PR makes the PI socket-pipe finished-debounce **honour that rejection** and route zero-output exits to `StateError` with the `"has errored"` wording instead.

## What changed

- **`internal/sidecar/events.go` (`handleSessionFinished`)** — before writing `StateFinished`, the debounce-fire closure now checks two corroborating signals from the issue and routes to `StateError` when **both** hold:
  - **(3)** the persisted-state machine rejects the transition to finished — the session never reached `active` (no `turn_start` upserted the row out of `idle`), so `agent.Transition(currentState, StateFinished)` errors; and
  - **(1)** the session produced no assistant output this lifetime (`sawAssistantOutput == false`).

  `idle → error` is a valid transition, so the DB write is clean. Requiring **both** signals keeps the fix narrow — a session that did real work, or reached a state from which finishing is legal (`active`/`waiting`), is untouched.
- **`internal/sidecar/sidecar.go`** — new set-once `sawAssistantOutput` field, set on the first non-empty `turn_end`.
- **`internal/sidecar/notify.go`** — `notifyCoordinator` is refactored into `notifyCoordinatorWithState(state)` so the error path can select the `"has errored its current task"` body via `coordinatorNotifyText`. Existing clean-exit call sites keep the `"has finished"` wording through a thin wrapper — all suppression guards (coordinator-self, review-agent, investigate-agent, escalated, muted) are preserved.
- **`modules/programs/prism/skills/prism/SKILL.md`** — the wording table's `error` row now notes zero-output exits; the verbatim strings still match the code.

## Tests (`internal/sidecar/sidecar_zero_output_test.go`)

- `TestSocketPipe_ZeroOutputExit_ClassifiedAsError` — drives the exact reproducer (empty `turn_end` with no `turn_start`/output → `state_change{finished}`) and asserts the session lands in `StateError` with the `"has errored its current task"` notification.
- `TestSocketPipe_NormalExit_StillClassifiedAsFinished` — negative case: a normal worker turn with output still classifies as `StateFinished` with the `"has finished"` notification.
- `TestSocketPipe_OutputWithoutActive_StillFinishes` — combination boundary: output without `active` still finishes, proving the guard requires **both** signals.

All use the socket-pipe isolation harness (temp `XDG_STATE_HOME`, `PRISM_TEST_MODE_RESTRICT_HOSTAPI=1`, temp DB, capturing delivery seam) and `prism-test@` session names per AGENTS.md.

## Verification

- `go build ./...`, `go test ./...` — all green.
- `go test ./internal/sidecar/ -race -run 'TestSocketPipe|TestNotify'` — green.
- `nix build .#prism` — green.

Closes #2081

## Relationship to #2094 (sequencing)

Issue #2081 carries a note from Ben: **#2094** (cleanup not clearing `agent_status.state`) is a prerequisite for *the natural fix of tightening `checkTransition` to return errors* — that approach would hard-block every re-spawn-after-cleanup path (`error → idle`) until #2094 lands.

**This PR deliberately does not take that approach.** It does not touch the DB layer at all — `checkTransition`, `UpsertStatusWithRootAgent`, and `UpsertStatusSeedRootAgentName` remain advisory and unchanged. The classification decision is made entirely in the sidecar's in-memory finished-debounce via a new, **read-only** `agent.Transition(currentState, StateFinished)` check that routes to `StateError`; it never blocks a DB write. Consequently the `error → idle` re-spawn-after-cleanup path is unaffected, and **this PR is safe to merge independently of #2094** — it does not introduce the regression that note warns about.

> Note: a sibling PR (#2096) from the parallel A/B session also targets #2081 with a different implementation. The merger should pick one.
