### PR TITLE
prism: allow error → idle so cleanup→re-spawn is warning-free (#2094)

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -545,10 +545,17 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 				broken := existing.State == "error" || existing.State == "deleted"
 				if reuseFlag {
 					if broken {
+						// Cleaning up a broken session then re-spawning on the
+						// same branch is a clean recovery: cleanup marks the row
+						// ended and the next spawn re-seeds it to idle, which the
+						// state machine now permits for any terminal state
+						// including error (issue #2094). Point the operator at the
+						// full path so the hint is not a dead end.
 						return fmt.Errorf(
 							"prism spawn --reuse: existing session %q is in a broken state (%s)\n"+
-								"run: prism cleanup --yes --session %s",
-							existing.SessionName, existing.State, existing.SessionName)
+								"clean it up, then re-spawn on the same branch:\n"+
+								"  prism cleanup --yes --session %s && prism spawn --branch %s",
+							existing.SessionName, existing.State, existing.SessionName, branch)
 					}
 					// Healthy session — emit its details and exit 0.
 					agentName := ""

--- a/modules/programs/prism/prism/internal/agent/machine.go
+++ b/modules/programs/prism/prism/internal/agent/machine.go
@@ -42,6 +42,12 @@ import "fmt"
 //     manual kill+recreate).
 //   - interrupted → active: session resumed after an interruption.
 //   - interrupted → idle: same as finished → idle but starting from interrupted.
+//   - error → idle: same as finished/interrupted → idle — tmux-session-start
+//     resets a previously-errored session back to idle when the tmux session is
+//     recreated, e.g. re-spawning on the same branch name after `prism cleanup`
+//     (issue #2094). error is the failure-path twin of interrupted/finished;
+//     omitting it blocked the re-spawn-after-cleanup path with a spurious
+//     advisory warning.
 //   - * → deleted: any state can transition to deleted when session.deleted fires.
 //
 // The TypeScript plugin writes state directly to SQLite and is not constrained
@@ -75,10 +81,17 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 		StateInterrupted: true,
 		StateDeleted:     true,
 	},
+	// error→active: retry / next turn after a transient error.
+	// error→interrupted: pane-died after an error.
+	// error→finished: idle debounce after an error.
+	// error→idle: tmux-session-start resets the session on recreate — the
+	// re-spawn-after-cleanup path (issue #2094). Mirrors finished→idle and
+	// interrupted→idle; error is the failure-path twin of those terminal states.
 	StateError: {
 		StateActive:      true,
 		StateInterrupted: true,
 		StateFinished:    true,
+		StateIdle:        true,
 		StateDeleted:     true,
 	},
 	// reviewing→finished: PASS verdict received; coordinator notified now.

--- a/modules/programs/prism/prism/internal/agent/machine_test.go
+++ b/modules/programs/prism/prism/internal/agent/machine_test.go
@@ -23,6 +23,7 @@ func TestTransition_ValidPairs(t *testing.T) {
 		{StateError, StateActive, "retry / next turn after error"},
 		{StateWaiting, StateError, "session.error while waiting"},
 		{StateError, StateFinished, "idle debounce after error"},
+		{StateError, StateIdle, "tmux-session-start resets errored session on recreate after cleanup (#2094)"},
 
 		// Interruption paths
 		{StateActive, StateInterrupted, "pane-died / SIGINT / MessageAbortedError"},

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -2643,6 +2643,151 @@ func TestCheckTransition_EmptyStates(t *testing.T) {
 	// If we reach here, no panic occurred.
 }
 
+// TestRespawnAfterCleanup_NoInvalidTransition is the end-to-end regression
+// guard for issue #2094. It reproduces the full post-cleanup → re-spawn cycle
+// at the DB layer:
+//
+//  1. A failed/closed session leaves a row in a terminal state (error,
+//     finished, or interrupted).
+//  2. `prism cleanup` marks that row ended via SetEnded (ended_at set; state
+//     column intentionally untouched — cleanup never writes state).
+//  3. Re-spawning on the SAME branch name re-seeds the row to idle via
+//     UpsertStatusSeedRootAgentName, then ClearEnded restores visibility
+//     (this mirrors the tmux-session-start hook in cmd/event.go).
+//
+// The invariant under test: step 3 must NOT emit an "invalid transition"
+// advisory warning for any prior terminal state, and the row must end up idle
+// with ended_at cleared. Before the fix, error → idle was missing from
+// ValidTransitions, so the error case logged a spurious warning (and would
+// hard-block a re-spawn once checkTransition is tightened to return errors).
+func TestRespawnAfterCleanup_NoInvalidTransition(t *testing.T) {
+	// All terminal states a worktree session can leave behind on the row.
+	// finished and interrupted already permit → idle; error is the case the
+	// fix adds. All three are asserted so the invariant covers AC #1 fully.
+	terminalStates := []string{"error", "finished", "interrupted"}
+	for _, st := range terminalStates {
+		t.Run(st, func(t *testing.T) {
+			d := openTestDB(t)
+			const session = "repo@feature"
+			const worktree = "/code/repo/feature"
+
+			// 1. Seed a row that ended in a terminal state.
+			if err := d.UpsertStatusSeedRootAgentName(session, "repo", worktree, st, nil, nil, "worker", "pi", "podman"); err != nil {
+				t.Fatalf("seed terminal row (%s): %v", st, err)
+			}
+
+			// 2. `prism cleanup` marks the row ended (state column untouched).
+			if err := d.SetEnded(session); err != nil {
+				t.Fatalf("SetEnded (cleanup): %v", err)
+			}
+
+			// 3. Re-spawn on the same branch: capture stderr so we can assert
+			// that no invalid-transition warning is emitted by checkTransition.
+			origStderr := os.Stderr
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("os.Pipe: %v", err)
+			}
+			os.Stderr = w
+
+			seedErr := d.UpsertStatusSeedRootAgentName(session, "repo", worktree, "idle", nil, nil, "worker", "pi", "podman")
+			clearErr := d.ClearEnded(session)
+
+			w.Close()
+			os.Stderr = origStderr
+			var buf bytes.Buffer
+			if _, err := io.Copy(&buf, r); err != nil {
+				t.Fatalf("read captured stderr: %v", err)
+			}
+			r.Close()
+
+			if seedErr != nil {
+				t.Fatalf("re-seed idle: %v", seedErr)
+			}
+			if clearErr != nil {
+				t.Fatalf("ClearEnded: %v", clearErr)
+			}
+			if strings.Contains(buf.String(), "invalid transition") {
+				t.Errorf("re-spawn after cleanup from %q emitted an invalid-transition warning:\n%s", st, buf.String())
+			}
+
+			// Invariant: the row is idle and visible (active) again.
+			s, err := d.CurrentStatus(session)
+			if err != nil {
+				t.Fatalf("CurrentStatus: %v", err)
+			}
+			if s == nil {
+				t.Fatalf("CurrentStatus: row missing after re-spawn")
+			}
+			if s.State != "idle" {
+				t.Errorf("state after re-spawn from %q: got %q, want \"idle\"", st, s.State)
+			}
+			if s.EndedAt != nil {
+				t.Errorf("ended_at after re-spawn from %q: got %v, want nil", st, *s.EndedAt)
+			}
+		})
+	}
+}
+
+// TestRespawnDifferentBranch_AfterCleanup is the over-broad-fix guard
+// (issue #2094, negative test #1). Widening error → idle must not change the
+// behaviour of spawning a DIFFERENT branch after cleaning up a broken one: a
+// new branch name is a fresh INSERT with no prior row, so checkTransition has
+// nothing to validate and no warning is emitted — exactly as before the fix.
+func TestRespawnDifferentBranch_AfterCleanup(t *testing.T) {
+	d := openTestDB(t)
+
+	// Branch A ends in error, then is cleaned up.
+	if err := d.UpsertStatusSeedRootAgentName("repo@branch-a", "repo", "/code/repo/a", "error", nil, nil, "worker", "pi", "podman"); err != nil {
+		t.Fatalf("seed branch-a error: %v", err)
+	}
+	if err := d.SetEnded("repo@branch-a"); err != nil {
+		t.Fatalf("SetEnded branch-a: %v", err)
+	}
+
+	// Spawn a DIFFERENT branch B — capture stderr to assert no warning.
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	seedErr := d.UpsertStatusSeedRootAgentName("repo@branch-b", "repo", "/code/repo/b", "idle", nil, nil, "worker", "pi", "podman")
+
+	w.Close()
+	os.Stderr = origStderr
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read captured stderr: %v", err)
+	}
+	r.Close()
+
+	if seedErr != nil {
+		t.Fatalf("seed branch-b: %v", seedErr)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("spawning a different branch produced unexpected log output:\n%s", buf.String())
+	}
+
+	// Branch B is a fresh idle row.
+	sb, err := d.CurrentStatus("repo@branch-b")
+	if err != nil {
+		t.Fatalf("CurrentStatus branch-b: %v", err)
+	}
+	if sb == nil || sb.State != "idle" {
+		t.Errorf("branch-b state: got %+v, want idle row", sb)
+	}
+	// Branch A's row is untouched by the branch-B spawn and still ended.
+	sa, err := d.CurrentStatus("repo@branch-a")
+	if err != nil {
+		t.Fatalf("CurrentStatus branch-a: %v", err)
+	}
+	if sa == nil || sa.EndedAt == nil {
+		t.Errorf("branch-a should remain ended after a different-branch spawn: got %+v", sa)
+	}
+}
+
 // ── TestOpen_CreatesSchema addendum: session_groups and group_id column ────────
 
 // TestOpen_CreatesSessionGroupsTable verifies that the session_groups table and

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -547,6 +547,7 @@ prism cleanup --yes --session "nixos-config@update-plex"
 - Remove the git worktree
 - Force-delete the local branch (relies on the orchestrator-trust contract: call this only after confirming the PR is merged)
 - Kill the tmux session, redirecting any attached client to `scratchpad`
+- Mark the session's `agent_status` row ended (it drops out of `prism sessions list`) and release its port allocation. The row itself is **not** deleted — re-spawning on the same branch name re-seeds it to `idle`, which succeeds for any prior terminal state (`error`, `finished`, or `interrupted`).
 
 Only call this after you have confirmed the PR is merged. The `--yes` path always force-deletes the branch — it does not check whether the branch is reachable from main, because squash-merges produce a different SHA on main than the branch tip.
 
@@ -904,7 +905,7 @@ A lookup table of log patterns, their causes, and remediation hints:
 
 - **Session name doesn't match expected shape** (e.g. `~review` where `~review-1-review-code` is expected) — the agent-list construction produced the wrong agent names, or the `--agent` flag value is incorrect. Check the container's `harness-config.json` for the `agent` block contents and the sidecar log for the `--agent` flag value used in the command line.
 
-- **Zombie DB rows (session in `prism sessions list` but no live tmux session)** — a previous session's process died without cleaning up DB state. Use `prism cleanup --yes --session <name>` to remove the stale row and any dangling port allocation.
+- **Zombie DB rows (session in `prism sessions list` but no live tmux session)** — a previous session's process died without cleaning up DB state. Use `prism cleanup --yes --session <name>` to mark the stale row ended (it drops out of `prism sessions list`) and release any dangling port allocation. The row is not deleted; re-spawning on the same branch name re-seeds it to `idle`.
 
 ### Escalation
 


### PR DESCRIPTION
Closes #2094

## Summary

`prism cleanup --yes --session <name>` marks an `agent_status` row ended but
**never writes the `state` column** — so a failed session's row stays at
`state='error'`. Re-spawning on the same branch name re-seeds the row to `idle`,
a transition the agent state machine rejected (`error → idle` was absent from
`ValidTransitions`), emitting:

```
[prism] UpsertStatusSeedRootAgentName: invalid transition for session "...": agent state machine: invalid transition "error" → "idle"
```

The skill text and the spawn error message both told operators to run `prism
cleanup` to recover — pointing them at a command that appeared to no-op the
residue they were objecting to.

## Fix — Option C (internal-consistency)

Per the AC ("pick the smallest correct shape"), this adds `error → idle` to
`ValidTransitions[StateError]` in `internal/agent/machine.go`, mirroring the
existing `finished → idle` and `interrupted → idle` entries. `error` is the
failure-path twin of `interrupted`/`finished`; the omission read as an oversight
(no comment explained it, and `error` was the only non-`deleted` terminal state
that blocked a fresh `idle` seed).

This is lower-risk than reordering cleanup to `DELETE` the row (Option A), which
would have to preserve the archive-lookup read of `harness_session_id` and the
`CleanupReviewSessionsForParent` cascade. Cleanup behaviour is left unchanged.

Operator-facing surfaces are corrected to match the actual (non-deleting)
behaviour:
- `SKILL.md` cleanup behaviour block — now states the row is marked **ended**
  (drops out of `prism sessions list`) and the port released; the row is not
  deleted and re-spawning on the same branch re-seeds it to `idle`.
- `SKILL.md` zombie-row recovery note — no longer claims the row is **removed**.
- `cmd/spawn.go` `--reuse` broken-state hint — now points at the full
  `cleanup → re-spawn` recovery rather than a bare `cleanup` that looked like a
  dead end.

## AC coverage

- **AC #1 / AC #3** — `internal/db/db_test.go::TestRespawnAfterCleanup_NoInvalidTransition`:
  seed a terminal-state row → `SetEnded` (cleanup) → re-seed `idle` + `ClearEnded`,
  asserting no `invalid transition` warning fires and the row ends up `idle` with
  `ended_at` cleared, for **all three** prior terminal states (`error`,
  `finished`, `interrupted`). The state-machine table itself is covered by the new
  `{StateError, StateIdle}` valid pair in `machine_test.go`.
- **Negative #1 (over-broad-fix guard)** — `TestRespawnDifferentBranch_AfterCleanup`:
  spawning a *different* branch after cleaning up a broken one is a fresh INSERT
  (no prior row, no transition) and stays warning-free.
- **Negative #2 (review-child cleanup)** — `headlessCleanupWithJSON` is **not**
  altered or reordered by this change, so `CleanupReviewSessionsForParent`
  (`cmd/cleanup.go:562`) is untouched; the DB-layer cascade remains covered by the
  existing `TestSetEnded_CascadesToReviewChildren`.
- **Negative #3 (`deleted → idle` still rejected)** — unchanged; covered by the
  existing `machine_test.go` invalid-pairs and `TestTransition_DeletedIsTerminal`.
- **Archive-lookup ordering** — cleanup is not reordered, so `runSessionArchive`'s
  read of `harness_session_id` is unaffected.

The widening is behaviourally safe today: all `agent.Transition` call sites in
`internal/db/status.go` are advisory (log-only) and never gate control flow, and
the change is independent of #2081's in-memory `idle → finished` classification in
`internal/sidecar/events.go::handleSessionFinished`.

## Sequencing note (updated)

The ticket's original "prerequisite for #2081" framing is superseded. **#2081 has
landed** (via PR #2096) and its merged fix deliberately did **not** tighten
`checkTransition` to return errors — it kept the advisory log path and made the
classification decision in the sidecar's in-memory finished-debounce. So:

- This change is **no longer a hard prerequisite** for any open work; the merged
  #2081 fix is unaffected.
- It **is** a prerequisite for any **future** work that tightens `checkTransition`
  (or the helpers it guards) to actually return errors. Without `error → idle` in
  the table, that future tightening would create a hard regression on every
  re-spawn-after-cleanup path.

## Test plan

```
# from modules/programs/prism/prism/
go build ./...
go test ./...        # all green
gofmt -l <changed>   # clean
go vet ./internal/agent/ ./internal/db/ ./cmd/
```