### PR TITLE
prism/agent: allow error→idle so re-spawn after cleanup succeeds (#2094)

### DIFF
--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -539,6 +539,15 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			defer d.Close()
 			repoName := strings.TrimSuffix(filepath.Base(bareRoot), ".git")
 			existing, lookupErr := d.ActiveStatusForRepoBranch(repoName, branch)
+			// ActiveStatusForRepoBranch filters by ended_at IS NULL, so a
+			// session whose row was just `prism cleanup`’d (ended_at
+			// stamped) is invisible here — a re-spawn on the same branch
+			// proceeds and the state-machine table allows the row to be
+			// re-seeded from any non-deleted terminal state (error /
+			// finished / interrupted) back to idle. That is why both
+			// recovery messages below truthfully point at `prism cleanup`
+			// (issue #2094 — prerequisite for any future tightening of
+			// checkTransition raised by #2081).
 			if lookupErr == nil && existing != nil {
 				// There is an active session for this branch.
 				// Healthy = state not "error" and not "deleted".

--- a/modules/programs/prism/prism/internal/agent/machine.go
+++ b/modules/programs/prism/prism/internal/agent/machine.go
@@ -42,6 +42,15 @@ import "fmt"
 //     manual kill+recreate).
 //   - interrupted → active: session resumed after an interruption.
 //   - interrupted → idle: same as finished → idle but starting from interrupted.
+//   - error → idle: same as finished → idle but starting from error. After
+//     `prism cleanup --yes --session <name>` ends a session whose last state
+//     was error, re-spawning on the same branch name reuses the existing
+//     agent_status row — tmux-session-start writes idle to seed the new
+//     incarnation. Without this entry, every re-spawn-after-cleanup on a
+//     session that ended in error logs an advisory transition warning, and
+//     would become a hard failure if checkTransition is ever tightened to
+//     return errors (issue #2094, prerequisite for any future tightening of
+//     checkTransition raised by #2081).
 //   - * → deleted: any state can transition to deleted when session.deleted fires.
 //
 // The TypeScript plugin writes state directly to SQLite and is not constrained
@@ -75,10 +84,18 @@ var ValidTransitions = map[AgentState]map[AgentState]bool{
 		StateInterrupted: true,
 		StateDeleted:     true,
 	},
+	// error→active: retry / next turn after a transient error.
+	// error→finished: idle debounce fires after error is resolved.
+	// error→interrupted: pane-died after error.
+	// error→idle: tmux-session-start resets a previously-errored session on
+	// recreate. Mirrors finished→idle and interrupted→idle so that
+	// re-spawning on the same branch name after `prism cleanup` succeeds
+	// without an advisory transition warning (issue #2094).
 	StateError: {
 		StateActive:      true,
 		StateInterrupted: true,
 		StateFinished:    true,
+		StateIdle:        true,
 		StateDeleted:     true,
 	},
 	// reviewing→finished: PASS verdict received; coordinator notified now.

--- a/modules/programs/prism/prism/internal/agent/machine_test.go
+++ b/modules/programs/prism/prism/internal/agent/machine_test.go
@@ -40,6 +40,7 @@ func TestTransition_ValidPairs(t *testing.T) {
 		{StateFinished, StateIdle, "tmux-session-start resets finished session on recreate"},
 		{StateInterrupted, StateActive, "session resumed after interruption"},
 		{StateInterrupted, StateIdle, "tmux-session-start resets interrupted session on recreate"},
+		{StateError, StateIdle, "tmux-session-start resets errored session on recreate (issue #2094)"},
 
 		// Reviewing state (issue #1033)
 		{StateActive, StateReviewing, "prism review called — entering reviewing state"},

--- a/modules/programs/prism/prism/internal/db/respawn_after_cleanup_test.go
+++ b/modules/programs/prism/prism/internal/db/respawn_after_cleanup_test.go
@@ -1,0 +1,339 @@
+package db_test
+
+// respawn_after_cleanup_test.go — regression tests for issue #2094.
+//
+// `prism cleanup --yes --session <name>` does not touch agent_status.state;
+// it sets ended_at. Re-spawning on the same branch name calls
+// UpsertStatusSeedRootAgentName with state="idle", which routes through
+// the state-machine advisory checkTransition. Before #2094, the
+// ValidTransitions[StateError] map did not include StateIdle, so the
+// re-spawn-after-error path logged
+//
+//   [prism] UpsertStatusSeedRootAgentName: invalid transition for session
+//   "...": agent state machine: invalid transition "error" → "idle"
+//
+// even though the structurally analogous finished→idle and interrupted→idle
+// transitions were already allowed. These tests assert the observable
+// invariant from the issue's AC #1: after the post-cleanup row is left
+// with a prior terminal state (error / finished / interrupted), a re-seed
+// to idle produces no advisory warning on stderr.
+//
+// Why a stderr-capture test, given that checkTransition is currently
+// advisory-only? Because that is the user-visible regression surface:
+// operators report the warning ("warning fires on every re-spawn"), and
+// any future tightening of checkTransition that converted advisory logs
+// into errors would silently regress this path without a test that
+// asserts the no-warning invariant. The capture pins the observable.
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// captureStderr runs fn with os.Stderr redirected to a pipe, drains the pipe
+// concurrently to avoid the pipe-buffer deadlock documented in
+// docs/stdout-capture-testing.md (issue #1798), and returns the captured
+// bytes. Stderr is always restored even if fn panics.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	// Drain the pipe concurrently so a write larger than the kernel buffer
+	// cannot block fn (see docs/stdout-capture-testing.md).
+	doneCh := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		doneCh <- buf.Bytes()
+	}()
+
+	defer func() {
+		os.Stderr = orig
+	}()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	captured := <-doneCh
+	if err := r.Close(); err != nil {
+		t.Fatalf("close pipe reader: %v", err)
+	}
+	return string(captured)
+}
+
+// simulateCleanup mirrors what cmd.headlessCleanupWithJSON does to the
+// agent_status row for the purpose of this unit test: it releases the port,
+// nulls harness_session_id, and sets ended_at. The state column is
+// intentionally left at its prior terminal value — that is the residue the
+// re-spawn must tolerate.
+func simulateCleanup(t *testing.T, d *db.DB, session string) {
+	t.Helper()
+	// ReleasePort errors when the session does not exist; tolerate that for
+	// tests that never allocated a port.
+	_ = d.ReleasePort(session)
+	if err := d.ClearHarnessSessionID(session); err != nil {
+		t.Fatalf("ClearHarnessSessionID: %v", err)
+	}
+	if err := d.SetEnded(session); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+}
+
+// TestRespawnAfterCleanup_NoTransitionWarning is AC #1 from issue #2094:
+// after cleanup leaves the row at a terminal state (error / finished /
+// interrupted), re-seeding via UpsertStatusSeedRootAgentName with state=idle
+// must not log "invalid transition" for any of those prior states.
+//
+// This is the user-visible regression test: it captures stderr and asserts
+// the warning is absent.
+func TestRespawnAfterCleanup_NoTransitionWarning(t *testing.T) {
+	// All four non-deleted terminal states must be tolerated; the parametric
+	// loop also guards against a regression where only one is fixed in
+	// isolation (e.g. a future change that removes error→idle but keeps
+	// finished→idle).
+	priorStates := []string{"error", "finished", "interrupted"}
+
+	for _, priorState := range priorStates {
+		t.Run(priorState, func(t *testing.T) {
+			d := openTestDB(t)
+			const session = "myrepo@feature"
+			const repo = "myrepo"
+			const worktree = "/code/myrepo/feature"
+
+			// Seed the row at the prior terminal state. We must go through
+			// active because idle→finished is not a valid direct transition
+			// in the state machine (idle→error and idle→interrupted ARE
+			// allowed directly, but routing through active uniformly keeps
+			// the setup faithful to the real lifecycle).
+			if err := d.UpsertStatusSeedRootAgentName(session, repo, worktree, "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+				t.Fatalf("seed idle: %v", err)
+			}
+			if err := d.UpsertStatusWithRootAgent(session, repo, worktree, "active", nil, nil, nil, nil); err != nil {
+				t.Fatalf("transition to active: %v", err)
+			}
+			if err := d.UpsertStatusWithRootAgent(session, repo, worktree, priorState, nil, nil, nil, nil); err != nil {
+				t.Fatalf("transition to %s: %v", priorState, err)
+			}
+
+			// Apply the agent_status mutations that prism cleanup performs.
+			simulateCleanup(t, d, session)
+
+			// Re-spawn on the same branch name: this is exactly what
+			// cmd/event.go::tmux-session-start invokes when the operator
+			// re-runs `prism spawn --branch <name>` after cleanup.
+			stderr := captureStderr(t, func() {
+				if err := d.UpsertStatusSeedRootAgentName(session, repo, worktree, "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+					t.Fatalf("re-spawn UpsertStatusSeedRootAgentName: %v", err)
+				}
+			})
+
+			if strings.Contains(stderr, "invalid transition") {
+				t.Errorf("re-spawn after cleanup with prior state %q produced an 'invalid transition' warning:\n%s",
+					priorState, stderr)
+			}
+
+			// Sanity: the row's state column must reflect the re-seed.
+			s, err := d.CurrentStatus(session)
+			if err != nil {
+				t.Fatalf("CurrentStatus: %v", err)
+			}
+			if s == nil {
+				t.Fatal("CurrentStatus: nil after re-spawn")
+			}
+			if s.State != "idle" {
+				t.Errorf("State after re-spawn: got %q, want \"idle\"", s.State)
+			}
+		})
+	}
+}
+
+// TestRespawnAfterCleanup_DifferentBranchName is AC negative test #1:
+// over-broad-fix guard. Re-spawning on a different branch name must still
+// work — and must not be regressed by any state-machine widening. The
+// "different branch" path goes through a fresh INSERT (no prior row, so
+// checkTransition's fromState is empty and validation is skipped).
+func TestRespawnAfterCleanup_DifferentBranchName(t *testing.T) {
+	d := openTestDB(t)
+	const oldSession = "myrepo@feature-old"
+	const newSession = "myrepo@feature-new"
+	const repo = "myrepo"
+
+	// Seed and bring oldSession to error, then simulate cleanup.
+	if err := d.UpsertStatusSeedRootAgentName(oldSession, repo, "/code/myrepo/feature-old", "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+		t.Fatalf("seed old: %v", err)
+	}
+	// idle→error is permitted directly (container startup failure).
+	if err := d.UpsertStatusWithRootAgent(oldSession, repo, "/code/myrepo/feature-old", "error", nil, nil, nil, nil); err != nil {
+		t.Fatalf("transition old to error: %v", err)
+	}
+	simulateCleanup(t, d, oldSession)
+
+	// Re-spawn on a DIFFERENT branch name — no prior row for this session,
+	// so the fresh-insert path is exercised. Must succeed with no warning.
+	stderr := captureStderr(t, func() {
+		if err := d.UpsertStatusSeedRootAgentName(newSession, repo, "/code/myrepo/feature-new", "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+			t.Fatalf("re-spawn on different branch: %v", err)
+		}
+	})
+	if strings.Contains(stderr, "invalid transition") {
+		t.Errorf("re-spawn on different branch produced unexpected warning:\n%s", stderr)
+	}
+
+	// Sanity: the new row exists and is at idle.
+	s, err := d.CurrentStatus(newSession)
+	if err != nil {
+		t.Fatalf("CurrentStatus(new): %v", err)
+	}
+	if s == nil || s.State != "idle" {
+		t.Errorf("new session state: got %+v, want state=idle", s)
+	}
+
+	// Sanity: the old row is still present with ended_at set (cleanup did
+	// not delete it under Option C).
+	old, err := d.CurrentStatus(oldSession)
+	if err != nil {
+		t.Fatalf("CurrentStatus(old): %v", err)
+	}
+	if old == nil {
+		t.Fatal("old session row missing")
+	}
+	if old.EndedAt == nil {
+		t.Errorf("old session EndedAt: got nil, want non-nil (cleanup must have stamped it)")
+	}
+}
+
+// TestRespawnAfterCleanup_ReviewChildrenStillEndedByCleanup is AC negative
+// test #2: review-child cleanup is not regressed. cleanup uses SetEnded with
+// a LIKE-cascade for "<parent>~review-%" rows, and the fix here does NOT
+// touch the cleanup path — but adding a guard here makes the invariant
+// explicit, so any future reordering of headlessCleanupWithJSON cannot
+// silently break review-child end-cascade.
+func TestRespawnAfterCleanup_ReviewChildrenStillEndedByCleanup(t *testing.T) {
+	d := openTestDB(t)
+	const parent = "myrepo@feature"
+	child1 := parent + "~review-1-review-code"
+	child2 := parent + "~review-1-review-goal"
+
+	// Seed parent and two review children, all in active state.
+	for _, name := range []string{parent, child1, child2} {
+		if err := d.UpsertStatusSeedRootAgentName(name, "myrepo", "/code/myrepo/feature", "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+			t.Fatalf("seed %q: %v", name, err)
+		}
+		if err := d.UpsertStatusWithRootAgent(name, "myrepo", "/code/myrepo/feature", "active", nil, nil, nil, nil); err != nil {
+			t.Fatalf("transition %q to active: %v", name, err)
+		}
+	}
+
+	// SetEnded on the parent must cascade to the review children via the
+	// existing LIKE pattern. This is the invariant cmd.headlessCleanup
+	// relies on; we assert it here so a future refactor of cleanup that
+	// hides this behind a different helper still exercises the cascade.
+	if err := d.SetEnded(parent); err != nil {
+		t.Fatalf("SetEnded(parent): %v", err)
+	}
+
+	for _, name := range []string{parent, child1, child2} {
+		s, err := d.CurrentStatus(name)
+		if err != nil {
+			t.Fatalf("CurrentStatus(%q): %v", name, err)
+		}
+		if s == nil {
+			t.Fatalf("row %q missing after SetEnded", name)
+		}
+		if s.EndedAt == nil {
+			t.Errorf("EndedAt for %q: got nil, want non-nil (cleanup cascade broken)", name)
+		}
+	}
+}
+
+// TestRespawnAfterCleanup_ArchiveLookupOrdering is AC "no regression in
+// archive lookup": cmd.runSessionArchive reads harness_session_id from
+// agent_status before SetEnded is called by cleanup. Under Option C the
+// row is not deleted, so the read continues to work. This test pins the
+// invariant: a row written with harness_session_id is readable both
+// before and after SetEnded, so any future re-ordering of cleanup that
+// moves the archive read past SetEnded does not silently break.
+func TestRespawnAfterCleanup_ArchiveLookupOrdering(t *testing.T) {
+	d := openTestDB(t)
+	const session = "myrepo@feature"
+	const sid = "019e0000-0000-0000-0000-000000000042"
+
+	if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", "/code/myrepo/feature", "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := d.UpdateHarnessSessionID(session, sid); err != nil {
+		t.Fatalf("UpdateHarnessSessionID: %v", err)
+	}
+
+	// Pre-SetEnded read (the path cleanup exercises today).
+	pre, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus pre-SetEnded: %v", err)
+	}
+	if pre == nil || pre.HarnessSessionID == nil || *pre.HarnessSessionID != sid {
+		t.Fatalf("pre-SetEnded HarnessSessionID: got %+v, want %q", pre, sid)
+	}
+
+	if err := d.SetEnded(session); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+
+	// Post-SetEnded read: the row must still be present (Option C does not
+	// delete the row). This is the invariant the archive path needs if it
+	// ever moves the read past SetEnded.
+	post, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus post-SetEnded: %v", err)
+	}
+	if post == nil {
+		t.Fatal("row removed by SetEnded; Option C contract violated (the row must remain so cleanup's other reads succeed)")
+	}
+	if post.EndedAt == nil {
+		t.Errorf("EndedAt post-SetEnded: got nil, want non-nil")
+	}
+}
+
+// TestRespawnAfterCleanup_WithRealDBFile pins the same invariant against
+// a real on-disk SQLite file (not just the openTestDB temp DB). This guards
+// against an unlikely-but-real regression where the in-memory schema and
+// the on-disk schema diverge on the agent_status row's ended_at semantics.
+func TestRespawnAfterCleanup_WithRealDBFile(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	const session = "myrepo@feature"
+	if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", "/code/myrepo/feature", "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// idle→error is permitted directly (container startup failure path).
+	if err := d.UpsertStatusWithRootAgent(session, "myrepo", "/code/myrepo/feature", "error", nil, nil, nil, nil); err != nil {
+		t.Fatalf("transition to error: %v", err)
+	}
+	simulateCleanup(t, d, session)
+
+	stderr := captureStderr(t, func() {
+		if err := d.UpsertStatusSeedRootAgentName(session, "myrepo", "/code/myrepo/feature", "idle", nil, nil, "worker", "pi", "bwrap"); err != nil {
+			t.Fatalf("re-spawn UpsertStatusSeedRootAgentName: %v", err)
+		}
+	})
+	if strings.Contains(stderr, "invalid transition") {
+		t.Errorf("real-DB re-spawn after cleanup produced unexpected warning:\n%s", stderr)
+	}
+}

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -547,6 +547,9 @@ prism cleanup --yes --session "nixos-config@update-plex"
 - Remove the git worktree
 - Force-delete the local branch (relies on the orchestrator-trust contract: call this only after confirming the PR is merged)
 - Kill the tmux session, redirecting any attached client to `scratchpad`
+- Mark the `agent_status` row as ended (stamps `ended_at`, releases the harness port, and clears the pi `harness_session_id` so the next spawn starts a fresh conversation)
+
+The `agent_status` row itself is preserved — it is not deleted. Re-spawning on the same branch name reuses the row: `tmux-session-start` re-seeds it to `idle`, which the state machine accepts from any non-`deleted` terminal state (`error`, `finished`, `interrupted`). Long-term retention is handled by the 90-day `Prune` job.
 
 Only call this after you have confirmed the PR is merged. The `--yes` path always force-deletes the branch — it does not check whether the branch is reachable from main, because squash-merges produce a different SHA on main than the branch tip.
 
@@ -904,7 +907,7 @@ A lookup table of log patterns, their causes, and remediation hints:
 
 - **Session name doesn't match expected shape** (e.g. `~review` where `~review-1-review-code` is expected) — the agent-list construction produced the wrong agent names, or the `--agent` flag value is incorrect. Check the container's `harness-config.json` for the `agent` block contents and the sidecar log for the `--agent` flag value used in the command line.
 
-- **Zombie DB rows (session in `prism sessions list` but no live tmux session)** — a previous session's process died without cleaning up DB state. Use `prism cleanup --yes --session <name>` to remove the stale row and any dangling port allocation.
+- **Zombie DB rows (session in `prism sessions list` but no live tmux session)** — a previous session's process died without cleaning up DB state. Use `prism cleanup --yes --session <name>` to end the row (stamps `ended_at`, releases any dangling port, clears the pi resume linkage) so it drops out of the active-session view. The row itself is preserved; re-spawning on the same branch name reuses it by re-seeding `state` back to `idle`.
 
 ### Escalation
 


### PR DESCRIPTION
## Summary

Adds the missing `StateError → StateIdle` entry to `agent.ValidTransitions`, mirroring the existing `StateFinished → StateIdle` and `StateInterrupted → StateIdle` entries. This removes the `invalid transition "error" → "idle"` advisory warning operators were seeing on every `prism spawn --branch <name>` after a `prism cleanup --yes --session <name>` on a session that ended at `state='error'`.

This is **Option C** from the issue (state-machine table widening), chosen for being the smallest correct shape:

- Among the four non-`deleted` terminal states, `error` was the only one blocking a fresh `idle` seed — clearly an oversight (no comment in the code explained the omission).
- Avoids the archive-lookup ordering risk Option A would introduce (`runSessionArchive` reads `harness_session_id` from `agent_status` after `SetEnded`, so deleting the row would force a re-order).
- The 90-day `Prune` job (intentionally out of scope) still owns long-term retention.

## Acceptance criteria

- [x] **AC #1.** Re-spawning on the same branch name after `prism cleanup --yes --session <name>` succeeds without emitting `invalid transition "..." → "idle"` for any prior terminal state (`error`, `finished`, `interrupted`). Pinned by `TestRespawnAfterCleanup_NoTransitionWarning` (parametric over all three states) and `TestRespawnAfterCleanup_WithRealDBFile`.
- [x] **AC #2.** The fix removes the warning at its source by widening the state-machine table — `error → idle` now sits alongside `finished → idle` and `interrupted → idle`.
- [x] **AC #3.** Unit test asserts the post-cleanup → re-spawn invariant — placed in `internal/db/respawn_after_cleanup_test.go` so it exercises the full `SetEnded → UpsertStatusSeedRootAgentName` cycle end-to-end (not just the in-memory `Transition` function). Sidecar is not involved on this path, so `sidecartest.NewIsolated` does not apply.
- [x] **AC #4. Negative #1 — over-broad-fix guard.** `TestRespawnAfterCleanup_DifferentBranchName` confirms a fresh-INSERT path on a different branch name still works and emits no warning.
- [x] **AC #5. Negative #2 — review-child cleanup not regressed.** `TestRespawnAfterCleanup_ReviewChildrenStillEndedByCleanup` pins the `SetEnded` LIKE-cascade to `<parent>~review-%` children. The fix does not touch `headlessCleanupWithJSON` so `CleanupReviewSessionsForParent` (cleanup.go:240/627/810) is unaffected; the test makes the invariant explicit for any future refactor.
- [x] **AC #6. Negative #3 — `StateDeleted → StateIdle` still rejected.** The pre-existing `{StateDeleted, StateIdle, "deleted → idle"}` entry in `TestTransition_InvalidPairs` already covers this; `StateDeleted` retains its empty out-edge set in `ValidTransitions`.
- [x] **AC #7. No regression in archive lookup.** `TestRespawnAfterCleanup_ArchiveLookupOrdering` verifies the row remains readable both before and after `SetEnded`. Under Option C the row is not deleted, so `runSessionArchive`'s `HarnessSessionIDForInstance` read continues to work — the existing ordering in `headlessCleanupWithJSON` is preserved.
- [x] **AC #8a.** `modules/programs/prism/skills/prism/SKILL.md` — `prism cleanup --yes --session` behaviour block now spells out the `agent_status` row lifecycle (ends the row by stamping `ended_at`, releases the port, clears `harness_session_id`) and the re-spawn-reuse semantics.
- [x] **AC #8b.** SKILL.md zombie-row recovery note corrected — it no longer claims cleanup removes the row.
- [x] **AC #8c.** Spawn error message at `cmd/spawn.go` (now ~lines 548–561) truthfully points at `prism cleanup` post-fix: `ActiveStatusForRepoBranch` filters by `ended_at IS NULL`, so cleanup unblocks the dedupe check; then the widened state-machine table allows the `error → idle` re-seed. An inline comment documents the dependency chain.
- [x] **AC #9. Updated sequencing note (see below).**

## Sequencing note

> **This ticket is no longer a hard prerequisite for any open work.** The merged #2081 fix (PR #2096) deliberately kept `checkTransition` advisory and made the classification decision in the sidecar's in-memory finished-debounce — so the warning targeted by this PR remained cosmetic on `main`.
>
> **This ticket IS a prerequisite for any future tightening of `checkTransition` to return errors.** Without this fix landing first, that future work would create a hard regression on every re-spawn-after-cleanup path whose previous state was `error`.

## Implementation notes

- `internal/agent/machine.go`: added `StateError → StateIdle` to `ValidTransitions[StateError]`, plus a clarifying comment block on the entry and an update to the design-notes header explaining the symmetry with `finished → idle` and `interrupted → idle`.
- `internal/agent/machine_test.go`: one new positive entry `{StateError, StateIdle, ...}`. The `TestValidTransitionsCompleteness` and `TestTransition_DeletedIsTerminal` guards already cover the structural invariants.
- `internal/db/respawn_after_cleanup_test.go` (new): end-to-end cleanup → re-spawn invariant suite. Includes a `captureStderr` helper that drains the read end concurrently per `docs/stdout-capture-testing.md` (issue #1798).
- `cmd/spawn.go`: comment-only change near the dedupe check explaining why both recovery messages point at `prism cleanup`.
- `skills/prism/SKILL.md`: behaviour-block + zombie-row note rewrites.

## Verification

```
# from modules/programs/prism/prism/
go build ./...
go test ./... -count=1             # all packages green
go test ./internal/agent/ ./internal/db/ -race -count=1   # race-clean

# from repo root
nix build .#prism --no-link        # builds clean
```

I also stashed the `machine.go` change locally and re-ran `TestRespawnAfterCleanup_NoTransitionWarning` to confirm the `error` subtest **fails** on the unmodified code — this is a real regression test, not a vacuous pass.

Closes #2094
