### PR TITLE
prism: populate stats compare between terminal-state and cleanup; fix spawn_inputs renderer (#2102)

### DIFF
--- a/modules/programs/prism/prism/cmd/investigate.go
+++ b/modules/programs/prism/prism/cmd/investigate.go
@@ -160,8 +160,12 @@ func spawnInvestigateSession(invokerSession, promptText, suppliedName string) er
 		// spawn_inputs audit (#2087): record the agent role on the audit row
 		// so investigate spawns show up in `prism stats` group-by queries
 		// alongside `prism spawn` / `prism pr` rows.
-		AgentFlag:        "investigate",
-		HarnessFlag:      harnessName,
+		AgentFlag:   "investigate",
+		HarnessFlag: harnessName,
+		// spawn_inputs.isolation_flag: record the resolved isolation mode
+		// so investigate spawns surface alongside `prism spawn` rows in the
+		// stats compare "Spawn Inputs" block (issue #2102 Layer 2).
+		IsolationFlag:    string(isoMode),
 		Layout:           session.LayoutAgentOnly,
 		IsolationMode:    string(isoMode),
 		PluginHostPath:   cfg.SidecarPluginPath,

--- a/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
@@ -344,6 +344,59 @@ func TestSpawnInputsFromOpts_InvestigateMinimalRow(t *testing.T) {
 	assertStringPtr(t, "HarnessFlag", got.HarnessFlag, "pi")
 }
 
+// TestSpawnInputsFromOpts_AbtestPairCarriesRendererFields is the issue #2102
+// Layer 2 AC at the writer level: every --abtest leg must persist the columns
+// that `prism stats compare`'s Spawn Inputs block actually reads —
+// profile_name, harness_flag, isolation_flag, agent_flag — with non-empty
+// values. Without these, the renderer collapses each leg to "—" and the
+// A/B-test merge-decision workflow loses its leg-discriminating data.
+func TestSpawnInputsFromOpts_AbtestPairCarriesRendererFields(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	pairID := uuid.New().String()
+	legs := []struct {
+		name      string
+		profile   string
+		isolation string
+		agent     string
+	}{
+		{"prism-test@worker-abtest-renderer-a", "anthropic", "bwrap", "worker"},
+		{"prism-test@worker-abtest-renderer-b", "google-gemini", "bwrap", "worker"},
+	}
+	for _, leg := range legs {
+		iid := uuid.New().String()
+		seedSessionForSpawnInputs(t, d, iid, leg.name)
+		si := session.SpawnInputsFromOpts(session.SpawnOpts{
+			InstanceID:    iid,
+			Prompt:        "abtest leg prompt",
+			PromptSource:  "cli-positional",
+			ProfileName:   leg.profile,
+			HarnessFlag:   "pi",
+			IsolationFlag: leg.isolation,
+			AgentFlag:     leg.agent,
+			AbtestPairID:  pairID,
+		})
+		if err := d.InsertSpawnInputs(si); err != nil {
+			t.Fatalf("InsertSpawnInputs leg %q: %v", leg.name, err)
+		}
+		got, err := d.SpawnInputsByInstanceID(iid)
+		if err != nil {
+			t.Fatalf("SpawnInputsByInstanceID leg %q: %v", leg.name, err)
+		}
+		if got == nil {
+			t.Fatalf("leg %q: got nil row", leg.name)
+		}
+		// Every column the `prism stats compare` Spawn Inputs renderer reads
+		// must be populated. Missing fields would collapse the leg to "—".
+		assertStringPtr(t, "ProfileName/"+leg.name, got.ProfileName, leg.profile)
+		assertStringPtr(t, "HarnessFlag/"+leg.name, got.HarnessFlag, "pi")
+		assertStringPtr(t, "IsolationFlag/"+leg.name, got.IsolationFlag, leg.isolation)
+		assertStringPtr(t, "AgentFlag/"+leg.name, got.AgentFlag, leg.agent)
+		assertStringPtr(t, "AbtestPairID/"+leg.name, got.AbtestPairID, pairID)
+	}
+}
+
 // assertStringPtr fails the test if got is nil or *got != want. Used to keep
 // the per-field assertions in the tests above concise.
 func assertStringPtr(t *testing.T, name string, got *string, want string) {

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -28,6 +28,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
@@ -142,9 +143,19 @@ func runStatsAbtest(cmd *cobra.Command, args []string) error {
 
 // compareRun holds per-run data for the comparison.
 type compareRun struct {
-	Label       string
-	Session     *db.Session
-	Outcome     *db.SpawnOutcome // may be nil if not yet computed
+	Label   string
+	Session *db.Session
+	// Outcome may be nil when the session is still in-progress (live state
+	// such as active/idle/reviewing). When a session has reached a terminal
+	// state (finished/error/interrupted) but no spawn_outcome row exists yet
+	// (the window between terminal transition and prism cleanup), Outcome is
+	// populated by an on-the-fly call to db.ComputeSpawnOutcome — see
+	// loadCompareRuns and issue #2102.
+	Outcome *db.SpawnOutcome
+	// Inputs is the spawn_inputs row for this session, or nil when no row
+	// exists (pre-#2087 spawns, or a session created outside of the
+	// SpawnSession chokepoint).
+	Inputs *db.SpawnInputs
 }
 
 // axisRow is a single row in the comparison table: a label and one value per run.
@@ -169,12 +180,7 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 	}
 
 	// Build run labels as run-A, run-B, run-C...
-	runs := make([]compareRun, len(sessions))
-	for i, sess := range sessions {
-		label := "run-" + string(rune('A'+i))
-		out, _ := d.SpawnOutcomeByInstanceID(sess.InstanceID) // nil is ok
-		runs[i] = compareRun{Label: label, Session: sess, Outcome: out}
-	}
+	runs := loadCompareRuns(d, sessions)
 
 	// Collect desired axes.
 	wantAxes := defaultAxes()
@@ -200,6 +206,82 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 	default:
 		return renderCompareTable(runs, wantAxes, includeInputs, includeRubric, diffOnly)
 	}
+}
+
+// loadCompareRuns assembles the per-run data shown by `prism stats compare`.
+//
+// For each session it reads the spawn_outcome and spawn_inputs rows. When a
+// session has reached a terminal state (finished / error / interrupted)
+// but no spawn_outcome row exists yet — the window between the sidecar's
+// terminal-state transition and `prism cleanup` — the outcome is computed
+// on the fly from agent_events via db.ComputeSpawnOutcome. ComputeSpawnOutcome
+// is the same code path WriteSpawnOutcome uses internally, so the values
+// surfaced here agree byte-for-byte with the row the cleanup pass will
+// later write (issue #2102).
+//
+// Live sessions (active / idle / reviewing / escalated) keep Outcome == nil
+// so the renderer shows “—” — the aggregates are not yet meaningful.
+func loadCompareRuns(d *db.DB, sessions []*db.Session) []compareRun {
+	runs := make([]compareRun, len(sessions))
+	for i, sess := range sessions {
+		label := "run-" + string(rune('A'+i))
+		run := compareRun{Label: label, Session: sess}
+
+		// Read the persisted spawn_outcome row first. nil is ok — the
+		// session may be in the gap between terminal-state transition and
+		// cleanup, or still in-progress.
+		if out, _ := d.SpawnOutcomeByInstanceID(sess.InstanceID); out != nil {
+			run.Outcome = out
+		} else if sessionIsTerminal(d, sess) {
+			// Terminal state but no persisted row — compute on the fly
+			// using the canonical aggregation. The row will later be
+			// persisted by `prism cleanup`; the two paths must agree.
+			if computed, err := d.ComputeSpawnOutcome(sess.InstanceID); err == nil && computed != nil {
+				run.Outcome = computed
+			}
+		}
+
+		// Load the spawn_inputs row. Best-effort: pre-#2087 sessions may
+		// have no row, in which case Inputs stays nil and the renderer
+		// surfaces what it can from the sessions row instead.
+		if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil {
+			run.Inputs = inputs
+		}
+
+		runs[i] = run
+	}
+	return runs
+}
+
+// sessionIsTerminal reports whether the agent_status row for sess shows a
+// terminal state (finished / error / interrupted / deleted) — the gate for
+// computing spawn_outcome on the fly when no persisted row exists yet.
+//
+// Falls back to sess.EndState (sessions.end_state) for sessions whose
+// agent_status row has already been cleaned away but whose sessions row
+// still records a terminal end_state. Live sessions keep Outcome nil so the
+// renderer shows “—” for aggregate axes (the over-broad-fix negative-test
+// AC in #2102).
+func sessionIsTerminal(d *db.DB, sess *db.Session) bool {
+	if sess == nil {
+		return false
+	}
+	// agent_status is the live source of truth while the row still exists.
+	if st, err := d.CurrentStatus(sess.SessionName); err == nil && st != nil {
+		return agent.IsTerminal(agent.AgentState(st.State))
+	}
+	// Fall back to sessions.end_state, written by the sidecar shutdown / by
+	// `prism cleanup`. Any non-empty terminal-shaped value here counts as
+	// terminal — "reset" (the SetEnded marker) is excluded because it can
+	// be set before the more-specific UpdateSessionEnded call, and the
+	// aggregates may not yet be stable at that point.
+	if sess.EndState != nil {
+		switch *sess.EndState {
+		case "finished", "error", "interrupted", "deleted":
+			return true
+		}
+	}
+	return false
 }
 
 // defaultAxes returns the default axis set (all non-rubric axes).
@@ -561,11 +643,30 @@ func renderCompareTable(runs []compareRun, axes []string, includeInputs, include
 		fmt.Println(line)
 	}
 
-	// Spawn inputs block (show session name differences).
+	// Spawn inputs block: render the actual values written at spawn time by
+	// SpawnSession (#2087) and the `prism pr` writer. The renderer reads
+	// profile_name, isolation, harness, branch, agent_role, and the abtest
+	// pair id. Partial data is rendered as-is — missing fields collapse to
+	// “—” rather than treating the row as absent (issue #2102, Layer 2).
 	if includeInputs {
 		fmt.Println()
 		fmt.Println(styleHeader.Render("Spawn Inputs"))
-		fmt.Println(styleDim.Render("  (spawn_inputs table not yet populated — run `prism spawn` with C.1 to capture inputs)"))
+		if !anyInputsPresent(runs) {
+			// Best-effort placeholder for sessions that pre-date the
+			// spawn_inputs writer (#2087). The old “C.1” placeholder is
+			// gone — the writer is live for every front door, so the only
+			// reason a row is missing today is that the session is from
+			// before #2087 merged.
+			fmt.Println(styleDim.Render("  (no spawn_inputs rows for the runs being compared)"))
+		} else {
+			for _, row := range inputsAxisRows(runs, diffOnly) {
+				line := fmt.Sprintf("%-*s", wLabel, styleLabel.Render(row.Name+":"))
+				for _, v := range row.Values {
+					line += fmt.Sprintf("  %-*s", wVal, truncateStr(v, wVal))
+				}
+				fmt.Println(line)
+			}
+		}
 	}
 
 	// Section: process-level.
@@ -663,24 +764,143 @@ func renderSection(
 	}
 }
 
+// ---------- spawn_inputs renderer helpers ----------
+
+// inputsAxes is the canonical ordered list of spawn_inputs columns surfaced
+// by `prism stats compare`. The set must match the AC for issue #2102 Layer 2:
+// profile_name, isolation_mode, branch, agent_role, harness, plus the
+// abtest pair id (the data point that ties two sibling sessions together).
+var inputsAxes = []string{
+	"profile_name",
+	"harness",
+	"isolation_mode",
+	"agent_role",
+	"branch",
+	"abtest_pair_id",
+}
+
+// inputsValue returns the display string for a single spawn_inputs axis on
+// one run. Falls back from spawn_inputs columns to the sessions row for
+// harness and agent_role so that runs with a partial spawn_inputs row (or
+// no row at all) still surface what we know. Returns "—" for missing data.
+func inputsValue(axis string, run compareRun) string {
+	in := run.Inputs
+	switch axis {
+	case "profile_name":
+		if in != nil && in.ProfileName != nil && *in.ProfileName != "" {
+			return *in.ProfileName
+		}
+	case "harness":
+		if in != nil && in.HarnessFlag != nil && *in.HarnessFlag != "" {
+			return *in.HarnessFlag
+		}
+		if run.Session != nil && run.Session.Harness != "" {
+			return run.Session.Harness
+		}
+	case "isolation_mode":
+		if in != nil && in.IsolationFlag != nil && *in.IsolationFlag != "" {
+			return *in.IsolationFlag
+		}
+	case "agent_role":
+		if in != nil && in.AgentFlag != nil && *in.AgentFlag != "" {
+			return *in.AgentFlag
+		}
+		if run.Session != nil && run.Session.AgentRole != nil && *run.Session.AgentRole != "" {
+			return *run.Session.AgentRole
+		}
+	case "branch":
+		if in != nil && in.BranchFlag != nil && *in.BranchFlag != "" {
+			return *in.BranchFlag
+		}
+	case "abtest_pair_id":
+		if in != nil && in.AbtestPairID != nil && *in.AbtestPairID != "" {
+			return *in.AbtestPairID
+		}
+	}
+	return "—"
+}
+
+// anyInputsPresent reports whether any inputs axis has a non-“—” value on
+// at least one run — used to decide whether to render the Spawn Inputs
+// block at all, or fall back to the “no spawn_inputs rows” note.
+func anyInputsPresent(runs []compareRun) bool {
+	for _, axis := range inputsAxes {
+		for _, r := range runs {
+			if inputsValue(axis, r) != "—" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// inputsAxisRows builds the per-axis rows for the spawn_inputs block,
+// applying --diff-only consistently with the outcome sections.
+func inputsAxisRows(runs []compareRun, diffOnly bool) []axisRow {
+	var rows []axisRow
+	for _, axis := range inputsAxes {
+		vals := make([]string, len(runs))
+		allSame := true
+		for i, r := range runs {
+			vals[i] = inputsValue(axis, r)
+			if i > 0 && vals[i] != vals[0] {
+				allSame = false
+			}
+		}
+		if diffOnly && allSame {
+			continue
+		}
+		// Skip rows that are entirely missing across all runs — keeps the
+		// rendering compact when (e.g.) no leg in the pair set --branch.
+		nonEmpty := false
+		for _, v := range vals {
+			if v != "—" {
+				nonEmpty = true
+				break
+			}
+		}
+		if !nonEmpty {
+			continue
+		}
+		rows = append(rows, axisRow{Name: axis, Values: vals})
+	}
+	return rows
+}
+
+// inputsMapForRun returns the per-run spawn_inputs map used by the JSON
+// renderer. Missing fields are emitted as JSON null rather than the “—”
+// glyph used by the table renderer.
+func inputsMapForRun(run compareRun) map[string]interface{} {
+	m := make(map[string]interface{}, len(inputsAxes))
+	for _, axis := range inputsAxes {
+		v := inputsValue(axis, run)
+		if v == "—" {
+			m[axis] = nil
+		} else {
+			m[axis] = v
+		}
+	}
+	return m
+}
+
 // ---------- JSON renderer ----------
 
 // compareJSONOutput is the top-level JSON shape (C3 §6.3).
 type compareJSONOutput struct {
-	Runs  []compareJSONRun      `json:"runs"`
-	Diffs compareJSONDiffs      `json:"diffs"`
+	Runs  []compareJSONRun `json:"runs"`
+	Diffs compareJSONDiffs `json:"diffs"`
 }
 
 type compareJSONRun struct {
 	Label        string                 `json:"label"`
 	SessionName  string                 `json:"session_name"`
 	InstanceID   string                 `json:"instance_id"`
-	SpawnInputs  map[string]interface{} `json:"spawn_inputs"` // always {} until C.1 writes rows
+	SpawnInputs  map[string]interface{} `json:"spawn_inputs"`
 	SpawnOutcome map[string]interface{} `json:"spawn_outcome"`
 }
 
 type compareJSONDiffs struct {
-	SpawnInputs  []string `json:"spawn_inputs"`  // always [] until C.1
+	SpawnInputs  []string `json:"spawn_inputs"`
 	SpawnOutcome []string `json:"spawn_outcome"`
 }
 
@@ -702,7 +922,7 @@ func renderCompareJSON(runs []compareRun, axes []string, includeInputs, includeR
 			Label:       r.Label,
 			SessionName: r.Session.SessionName,
 			InstanceID:  r.Session.InstanceID,
-			SpawnInputs: map[string]interface{}{},
+			SpawnInputs: inputsMapForRun(r),
 		}
 		outcomeMap := make(map[string]interface{})
 		for _, axis := range effectiveAxes {
@@ -718,6 +938,11 @@ func renderCompareJSON(runs []compareRun, axes []string, includeInputs, includeR
 	}
 
 	// Compute diffs: axes where runs differ.
+	for _, axis := range inputsAxes {
+		if !inputsAxisAllSame(axis, runs) {
+			out.Diffs.SpawnInputs = append(out.Diffs.SpawnInputs, axis)
+		}
+	}
 	for _, axis := range effectiveAxes {
 		if !allSame(axis, runs) {
 			out.Diffs.SpawnOutcome = append(out.Diffs.SpawnOutcome, axis)
@@ -727,6 +952,20 @@ func renderCompareJSON(runs []compareRun, axes []string, includeInputs, includeR
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
+}
+
+// inputsAxisAllSame mirrors allSame() but for a single spawn_inputs axis.
+func inputsAxisAllSame(axis string, runs []compareRun) bool {
+	if len(runs) == 0 {
+		return true
+	}
+	first := inputsValue(axis, runs[0])
+	for _, r := range runs[1:] {
+		if inputsValue(axis, r) != first {
+			return false
+		}
+	}
+	return true
 }
 
 // ---------- CSV renderer ----------
@@ -751,6 +990,24 @@ func renderCompareCSV(runs []compareRun, axes []string, includeInputs, includeRu
 	}
 	if err := w.Write(header); err != nil {
 		return fmt.Errorf("csv: write header: %w", err)
+	}
+
+	// Inputs rows (CSV equivalent of the table renderer’s Spawn Inputs
+	// block). Emitted before outcome axes when --include-inputs is on so
+	// downstream consumers see the per-axis ordering: inputs, then outcome.
+	if includeInputs {
+		for _, row := range inputsAxisRows(runs, diffOnly) {
+			record := []string{row.Name}
+			record = append(record, row.Values...)
+			if len(runs) == 2 {
+				// Delta is meaningful only for numeric axes; spawn_inputs
+				// columns are all strings (profile_name, isolation, etc).
+				record = append(record, "")
+			}
+			if err := w.Write(record); err != nil {
+				return fmt.Errorf("csv: write inputs row: %w", err)
+			}
+		}
 	}
 
 	// Data rows.

--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -1,0 +1,524 @@
+package cmd
+
+// Tests for prism stats compare — focus on issue #2102:
+//
+//   Layer 1: spawn_outcome aggregates must be available to `prism stats
+//   compare` between terminal-state transition and `prism cleanup`. The
+//   read path falls back to db.ComputeSpawnOutcome when no persisted row
+//   exists yet.
+//
+//   Layer 2: the Spawn Inputs block must surface the values written at
+//   spawn time (profile_name, isolation, harness, branch, agent_role)
+//   rather than the stale C.1 placeholder.
+//
+// Tests use the openStatsTestDB / writeStatsEvent helpers defined in
+// stats_test.go. Sessions are constructed by hand to mimic the
+// post-spawn / post-terminal / pre-cleanup state without spinning up
+// tmux, sidecar, or a real agent.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedCompareSession inserts the minimum rows the compare engine reads:
+// agent_status (driver of sessionIsTerminal), sessions (driver of Outcome
+// fallback aggregation), and optionally spawn_inputs.
+//
+// finalState is the agent_status.state value the test wants the row to
+// carry — pass "active" / "idle" / "finished" / "error" / "interrupted" /
+// "deleted" depending on the case under test. The sessions row's
+// end_state mirrors the sidecar-shutdown / cleanup contract:
+//   - terminal final states populate sessions.end_state with the same value
+//     so the sessions-row fallback in sessionIsTerminal also returns true,
+//   - non-terminal final states leave sessions.end_state NULL.
+func seedCompareSession(t *testing.T, d *db.DB, sessionName string, startedAt time.Time, finalState agent.AgentState, inputs *db.SpawnInputs) (instanceID string) {
+	t.Helper()
+	instanceID = uuid.New().String()
+
+	if err := d.UpsertStatus(sessionName, "repo", "/wt/"+sessionName, string(finalState), nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("SetInstanceID %q: %v", sessionName, err)
+	}
+
+	sess := db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+
+	// Mirror the cleanup-path UpdateSessionEnded write only when the final
+	// state is terminal. Live sessions intentionally leave sessions.end_state
+	// NULL so the negative-test AC exercises the gate correctly.
+	if agent.IsTerminal(finalState) {
+		if err := d.UpdateSessionEnded(instanceID, string(finalState)); err != nil {
+			t.Fatalf("UpdateSessionEnded %q: %v", sessionName, err)
+		}
+	}
+
+	if inputs != nil {
+		inputs.InstanceID = instanceID
+		if inputs.CreatedAt == 0 {
+			inputs.CreatedAt = startedAt.UnixMilli()
+		}
+		if err := d.InsertSpawnInputs(*inputs); err != nil {
+			t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+		}
+	}
+	return instanceID
+}
+
+// writeAssistantTurn emits a msg_assistant event with the given token /
+// cost numbers, linking it to the session's instance_id so the aggregation
+// query picks it up.
+func writeAssistantTurn(t *testing.T, d *db.DB, sessionName, instanceID string, ts time.Time, inputTokens, outputTokens, cacheRead, cacheWrite int, cost float64) {
+	t.Helper()
+	payload := assistantPayloadWithTokens("turn-"+uuid.New().String(), "reply", inputTokens, outputTokens, cacheRead, cacheWrite, 5000, 25.0)
+	ev := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		InstanceID:  &instanceID,
+		Type:        "msg_assistant",
+		Payload:     payload,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(ev); err != nil {
+		t.Fatalf("WriteEvent (msg_assistant): %v", err)
+	}
+	if cost > 0 {
+		// Replace payload to embed the cost field; the assistantPayloadWithTokens
+		// helper does not include it. Cheaper than building a parallel helper.
+		// Use a second event purely for cost aggregation — the aggregation
+		// SUM picks up the cost field from any msg_assistant row.
+		costPayload := assistantPayloadWithEventCost("cost-"+uuid.New().String(), "anthropic/claude-sonnet-4-6", 0, 0, cost)
+		ev2 := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: sessionName,
+			Repo:        "repo",
+			Worktree:    "/wt/" + sessionName,
+			InstanceID:  &instanceID,
+			Type:        "msg_assistant",
+			Payload:     costPayload,
+			CreatedAt:   ts.Add(time.Millisecond),
+		}
+		if err := d.WriteEvent(ev2); err != nil {
+			t.Fatalf("WriteEvent (msg_assistant cost): %v", err)
+		}
+	}
+}
+
+// writeToolCall emits a tool_call event tied to instance_id.
+func writeToolCall(t *testing.T, d *db.DB, sessionName, instanceID, tool string, ts time.Time) {
+	t.Helper()
+	ev := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		InstanceID:  &instanceID,
+		Type:        "tool_call",
+		Payload:     toolCallPayloadWithDuration("tc-"+uuid.New().String(), tool, "args", 100),
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(ev); err != nil {
+		t.Fatalf("WriteEvent (tool_call): %v", err)
+	}
+}
+
+// ── Layer 1 — spawn_outcome on-the-fly compute ───────────────────────────────
+
+// TestLoadCompareRuns_TerminalFinishedNoOutcome covers the core AC: a
+// session that has transitioned to `finished` but has not yet been cleaned
+// up — `prism stats compare` must populate every aggregate axis without
+// the spawn_outcome row, by computing on the fly from agent_events.
+func TestLoadCompareRuns_TerminalFinishedNoOutcome(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+
+	const sessionName = "repo@finished-no-cleanup"
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, nil)
+
+	// Two assistant turns + a tool call. Numbers picked so each aggregate
+	// has a distinctive sum, making mis-aggregation easy to catch.
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(10*time.Second), 1500, 700, 300, 150, 0.12)
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(40*time.Second), 2000, 900, 400, 200, 0.34)
+	writeToolCall(t, d, sessionName, iid, "bash", startedAt.Add(20*time.Second))
+
+	// Sanity: no spawn_outcome row exists yet (cleanup has not run).
+	if got, err := d.SpawnOutcomeByInstanceID(iid); err != nil || got != nil {
+		t.Fatalf("pre-condition: SpawnOutcomeByInstanceID = (%v, %v), want (nil, nil)", got, err)
+	}
+
+	sess, err := d.SessionByInstanceID(iid)
+	if err != nil || sess == nil {
+		t.Fatalf("SessionByInstanceID: sess=%v err=%v", sess, err)
+	}
+
+	runs := loadCompareRuns(d, []*db.Session{sess})
+	if len(runs) != 1 || runs[0].Outcome == nil {
+		t.Fatalf("loadCompareRuns: outcome nil (terminal+no-cleanup case must populate via ComputeSpawnOutcome)")
+	}
+	out := runs[0].Outcome
+	if out.TokensInputTotal != 3500 {
+		t.Errorf("TokensInputTotal: got %d, want 3500 (1500+2000)", out.TokensInputTotal)
+	}
+	if out.TokensOutputTotal != 1600 {
+		t.Errorf("TokensOutputTotal: got %d, want 1600 (700+900)", out.TokensOutputTotal)
+	}
+	if out.MsgAssistantCount != 4 {
+		// 2 token-bearing turns + 2 cost-bearing turns = 4 msg_assistant rows.
+		t.Errorf("MsgAssistantCount: got %d, want 4", out.MsgAssistantCount)
+	}
+	if out.ToolCallCount != 1 {
+		t.Errorf("ToolCallCount: got %d, want 1", out.ToolCallCount)
+	}
+	if out.CostUSDTotal < 0.45 || out.CostUSDTotal > 0.47 {
+		t.Errorf("CostUSDTotal: got %.4f, want ~0.46 (0.12+0.34)", out.CostUSDTotal)
+	}
+	if out.EndState == nil || *out.EndState != "finished" {
+		t.Errorf("EndState: got %v, want \"finished\"", out.EndState)
+	}
+	if out.TimeToFirstEventMs == nil || *out.TimeToFirstEventMs <= 0 {
+		t.Errorf("TimeToFirstEventMs: got %v, want >0", out.TimeToFirstEventMs)
+	}
+}
+
+// TestLoadCompareRuns_TerminalErrorNoOutcome verifies the same shape for an
+// `error` terminal state (issue #2081 path: zero-output exit transitions to
+// error). The AC requires identical behaviour across finished/error/interrupted.
+func TestLoadCompareRuns_TerminalErrorNoOutcome(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+
+	const sessionName = "repo@error-no-cleanup"
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateError, nil)
+
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(5*time.Second), 800, 400, 0, 0, 0.05)
+	// An error event between the assistant turn and termination, to exercise
+	// ErrorEventCount aggregation.
+	ev := db.Event{
+		ID: uuid.New().String(), SessionName: sessionName, Repo: "repo",
+		Worktree: "/wt/" + sessionName, InstanceID: &iid,
+		Type: "error", Payload: `{"message":"transient"}`,
+		CreatedAt: startedAt.Add(7 * time.Second),
+	}
+	if err := d.WriteEvent(ev); err != nil {
+		t.Fatalf("WriteEvent (error): %v", err)
+	}
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+	if runs[0].Outcome == nil {
+		t.Fatalf("Outcome nil on state=error (must be computed on the fly)")
+	}
+	out := runs[0].Outcome
+	if out.EndState == nil || *out.EndState != "error" {
+		t.Errorf("EndState: got %v, want \"error\"", out.EndState)
+	}
+	if out.TokensInputTotal != 800 {
+		t.Errorf("TokensInputTotal: got %d, want 800", out.TokensInputTotal)
+	}
+	if out.ErrorEventCount != 1 {
+		t.Errorf("ErrorEventCount: got %d, want 1", out.ErrorEventCount)
+	}
+}
+
+// TestLoadCompareRuns_TerminalInterruptedNoOutcome covers the interrupted
+// terminal path.
+func TestLoadCompareRuns_TerminalInterruptedNoOutcome(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+
+	const sessionName = "repo@interrupted-no-cleanup"
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateInterrupted, nil)
+
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(5*time.Second), 600, 300, 0, 0, 0.02)
+	// Interrupted: a state_change event with state=interrupted.
+	ev := db.Event{
+		ID: uuid.New().String(), SessionName: sessionName, Repo: "repo",
+		Worktree: "/wt/" + sessionName, InstanceID: &iid,
+		Type: "state_change", Payload: `{"state":"interrupted"}`,
+		CreatedAt: startedAt.Add(6 * time.Second),
+	}
+	if err := d.WriteEvent(ev); err != nil {
+		t.Fatalf("WriteEvent (state_change interrupted): %v", err)
+	}
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+	if runs[0].Outcome == nil {
+		t.Fatalf("Outcome nil on state=interrupted (must be computed on the fly)")
+	}
+	out := runs[0].Outcome
+	if out.EndState == nil || *out.EndState != "interrupted" {
+		t.Errorf("EndState: got %v, want \"interrupted\"", out.EndState)
+	}
+	if out.InterruptedCount != 1 {
+		t.Errorf("InterruptedCount: got %d, want 1", out.InterruptedCount)
+	}
+}
+
+// TestLoadCompareRuns_TerminalThenCleanup verifies the idempotence AC: the
+// values surfaced before cleanup must match the values surfaced after
+// cleanup. Compute → WriteSpawnOutcome → read → must agree, byte for byte
+// on every aggregate column.
+func TestLoadCompareRuns_TerminalThenCleanup(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-3 * time.Minute)
+
+	const sessionName = "repo@finished-then-cleanup"
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, nil)
+
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(10*time.Second), 1200, 600, 100, 50, 0.10)
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(30*time.Second), 800, 400, 50, 25, 0.07)
+	writeToolCall(t, d, sessionName, iid, "bash", startedAt.Add(15*time.Second))
+	writeToolCall(t, d, sessionName, iid, "read", startedAt.Add(25*time.Second))
+
+	sess, _ := d.SessionByInstanceID(iid)
+
+	// Before cleanup: outcome is computed on the fly.
+	before := loadCompareRuns(d, []*db.Session{sess})[0].Outcome
+	if before == nil {
+		t.Fatalf("pre-cleanup outcome nil")
+	}
+
+	// Run the cleanup-equivalent write.
+	if err := d.WriteSpawnOutcome(iid); err != nil {
+		t.Fatalf("WriteSpawnOutcome: %v", err)
+	}
+
+	// After cleanup: same values, now from the persisted row.
+	after := loadCompareRuns(d, []*db.Session{sess})[0].Outcome
+	if after == nil {
+		t.Fatalf("post-cleanup outcome nil")
+	}
+
+	if before.TokensInputTotal != after.TokensInputTotal ||
+		before.TokensOutputTotal != after.TokensOutputTotal ||
+		before.TokensCacheReadTotal != after.TokensCacheReadTotal ||
+		before.TokensCacheWriteTotal != after.TokensCacheWriteTotal ||
+		before.ToolCallCount != after.ToolCallCount ||
+		before.MsgAssistantCount != after.MsgAssistantCount {
+		t.Errorf("idempotence drift\n  before: %+v\n  after:  %+v", before, after)
+	}
+	// Cost is a float; allow a tiny epsilon though INSERT OR REPLACE should
+	// produce an exact round-trip on the same SUM.
+	if absDiff(before.CostUSDTotal, after.CostUSDTotal) > 1e-9 {
+		t.Errorf("CostUSDTotal drift: before=%.6f, after=%.6f", before.CostUSDTotal, after.CostUSDTotal)
+	}
+}
+
+// TestLoadCompareRuns_ActiveSessionReturnsDash is the over-broad-fix negative
+// test: a session still in state=active must surface — for aggregate axes,
+// not stale numbers. Live sessions are excluded from the on-the-fly compute
+// gate even if events have been written for them.
+func TestLoadCompareRuns_ActiveSessionReturnsDash(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-30 * time.Second)
+
+	const sessionName = "repo@still-active"
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, nil)
+
+	// Events exist but the session has NOT transitioned to terminal.
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(5*time.Second), 1000, 500, 0, 0, 0.05)
+	writeToolCall(t, d, sessionName, iid, "bash", startedAt.Add(10*time.Second))
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+	if runs[0].Outcome != nil {
+		t.Errorf("active session must surface nil Outcome (renderer shows \"—\"); got non-nil: %+v", runs[0].Outcome)
+	}
+
+	// The axisValue path must also collapse to "—" for aggregate axes on a
+	// live session — this is what the renderer actually emits.
+	for _, axis := range []string{"tokens_input", "tokens_output", "cost_usd", "tool_call", "duration_ms"} {
+		if got := axisValue(axis, runs[0]); got != "—" {
+			t.Errorf("axisValue(%q) on active session = %q, want \"—\"", axis, got)
+		}
+	}
+}
+
+// ── Layer 2 — spawn_inputs renderer ──────────────────────────────────────────
+
+// TestInputsValue_PullsFromSpawnInputs verifies the per-axis lookup against
+// a populated spawn_inputs row.
+func TestInputsValue_PullsFromSpawnInputs(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-full"
+	inputs := &db.SpawnInputs{
+		ProfileName:   strPtr("anthropic"),
+		HarnessFlag:   strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"),
+		AgentFlag:     strPtr("worker"),
+		BranchFlag:    strPtr("feature/x"),
+		AbtestPairID:  strPtr("pair-uuid-0001"),
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	want := map[string]string{
+		"profile_name":   "anthropic",
+		"harness":        "pi",
+		"isolation_mode": "bwrap",
+		"agent_role":     "worker",
+		"branch":         "feature/x",
+		"abtest_pair_id": "pair-uuid-0001",
+	}
+	for axis, wantVal := range want {
+		if got := inputsValue(axis, runs[0]); got != wantVal {
+			t.Errorf("inputsValue(%q) = %q, want %q", axis, got, wantVal)
+		}
+	}
+}
+
+// TestInputsValue_PartialRowSurfacesWhatExists guards the Layer 2 AC: a row
+// with only profile_name set (the #2092/#2093 case) must surface that field
+// rather than treating the whole row as absent.
+func TestInputsValue_PartialRowSurfacesWhatExists(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-partial"
+	inputs := &db.SpawnInputs{
+		ProfileName: strPtr("anthropic-opus-max"),
+		// All other flags intentionally nil — partial row case.
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("profile_name", runs[0]); got != "anthropic-opus-max" {
+		t.Errorf("profile_name on partial row = %q, want \"anthropic-opus-max\"", got)
+	}
+	// Harness falls back to sessions.harness (the InsertSession default in
+	// seedCompareSession is "pi"), which is the intended graceful-degrade.
+	if got := inputsValue("harness", runs[0]); got != "pi" {
+		t.Errorf("harness on partial row = %q, want fallback to sessions.harness (\"pi\")", got)
+	}
+	// Branch is absent — must surface as "—" rather than blank.
+	if got := inputsValue("branch", runs[0]); got != "—" {
+		t.Errorf("branch on partial row = %q, want \"—\"", got)
+	}
+}
+
+// TestRenderCompareTable_NoCInOnePlaceholder is the smoke test for the
+// stale-placeholder removal AC. The old text "(spawn_inputs table not yet
+// populated — run prism spawn with C.1 to capture inputs)" must not appear
+// in the rendered table for a session with a populated spawn_inputs row.
+func TestRenderCompareTable_NoCInOnePlaceholder(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionA = "repo@compare-a"
+	const sessionB = "repo@compare-b"
+	inputsA := &db.SpawnInputs{
+		ProfileName: strPtr("anthropic"), HarnessFlag: strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"), AgentFlag: strPtr("worker"),
+	}
+	inputsB := &db.SpawnInputs{
+		ProfileName: strPtr("google-gemini"), HarnessFlag: strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"), AgentFlag: strPtr("worker"),
+	}
+	iidA := seedCompareSession(t, d, sessionA, startedAt, agent.StateFinished, inputsA)
+	iidB := seedCompareSession(t, d, sessionB, startedAt, agent.StateFinished, inputsB)
+	writeAssistantTurn(t, d, sessionA, iidA, startedAt.Add(time.Second), 100, 50, 0, 0, 0.01)
+	writeAssistantTurn(t, d, sessionB, iidB, startedAt.Add(time.Second), 200, 75, 0, 0, 0.02)
+
+	sessA, _ := d.SessionByInstanceID(iidA)
+	sessB, _ := d.SessionByInstanceID(iidB)
+	runs := loadCompareRuns(d, []*db.Session{sessA, sessB})
+
+	out := captureStdout(t, func() {
+		if err := renderCompareTable(runs, defaultAxes(), true /* includeInputs */, false, false); err != nil {
+			t.Fatalf("renderCompareTable: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "C.1") {
+		t.Errorf("rendered output still mentions C.1:\n%s", out)
+	}
+	if strings.Contains(out, "spawn_inputs table not yet populated") {
+		t.Errorf("rendered output still carries the stale placeholder:\n%s", out)
+	}
+	// Both profile names must appear — they're the per-leg discriminator
+	// for an A/B-test comparison, and the whole point of Layer 2.
+	if !strings.Contains(out, "anthropic") {
+		t.Errorf("rendered output missing run-A profile_name:\n%s", out)
+	}
+	if !strings.Contains(out, "google-gemini") {
+		t.Errorf("rendered output missing run-B profile_name:\n%s", out)
+	}
+	if !strings.Contains(out, "profile_name:") {
+		t.Errorf("rendered output missing profile_name row label:\n%s", out)
+	}
+	// Aggregate axes for the terminal-no-cleanup case must NOT all be "—".
+	// Token totals from the two assistant turns must appear in the table.
+	if !strings.Contains(out, "tokens_input:") {
+		t.Errorf("rendered output missing tokens_input row:\n%s", out)
+	}
+}
+
+// TestRenderCompareTable_LiveSessionStillShowsDash verifies the negative
+// AC at the table-renderer level: an active session in the pair must
+// render aggregate axes as "—" even when spawn_inputs are populated.
+func TestRenderCompareTable_LiveSessionStillShowsDash(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-30 * time.Second)
+
+	const sessionName = "repo@live-active"
+	inputs := &db.SpawnInputs{
+		ProfileName: strPtr("anthropic"), HarnessFlag: strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"),
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
+	writeAssistantTurn(t, d, sessionName, iid, startedAt.Add(time.Second), 100, 50, 0, 0, 0.01)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess, sess})
+
+	out := captureStdout(t, func() {
+		if err := renderCompareTable(runs, defaultAxes(), true, false, false); err != nil {
+			t.Fatalf("renderCompareTable: %v", err)
+		}
+	})
+
+	// Inputs block must still appear (those values ARE known at spawn time).
+	if !strings.Contains(out, "anthropic") {
+		t.Errorf("rendered output missing profile_name on live session:\n%s", out)
+	}
+	// But aggregate axes must read "—" — the session is still in progress.
+	if strings.Contains(out, "100") || strings.Contains(out, "150") {
+		// "100" / "150" are the seeded tokens from writeAssistantTurn —
+		// they must not surface for a still-active session.
+		t.Errorf("rendered output leaks aggregate data for an active session:\n%s", out)
+	}
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+func absDiff(a, b float64) float64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/modules/programs/prism/prism/internal/agent/agent.go
+++ b/modules/programs/prism/prism/internal/agent/agent.go
@@ -36,3 +36,24 @@ const (
 	// `session.escalated` bus event already informed the coordinator.
 	StateEscalated AgentState = "escalated"
 )
+
+// IsTerminal reports whether s is a terminal agent state. Terminal states
+// are the lifecycle endpoints for which post-hoc aggregates (token totals,
+// cost, durations) are meaningful: the agent has stopped producing new
+// events, so a snapshot taken at this point will not be invalidated by
+// later activity.
+//
+// The set is the same one the cleanup pipeline and `prism stats compare`
+// treat as "data is final": finished, error, interrupted, and deleted. It
+// excludes the in-progress states (active, idle, waiting, compacting,
+// reviewing, escalated) — those sessions may still emit events.
+//
+// Called by `prism stats compare` to decide whether to compute an outcome
+// on the fly when no `spawn_outcome` row exists yet (issue #2102).
+func IsTerminal(s AgentState) bool {
+	switch s {
+	case StateFinished, StateError, StateInterrupted, StateDeleted:
+		return true
+	}
+	return false
+}

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -7558,6 +7559,163 @@ func TestWriteSpawnOutcome_NoSession(t *testing.T) {
 	d := openTestDB(t)
 	if err := d.WriteSpawnOutcome("does-not-exist-" + uuid.New().String()); err != nil {
 		t.Fatalf("WriteSpawnOutcome on missing session: %v (want nil)", err)
+	}
+}
+
+// TestComputeSpawnOutcome_MatchesWriteSpawnOutcome is the byte-for-byte
+// idempotence guard required by issue #2102. It verifies that the on-the-fly
+// aggregation surfaced to `prism stats compare` (ComputeSpawnOutcome) and the
+// persisted aggregation that `prism cleanup` writes (WriteSpawnOutcome +
+// SpawnOutcomeByInstanceID) produce identical values — every count, every
+// token total, every cost. If the two paths drift, the comparison surface
+// would silently report different numbers before vs after cleanup.
+func TestComputeSpawnOutcome_MatchesWriteSpawnOutcome(t *testing.T) {
+	d := openTestDB(t)
+
+	iid := uuid.New().String()
+	startedAt := time.Now().Add(-10 * time.Minute)
+	endedAt := startedAt.Add(5 * time.Minute)
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: "test@compute-match",
+		Repo:        "repo",
+		Worktree:    "/wt",
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	if err := d.UpdateSessionEnded(iid, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded: %v", err)
+	}
+
+	// Seed a representative event mix: an assistant turn with tokens + cost,
+	// a tool_call, a permission_ask, and an error event. Every aggregate
+	// column must show up identical between the two paths.
+	events := []struct {
+		typ     string
+		payload string
+		at      time.Time
+	}{
+		{"msg_assistant", `{"inputTokens":1500,"outputTokens":700,"cacheReadTokens":300,"cacheWriteTokens":150,"cost":0.123}`, startedAt.Add(30 * time.Second)},
+		{"msg_assistant", `{"inputTokens":2000,"outputTokens":900,"cacheReadTokens":400,"cacheWriteTokens":200,"cost":0.456}`, startedAt.Add(90 * time.Second)},
+		{"tool_call", `{"name":"bash"}`, startedAt.Add(60 * time.Second)},
+		{"tool_call", `{"name":"read"}`, startedAt.Add(70 * time.Second)},
+		{"permission_ask", `{"tool":"write"}`, startedAt.Add(80 * time.Second)},
+		{"error", `{"message":"transient"}`, startedAt.Add(100 * time.Second)},
+		{"state_change", `{"state":"finished"}`, endedAt},
+	}
+	for i, e := range events {
+		ev := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: "test@compute-match",
+			Repo:        "repo",
+			Worktree:    "/wt",
+			InstanceID:  &iid,
+			Type:        e.typ,
+			Payload:     e.payload,
+			CreatedAt:   e.at,
+		}
+		if err := d.WriteEvent(ev); err != nil {
+			t.Fatalf("WriteEvent[%d]: %v", i, err)
+		}
+	}
+
+	// On-the-fly compute (the prism stats compare read path).
+	computed, err := d.ComputeSpawnOutcome(iid)
+	if err != nil {
+		t.Fatalf("ComputeSpawnOutcome: %v", err)
+	}
+	if computed == nil {
+		t.Fatal("ComputeSpawnOutcome: got nil, want a populated outcome")
+	}
+
+	// Write and read back (the prism cleanup write path).
+	if err := d.WriteSpawnOutcome(iid); err != nil {
+		t.Fatalf("WriteSpawnOutcome: %v", err)
+	}
+	written, err := d.SpawnOutcomeByInstanceID(iid)
+	if err != nil {
+		t.Fatalf("SpawnOutcomeByInstanceID: %v", err)
+	}
+	if written == nil {
+		t.Fatal("SpawnOutcomeByInstanceID: got nil, want a row")
+	}
+
+	// Compare every aggregate column. ComputedAt is allowed to differ
+	// because each pass stamps its own clock read — the AC is data shape
+	// agreement, not snapshot-time agreement.
+	written.ComputedAt = computed.ComputedAt
+	if !reflect.DeepEqual(computed, written) {
+		t.Errorf("compute vs write drift\n  compute: %+v\n  written: %+v", computed, written)
+	}
+}
+
+// TestWriteSpawnOutcome_IdempotentOverwrite verifies that a second
+// WriteSpawnOutcome call after intervening events still produces a row that
+// matches a fresh ComputeSpawnOutcome — the incremental/cleanup overwrite
+// must not double-count or miss deltas (issue #2102 AC).
+func TestWriteSpawnOutcome_IdempotentOverwrite(t *testing.T) {
+	d := openTestDB(t)
+
+	iid := uuid.New().String()
+	startedAt := time.Now().Add(-3 * time.Minute)
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: "test@idempotent",
+		Repo:        "repo",
+		Worktree:    "/wt",
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	// First write with two assistant turns.
+	for i, payload := range []string{
+		`{"inputTokens":100,"outputTokens":50}`,
+		`{"inputTokens":200,"outputTokens":75}`,
+	} {
+		ev := db.Event{
+			ID:          uuid.New().String(),
+			SessionName: "test@idempotent",
+			Repo:        "repo",
+			Worktree:    "/wt",
+			InstanceID:  &iid,
+			Type:        "msg_assistant",
+			Payload:     payload,
+			CreatedAt:   startedAt.Add(time.Duration(i+1) * 10 * time.Second),
+		}
+		if err := d.WriteEvent(ev); err != nil {
+			t.Fatalf("WriteEvent: %v", err)
+		}
+	}
+	if err := d.WriteSpawnOutcome(iid); err != nil {
+		t.Fatalf("WriteSpawnOutcome (first): %v", err)
+	}
+
+	// Second write after the same events have all been seen — no new
+	// events between the two writes, so the second row must match the
+	// fresh recompute exactly. INSERT OR REPLACE means the row overwrites
+	// cleanly without doubling.
+	if err := d.WriteSpawnOutcome(iid); err != nil {
+		t.Fatalf("WriteSpawnOutcome (second): %v", err)
+	}
+	written, err := d.SpawnOutcomeByInstanceID(iid)
+	if err != nil {
+		t.Fatalf("SpawnOutcomeByInstanceID: %v", err)
+	}
+	if written == nil {
+		t.Fatal("SpawnOutcomeByInstanceID: got nil, want a row")
+	}
+	if written.TokensInputTotal != 300 {
+		t.Errorf("TokensInputTotal after double-write: got %d, want 300 (100+200, no double-count)", written.TokensInputTotal)
+	}
+	if written.TokensOutputTotal != 125 {
+		t.Errorf("TokensOutputTotal after double-write: got %d, want 125 (50+75, no double-count)", written.TokensOutputTotal)
+	}
+	if written.MsgAssistantCount != 2 {
+		t.Errorf("MsgAssistantCount after double-write: got %d, want 2 (no double-count)", written.MsgAssistantCount)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/db/sessions.go
+++ b/modules/programs/prism/prism/internal/db/sessions.go
@@ -269,24 +269,31 @@ SELECT COALESCE(JSON_EXTRACT(payload, '$.model'), ''),
 	return turns, nil
 }
 
-// WriteSpawnOutcome computes all aggregated columns for the given instanceID
-// from agent_events and sessions, then upserts a spawn_outcome row. The write
-// is idempotent (INSERT OR REPLACE). Calling it twice produces the same result.
+// ComputeSpawnOutcome computes all aggregated columns for the given
+// instanceID from agent_events, sessions, pending_merges, and any
+// review-group rollup, and returns a fully-populated *SpawnOutcome
+// without persisting it.
 //
-// The function does not return an error when the sessions row does not exist
-// (e.g. for pre-migration instances). In that case it is a silent no-op.
+// It is the canonical aggregation pass shared by:
 //
-// Review-group verdict is rolled up from GroupResults when a review group
-// exists for the session. PR number and merge timestamp come from
-// pending_merges (merge-queue path only).
-func (d *DB) WriteSpawnOutcome(instanceID string) error {
+//   - WriteSpawnOutcome (the persist path called from `prism cleanup`)
+//   - prism stats compare (the read path that needs the same data shape
+//     between terminal-state transition and cleanup, issue #2102)
+//
+// Returns (nil, nil) when the sessions row does not exist (pre-migration
+// or unknown instance) so callers can treat the result as a silent no-op.
+//
+// Both call sites must use this helper to guarantee byte-for-byte
+// identical aggregates — the AC for issue #2102 requires that the
+// on-the-fly compute path and the cleanup write path agree.
+func (d *DB) ComputeSpawnOutcome(instanceID string) (*SpawnOutcome, error) {
 	// Fetch the sessions row; skip if not found.
 	sess, err := d.SessionByInstanceID(instanceID)
 	if err != nil {
-		return fmt.Errorf("db: write spawn outcome: fetch session: %w", err)
+		return nil, fmt.Errorf("db: compute spawn outcome: fetch session: %w", err)
 	}
 	if sess == nil {
-		return nil // pre-migration or unknown instance — silent no-op
+		return nil, nil // pre-migration or unknown instance — silent no-op
 	}
 
 	now := time.Now().UnixMilli()
@@ -339,7 +346,7 @@ WHERE instance_id = ?`
 		&out.CostUSDTotal,
 		&minCreatedAt,
 	); scanErr != nil {
-		return fmt.Errorf("db: write spawn outcome: aggregate events: %w", scanErr)
+		return nil, fmt.Errorf("db: compute spawn outcome: aggregate events: %w", scanErr)
 	}
 
 	// time_to_first_event_ms: min(event.created_at) − session.started_at
@@ -405,6 +412,34 @@ SELECT group_id FROM session_groups
 			}
 			out.ReviewVerdict = &verdict
 		}
+	}
+
+	return &out, nil
+}
+
+// WriteSpawnOutcome computes all aggregated columns for the given instanceID
+// from agent_events and sessions, then upserts a spawn_outcome row. The write
+// is idempotent (INSERT OR REPLACE). Calling it twice produces the same result.
+//
+// The function does not return an error when the sessions row does not exist
+// (e.g. for pre-migration instances). In that case it is a silent no-op.
+//
+// Review-group verdict is rolled up from GroupResults when a review group
+// exists for the session. PR number and merge timestamp come from
+// pending_merges (merge-queue path only).
+//
+// Implementation note: this function delegates to ComputeSpawnOutcome to
+// produce the in-memory aggregate, then performs the INSERT OR REPLACE.
+// The two call sites (write-time via cleanup, read-time via
+// `prism stats compare` for terminal-but-not-cleaned-up sessions) share the
+// aggregation pass so the produced rows agree byte-for-byte (issue #2102).
+func (d *DB) WriteSpawnOutcome(instanceID string) error {
+	out, err := d.ComputeSpawnOutcome(instanceID)
+	if err != nil {
+		return fmt.Errorf("db: write spawn outcome: %w", err)
+	}
+	if out == nil {
+		return nil // sessions row missing — silent no-op
 	}
 
 	// --- INSERT OR REPLACE ---

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -254,8 +254,12 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			// harness so review fan-out rows are queryable alongside other
 			// spawn front doors. PromptSource / PromptTemplateHash above
 			// already feed the centralised SpawnSession writer.
-			AgentFlag:   ag.Name,
-			HarnessFlag: agentHarnessName,
+			// IsolationFlag mirrors the resolved isolation mode so the
+			// `prism stats compare` Spawn Inputs block surfaces it for
+			// review-fan-out rows too (issue #2102 Layer 2).
+			AgentFlag:     ag.Name,
+			HarnessFlag:   agentHarnessName,
+			IsolationFlag: opts.IsolationMode,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
@@ -553,8 +557,10 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			// PIExtensionDir for host-mode pi launches (#2065).
 			PIExtensionDir: opts.PIExtensionDir,
 			// spawn_inputs audit (#2087): mirror the sync fan-out block.
-			AgentFlag:   ag.Name,
-			HarnessFlag: asyncAgentHarnessName,
+			// IsolationFlag mirrors the resolved isolation mode (#2102 Layer 2).
+			AgentFlag:     ag.Name,
+			HarnessFlag:   asyncAgentHarnessName,
+			IsolationFlag: opts.IsolationMode,
 		}
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -555,6 +555,32 @@ Only call this after you have confirmed the PR is merged. The `--yes` path alway
 
 Pi sessions block `git worktree prune` and `git worktree remove` at the extension layer. When recovering from a failed spawn, use `prism cleanup` — do not reach for git plumbing.
 
+## A/B-test workflow: `prism spawn --abtest`, `prism stats compare`, merge decision, cleanup
+
+An A/B test spawns two sibling sessions on the same prompt with different model profiles (or other configuration), lets both run to completion, then compares the two outcomes to decide which one to merge.
+
+The workflow is:
+
+1. **Spawn the pair.** `prism spawn --abtest <profile-a>,<profile-b> --prompt '<the prompt>'` creates two sessions that share a single `abtest_pair_id` in `spawn_inputs`. Each leg runs in its own worktree on its own branch and opens its own PR when it finishes.
+2. **Wait for both workers to finish.** Each session lands in a terminal state (`finished`, `error`, or `interrupted`). You can watch them in `prism sessions list`; both legs will surface terminal-state notifications via the usual coordinator-notification surface (see *Worker terminal-state notifications* below).
+3. **Run `prism stats compare` for the merge-decision data.** Once both legs have transitioned to terminal state — *before* you merge either PR — compare them:
+
+   ```bash
+   prism stats compare <instance-id-A> <instance-id-B>
+   # or, if you minted the pair via --abtest, by the shared pair id:
+   prism stats abtest <pair-id>
+   ```
+
+   The output carries the `Spawn Inputs` block (profile, harness, isolation, agent role, branch, abtest_pair_id) plus per-axis aggregates (tokens, cost, tool calls, durations, end_state). The aggregates are available *between* terminal-state transition and `prism cleanup` — they no longer require cleanup to materialise (issue #2102). Use the cost / duration / msg_assistant axes alongside the quality of the produced PRs to pick a winner.
+4. **Merge the winner, close the loser.** Standard merge / close flow on the two PRs.
+5. **Cleanup both sessions.** `prism cleanup --yes --session <winner>` and `prism cleanup --yes --session <loser>`. Cleanup persists the `spawn_outcome` row for long-term querying via `prism stats --group-by profile|model|...`; until then the row is computed on the fly from `agent_events` whenever `prism stats compare` is run.
+
+Notes:
+
+- `prism stats compare` shows `—` for aggregate axes while a session is still in progress (state `active`, `idle`, or `reviewing`). The aggregates only stabilise at terminal transition.
+- The `Spawn Inputs` block surfaces whatever the writer captured at spawn time. Pre-#2087 sessions may have a partial row — missing columns render as `—` rather than collapsing the whole block.
+- Use `--format json` for machine-readable output (e.g. when scripting the winner decision); the `spawn_inputs` object carries the same fields shown in the table.
+
 ## Querying prism state — prefer `--json` for scripting
 
 Every list-style and lookup-style prism subcommand supports a `--json` flag that emits a single JSON document to stdout — keys are snake_case, timestamps are RFC 3339, empty lists are `[]` (never null, never absent), and any informational/progress text routes to stderr. **When you need to parse prism output programmatically, always pass `--json`.** Screen-scraping tabular human-readable output is fragile and burns tokens.


### PR DESCRIPTION
Closes #2102

## Summary

Two-layer fix to `prism stats compare`:

- **Layer 1**: `spawn_outcome` aggregates are now available to `prism stats compare` between a session's terminal-state transition and `prism cleanup`. Previously every axis read `—` until cleanup ran.
- **Layer 2**: the `Spawn Inputs` block now renders the values written at spawn time (profile, harness, isolation, agent role, branch, abtest pair id) instead of the stale `(spawn_inputs table not yet populated — run prism spawn with C.1 to capture inputs)` placeholder.

## What "C.1" referred to

`C.1` is a design-doc reference: `docs/reviews/C1-ab-readiness-and-schema-delta.md` (the original schema-delta proposal that introduced the `spawn_inputs` table). That doc was deleted in #1659 once the schema landed. The spawn_inputs writer has been live in `session.SpawnSession` since #2087, and `profile_name` specifically since #2092 / #2093. The renderer just kept printing the placeholder because nobody updated it after the writer went in.

C.1 is not a feature flag and there is no gate to turn on. The placeholder text is deleted in this PR.

## Layer 1 design fork — pick (b), on-the-fly compute

The issue body lays out two options. I picked **(b)**:

- **Single write path** — only `prism cleanup` ever writes `spawn_outcome`. No double-write paths, no idempotence trap. The sidecar's state-machine code (recently touched by #2081 and #2094) stays untouched.
- **Single aggregation query** — the canonical aggregation lives in `db.ComputeSpawnOutcome` and is shared between the read path (`prism stats compare`) and the write path (`WriteSpawnOutcome` from cleanup). The two paths cannot drift because they ARE the same code.
- **Live sessions still show `—`** — the on-the-fly compute is gated on `agent.IsTerminal(state)`, so `active` / `idle` / `reviewing` / `escalated` sessions surface `Outcome == nil` and the renderer prints `—`. This is the over-broad-fix negative-test AC.

### Implementation

- `db.ComputeSpawnOutcome(instanceID)` — extracted from the existing `WriteSpawnOutcome`. Runs the same aggregation query (the canonical source of truth named in the AC) and returns a `*SpawnOutcome` without persisting it.
- `WriteSpawnOutcome` now delegates: compute → INSERT OR REPLACE. The aggregation pass is byte-for-byte identical between read- and write-time.
- `agent.IsTerminal(s AgentState) bool` — new helper.
- `cmd/stats_compare.go::loadCompareRuns` — when `SpawnOutcomeByInstanceID` returns nil, falls back to `ComputeSpawnOutcome` for terminal sessions only.
- Cleanup path completely unchanged. `cmd/cleanup.go:584` (and its three sibling call sites) still call `WriteSpawnOutcome`. `INSERT OR REPLACE` keeps the row idempotent.

## Layer 2 — spawn_inputs renderer

The renderer now reads:

- `profile_name` from `spawn_inputs.profile_name`
- `harness` from `spawn_inputs.harness_flag`, falling back to `sessions.harness`
- `isolation_mode` from `spawn_inputs.isolation_flag`
- `agent_role` from `spawn_inputs.agent_flag`, falling back to `sessions.agent_role`
- `branch` from `spawn_inputs.branch_flag`
- `abtest_pair_id` from `spawn_inputs.abtest_pair_id`

Missing columns render as `—`; partial rows (e.g. just `profile_name` from #2092) surface what's there rather than being treated as absent.

### Spawn-entry path audit

Verified every front door writes the columns the renderer reads:

| Front door | Profile | Harness | Isolation | Agent | Branch | Abtest |
|------------|---------|---------|-----------|-------|--------|--------|
| `prism spawn` (top-level) | ✓ | ✓ | ✓ | ✓ | ✓ | n/a |
| `prism spawn --abtest` (per leg) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| `prism pr` | ✓ | ✓ | ✓ | ✓ | n/a | n/a |
| `prism investigate` | ✓ | ✓ | **fixed (was missing)** | ✓ | n/a | n/a |
| Review fan-out (sync + async) | ✓ | ✓ | **fixed (was missing)** | ✓ | n/a | n/a |

The investigate and review-fan-out paths previously set `SpawnOpts.IsolationMode` (used for the layout) but not `SpawnOpts.IsolationFlag` (used by the audit row). Both now mirror the resolved isolation mode into `IsolationFlag` too.

### JSON renderer

`spawn_inputs` and `diffs.spawn_inputs` now carry actual data instead of always being `{}` / `[]`. Missing fields emit JSON `null`.

## Tests

### `internal/db`

- `TestComputeSpawnOutcome_MatchesWriteSpawnOutcome` — byte-for-byte equality between the on-the-fly compute and the persisted write, on a representative event mix (assistant turns, tool calls, errors, permission asks, state changes).
- `TestWriteSpawnOutcome_IdempotentOverwrite` — a second `WriteSpawnOutcome` over the same events produces the same row. No double-counting.

### `cmd`

- `TestLoadCompareRuns_TerminalFinishedNoOutcome` — `state=finished` without cleanup populates every aggregate (the headline AC).
- `TestLoadCompareRuns_TerminalErrorNoOutcome` — same shape for `state=error` (the #2081 zero-output-exit path).
- `TestLoadCompareRuns_TerminalInterruptedNoOutcome` — same shape for `state=interrupted`.
- `TestLoadCompareRuns_TerminalThenCleanup` — pre- and post-cleanup values agree (no drift across the materialisation boundary).
- `TestLoadCompareRuns_ActiveSessionReturnsDash` — **negative test**: `state=active` surfaces `—` for aggregate axes even when events exist (the over-broad-fix guard).
- `TestInputsValue_PullsFromSpawnInputs` — every renderer-read column surfaces its value on a full spawn_inputs row.
- `TestInputsValue_PartialRowSurfacesWhatExists` — partial rows (just `profile_name`) degrade gracefully; harness falls back to `sessions.harness`.
- `TestRenderCompareTable_NoCInOnePlaceholder` — the rendered table no longer contains "C.1" or "spawn_inputs table not yet populated"; both runs' `profile_name` appear.
- `TestRenderCompareTable_LiveSessionStillShowsDash` — table-level negative AC: aggregate axes for an active session render as `—` even when `spawn_inputs` is populated.
- `TestSpawnInputsFromOpts_AbtestPairCarriesRendererFields` — every `--abtest` leg persists `profile_name`, `harness_flag`, `isolation_flag`, `agent_flag`, and the shared `abtest_pair_id`.

## Docs

`modules/programs/prism/skills/prism/SKILL.md` gains a new section, "A/B-test workflow: `prism spawn --abtest`, `prism stats compare`, merge decision, cleanup", documenting the five-step flow exactly as the issue's doc AC specifies: spawn pair → both finish → `prism stats compare` for merge-decision data → merge winner / close loser → cleanup both.

## Pre-PR self-check

- `go build ./...` ✓ from `modules/programs/prism/prism/`
- `go test ./...` ✓ from `modules/programs/prism/prism/`
- `go test ./... -race` ✓ for the touched packages (cmd, internal/db, internal/agent)
- `nix build .#prism` ✓ from repo root

The homeless-shelter signal will be exercised by CI on this PR.