### PR TITLE
prism/stats: surface compare data between terminal state and cleanup (#2102)

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -263,6 +263,7 @@ var prCmd = &cobra.Command{
 			agentFlag:            agentFlag,
 			harnessFlag:          effectiveHarness,
 			isolationFlag:        isolationFlag,
+			isolationMode:        string(isoMode),
 			prNumber:             prNumber,
 			ignoreConcurrencyCap: ignoreConcurrencyCapFlag,
 			modelsByRole:         modelsByRole,
@@ -288,6 +289,7 @@ type prSpawnInputsArgs struct {
 	agentFlag            string
 	harnessFlag          string
 	isolationFlag        string
+	isolationMode        string
 	prNumber             string
 	ignoreConcurrencyCap bool
 	modelsByRole         map[string]string
@@ -346,8 +348,13 @@ func writeSpawnInputsForPR(cmd *cobra.Command, a prSpawnInputsArgs) {
 	if a.harnessFlag != "" {
 		si.HarnessFlag = &a.harnessFlag
 	}
+	// Mirror spawnInputsFromOpts (#2102): record the raw --isolation flag when
+	// passed, else fall back to the resolved effective mode so the column is
+	// always populated for the compare Spawn Inputs block.
 	if a.isolationFlag != "" {
 		si.IsolationFlag = &a.isolationFlag
+	} else if a.isolationMode != "" {
+		si.IsolationFlag = &a.isolationMode
 	}
 	if a.prNumber != "" {
 		if n, convErr := strconv.Atoi(a.prNumber); convErr == nil {

--- a/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
@@ -260,6 +260,52 @@ func TestSpawnInputsFromOpts_AbtestPair(t *testing.T) {
 	}
 }
 
+// TestSpawnInputsFromOpts_AbtestLegCapturesEffectiveIsolation verifies the
+// Layer-2 AC for issue #2102: every --abtest leg's spawn_inputs row carries
+// profile_name AND isolation_mode with non-empty values, even when no explicit
+// --isolation flag was passed. The abtest path leaves IsolationFlag empty but
+// always sets the resolved IsolationMode; spawnInputsFromOpts must fall back to
+// the effective mode so the compare "Spawn Inputs" block is populated.
+func TestSpawnInputsFromOpts_AbtestLegCapturesEffectiveIsolation(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	pairID := uuid.New().String()
+	for _, leg := range []struct{ name, profile string }{
+		{"prism-test@worker-iso-a", "anthropic"},
+		{"prism-test@worker-iso-b", "gemini"},
+	} {
+		instanceID := uuid.New().String()
+		seedSessionForSpawnInputs(t, d, instanceID, leg.name)
+		// Mirror an --abtest leg: ProfileName + the resolved IsolationMode are
+		// set; the raw IsolationFlag is left empty (no --isolation passed).
+		si := session.SpawnInputsFromOpts(session.SpawnOpts{
+			InstanceID:    instanceID,
+			Prompt:        "abtest leg prompt",
+			PromptSource:  "cli-positional",
+			ProfileName:   leg.profile,
+			IsolationMode: "bwrap", // effective resolved mode
+			AbtestPairID:  pairID,
+		})
+		if err := d.InsertSpawnInputs(si); err != nil {
+			t.Fatalf("InsertSpawnInputs leg %q: %v", leg.name, err)
+		}
+		got, err := d.SpawnInputsByInstanceID(instanceID)
+		if err != nil {
+			t.Fatalf("SpawnInputsByInstanceID leg %q: %v", leg.name, err)
+		}
+		if got == nil {
+			t.Fatalf("leg %q: got nil row", leg.name)
+		}
+		// profile_name non-empty.
+		if got.ProfileName == nil || *got.ProfileName == "" {
+			t.Errorf("leg %q: ProfileName empty, want %q", leg.name, leg.profile)
+		}
+		// isolation_mode captured from the effective mode (non-empty).
+		assertStringPtr(t, "IsolationFlag/"+leg.name, got.IsolationFlag, "bwrap")
+	}
+}
+
 // TestSpawnInputsFromOpts_ModelOverrideJSON verifies the JSON shape written
 // to model_variant_overrides for --model-override flag repeats. Downstream
 // readers parse this back into a map, so the round trip must be lossless.

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -142,9 +142,10 @@ func runStatsAbtest(cmd *cobra.Command, args []string) error {
 
 // compareRun holds per-run data for the comparison.
 type compareRun struct {
-	Label       string
-	Session     *db.Session
-	Outcome     *db.SpawnOutcome // may be nil if not yet computed
+	Label   string
+	Session *db.Session
+	Outcome *db.SpawnOutcome // may be nil if not yet computed
+	Inputs  *db.SpawnInputs  // may be nil if no spawn_inputs row was written
 }
 
 // axisRow is a single row in the comparison table: a label and one value per run.
@@ -172,8 +173,13 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 	runs := make([]compareRun, len(sessions))
 	for i, sess := range sessions {
 		label := "run-" + string(rune('A'+i))
-		out, _ := d.SpawnOutcomeByInstanceID(sess.InstanceID) // nil is ok
-		runs[i] = compareRun{Label: label, Session: sess, Outcome: out}
+		// SpawnOutcomeForCompare returns the persisted spawn_outcome row when
+		// present (post-cleanup) and otherwise computes the aggregates on the fly
+		// for a terminal-state session that has not been cleaned up yet (issue
+		// #2102). An in-progress session yields nil → every aggregate axis "—".
+		out, _ := d.SpawnOutcomeForCompare(sess.InstanceID)     // nil is ok
+		inputs, _ := d.SpawnInputsByInstanceID(sess.InstanceID) // nil is ok
+		runs[i] = compareRun{Label: label, Session: sess, Outcome: out, Inputs: inputs}
 	}
 
 	// Collect desired axes.
@@ -561,11 +567,13 @@ func renderCompareTable(runs []compareRun, axes []string, includeInputs, include
 		fmt.Println(line)
 	}
 
-	// Spawn inputs block (show session name differences).
+	// Spawn inputs block — surface the captured spawn_inputs columns
+	// (profile, isolation, harness, agent role, branch, …). Written on every
+	// spawn path via the centralised SpawnSession writer (#2087); partial rows
+	// (some columns NULL) are surfaced as what's there rather than treated as
+	// absent (issue #2102).
 	if includeInputs {
-		fmt.Println()
-		fmt.Println(styleHeader.Render("Spawn Inputs"))
-		fmt.Println(styleDim.Render("  (spawn_inputs table not yet populated — run `prism spawn` with C.1 to capture inputs)"))
+		renderSpawnInputs(styleHeader, styleLabel, styleDim, runs, wLabel, wVal)
 	}
 
 	// Section: process-level.
@@ -598,6 +606,147 @@ func renderCompareTable(runs []compareRun, axes []string, includeInputs, include
 	}
 
 	return nil
+}
+
+// spawnInputFields is the ordered list of spawn_inputs rows shown in the
+// "Spawn Inputs" block of the table renderer. Each derives its display value
+// from the run's spawn_inputs row, falling back to the sessions row (for the
+// effective harness / agent role / branch) so the block is meaningful even
+// when a flag was left at its default (NULL in spawn_inputs).
+var spawnInputFields = []struct {
+	label string
+	fn    func(compareRun) string
+}{
+	{"profile_name", func(r compareRun) string { return spawnInputProfile(r) }},
+	{"isolation_mode", func(r compareRun) string { return spawnInputIsolation(r) }},
+	{"harness", func(r compareRun) string { return spawnInputHarness(r) }},
+	{"agent_role", func(r compareRun) string { return spawnInputAgentRole(r) }},
+	{"branch", func(r compareRun) string { return spawnInputBranch(r) }},
+	{"model", func(r compareRun) string { return strPtrOr(inputsModel(r), "(profile default)") }},
+	{"variant", func(r compareRun) string { return strPtrOr(inputsVariant(r), "(profile default)") }},
+	{"host_mode", func(r compareRun) string { return spawnInputHostMode(r) }},
+	{"abtest_pair_id", func(r compareRun) string { return strPtrOr(inputsAbtest(r), "—") }},
+}
+
+func inputsModel(r compareRun) *string {
+	if r.Inputs != nil {
+		return r.Inputs.ModelFlag
+	}
+	return nil
+}
+func inputsVariant(r compareRun) *string {
+	if r.Inputs != nil {
+		return r.Inputs.VariantFlag
+	}
+	return nil
+}
+func inputsAbtest(r compareRun) *string {
+	if r.Inputs != nil {
+		return r.Inputs.AbtestPairID
+	}
+	return nil
+}
+
+// strPtrOr returns *p when non-nil/non-empty, otherwise the fallback.
+func strPtrOr(p *string, fallback string) string {
+	if p != nil && *p != "" {
+		return *p
+	}
+	return fallback
+}
+
+func spawnInputProfile(r compareRun) string {
+	if r.Inputs != nil {
+		return strPtrOr(r.Inputs.ProfileName, "(default)")
+	}
+	return "(default)"
+}
+
+// spawnInputIsolation reads the captured isolation mode. spawnInputsFromOpts
+// records the effective resolved mode when no explicit --isolation flag was
+// passed (issue #2102), so this is populated for every spawn path.
+func spawnInputIsolation(r compareRun) string {
+	if r.Inputs != nil {
+		return strPtrOr(r.Inputs.IsolationFlag, "(default)")
+	}
+	return "(default)"
+}
+
+// spawnInputHarness prefers the captured flag, falling back to the effective
+// harness recorded on the sessions row (always set).
+func spawnInputHarness(r compareRun) string {
+	if r.Inputs != nil && r.Inputs.HarnessFlag != nil && *r.Inputs.HarnessFlag != "" {
+		return *r.Inputs.HarnessFlag
+	}
+	if r.Session != nil && r.Session.Harness != "" {
+		return r.Session.Harness
+	}
+	return "(default)"
+}
+
+// spawnInputAgentRole prefers the captured flag, falling back to the effective
+// agent role recorded on the sessions row.
+func spawnInputAgentRole(r compareRun) string {
+	if r.Inputs != nil && r.Inputs.AgentFlag != nil && *r.Inputs.AgentFlag != "" {
+		return *r.Inputs.AgentFlag
+	}
+	if r.Session != nil && r.Session.AgentRole != nil && *r.Session.AgentRole != "" {
+		return *r.Session.AgentRole
+	}
+	return "(default)"
+}
+
+// spawnInputBranch prefers the captured --branch flag, otherwise derives the
+// branch from the session name (the `repo@branch` slug).
+func spawnInputBranch(r compareRun) string {
+	if r.Inputs != nil && r.Inputs.BranchFlag != nil && *r.Inputs.BranchFlag != "" {
+		return *r.Inputs.BranchFlag
+	}
+	if r.Session != nil {
+		if at := strings.Index(r.Session.SessionName, "@"); at >= 0 && at+1 < len(r.Session.SessionName) {
+			return r.Session.SessionName[at+1:]
+		}
+	}
+	return "(derived)"
+}
+
+func spawnInputHostMode(r compareRun) string {
+	if r.Inputs == nil {
+		return "—"
+	}
+	if r.Inputs.HostModeFlag {
+		return "yes"
+	}
+	return "no"
+}
+
+// renderSpawnInputs prints the "Spawn Inputs" block. Rows whose value is the
+// same across all runs are still shown (spawn inputs are sparse and the few
+// rows that differ between A/B legs — typically profile — are the point).
+func renderSpawnInputs(
+	styleHeader, styleLabel, styleDim lipgloss.Style,
+	runs []compareRun,
+	wLabel, wVal int,
+) {
+	fmt.Println()
+	fmt.Println(styleHeader.Render("Spawn Inputs"))
+	anyRow := false
+	for _, r := range runs {
+		if r.Inputs != nil {
+			anyRow = true
+			break
+		}
+	}
+	if !anyRow {
+		fmt.Println(styleDim.Render("  (no spawn_inputs row recorded for these sessions; showing session-derived values)"))
+	}
+	for _, field := range spawnInputFields {
+		line := fmt.Sprintf("%-*s", wLabel, styleLabel.Render(field.label+":"))
+		for _, r := range runs {
+			line += fmt.Sprintf("  %-*s", wVal, truncateStr(field.fn(r), wVal))
+		}
+		fmt.Println(line)
+	}
 }
 
 // renderSection prints a named section of the comparison table.
@@ -667,21 +816,54 @@ func renderSection(
 
 // compareJSONOutput is the top-level JSON shape (C3 §6.3).
 type compareJSONOutput struct {
-	Runs  []compareJSONRun      `json:"runs"`
-	Diffs compareJSONDiffs      `json:"diffs"`
+	Runs  []compareJSONRun `json:"runs"`
+	Diffs compareJSONDiffs `json:"diffs"`
 }
 
 type compareJSONRun struct {
 	Label        string                 `json:"label"`
 	SessionName  string                 `json:"session_name"`
 	InstanceID   string                 `json:"instance_id"`
-	SpawnInputs  map[string]interface{} `json:"spawn_inputs"` // always {} until C.1 writes rows
+	SpawnInputs  map[string]interface{} `json:"spawn_inputs"`
 	SpawnOutcome map[string]interface{} `json:"spawn_outcome"`
 }
 
 type compareJSONDiffs struct {
-	SpawnInputs  []string `json:"spawn_inputs"`  // always [] until C.1
+	SpawnInputs  []string `json:"spawn_inputs"`
 	SpawnOutcome []string `json:"spawn_outcome"`
+}
+
+// spawnInputsJSON renders the spawn_inputs row for a run into the JSON contract
+// shape. Placeholder display sentinels ("(default)", "(derived)", …) map to a
+// JSON null so machine consumers see absence explicitly rather than the
+// human-facing fallback string.
+func spawnInputsJSON(r compareRun) map[string]interface{} {
+	m := make(map[string]interface{}, len(spawnInputFields))
+	for _, f := range spawnInputFields {
+		v := f.fn(r)
+		switch v {
+		case "(default)", "(derived)", "(profile default)", "—":
+			m[f.label] = nil
+		default:
+			m[f.label] = v
+		}
+	}
+	return m
+}
+
+// spawnInputsAllSame reports whether every run renders the same value for the
+// given spawn-input field.
+func spawnInputsAllSame(fn func(compareRun) string, runs []compareRun) bool {
+	if len(runs) == 0 {
+		return true
+	}
+	first := fn(runs[0])
+	for _, r := range runs[1:] {
+		if fn(r) != first {
+			return false
+		}
+	}
+	return true
 }
 
 func renderCompareJSON(runs []compareRun, axes []string, includeInputs, includeRubric bool) error {
@@ -702,7 +884,7 @@ func renderCompareJSON(runs []compareRun, axes []string, includeInputs, includeR
 			Label:       r.Label,
 			SessionName: r.Session.SessionName,
 			InstanceID:  r.Session.InstanceID,
-			SpawnInputs: map[string]interface{}{},
+			SpawnInputs: spawnInputsJSON(r),
 		}
 		outcomeMap := make(map[string]interface{})
 		for _, axis := range effectiveAxes {
@@ -721,6 +903,15 @@ func renderCompareJSON(runs []compareRun, axes []string, includeInputs, includeR
 	for _, axis := range effectiveAxes {
 		if !allSame(axis, runs) {
 			out.Diffs.SpawnOutcome = append(out.Diffs.SpawnOutcome, axis)
+		}
+	}
+
+	// Compute spawn_inputs diffs: fields where runs differ.
+	if includeInputs {
+		for _, f := range spawnInputFields {
+			if !spawnInputsAllSame(f.fn, runs) {
+				out.Diffs.SpawnInputs = append(out.Diffs.SpawnInputs, f.label)
+			}
 		}
 	}
 

--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+// Renderer-level tests for `prism stats compare` (issue #2102). These drive the
+// real command runner (runStatsCompare → runComparison → renderCompareTable)
+// against a seeded temp DB and assert on the captured table output:
+//
+//   - a terminal-state session that has NOT been cleaned up still renders full
+//     aggregate axes (Layer 1, on-the-fly compute);
+//   - an in-progress (active) session renders "—" for its aggregate axes
+//     (negative / over-broad-fix guard);
+//   - the Spawn Inputs block is populated from spawn_inputs rather than the old
+//     "not yet populated … C.1" placeholder (Layer 2, renderer fix).
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// newCompareTestCmd builds a *cobra.Command with the same flag set the real
+// `prism stats compare` registers, so runStatsCompare can read them.
+func newCompareTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "compare", RunE: runStatsCompare}
+	c.Flags().StringSlice("axes", nil, "")
+	c.Flags().String("format", "table", "")
+	c.Flags().Bool("diff-only", false, "")
+	c.Flags().String("sort", "", "")
+	c.Flags().Bool("include-inputs", false, "")
+	c.Flags().Bool("include-rubric", false, "")
+	return c
+}
+
+// seedCompareSession seeds a pre-cleanup session: sessions row (no end_state),
+// token/tool/error events, a spawn_inputs row (profile + effective isolation),
+// and an agent_status row in the given state linked by instance_id.
+func seedCompareSession(t *testing.T, d *db.DB, state, profile, isolation string) string {
+	t.Helper()
+	iid := uuid.New().String()
+	sessName := "prism-test@cmp-" + iid[:8]
+	startedAt := time.Now().Add(-8 * time.Minute)
+
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: sessName,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/" + iid[:8],
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	writeStatsEventIID(t, d, sessName, iid, "msg_assistant",
+		`{"inputTokens":120,"outputTokens":60,"cacheReadTokens":10,"cacheWriteTokens":5,"cost":0.0015}`,
+		startedAt.Add(1*time.Minute))
+	writeStatsEventIID(t, d, sessName, iid, "tool_call", `{"name":"bash"}`, startedAt.Add(70*time.Second))
+	writeStatsEventIID(t, d, sessName, iid, "tool_error", `{"name":"bash"}`, startedAt.Add(80*time.Second))
+
+	si := db.SpawnInputs{InstanceID: iid, CreatedAt: startedAt.UnixMilli()}
+	if profile != "" {
+		si.ProfileName = &profile
+	}
+	if isolation != "" {
+		si.IsolationFlag = &isolation
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	if err := d.UpsertStatus(sessName, "testrepo", "/code/testrepo/"+iid[:8], state, nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(%q): %v", state, err)
+	}
+	if err := d.SetInstanceID(sessName, iid); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	return iid
+}
+
+// writeStatsEventIID writes an instance_id-linked event.
+func writeStatsEventIID(t *testing.T, d *db.DB, sess, iid, typ, payload string, ts time.Time) {
+	t.Helper()
+	if err := d.WriteEvent(db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sess,
+		InstanceID:  &iid,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/wt",
+		Type:        typ,
+		Payload:     payload,
+		CreatedAt:   ts,
+	}); err != nil {
+		t.Fatalf("WriteEvent(%s): %v", typ, err)
+	}
+}
+
+// TestRunStatsCompare_TerminalSessionRendersAggregates verifies the headline
+// Layer-1 outcome: two finished-but-not-cleaned-up sessions render populated
+// aggregate axes in the table (not "—").
+func TestRunStatsCompare_TerminalSessionRendersAggregates(t *testing.T) {
+	d := openStatsTestDB(t)
+	iidA := seedCompareSession(t, d, "finished", "anthropic", "bwrap")
+	iidB := seedCompareSession(t, d, "finished", "gemini", "bwrap")
+
+	cmd := newCompareTestCmd()
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(cmd, []string{iidA, iidB}); err != nil {
+			t.Fatalf("runStatsCompare: %v", err)
+		}
+	})
+
+	// The per-axis aggregations section must carry real numbers. tool_call=1,
+	// tool_error=1, msg_assistant=1 per leg; tokens populated.
+	for _, want := range []string{
+		"Per-axis aggregations",
+		"tokens_input",
+		"tokens_output",
+		"cost_usd",
+		"end_state",
+		"finished",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("compare output missing %q; got:\n%s", want, out)
+		}
+	}
+
+	// A finished session must not render the whole aggregations block as dashes.
+	// Find the tokens_input row and assert it isn't "—".
+	if line := lineContaining(out, "tokens_input:"); line == "" {
+		t.Fatalf("no tokens_input row in output:\n%s", out)
+	} else if !strings.Contains(line, "120") {
+		t.Errorf("tokens_input row should show 120 per leg, got: %q", line)
+	}
+}
+
+// TestRunStatsCompare_ActiveSessionRendersDashes is the negative test: an
+// in-progress session must render "—" for its aggregate axes, not stale data.
+func TestRunStatsCompare_ActiveSessionRendersDashes(t *testing.T) {
+	d := openStatsTestDB(t)
+	iidA := seedCompareSession(t, d, "active", "anthropic", "bwrap")
+	iidB := seedCompareSession(t, d, "active", "gemini", "bwrap")
+
+	cmd := newCompareTestCmd()
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(cmd, []string{iidA, iidB}); err != nil {
+			t.Fatalf("runStatsCompare: %v", err)
+		}
+	})
+
+	// tokens_input must be all dashes for active sessions.
+	line := lineContaining(out, "tokens_input:")
+	if line == "" {
+		t.Fatalf("no tokens_input row in output:\n%s", out)
+	}
+	if strings.Contains(line, "120") {
+		t.Errorf("active session leaked aggregate data into tokens_input: %q", line)
+	}
+	if !strings.Contains(line, "—") {
+		t.Errorf("active session tokens_input should be '—', got: %q", line)
+	}
+}
+
+// TestRunStatsCompare_SpawnInputsBlockPopulated verifies Layer 2: the Spawn
+// Inputs block surfaces the captured spawn_inputs columns and no longer prints
+// the "not yet populated … C.1" placeholder.
+func TestRunStatsCompare_SpawnInputsBlockPopulated(t *testing.T) {
+	d := openStatsTestDB(t)
+	iidA := seedCompareSession(t, d, "finished", "anthropic", "bwrap")
+	iidB := seedCompareSession(t, d, "finished", "gemini", "sandbox-exec")
+
+	cmd := newCompareTestCmd()
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(cmd, []string{iidA, iidB}); err != nil {
+			t.Fatalf("runStatsCompare: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "not yet populated") || strings.Contains(out, "C.1") {
+		t.Errorf("stale placeholder still present in Spawn Inputs block:\n%s", out)
+	}
+	for _, want := range []string{
+		"Spawn Inputs",
+		"profile_name",
+		"anthropic",
+		"gemini",
+		"isolation_mode",
+		"bwrap",
+		"sandbox-exec",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Spawn Inputs block missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// lineContaining returns the first line of s that contains sub, or "".
+func lineContaining(s, sub string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	return ""
+}

--- a/modules/programs/prism/prism/internal/db/sessions.go
+++ b/modules/programs/prism/prism/internal/db/sessions.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
 )
 
 // scanSession scans a sessions row from the given scanner into a Session value.
@@ -269,24 +271,36 @@ SELECT COALESCE(JSON_EXTRACT(payload, '$.model'), ''),
 	return turns, nil
 }
 
-// WriteSpawnOutcome computes all aggregated columns for the given instanceID
-// from agent_events and sessions, then upserts a spawn_outcome row. The write
-// is idempotent (INSERT OR REPLACE). Calling it twice produces the same result.
+// computeSpawnOutcome aggregates every spawn_outcome column for instanceID from
+// agent_events and the sessions / agent_status rows, returning the computed
+// *SpawnOutcome WITHOUT persisting it. It returns (nil, nil) when no sessions
+// row exists (pre-migration or unknown instance).
 //
-// The function does not return an error when the sessions row does not exist
-// (e.g. for pre-migration instances). In that case it is a silent no-op.
+// This is the single canonical aggregation, shared by two callers so their
+// values can never drift:
+//
+//   - WriteSpawnOutcome persists the result (INSERT OR REPLACE) — the
+//     cleanup-path writer (cmd/cleanup.go).
+//   - SpawnOutcomeForCompare returns it directly at read time for a terminal
+//     session that has not been cleaned up yet, so `prism stats compare` shows
+//     full data between the terminal transition and cleanup (issue #2102).
+//
+// Because both paths run the identical agent_events aggregation query, the
+// event-derived axes (token / cost / tool / msg counts) agree byte-for-byte:
+// there is no double-counting and no missed delta when cleanup later overwrites
+// the row with the same numbers.
 //
 // Review-group verdict is rolled up from GroupResults when a review group
 // exists for the session. PR number and merge timestamp come from
 // pending_merges (merge-queue path only).
-func (d *DB) WriteSpawnOutcome(instanceID string) error {
+func (d *DB) computeSpawnOutcome(instanceID string) (*SpawnOutcome, error) {
 	// Fetch the sessions row; skip if not found.
 	sess, err := d.SessionByInstanceID(instanceID)
 	if err != nil {
-		return fmt.Errorf("db: write spawn outcome: fetch session: %w", err)
+		return nil, fmt.Errorf("db: compute spawn outcome: fetch session: %w", err)
 	}
 	if sess == nil {
-		return nil // pre-migration or unknown instance — silent no-op
+		return nil, nil // pre-migration or unknown instance — silent no-op
 	}
 
 	now := time.Now().UnixMilli()
@@ -296,14 +310,18 @@ func (d *DB) WriteSpawnOutcome(instanceID string) error {
 		SchemaVersion: 1,
 	}
 
-	// --- Process-level ---
-
+	// --- Process-level: end_state ---
+	//
+	// sessions.end_state is only stamped at cleanup (UpdateSessionEnded). Between
+	// the agent reaching a terminal state and cleanup running it is NULL, so fall
+	// back to the live agent_status.state when that is terminal. The cleanup path
+	// is unchanged (sess.EndState is already set there); only the read-time compute
+	// uses the fallback to surface the real terminal state pre-cleanup.
 	out.EndState = sess.EndState
-	if sess.EndedAt != nil && sess.StartedAt.UnixMilli() > 0 {
-		dur := sess.EndedAt.Sub(sess.StartedAt).Milliseconds()
-		out.DurationMs = &dur
-		if sess.EndState != nil && *sess.EndState == "finished" {
-			out.TimeToFinishedMs = &dur
+	if out.EndState == nil {
+		if st, terminal, stErr := d.agentTerminalState(instanceID); stErr == nil && terminal {
+			s := string(st)
+			out.EndState = &s
 		}
 	}
 
@@ -324,12 +342,13 @@ SELECT
     COALESCE(SUM(CASE WHEN type = 'msg_assistant' THEN COALESCE(JSON_EXTRACT(payload,'$.cacheReadTokens'), 0) ELSE 0 END), 0),
     COALESCE(SUM(CASE WHEN type = 'msg_assistant' THEN COALESCE(JSON_EXTRACT(payload,'$.cacheWriteTokens'),0) ELSE 0 END), 0),
     COALESCE(SUM(CASE WHEN type = 'msg_assistant' THEN COALESCE(JSON_EXTRACT(payload,'$.cost'),          0) ELSE 0.0 END), 0.0),
-    MIN(created_at)
+    MIN(created_at),
+    MAX(created_at)
 FROM agent_events
 WHERE instance_id = ?`
 
 	row := d.conn.QueryRow(aggQ, instanceID)
-	var minCreatedAt *int64
+	var minCreatedAt, maxCreatedAt *int64
 	if scanErr := row.Scan(
 		&out.InterruptedCount, &out.CompactionCount, &out.ErrorEventCount,
 		&out.PermissionAskCount, &out.PermissionDeniedCount, &out.DoomLoopCount,
@@ -337,9 +356,9 @@ WHERE instance_id = ?`
 		&out.TokensInputTotal, &out.TokensOutputTotal,
 		&out.TokensCacheReadTotal, &out.TokensCacheWriteTotal,
 		&out.CostUSDTotal,
-		&minCreatedAt,
+		&minCreatedAt, &maxCreatedAt,
 	); scanErr != nil {
-		return fmt.Errorf("db: write spawn outcome: aggregate events: %w", scanErr)
+		return nil, fmt.Errorf("db: compute spawn outcome: aggregate events: %w", scanErr)
 	}
 
 	// time_to_first_event_ms: min(event.created_at) − session.started_at
@@ -347,6 +366,32 @@ WHERE instance_id = ?`
 		ttfe := *minCreatedAt - sess.StartedAt.UnixMilli()
 		if ttfe >= 0 {
 			out.TimeToFirstEventMs = &ttfe
+		}
+	}
+
+	// --- Process-level: duration_ms / time_to_finished_ms ---
+	//
+	// Prefer the cleanup-stamped sessions.ended_at (the post-cleanup value). Before
+	// cleanup runs that column is NULL, so fall back to the last agent_event
+	// timestamp — a point that does not move once the agent stops emitting events —
+	// so duration is populated on the pre-cleanup compare surface too.
+	var endedAtMs int64
+	hasEnded := false
+	switch {
+	case sess.EndedAt != nil:
+		endedAtMs = sess.EndedAt.UnixMilli()
+		hasEnded = true
+	case maxCreatedAt != nil:
+		endedAtMs = *maxCreatedAt
+		hasEnded = true
+	}
+	if hasEnded && sess.StartedAt.UnixMilli() > 0 {
+		dur := endedAtMs - sess.StartedAt.UnixMilli()
+		if dur >= 0 {
+			out.DurationMs = &dur
+			if out.EndState != nil && *out.EndState == "finished" {
+				out.TimeToFinishedMs = &dur
+			}
 		}
 	}
 
@@ -407,6 +452,27 @@ SELECT group_id FROM session_groups
 		}
 	}
 
+	return &out, nil
+}
+
+// WriteSpawnOutcome computes the aggregated spawn_outcome columns for
+// instanceID (via computeSpawnOutcome) and upserts the row. The write is
+// idempotent (INSERT OR REPLACE): calling it twice — or after the read-time
+// compute (SpawnOutcomeForCompare) has already surfaced the same numbers —
+// produces the identical row.
+//
+// It is a silent no-op when no sessions row exists (pre-migration / unknown
+// instance). Called from cmd/cleanup.go after UpdateSessionEnded stamps the
+// terminal end_state.
+func (d *DB) WriteSpawnOutcome(instanceID string) error {
+	out, err := d.computeSpawnOutcome(instanceID)
+	if err != nil {
+		return err
+	}
+	if out == nil {
+		return nil // pre-migration or unknown instance — silent no-op
+	}
+
 	// --- INSERT OR REPLACE ---
 	const insertQ = `
 INSERT OR REPLACE INTO spawn_outcome (
@@ -438,7 +504,7 @@ INSERT OR REPLACE INTO spawn_outcome (
     ?, ?, ?,
     ?, ?
 )`
-	_, err = d.conn.Exec(insertQ,
+	if _, execErr := d.conn.Exec(insertQ,
 		out.InstanceID,
 		out.EndState, out.ExitCode, out.DurationMs,
 		out.InterruptedCount, out.CompactionCount, out.ErrorEventCount,
@@ -452,11 +518,65 @@ INSERT OR REPLACE INTO spawn_outcome (
 		out.CostUSDTotal, out.ToolCallCount, out.ToolErrorCount,
 		out.MsgAssistantCount, out.TimeToFirstEventMs, out.TimeToFinishedMs,
 		out.ComputedAt, out.SchemaVersion,
-	)
-	if err != nil {
-		return fmt.Errorf("db: write spawn outcome: insert: %w", err)
+	); execErr != nil {
+		return fmt.Errorf("db: write spawn outcome: insert: %w", execErr)
 	}
 	return nil
+}
+
+// agentTerminalState returns the current agent_status.state for instanceID and
+// whether it is one of the terminal agent states (finished / error /
+// interrupted). It returns ("", false, nil) when no agent_status row exists.
+//
+// deleted is intentionally excluded: a deleted session has been cleaned up, so
+// its spawn_outcome row already exists (or its events were purged) and the
+// on-the-fly compute path does not apply.
+func (d *DB) agentTerminalState(instanceID string) (agent.AgentState, bool, error) {
+	var state string
+	err := d.conn.QueryRow(
+		`SELECT state FROM agent_status WHERE instance_id = ? ORDER BY last_seen DESC LIMIT 1`,
+		instanceID,
+	).Scan(&state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("db: agent terminal state for %q: %w", instanceID, err)
+	}
+	st := agent.AgentState(state)
+	switch st {
+	case agent.StateFinished, agent.StateError, agent.StateInterrupted:
+		return st, true, nil
+	}
+	return st, false, nil
+}
+
+// SpawnOutcomeForCompare returns the spawn_outcome data for instanceID for the
+// `prism stats compare` read path (issue #2102). It prefers the persisted
+// spawn_outcome row (present post-cleanup). When that row is absent it computes
+// the aggregates on the fly from agent_events — but only when the session has
+// reached a terminal agent state, so an in-progress (active / idle / ...)
+// session still reports "—" for its aggregate axes rather than partial
+// mid-flight data.
+//
+// Returns (nil, nil) when there is no persisted row and the session is not
+// terminal.
+func (d *DB) SpawnOutcomeForCompare(instanceID string) (*SpawnOutcome, error) {
+	out, err := d.SpawnOutcomeByInstanceID(instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if out != nil {
+		return out, nil
+	}
+	_, terminal, err := d.agentTerminalState(instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if !terminal {
+		return nil, nil
+	}
+	return d.computeSpawnOutcome(instanceID)
 }
 
 // SpawnOutcomeByInstanceID returns the spawn_outcome row for instanceID, or nil

--- a/modules/programs/prism/prism/internal/db/spawn_outcome_compare_test.go
+++ b/modules/programs/prism/prism/internal/db/spawn_outcome_compare_test.go
@@ -1,0 +1,277 @@
+package db_test
+
+// Tests for the read-time spawn_outcome compute path (issue #2102):
+// SpawnOutcomeForCompare returns the persisted row post-cleanup and otherwise
+// computes the aggregates on the fly for a terminal-state session that has not
+// been cleaned up yet — while leaving in-progress sessions reporting "—".
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedComputeSession inserts a sessions row (no ended_at / end_state — i.e.
+// pre-cleanup), a handful of token / tool / error-bearing agent_events, and an
+// agent_status row in the given state linked by instance_id. It mirrors a real
+// session that has reached a terminal agent state but has not yet been cleaned
+// up (so the spawn_outcome row is still absent).
+func seedComputeSession(t *testing.T, d *db.DB, state string) string {
+	t.Helper()
+	iid := uuid.New().String()
+	sessName := "prism-test@compute-" + iid[:8]
+	startedAt := time.Now().Add(-10 * time.Minute)
+
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: sessName,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/" + iid[:8],
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+
+	// Two assistant messages carrying tokens + cost.
+	writeComputeEvent(t, d, sessName, iid, "msg_assistant",
+		`{"inputTokens":100,"outputTokens":50,"cacheReadTokens":10,"cacheWriteTokens":5,"cost":0.0010}`,
+		startedAt.Add(1*time.Minute))
+	writeComputeEvent(t, d, sessName, iid, "msg_assistant",
+		`{"inputTokens":200,"outputTokens":80,"cacheReadTokens":20,"cacheWriteTokens":7,"cost":0.0020}`,
+		startedAt.Add(2*time.Minute))
+	// Tool activity: two calls, one error.
+	writeComputeEvent(t, d, sessName, iid, "tool_call", `{"name":"bash"}`, startedAt.Add(90*time.Second))
+	writeComputeEvent(t, d, sessName, iid, "tool_call", `{"name":"read"}`, startedAt.Add(100*time.Second))
+	writeComputeEvent(t, d, sessName, iid, "tool_error", `{"name":"bash"}`, startedAt.Add(110*time.Second))
+
+	// agent_status in the requested state, linked to the instance.
+	if err := d.UpsertStatus(sessName, "testrepo", "/code/testrepo/"+iid[:8], state, nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(%q): %v", state, err)
+	}
+	if err := d.SetInstanceID(sessName, iid); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	return iid
+}
+
+func writeComputeEvent(t *testing.T, d *db.DB, sess, iid, typ, payload string, ts time.Time) {
+	t.Helper()
+	if err := d.WriteEvent(db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sess,
+		InstanceID:  &iid,
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/wt",
+		Type:        typ,
+		Payload:     payload,
+		CreatedAt:   ts,
+	}); err != nil {
+		t.Fatalf("WriteEvent(%s): %v", typ, err)
+	}
+}
+
+// assertSeededAggregates checks the aggregate axes against the fixed values
+// written by seedComputeSession.
+func assertSeededAggregates(t *testing.T, out *db.SpawnOutcome) {
+	t.Helper()
+	if out == nil {
+		t.Fatal("SpawnOutcomeForCompare: got nil, want populated outcome")
+	}
+	if out.TokensInputTotal != 300 {
+		t.Errorf("TokensInputTotal: got %d, want 300", out.TokensInputTotal)
+	}
+	if out.TokensOutputTotal != 130 {
+		t.Errorf("TokensOutputTotal: got %d, want 130", out.TokensOutputTotal)
+	}
+	if out.TokensCacheReadTotal != 30 {
+		t.Errorf("TokensCacheReadTotal: got %d, want 30", out.TokensCacheReadTotal)
+	}
+	if out.TokensCacheWriteTotal != 12 {
+		t.Errorf("TokensCacheWriteTotal: got %d, want 12", out.TokensCacheWriteTotal)
+	}
+	if out.CostUSDTotal < 0.0029 || out.CostUSDTotal > 0.0031 {
+		t.Errorf("CostUSDTotal: got %v, want ~0.003", out.CostUSDTotal)
+	}
+	if out.ToolCallCount != 2 {
+		t.Errorf("ToolCallCount: got %d, want 2", out.ToolCallCount)
+	}
+	if out.ToolErrorCount != 1 {
+		t.Errorf("ToolErrorCount: got %d, want 1", out.ToolErrorCount)
+	}
+	if out.MsgAssistantCount != 2 {
+		t.Errorf("MsgAssistantCount: got %d, want 2", out.MsgAssistantCount)
+	}
+	if out.TimeToFirstEventMs == nil {
+		t.Error("TimeToFirstEventMs: got nil, want populated")
+	}
+	if out.DurationMs == nil {
+		t.Error("DurationMs: got nil, want populated (fallback to last event ts pre-cleanup)")
+	}
+}
+
+// TestSpawnOutcomeForCompare_TerminalStatesPopulate verifies the headline
+// Layer-1 AC: after a session reaches a terminal state (finished / error /
+// interrupted) but BEFORE cleanup, prism stats compare's data source returns
+// the full aggregate axes computed on the fly from agent_events.
+func TestSpawnOutcomeForCompare_TerminalStatesPopulate(t *testing.T) {
+	for _, state := range []string{"finished", "error", "interrupted"} {
+		state := state
+		t.Run(state, func(t *testing.T) {
+			d := openComputeTestDB(t)
+			iid := seedComputeSession(t, d, state)
+
+			// No spawn_outcome row was written (no cleanup ran).
+			if persisted, err := d.SpawnOutcomeByInstanceID(iid); err != nil {
+				t.Fatalf("SpawnOutcomeByInstanceID: %v", err)
+			} else if persisted != nil {
+				t.Fatal("precondition: spawn_outcome row should be absent pre-cleanup")
+			}
+
+			out, err := d.SpawnOutcomeForCompare(iid)
+			if err != nil {
+				t.Fatalf("SpawnOutcomeForCompare: %v", err)
+			}
+			assertSeededAggregates(t, out)
+
+			// end_state reflects the real terminal agent state pre-cleanup.
+			if out.EndState == nil || *out.EndState != state {
+				t.Errorf("EndState: got %v, want %q", out.EndState, state)
+			}
+		})
+	}
+}
+
+// TestSpawnOutcomeForCompare_ActiveReturnsNil is the over-broad-fix guard
+// (negative test): a session still in a non-terminal state must report "—"
+// (nil outcome), not stale aggregates.
+func TestSpawnOutcomeForCompare_ActiveReturnsNil(t *testing.T) {
+	for _, state := range []string{"active", "idle", "waiting", "reviewing"} {
+		state := state
+		t.Run(state, func(t *testing.T) {
+			d := openComputeTestDB(t)
+			iid := seedComputeSession(t, d, state)
+
+			out, err := d.SpawnOutcomeForCompare(iid)
+			if err != nil {
+				t.Fatalf("SpawnOutcomeForCompare: %v", err)
+			}
+			if out != nil {
+				t.Errorf("SpawnOutcomeForCompare(%s): got non-nil outcome, want nil (in progress)", state)
+			}
+		})
+	}
+}
+
+// TestSpawnOutcomeForCompare_NoStatusRowReturnsNil verifies that a session with
+// no agent_status row at all (and no persisted outcome) is treated as
+// non-terminal — nil, not a stale/partial compute.
+func TestSpawnOutcomeForCompare_NoStatusRowReturnsNil(t *testing.T) {
+	d := openComputeTestDB(t)
+	iid := uuid.New().String()
+	startedAt := time.Now().Add(-5 * time.Minute)
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: "prism-test@nostatus",
+		Repo:        "testrepo",
+		Worktree:    "/code/testrepo/nostatus",
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	out, err := d.SpawnOutcomeForCompare(iid)
+	if err != nil {
+		t.Fatalf("SpawnOutcomeForCompare: %v", err)
+	}
+	if out != nil {
+		t.Errorf("SpawnOutcomeForCompare: got non-nil, want nil (no agent_status row)")
+	}
+}
+
+// TestSpawnOutcomeForCompare_IdempotentAcrossCleanup verifies the idempotence
+// AC: the aggregate axes returned pre-cleanup (on-the-fly compute) are
+// byte-identical to those returned post-cleanup (the persisted row written by
+// WriteSpawnOutcome). The shared computeSpawnOutcome aggregation is the
+// canonical source of truth, so there is no double-counting and no missed
+// delta when cleanup overwrites the row.
+func TestSpawnOutcomeForCompare_IdempotentAcrossCleanup(t *testing.T) {
+	d := openComputeTestDB(t)
+	iid := seedComputeSession(t, d, "finished")
+
+	// Pre-cleanup: computed on the fly.
+	pre, err := d.SpawnOutcomeForCompare(iid)
+	if err != nil {
+		t.Fatalf("SpawnOutcomeForCompare (pre-cleanup): %v", err)
+	}
+	assertSeededAggregates(t, pre)
+
+	// Simulate cleanup: UpdateSessionEnded then WriteSpawnOutcome (the exact
+	// cmd/cleanup.go sequence). This persists the spawn_outcome row.
+	if err := d.UpdateSessionEnded(iid, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded: %v", err)
+	}
+	if err := d.WriteSpawnOutcome(iid); err != nil {
+		t.Fatalf("WriteSpawnOutcome: %v", err)
+	}
+
+	// Post-cleanup: served from the persisted row.
+	post, err := d.SpawnOutcomeForCompare(iid)
+	if err != nil {
+		t.Fatalf("SpawnOutcomeForCompare (post-cleanup): %v", err)
+	}
+	if post == nil {
+		t.Fatal("SpawnOutcomeForCompare (post-cleanup): got nil, want persisted row")
+	}
+
+	// The event-derived aggregate axes must agree byte-for-byte.
+	if pre.TokensInputTotal != post.TokensInputTotal {
+		t.Errorf("TokensInputTotal drift: pre=%d post=%d", pre.TokensInputTotal, post.TokensInputTotal)
+	}
+	if pre.TokensOutputTotal != post.TokensOutputTotal {
+		t.Errorf("TokensOutputTotal drift: pre=%d post=%d", pre.TokensOutputTotal, post.TokensOutputTotal)
+	}
+	if pre.TokensCacheReadTotal != post.TokensCacheReadTotal {
+		t.Errorf("TokensCacheReadTotal drift: pre=%d post=%d", pre.TokensCacheReadTotal, post.TokensCacheReadTotal)
+	}
+	if pre.TokensCacheWriteTotal != post.TokensCacheWriteTotal {
+		t.Errorf("TokensCacheWriteTotal drift: pre=%d post=%d", pre.TokensCacheWriteTotal, post.TokensCacheWriteTotal)
+	}
+	if pre.CostUSDTotal != post.CostUSDTotal {
+		t.Errorf("CostUSDTotal drift: pre=%v post=%v", pre.CostUSDTotal, post.CostUSDTotal)
+	}
+	if pre.ToolCallCount != post.ToolCallCount {
+		t.Errorf("ToolCallCount drift: pre=%d post=%d", pre.ToolCallCount, post.ToolCallCount)
+	}
+	if pre.ToolErrorCount != post.ToolErrorCount {
+		t.Errorf("ToolErrorCount drift: pre=%d post=%d", pre.ToolErrorCount, post.ToolErrorCount)
+	}
+	if pre.MsgAssistantCount != post.MsgAssistantCount {
+		t.Errorf("MsgAssistantCount drift: pre=%d post=%d", pre.MsgAssistantCount, post.MsgAssistantCount)
+	}
+	if (pre.TimeToFirstEventMs == nil) != (post.TimeToFirstEventMs == nil) {
+		t.Errorf("TimeToFirstEventMs nil-ness drift: pre=%v post=%v", pre.TimeToFirstEventMs, post.TimeToFirstEventMs)
+	} else if pre.TimeToFirstEventMs != nil && *pre.TimeToFirstEventMs != *post.TimeToFirstEventMs {
+		t.Errorf("TimeToFirstEventMs drift: pre=%d post=%d", *pre.TimeToFirstEventMs, *post.TimeToFirstEventMs)
+	}
+
+	// Calling WriteSpawnOutcome a second time must remain idempotent.
+	if err := d.WriteSpawnOutcome(iid); err != nil {
+		t.Fatalf("WriteSpawnOutcome (second call): %v", err)
+	}
+	post2, err := d.SpawnOutcomeByInstanceID(iid)
+	if err != nil {
+		t.Fatalf("SpawnOutcomeByInstanceID (after second write): %v", err)
+	}
+	if post2 == nil || post2.TokensInputTotal != post.TokensInputTotal {
+		t.Errorf("idempotent second write changed aggregates: %+v", post2)
+	}
+}
+
+// openComputeTestDB is a thin wrapper to keep these tests self-documenting.
+func openComputeTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	return openTestDB(t)
+}

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -1166,8 +1166,17 @@ func spawnInputsFromOpts(opts SpawnOpts) db.SpawnInputs {
 		s := opts.HarnessFlag
 		si.HarnessFlag = &s
 	}
+	// Capture the isolation mode for the audit row. Prefer the raw --isolation
+	// flag as the user passed it; when no flag was passed (the common case) fall
+	// back to the resolved effective mode (opts.IsolationMode) so the column is
+	// always populated for the `prism stats compare` Spawn Inputs block rather
+	// than NULL-by-default (issue #2102). IsolationMode is the mode the session
+	// actually ran under, which is exactly what an A/B comparison wants to show.
 	if opts.IsolationFlag != "" {
 		s := opts.IsolationFlag
+		si.IsolationFlag = &s
+	} else if opts.IsolationMode != "" {
+		s := opts.IsolationMode
 		si.IsolationFlag = &s
 	}
 	si.HostModeFlag = opts.HostModeFlag

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -527,6 +527,48 @@ prism spawn \
   --prompt "Please take a look at PROJ-123, cover off the work required, and open a pull request."
 ```
 
+## A/B-testing two profiles on the same task (`--abtest`)
+
+`prism spawn --abtest <profileA> --abtest <profileB>` spawns **two** sibling
+worker sessions on the same task, each running a different model profile, in
+separate worktrees. Use it when you want head-to-head evidence — cost, token
+usage, speed, tool-call volume — to inform which profile's result to merge.
+
+The merge-decision flow is:
+
+1. **Spawn the pair.** Both legs share an `abtest_pair_id` and get their own
+   branch / worktree.
+   ```bash
+   prism spawn --abtest anthropic --abtest gemini \
+     --branch try-new-parser \
+     --prompt 'implement the new parser per issue #123 and open a PR'
+   ```
+2. **Let both workers finish** and open their PRs. Each leg runs its own
+   `prism review` cycle independently — do not coordinate them.
+3. **Compare the legs for the merge-decision data.** Run `prism stats compare`
+   on the two instances (or `prism stats abtest <group_id>`) to get the
+   side-by-side cost / token / duration / `msg_assistant` / `tool_call`
+   numbers **and** the captured Spawn Inputs (profile, isolation mode, branch,
+   harness):
+   ```bash
+   prism stats compare <instance-A> <instance-B>
+   # or, by group:
+   prism stats abtest <group_id>
+   ```
+   This works **as soon as both legs reach a terminal state** (`finished` /
+   `error` / `interrupted`) — you do **not** need to clean up first. The
+   aggregate axes are computed on the fly from the event stream between the
+   terminal transition and cleanup, so the comparison is available exactly when
+   you need it to make the call (issue #2102).
+4. **Pick the winner** on quality **plus** the cost/speed evidence. Merge the
+   winner's PR, close the loser's PR.
+5. **Cleanup both** legs (see the next section) once the decision is made.
+
+> Run the comparison **before** you merge/cleanup — that is the whole point of
+> the A/B test. Cleaning up first is fine too (the persisted `spawn_outcome`
+> row carries the identical numbers), but it is no longer required for the
+> data to be available.
+
 ## Lifecycle: cleaning up after a merge
 
 When you spawn a session and later merge its PR yourself, you are responsible for cleaning up the worktree and session. The spawned agent cannot do this — it would be tearing down its own environment.


### PR DESCRIPTION
Closes #2102

## Summary

`prism stats compare` returned a near-empty table (every aggregate axis `—`) for any session that had reached a terminal agent state (`finished`/`error`/`interrupted`) but had not yet been cleaned up, because `spawn_outcome` was only written by `prism cleanup`. The `Spawn Inputs` block was *also* empty for every session, showing a `(spawn_inputs table not yet populated — run prism spawn with C.1 to capture inputs)` placeholder. Both gaps broke the A/B-test merge-decision workflow, where the comparison must happen **before** the merge/cleanup it informs.

## Layer 1 — `spawn_outcome` timing → **Option (b): on-the-fly compute**

I chose **(b)** over **(a)** (incremental write from the sidecar) deliberately:

- It avoids re-touching the sidecar finished-debounce / error-routing seams that #2081 and #2094 just landed.
- It cannot double-count: nothing new is persisted at read time, so the cleanup-path `WriteSpawnOutcome` remains the sole writer and stays idempotent against its own row.

Implementation:

- `WriteSpawnOutcome` is refactored into a shared **`computeSpawnOutcome`** (the canonical aggregation — the exact query cited as the source of truth — returning a `*SpawnOutcome` without persisting) plus a thin persistence wrapper. `WriteSpawnOutcome`'s output is unchanged.
- New **`SpawnOutcomeForCompare`**: returns the persisted row when present (post-cleanup, unchanged) and otherwise computes the aggregates on the fly — **only when the session is in a terminal agent state** (`agentTerminalState`). In-progress sessions return `nil` → `—`.
- `prism stats compare` now reads through `SpawnOutcomeForCompare`.

Because both the read-time and cleanup-time paths run the **identical** `agent_events` aggregation, the event-derived axes (tokens / cost / tool / msg counts, `time_to_first_event`) agree byte-for-byte — no double-counting, no missed deltas. `end_state` falls back to the live `agent_status.state` pre-cleanup; `duration_ms` falls back to the last event timestamp pre-cleanup (a stable point), and is later refined to the cleanup-stamped `ended_at` — the cleanup path itself is unchanged.

## Layer 2 — `spawn_inputs` → **renderer-fix**

**What "C.1" turned out to be:** a **spec-section reference, not a feature flag.** The schema migration comments tag the table `C.1/C.4 §4.1` (`internal/db/db.go`), and the renderer's stale placeholder told users to "run prism spawn with C.1". There is no flag to enable: the `spawn_inputs` table is **already written on every spawn path** via the centralised `SpawnSession` writer (#2087) — top-level `prism spawn`, each `--abtest` leg, `prism pr`, `prism investigate`, and the review fan-out. The renderer simply **never read the table** and hardcoded the placeholder.

So the fix is a renderer-fix (no schema change, no backfill):

- `prism stats compare` now reads `spawn_inputs` and surfaces `profile_name`, `isolation_mode`, `harness`, `agent_role`, `branch`, `model`, `variant`, `host_mode`, and `abtest_pair_id`. Partial rows are handled gracefully — each field falls back (effective `harness`/`agent_role` from the `sessions` row, `branch` derived from the session slug) rather than treating the whole block as absent. The placeholder is gone; the JSON renderer now emits real `spawn_inputs` and `diffs.spawn_inputs`.
- **Effective isolation mode capture:** the writers (`spawnInputsFromOpts` and the `prism pr` writer) previously recorded only the raw `--isolation` flag, which is NULL when the flag is omitted (the common case). They now fall back to the resolved effective mode, so `isolation_mode` is always populated — exactly what an A/B comparison wants. `isolation_flag` is not consulted by any `IS NULL`-sensitive query (it is not a `--group-by` axis), so this is a safe widening of an audit column.

## Tests

- `internal/db/spawn_outcome_compare_test.go`:
  - terminal states (`finished`/`error`/`interrupted`) populate every aggregate axis on the fly;
  - **negative test**: `active`/`idle`/`waiting`/`reviewing` (and no-status-row) return `nil` → `—`, no stale data;
  - idempotence: pre-cleanup compute vs post-cleanup persisted row agree byte-for-byte on the event-derived axes; second `WriteSpawnOutcome` is a no-op.
- `cmd/stats_compare_test.go`: drives `runStatsCompare` and asserts on the rendered table — terminal sessions show real numbers, active sessions show `—`, and the `Spawn Inputs` block is populated (no `C.1` / "not yet populated").
- `cmd/spawn_inputs_writer_test.go`: every `--abtest` leg's `spawn_inputs` row carries a non-empty `profile_name` and effective `isolation_mode`.

## Docs

- `modules/programs/prism/skills/prism/SKILL.md` gains an **A/B-test workflow** section: spawn pair → both finish → `prism stats compare` for the merge-decision data → merge winner / close loser → cleanup both.

## Verification

`go build ./...`, `go test ./...`, `go test -race ./internal/db/ ./cmd/ ./internal/session/`, and `nix build .#prism` all pass.
