### PR TITLE
prism: proxy stats compare/abtest/--abtest via host-API from sandboxed sessions

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -162,6 +162,24 @@ func proxyToHostAPI(apiURL, endpoint string, body any, respDst any) error {
 // "/list-sessions"). params are appended as properly-encoded URL query
 // parameters. On success, response JSON is unmarshalled into respDst (may be nil).
 func proxyGetFromHostAPI(apiURL, endpoint string, params map[string]string, respDst any) error {
+	// Build url.Values from the single-valued map and delegate to the
+	// repeated-key form. q.Encode() sorts keys, so the encoded query is
+	// deterministic regardless of Go's map iteration order.
+	q := url.Values{}
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	return proxyGetValuesFromHostAPI(apiURL, endpoint, q, respDst)
+}
+
+// proxyGetValuesFromHostAPI is the url.Values form of proxyGetFromHostAPI. It
+// supports repeated query keys (e.g. id=A&id=B for /stats?view=compare), which
+// the map-based form cannot express. apiURL is either a unix:// or http:// URL;
+// endpoint is the path; query carries the (possibly repeated) parameters. On
+// success the response JSON is unmarshalled into respDst (may be nil).
+func proxyGetValuesFromHostAPI(apiURL, endpoint string, query url.Values, respDst any) error {
 	var client *http.Client
 	var rawURL string
 
@@ -177,17 +195,8 @@ func proxyGetFromHostAPI(apiURL, endpoint string, params map[string]string, resp
 		rawURL = "http://prism-hostapi" + endpoint
 	}
 
-	// Append properly percent-encoded query parameters.
-	if len(params) > 0 {
-		q := url.Values{}
-		for k, v := range params {
-			if v != "" {
-				q.Set(k, v)
-			}
-		}
-		if len(q) > 0 {
-			rawURL += "?" + q.Encode()
-		}
+	if enc := query.Encode(); enc != "" {
+		rawURL += "?" + enc
 	}
 
 	req, err := http.NewRequest(http.MethodGet, rawURL, nil)

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -150,8 +150,10 @@ func runStats(cmd *cobra.Command, args []string) error {
 	groupBy, _ := cmd.Flags().GetString("group-by")
 	jsonMode, _ := cmd.Flags().GetBool("json")
 
-	// --abtest: list all A/B test pairs with summary metrics.
-	// Not proxied (coordinator-only, no sandbox concern).
+	// --abtest: list all A/B test pairs with summary metrics. runStatsAbtestFlag
+	// performs its own PRISM_HOST_API proxy dispatch (issue #2098) so a
+	// sandboxed session lists pairs from the host DB rather than the empty
+	// shadow DB.
 	if abtest {
 		return runStatsAbtestFlag()
 	}

--- a/modules/programs/prism/prism/cmd/stats_abtest.go
+++ b/modules/programs/prism/prism/cmd/stats_abtest.go
@@ -10,7 +10,9 @@ package cmd
 //   - Outcome (both finished, one errored, one still running, etc.)
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -22,6 +24,19 @@ import (
 // runStatsAbtestFlag implements prism stats --abtest (the --abtest top-level flag,
 // distinct from `prism stats abtest <group_id>` which is runStatsAbtest in stats_compare.go).
 func runStatsAbtestFlag() error {
+	// PRISM_HOST_API proxy dispatch (issue #2098): inside a sandbox the local
+	// shadow DB carries no abtest pairs, so list them from the host DB via the
+	// sidecar /stats?view=abtest_list endpoint. Rendering stays on the CLI side
+	// for byte-identical output with the host-direct path.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		pairs, err := proxyStatsAbtestList(apiURL)
+		if err != nil {
+			return fmt.Errorf("stats --abtest: %w", err)
+		}
+		renderAbtestPairs(pairs)
+		return nil
+	}
+
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats --abtest: %w", err)
@@ -33,14 +48,36 @@ func runStatsAbtestFlag() error {
 		return fmt.Errorf("stats --abtest: %w", err)
 	}
 
+	renderAbtestPairs(pairs)
+	return nil
+}
+
+// proxyStatsAbtestList proxies `prism stats --abtest` to the host sidecar's
+// GET /stats?view=abtest_list endpoint and returns the pair rows for the CLI
+// to render.
+func proxyStatsAbtestList(apiURL string) ([]db.AbtestPairRow, error) {
+	raw, err := proxyStats(apiURL, "abtest_list", "", 0, "", 0)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Pairs []db.AbtestPairRow `json:"pairs"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal abtest_list response: %w", err)
+	}
+	return resp.Pairs, nil
+}
+
+// renderAbtestPairs renders the abtest pairs listing, handling the empty case
+// identically on the direct-DB and proxy paths (issue #2098).
+func renderAbtestPairs(pairs []db.AbtestPairRow) {
 	if len(pairs) == 0 {
 		fmt.Println("no abtest pairs recorded")
 		fmt.Println("  Use 'prism spawn --abtest <profileA> <profileB> --prompt \"...\"' to create a pair.")
-		return nil
+		return
 	}
-
 	renderAbtestPairsTable(pairs)
-	return nil
 }
 
 // renderAbtestPairsTable renders the abtest pairs table to stdout.
@@ -53,14 +90,14 @@ func renderAbtestPairsTable(pairs []db.AbtestPairRow) {
 	fmt.Println()
 
 	const (
-		wPairID   = 12
-		wSession  = 36
-		wProfile  = 16
-		wTurns    = 6
-		wTokIn    = 9
-		wTokOut   = 9
-		wDur      = 9
-		wState    = 12
+		wPairID  = 12
+		wSession = 36
+		wProfile = 16
+		wTurns   = 6
+		wTokIn   = 9
+		wTokOut  = 9
+		wDur     = 9
+		wState   = 12
 	)
 
 	header := fmt.Sprintf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s  %-*s",

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -211,10 +211,13 @@ type compareRun struct {
 	// populated by an on-the-fly call to db.ComputeSpawnOutcome — see
 	// loadCompareRuns and issue #2102.
 	Outcome *db.SpawnOutcome
-	// Inputs is the spawn_inputs row for this session, or nil when no row
-	// exists (pre-#2087 spawns, or a session created outside of the
-	// SpawnSession chokepoint).
-	Inputs *db.SpawnInputs
+	// Inputs is the slim, non-sensitive spawn_inputs projection for this
+	// session, or nil when no row exists (pre-#2087 spawns, or a session
+	// created outside of the SpawnSession chokepoint). It is db.CompareInputs
+	// rather than the full db.SpawnInputs so the conversation-bearing columns
+	// (prompt_text, …) never cross the all-roles host-API /stats boundary on
+	// the proxy path (issue #2098 security review).
+	Inputs *db.CompareInputs
 }
 
 // axisRow is a single row in the comparison table: a label and one value per run.

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -19,8 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -28,7 +28,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
-	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
@@ -82,6 +81,19 @@ func init() {
 // ---------- runner functions ----------
 
 func runStatsCompare(cmd *cobra.Command, args []string) error {
+	// PRISM_HOST_API proxy dispatch: inside a sandbox the local shadow DB does
+	// not carry the host's data, so the resolution + aggregation must run on the
+	// host. The sidecar returns the assembled per-run data and the rendering
+	// (Δ column, table/json/csv, all flags) stays on the CLI side — byte for
+	// byte identical to the host-direct path (issue #2098).
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		runs, err := proxyStatsCompare(apiURL, args)
+		if err != nil {
+			return fmt.Errorf("stats compare: %w", err)
+		}
+		return renderComparison(cmd, runs)
+	}
+
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats compare: %w", err)
@@ -104,39 +116,86 @@ func runStatsCompare(cmd *cobra.Command, args []string) error {
 func runStatsAbtest(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
 
+	// PRISM_HOST_API proxy dispatch (issue #2098): same contract as compare —
+	// the host resolves the group members and assembles per-run data; the CLI
+	// renders.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		runs, err := proxyStatsAbtest(apiURL, groupID)
+		if err != nil {
+			return fmt.Errorf("stats abtest: %w", err)
+		}
+		return renderComparison(cmd, runs)
+	}
+
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats abtest: %w", err)
 	}
 	defer d.Close()
 
-	// Resolve group members.
-	members, err := d.GroupResults(groupID)
+	// Resolve group members to their most recent sessions rows (sorted by
+	// session_name) — shared with the proxy path via db.AbtestGroupSessions.
+	sessions, err := d.AbtestGroupSessions(groupID)
 	if err != nil {
-		return fmt.Errorf("stats abtest: resolve group members: %w", err)
+		return fmt.Errorf("stats abtest: %w", err)
 	}
-	if len(members) == 0 {
-		return fmt.Errorf("stats abtest: no members found for group %q", groupID)
-	}
-
-	// Get the sessions rows for each member by session name (most recent).
-	var sessions []*db.Session
-	for _, m := range members {
-		sess, err := d.MostRecentSessionForName(m.SessionName)
-		if err != nil {
-			return fmt.Errorf("stats abtest: resolve member %q: %w", m.SessionName, err)
-		}
-		if sess == nil {
-			return fmt.Errorf("stats abtest: member session %q not found in sessions table", m.SessionName)
-		}
-		sessions = append(sessions, sess)
-	}
-	// Sort by session_name for deterministic output.
-	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].SessionName < sessions[j].SessionName
-	})
 
 	return runComparison(cmd, d, sessions)
+}
+
+// proxyStatsCompare proxies `prism stats compare <ids…>` to the host sidecar's
+// GET /stats?view=compare endpoint. The instance IDs / session names are sent
+// as repeated id= query params (preserving order, which drives run-A/run-B…
+// labelling). The host resolves each arg and returns the assembled per-run
+// data; resolution is atomic — if any arg fails to resolve the host returns a
+// 404 and no runs, matching the host-direct path which aborts on the first
+// unresolvable arg.
+func proxyStatsCompare(apiURL string, args []string) ([]compareRun, error) {
+	q := url.Values{}
+	q.Set("view", "compare")
+	for _, a := range args {
+		q.Add("id", a)
+	}
+	var resp struct {
+		Runs []db.CompareRunData `json:"runs"`
+	}
+	if err := proxyGetValuesFromHostAPI(apiURL, "/stats", q, &resp); err != nil {
+		return nil, err
+	}
+	return compareRunsFromData(resp.Runs), nil
+}
+
+// proxyStatsAbtest proxies `prism stats abtest <group_id>` to the host
+// sidecar's GET /stats?view=abtest endpoint. The host resolves the group
+// members, sorts them, and returns the assembled per-run data.
+func proxyStatsAbtest(apiURL, groupID string) ([]compareRun, error) {
+	q := url.Values{}
+	q.Set("view", "abtest")
+	q.Set("group", groupID)
+	var resp struct {
+		Runs []db.CompareRunData `json:"runs"`
+	}
+	if err := proxyGetValuesFromHostAPI(apiURL, "/stats", q, &resp); err != nil {
+		return nil, err
+	}
+	return compareRunsFromData(resp.Runs), nil
+}
+
+// compareRunsFromData converts the host-API per-run DTOs into the renderer's
+// compareRun values, assigning run-A / run-B / … labels in order. This is the
+// proxy-path analogue of loadCompareRuns: identical label assignment, fed the
+// data the host already assembled via db.AssembleCompareRun.
+func compareRunsFromData(data []db.CompareRunData) []compareRun {
+	runs := make([]compareRun, len(data))
+	for i, cr := range data {
+		runs[i] = compareRun{
+			Label:   "run-" + string(rune('A'+i)),
+			Session: cr.Session,
+			Outcome: cr.Outcome,
+			Inputs:  cr.Inputs,
+		}
+	}
+	return runs
 }
 
 // ---------- comparison engine ----------
@@ -164,8 +223,21 @@ type axisRow struct {
 	Values []string // one per run
 }
 
-// runComparison is the shared engine for compare and abtest.
+// runComparison is the shared engine for the direct-DB compare and abtest
+// paths. It assembles the per-run data from the local DB and hands off to
+// renderComparison, which is also used directly by the proxy path once the
+// host has assembled the runs.
 func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
+	return renderComparison(cmd, loadCompareRuns(d, sessions))
+}
+
+// renderComparison reads the rendering flags and dispatches to the table,
+// JSON, or CSV renderer. It takes fully-assembled runs so the direct-DB and
+// host-API proxy paths render byte-identically from the same code (issue
+// #2098): every rendering flag (--format, --diff-only, --axes,
+// --include-inputs, --include-rubric) is applied here, on the CLI side, so
+// none of them can silently degrade on the proxy path.
+func renderComparison(cmd *cobra.Command, runs []compareRun) error {
 	format, _ := cmd.Flags().GetString("format")
 	diffOnly, _ := cmd.Flags().GetBool("diff-only")
 	includeRubric, _ := cmd.Flags().GetBool("include-rubric")
@@ -176,11 +248,8 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 	includeInputsVal, _ := cmd.Flags().GetBool("include-inputs")
 	includeInputs := includeInputsVal
 	if !includeInputsFlagSet {
-		includeInputs = len(sessions) == 2
+		includeInputs = len(runs) == 2
 	}
-
-	// Build run labels as run-A, run-B, run-C...
-	runs := loadCompareRuns(d, sessions)
 
 	// Collect desired axes.
 	wantAxes := defaultAxes()
@@ -222,66 +291,16 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 // Live sessions (active / idle / reviewing / escalated) keep Outcome == nil
 // so the renderer shows “—” — the aggregates are not yet meaningful.
 func loadCompareRuns(d *db.DB, sessions []*db.Session) []compareRun {
-	runs := make([]compareRun, len(sessions))
+	data := make([]db.CompareRunData, len(sessions))
 	for i, sess := range sessions {
-		label := "run-" + string(rune('A'+i))
-		run := compareRun{Label: label, Session: sess}
-
-		// Read the persisted spawn_outcome row first. nil is ok — the
-		// session may be in the gap between terminal-state transition and
-		// cleanup, or still in-progress.
-		if out, _ := d.SpawnOutcomeByInstanceID(sess.InstanceID); out != nil {
-			run.Outcome = out
-		} else if sessionIsTerminal(d, sess) {
-			// Terminal state but no persisted row — compute on the fly
-			// using the canonical aggregation. The row will later be
-			// persisted by `prism cleanup`; the two paths must agree.
-			if computed, err := d.ComputeSpawnOutcome(sess.InstanceID); err == nil && computed != nil {
-				run.Outcome = computed
-			}
-		}
-
-		// Load the spawn_inputs row. Best-effort: pre-#2087 sessions may
-		// have no row, in which case Inputs stays nil and the renderer
-		// surfaces what it can from the sessions row instead.
-		if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil {
-			run.Inputs = inputs
-		}
-
-		runs[i] = run
+		// db.AssembleCompareRun is the canonical assembly shared with the
+		// host-API proxy path (db.AssembleCompareRun → CompareRunOutcome →
+		// SessionIsTerminal): persisted spawn_outcome, or an on-the-fly
+		// ComputeSpawnOutcome when the session is terminal but not yet
+		// cleaned up, plus the best-effort spawn_inputs row.
+		data[i] = d.AssembleCompareRun(sess)
 	}
-	return runs
-}
-
-// sessionIsTerminal reports whether the agent_status row for sess shows a
-// terminal state (finished / error / interrupted / deleted) — the gate for
-// computing spawn_outcome on the fly when no persisted row exists yet.
-//
-// Falls back to sess.EndState (sessions.end_state) for sessions whose
-// agent_status row has already been cleaned away but whose sessions row
-// still records a terminal end_state. Live sessions keep Outcome nil so the
-// renderer shows “—” for aggregate axes (the over-broad-fix negative-test
-// AC in #2102).
-func sessionIsTerminal(d *db.DB, sess *db.Session) bool {
-	if sess == nil {
-		return false
-	}
-	// agent_status is the live source of truth while the row still exists.
-	if st, err := d.CurrentStatus(sess.SessionName); err == nil && st != nil {
-		return agent.IsTerminal(agent.AgentState(st.State))
-	}
-	// Fall back to sessions.end_state, written by the sidecar shutdown / by
-	// `prism cleanup`. Any non-empty terminal-shaped value here counts as
-	// terminal — "reset" (the SetEnded marker) is excluded because it can
-	// be set before the more-specific UpdateSessionEnded call, and the
-	// aggregates may not yet be stable at that point.
-	if sess.EndState != nil {
-		switch *sess.EndState {
-		case "finished", "error", "interrupted", "deleted":
-			return true
-		}
-	}
-	return false
+	return compareRunsFromData(data)
 }
 
 // defaultAxes returns the default axis set (all non-rubric axes).

--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // seedCompareSession inserts the minimum rows the compare engine reads:
-// agent_status (driver of sessionIsTerminal), sessions (driver of Outcome
+// agent_status (driver of db.SessionIsTerminal), sessions (driver of Outcome
 // fallback aggregation), and optionally spawn_inputs.
 //
 // finalState is the agent_status.state value the test wants the row to
@@ -35,7 +35,7 @@ import (
 // "deleted" depending on the case under test. The sessions row's
 // end_state mirrors the sidecar-shutdown / cleanup contract:
 //   - terminal final states populate sessions.end_state with the same value
-//     so the sessions-row fallback in sessionIsTerminal also returns true,
+//     so the sessions-row fallback in db.SessionIsTerminal also returns true,
 //   - non-terminal final states leave sessions.end_state NULL.
 func seedCompareSession(t *testing.T, d *db.DB, sessionName string, startedAt time.Time, finalState agent.AgentState, inputs *db.SpawnInputs) (instanceID string) {
 	t.Helper()

--- a/modules/programs/prism/prism/cmd/stats_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/stats_proxy_test.go
@@ -16,6 +16,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
@@ -256,7 +259,7 @@ func TestRunStatsProxy_SummaryJSON(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", apiURL)
 
-	statsCmd.Flags().Set("json", "true")      //nolint:errcheck
+	statsCmd.Flags().Set("json", "true")        //nolint:errcheck
 	defer statsCmd.Flags().Set("json", "false") //nolint:errcheck
 
 	out := captureStdout(t, func() {
@@ -294,7 +297,7 @@ func TestRunStatsProxy_GroupByFallsThrough(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 
 	statsCmd.Flags().Set("group-by", "harness") //nolint:errcheck
-	defer statsCmd.Flags().Set("group-by", "") //nolint:errcheck
+	defer statsCmd.Flags().Set("group-by", "")  //nolint:errcheck
 
 	_ = captureStdout(t, func() {
 		// Uses local DB (empty) — should produce output from runStatsGroupBy,
@@ -322,7 +325,7 @@ func TestRunStatsProxy_DaysHistoricalFallsThrough(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 
-	statsCmd.Flags().Set("days", "7")  //nolint:errcheck
+	statsCmd.Flags().Set("days", "7")       //nolint:errcheck
 	defer statsCmd.Flags().Set("days", "0") //nolint:errcheck
 
 	_ = captureStdout(t, func() {
@@ -363,5 +366,410 @@ func TestRunStatsProxy_HostPathUnchanged(t *testing.T) {
 	}
 	if !strings.Contains(out, "Doom Loop Events") {
 		t.Errorf("output missing 'Doom Loop Events' heading for direct-DB path; got:\n%s", out)
+	}
+}
+
+// ── compare / abtest / --abtest proxy paths (#2098) ───────────────────────────
+//
+// These tests exercise the host-API proxy dispatch added in #2098 for
+// `prism stats compare`, `prism stats abtest <group>`, and
+// `prism stats --abtest`. The strongest guarantee is byte-identical output
+// between the direct-DB path and the proxy path: each test renders the same
+// seeded DB both ways and asserts the bytes match. The fake /stats server
+// delegates to the same db helpers the real sidecar handler calls
+// (db.ResolveSessionArg, db.AssembleCompareRun, db.AbtestGroupSessions,
+// db.AbtestPairsAll), so the comparison spans a real HTTP + JSON round-trip.
+
+// newCompareFlagsCmd returns a cobra.Command carrying the same flags the real
+// compare/abtest subcommands register, isolated from the global command's
+// flag state so each test can set flags without cross-test pollution.
+func newCompareFlagsCmd() *cobra.Command {
+	c := &cobra.Command{Use: "compare"}
+	c.Flags().StringSlice("axes", nil, "")
+	c.Flags().String("format", "table", "")
+	c.Flags().Bool("diff-only", false, "")
+	c.Flags().String("sort", "", "")
+	c.Flags().Bool("include-inputs", false, "")
+	c.Flags().Bool("include-rubric", false, "")
+	return c
+}
+
+// startStatsProxyDBServer stands up a Unix-socket /stats server that serves the
+// compare / abtest / abtest_list views by delegating to the same db helpers the
+// real sidecar handler uses. It is a faithful in-process stand-in for the host
+// sidecar, letting the proxy tests assert byte-identical output against the
+// direct-DB path across a real HTTP + JSON round-trip.
+func startStatsProxyDBServer(t *testing.T, d *db.DB) string {
+	t.Helper()
+	writeErr := func(w http.ResponseWriter, status int, msg string) {
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	}
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		switch q.Get("view") {
+		case "compare":
+			ids := q["id"]
+			if len(ids) < 2 {
+				writeErr(w, http.StatusBadRequest, "view=compare requires at least 2 id params")
+				return
+			}
+			runs := make([]db.CompareRunData, 0, len(ids))
+			for _, id := range ids {
+				sess, err := d.ResolveSessionArg(id, false)
+				if err != nil {
+					writeErr(w, http.StatusNotFound, err.Error())
+					return
+				}
+				runs = append(runs, d.AssembleCompareRun(sess))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"runs": runs})
+		case "abtest":
+			sessions, err := d.AbtestGroupSessions(q.Get("group"))
+			if err != nil {
+				writeErr(w, http.StatusNotFound, err.Error())
+				return
+			}
+			runs := make([]db.CompareRunData, 0, len(sessions))
+			for _, sess := range sessions {
+				runs = append(runs, d.AssembleCompareRun(sess))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"runs": runs})
+		case "abtest_list":
+			pairs, err := d.AbtestPairsAll()
+			if err != nil {
+				writeErr(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if pairs == nil {
+				pairs = []db.AbtestPairRow{}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"pairs": pairs})
+		default:
+			writeErr(w, http.StatusBadRequest, "unknown view")
+		}
+	})
+	return srv.apiURL()
+}
+
+// seedTwoCompareRuns seeds two terminal sessions (with token/cost events and a
+// spawn_inputs row) and returns their instance IDs. Both sessions are
+// `finished` so the compare engine computes an outcome on the fly.
+func seedTwoCompareRuns(t *testing.T, d *db.DB) (idA, idB string) {
+	t.Helper()
+	startedAt := time.Now().Add(-5 * time.Minute).Truncate(time.Second)
+
+	inputsA := &db.SpawnInputs{ProfileName: strPtrTest("opus-4-7"), HarnessFlag: strPtrTest("pi")}
+	inputsB := &db.SpawnInputs{ProfileName: strPtrTest("opus-4-8"), HarnessFlag: strPtrTest("pi")}
+
+	idA = seedCompareSession(t, d, "nixos-config@run-a", startedAt, agent.StateFinished, inputsA)
+	idB = seedCompareSession(t, d, "nixos-config@run-b", startedAt.Add(time.Second), agent.StateFinished, inputsB)
+
+	writeAssistantTurn(t, d, "nixos-config@run-a", idA, startedAt.Add(10*time.Second), 1500, 700, 300, 150, 0.12)
+	writeToolCall(t, d, "nixos-config@run-a", idA, "bash", startedAt.Add(20*time.Second))
+	writeAssistantTurn(t, d, "nixos-config@run-b", idB, startedAt.Add(11*time.Second), 2200, 900, 410, 205, 0.31)
+	writeToolCall(t, d, "nixos-config@run-b", idB, "edit", startedAt.Add(21*time.Second))
+	return idA, idB
+}
+
+func strPtrTest(s string) *string { return &s }
+
+// renderCompareDirect runs `prism stats compare` against the direct-DB path and
+// returns the captured stdout. PRISM_HOST_API must be unset on entry.
+func renderCompareDirect(t *testing.T, cmd *cobra.Command, args ...string) string {
+	t.Helper()
+	t.Setenv("PRISM_HOST_API", "")
+	return captureStdout(t, func() {
+		if err := runStatsCompare(cmd, args); err != nil {
+			t.Fatalf("runStatsCompare (direct): %v", err)
+		}
+	})
+}
+
+// renderCompareProxy runs `prism stats compare` against the proxy path (server
+// at apiURL) and returns the captured stdout.
+func renderCompareProxy(t *testing.T, cmd *cobra.Command, apiURL string, args ...string) string {
+	t.Helper()
+	t.Setenv("PRISM_HOST_API", apiURL)
+	return captureStdout(t, func() {
+		if err := runStatsCompare(cmd, args); err != nil {
+			t.Fatalf("runStatsCompare (proxy): %v", err)
+		}
+	})
+}
+
+// TestStatsCompareProxy_ByteIdentical_Table is the core #2098 AC: the table
+// output of `prism stats compare A B` must be byte-identical between the
+// direct-DB path and the host-API proxy path.
+func TestStatsCompareProxy_ByteIdentical_Table(t *testing.T) {
+	d := openStatsTestDB(t)
+	idA, idB := seedTwoCompareRuns(t, d)
+	apiURL := startStatsProxyDBServer(t, d)
+
+	direct := renderCompareDirect(t, newCompareFlagsCmd(), idA, idB)
+	proxy := renderCompareProxy(t, newCompareFlagsCmd(), apiURL, idA, idB)
+
+	if direct != proxy {
+		t.Errorf("compare table output not byte-identical between direct and proxy paths\n--- DIRECT ---\n%s\n--- PROXY ---\n%s", direct, proxy)
+	}
+	if !strings.Contains(direct, "run-a") || !strings.Contains(direct, "run-b") {
+		t.Errorf("expected both session names in output; got:\n%s", direct)
+	}
+}
+
+// TestStatsCompareProxy_ByteIdentical_FormatsAndFlags asserts byte-identical
+// output across --format json/csv and the --diff-only / --axes /
+// --include-inputs / --include-rubric flags (ACs #5 and #6).
+func TestStatsCompareProxy_ByteIdentical_FormatsAndFlags(t *testing.T) {
+	d := openStatsTestDB(t)
+	idA, idB := seedTwoCompareRuns(t, d)
+	apiURL := startStatsProxyDBServer(t, d)
+
+	type variant struct {
+		name  string
+		setup func(c *cobra.Command)
+	}
+	variants := []variant{
+		{"json", func(c *cobra.Command) { _ = c.Flags().Set("format", "json") }},
+		{"csv", func(c *cobra.Command) { _ = c.Flags().Set("format", "csv") }},
+		{"diff-only", func(c *cobra.Command) { _ = c.Flags().Set("diff-only", "true") }},
+		{"axes", func(c *cobra.Command) { _ = c.Flags().Set("axes", "tokens_input,cost_usd,tool_call") }},
+		{"include-inputs-off", func(c *cobra.Command) { _ = c.Flags().Set("include-inputs", "false") }},
+		{"include-rubric", func(c *cobra.Command) { _ = c.Flags().Set("include-rubric", "true") }},
+	}
+
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			dc := newCompareFlagsCmd()
+			v.setup(dc)
+			direct := renderCompareDirect(t, dc, idA, idB)
+
+			pc := newCompareFlagsCmd()
+			v.setup(pc)
+			proxy := renderCompareProxy(t, pc, apiURL, idA, idB)
+
+			if direct != proxy {
+				t.Errorf("%s: output not byte-identical\n--- DIRECT ---\n%s\n--- PROXY ---\n%s", v.name, direct, proxy)
+			}
+		})
+	}
+}
+
+// TestStatsCompareProxy_ByteIdentical_ThreeWay covers the 3+ run path
+// (MIN/MAX annotations, no Δ column) through the proxy.
+func TestStatsCompareProxy_ByteIdentical_ThreeWay(t *testing.T) {
+	d := openStatsTestDB(t)
+	idA, idB := seedTwoCompareRuns(t, d)
+	startedAt := time.Now().Add(-4 * time.Minute).Truncate(time.Second)
+	idC := seedCompareSession(t, d, "nixos-config@run-c", startedAt, agent.StateFinished, &db.SpawnInputs{ProfileName: strPtrTest("haiku")})
+	writeAssistantTurn(t, d, "nixos-config@run-c", idC, startedAt.Add(9*time.Second), 800, 300, 100, 50, 0.05)
+	apiURL := startStatsProxyDBServer(t, d)
+
+	direct := renderCompareDirect(t, newCompareFlagsCmd(), idA, idB, idC)
+	proxy := renderCompareProxy(t, newCompareFlagsCmd(), apiURL, idA, idB, idC)
+	if direct != proxy {
+		t.Errorf("3-way compare not byte-identical\n--- DIRECT ---\n%s\n--- PROXY ---\n%s", direct, proxy)
+	}
+}
+
+// TestStatsCompareProxy_404 verifies that an unresolvable instance via the
+// proxy surfaces as an error (AC: 404 case).
+func TestStatsCompareProxy_404(t *testing.T) {
+	d := openStatsTestDB(t)
+	idA, _ := seedTwoCompareRuns(t, d)
+	apiURL := startStatsProxyDBServer(t, d)
+
+	t.Setenv("PRISM_HOST_API", apiURL)
+	err := runStatsCompare(newCompareFlagsCmd(), []string{idA, "ghost-instance-that-does-not-exist"})
+	if err == nil {
+		t.Fatal("expected error for unresolvable instance via proxy, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost-instance-that-does-not-exist") {
+		t.Errorf("error should name the unresolvable arg; got: %v", err)
+	}
+}
+
+// TestStatsAbtestProxy_ByteIdentical seeds a session group and asserts
+// `prism stats abtest <group>` is byte-identical between direct and proxy.
+func TestStatsAbtestProxy_ByteIdentical(t *testing.T) {
+	d := openStatsTestDB(t)
+	seedTwoCompareRuns(t, d)
+	groupID, err := d.RegisterGroup("nixos-config@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID("nixos-config@run-a", groupID); err != nil {
+		t.Fatalf("SetGroupID run-a: %v", err)
+	}
+	if err := d.SetGroupID("nixos-config@run-b", groupID); err != nil {
+		t.Fatalf("SetGroupID run-b: %v", err)
+	}
+	apiURL := startStatsProxyDBServer(t, d)
+
+	t.Setenv("PRISM_HOST_API", "")
+	direct := captureStdout(t, func() {
+		if err := runStatsAbtest(newCompareFlagsCmd(), []string{groupID}); err != nil {
+			t.Fatalf("runStatsAbtest (direct): %v", err)
+		}
+	})
+	t.Setenv("PRISM_HOST_API", apiURL)
+	proxy := captureStdout(t, func() {
+		if err := runStatsAbtest(newCompareFlagsCmd(), []string{groupID}); err != nil {
+			t.Fatalf("runStatsAbtest (proxy): %v", err)
+		}
+	})
+	if direct != proxy {
+		t.Errorf("abtest output not byte-identical\n--- DIRECT ---\n%s\n--- PROXY ---\n%s", direct, proxy)
+	}
+}
+
+// seedAbtestPair seeds two finished sessions sharing an abtest_pair_id in their
+// spawn_inputs rows, so they surface in `prism stats --abtest`.
+func seedAbtestPair(t *testing.T, d *db.DB, pairID string) {
+	t.Helper()
+	startedAt := time.Now().Add(-6 * time.Minute).Truncate(time.Second)
+	inA := &db.SpawnInputs{ProfileName: strPtrTest("opus-4-7"), AbtestPairID: strPtrTest(pairID)}
+	inB := &db.SpawnInputs{ProfileName: strPtrTest("opus-4-8"), AbtestPairID: strPtrTest(pairID)}
+	idA := seedCompareSession(t, d, "nixos-config@pair-a", startedAt, agent.StateFinished, inA)
+	idB := seedCompareSession(t, d, "nixos-config@pair-b", startedAt.Add(time.Second), agent.StateFinished, inB)
+	writeAssistantTurn(t, d, "nixos-config@pair-a", idA, startedAt.Add(10*time.Second), 1500, 700, 300, 150, 0.12)
+	writeAssistantTurn(t, d, "nixos-config@pair-b", idB, startedAt.Add(11*time.Second), 2200, 900, 410, 205, 0.31)
+}
+
+// TestStatsAbtestFlagProxy_ByteIdentical seeds an abtest pair and asserts
+// `prism stats --abtest` is byte-identical between direct and proxy.
+func TestStatsAbtestFlagProxy_ByteIdentical(t *testing.T) {
+	d := openStatsTestDB(t)
+	seedAbtestPair(t, d, "pair-2098-aaaa-bbbb-cccc-dddddddddddd")
+	apiURL := startStatsProxyDBServer(t, d)
+
+	t.Setenv("PRISM_HOST_API", "")
+	direct := captureStdout(t, func() {
+		if err := runStatsAbtestFlag(); err != nil {
+			t.Fatalf("runStatsAbtestFlag (direct): %v", err)
+		}
+	})
+	t.Setenv("PRISM_HOST_API", apiURL)
+	proxy := captureStdout(t, func() {
+		if err := runStatsAbtestFlag(); err != nil {
+			t.Fatalf("runStatsAbtestFlag (proxy): %v", err)
+		}
+	})
+	if direct != proxy {
+		t.Errorf("--abtest listing not byte-identical\n--- DIRECT ---\n%s\n--- PROXY ---\n%s", direct, proxy)
+	}
+	if !strings.Contains(direct, "A/B Test Pairs") {
+		t.Errorf("expected pairs table header; got:\n%s", direct)
+	}
+}
+
+// TestStatsAbtestFlagProxy_Empty verifies the empty-pairs message is rendered
+// identically via the proxy.
+func TestStatsAbtestFlagProxy_Empty(t *testing.T) {
+	d := openStatsTestDB(t)
+	apiURL := startStatsProxyDBServer(t, d)
+
+	t.Setenv("PRISM_HOST_API", apiURL)
+	out := captureStdout(t, func() {
+		if err := runStatsAbtestFlag(); err != nil {
+			t.Fatalf("runStatsAbtestFlag (proxy, empty): %v", err)
+		}
+	})
+	if !strings.Contains(out, "no abtest pairs recorded") {
+		t.Errorf("expected 'no abtest pairs recorded' via proxy; got:\n%s", out)
+	}
+}
+
+// ── over-broad-fix guards: PRISM_HOST_API unset → direct DB, no proxy ──────────
+
+// TestStatsCompareProxy_UnsetUsesDirectDB verifies that with PRISM_HOST_API
+// unset, `prism stats compare` does not contact any server (direct-DB path).
+func TestStatsCompareProxy_UnsetUsesDirectDB(t *testing.T) {
+	d := openStatsTestDB(t) // clears PRISM_HOST_API
+	idA, idB := seedTwoCompareRuns(t, d)
+
+	requestCount := 0
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"runs":[]}`))
+	})
+	_ = srv // deliberately NOT setting PRISM_HOST_API
+
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(newCompareFlagsCmd(), []string{idA, idB}); err != nil {
+			t.Fatalf("runStatsCompare (direct): %v", err)
+		}
+	})
+	if requestCount != 0 {
+		t.Errorf("proxy server received %d request(s); compare must use direct DB when PRISM_HOST_API unset", requestCount)
+	}
+	if !strings.Contains(out, "run-a") {
+		t.Errorf("expected direct-DB rendered output; got:\n%s", out)
+	}
+}
+
+// TestStatsAbtestProxy_UnsetUsesDirectDB verifies the same for
+// `prism stats abtest <group>`.
+func TestStatsAbtestProxy_UnsetUsesDirectDB(t *testing.T) {
+	d := openStatsTestDB(t)
+	seedTwoCompareRuns(t, d)
+	groupID, err := d.RegisterGroup("nixos-config@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID("nixos-config@run-a", groupID); err != nil {
+		t.Fatalf("SetGroupID run-a: %v", err)
+	}
+	if err := d.SetGroupID("nixos-config@run-b", groupID); err != nil {
+		t.Fatalf("SetGroupID run-b: %v", err)
+	}
+
+	requestCount := 0
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"runs":[]}`))
+	})
+	_ = srv
+
+	out := captureStdout(t, func() {
+		if err := runStatsAbtest(newCompareFlagsCmd(), []string{groupID}); err != nil {
+			t.Fatalf("runStatsAbtest (direct): %v", err)
+		}
+	})
+	if requestCount != 0 {
+		t.Errorf("proxy server received %d request(s); abtest must use direct DB when PRISM_HOST_API unset", requestCount)
+	}
+	if !strings.Contains(out, "run-a") {
+		t.Errorf("expected direct-DB rendered output; got:\n%s", out)
+	}
+}
+
+// TestStatsAbtestFlagProxy_UnsetUsesDirectDB verifies the same for
+// `prism stats --abtest`.
+func TestStatsAbtestFlagProxy_UnsetUsesDirectDB(t *testing.T) {
+	d := openStatsTestDB(t)
+	seedAbtestPair(t, d, "pair-noproxy-aaaa-bbbb-cccc-dddddddddddd")
+
+	requestCount := 0
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"pairs":[]}`))
+	})
+	_ = srv
+
+	out := captureStdout(t, func() {
+		if err := runStatsAbtestFlag(); err != nil {
+			t.Fatalf("runStatsAbtestFlag (direct): %v", err)
+		}
+	})
+	if requestCount != 0 {
+		t.Errorf("proxy server received %d request(s); --abtest must use direct DB when PRISM_HOST_API unset", requestCount)
+	}
+	if !strings.Contains(out, "A/B Test Pairs") {
+		t.Errorf("expected direct-DB pairs table; got:\n%s", out)
 	}
 }

--- a/modules/programs/prism/prism/cmd/stats_render.go
+++ b/modules/programs/prism/prism/cmd/stats_render.go
@@ -101,45 +101,9 @@ func renderIncarnationDetailFromSession(sess *db.Session) {
 //  3. UUID prefix → SessionsByInstanceIDPrefix (must be unambiguous)
 //  4. Not found → error
 func resolveSessionArg(d *db.DB, arg string, forceInstance bool) (*db.Session, error) {
-	// Step 1: full UUID (36 chars) or --instance flag.
-	if forceInstance || len(arg) == 36 {
-		sess, err := d.SessionByInstanceID(arg)
-		if err != nil {
-			return nil, fmt.Errorf("stats: lookup instance %q: %w", arg, err)
-		}
-		if sess != nil {
-			return sess, nil
-		}
-		return nil, fmt.Errorf("stats: instance %q not found", arg)
-	}
-
-	// Step 2: try exact session_name match first.
-	sess, err := d.MostRecentSessionForName(arg)
-	if err != nil {
-		return nil, fmt.Errorf("stats: lookup session name %q: %w", arg, err)
-	}
-	if sess != nil {
-		return sess, nil
-	}
-
-	// Step 3: try UUID prefix match.
-	matches, err := d.SessionsByInstanceIDPrefix(arg)
-	if err != nil {
-		return nil, fmt.Errorf("stats: lookup instance prefix %q: %w", arg, err)
-	}
-	if len(matches) == 1 {
-		return &matches[0], nil
-	}
-	if len(matches) > 1 {
-		var candidates []string
-		for _, m := range matches {
-			candidates = append(candidates, m.InstanceID)
-		}
-		return nil, fmt.Errorf("stats: %q is ambiguous — multiple incarnations match:\n  %s\nuse the full instance_id to disambiguate",
-			arg, strings.Join(candidates, "\n  "))
-	}
-
-	return nil, fmt.Errorf("stats: %q is not a known instance_id or session_name", arg)
+	// Delegates to db.ResolveSessionArg so the host-API proxy path resolves
+	// session names / instance-id prefixes byte-for-byte identically (#2098).
+	return d.ResolveSessionArg(arg, forceInstance)
 }
 
 // renderIncarnationDetail renders the full detail block for a single sessions row.

--- a/modules/programs/prism/prism/internal/db/compare.go
+++ b/modules/programs/prism/prism/internal/db/compare.go
@@ -1,0 +1,178 @@
+package db
+
+// compare.go — canonical data-assembly for `prism stats compare`,
+// `prism stats abtest <group_id>`, and the resolution helpers they share.
+//
+// These functions are the single source of truth for the data shown by the
+// comparison engine. Both the CLI direct-DB path (cmd/stats_compare.go) and
+// the host-API proxy path (internal/sidecar host_api.go GET /stats?view=…)
+// call them, so the bytes rendered are identical regardless of whether the
+// query was served from the local DB or proxied to the host sidecar
+// (issue #2098). Keeping resolution + aggregation here — rather than
+// duplicating it on the sidecar side — is what guarantees the byte-identical
+// output contract.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// CompareRunData is the wire/render shape for one run in `prism stats compare`:
+// a resolved sessions row plus its assembled spawn_outcome and spawn_inputs.
+// It is the element type of the host-API /stats?view=compare and
+// view=abtest responses; the CLI renderer consumes the same struct on both
+// the direct and proxy paths. JSON tags are explicit so the proxy envelope is
+// stable across refactors of the underlying struct field names.
+type CompareRunData struct {
+	Session *Session      `json:"session"`
+	Outcome *SpawnOutcome `json:"outcome"`
+	Inputs  *SpawnInputs  `json:"inputs"`
+}
+
+// ResolveSessionArg resolves a user-supplied argument to a sessions row.
+// The argument may be a full 36-character instance_id, a session name, or an
+// unambiguous instance_id prefix. When forceInstance is true the argument is
+// treated as an instance_id regardless of length.
+//
+// This is the shared resolver behind both `prism stats <id>` and
+// `prism stats compare <id>…`; the sidecar proxy path calls it directly so
+// session-name / prefix resolution is byte-for-byte identical to the host
+// path (issue #2098).
+func (d *DB) ResolveSessionArg(arg string, forceInstance bool) (*Session, error) {
+	// Step 1: full UUID (36 chars) or --instance flag.
+	if forceInstance || len(arg) == 36 {
+		sess, err := d.SessionByInstanceID(arg)
+		if err != nil {
+			return nil, fmt.Errorf("stats: lookup instance %q: %w", arg, err)
+		}
+		if sess != nil {
+			return sess, nil
+		}
+		return nil, fmt.Errorf("stats: instance %q not found", arg)
+	}
+
+	// Step 2: try exact session_name match first.
+	sess, err := d.MostRecentSessionForName(arg)
+	if err != nil {
+		return nil, fmt.Errorf("stats: lookup session name %q: %w", arg, err)
+	}
+	if sess != nil {
+		return sess, nil
+	}
+
+	// Step 3: try UUID prefix match.
+	matches, err := d.SessionsByInstanceIDPrefix(arg)
+	if err != nil {
+		return nil, fmt.Errorf("stats: lookup instance prefix %q: %w", arg, err)
+	}
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+	if len(matches) > 1 {
+		var candidates []string
+		for _, m := range matches {
+			candidates = append(candidates, m.InstanceID)
+		}
+		return nil, fmt.Errorf("stats: %q is ambiguous — multiple incarnations match:\n  %s\nuse the full instance_id to disambiguate",
+			arg, strings.Join(candidates, "\n  "))
+	}
+
+	return nil, fmt.Errorf("stats: %q is not a known instance_id or session_name", arg)
+}
+
+// SessionIsTerminal reports whether sess is in a terminal state
+// (finished / error / interrupted / deleted) — the gate for computing
+// spawn_outcome on the fly when no persisted row exists yet.
+//
+// agent_status is the live source of truth while the row still exists; it
+// falls back to sessions.end_state for sessions whose agent_status row has
+// already been cleaned away but whose sessions row still records a terminal
+// end_state. The "reset" marker is deliberately excluded — it can be set
+// before the more-specific UpdateSessionEnded call, when the aggregates may
+// not yet be stable (issue #2102).
+func (d *DB) SessionIsTerminal(sess *Session) bool {
+	if sess == nil {
+		return false
+	}
+	if st, err := d.CurrentStatus(sess.SessionName); err == nil && st != nil {
+		return agent.IsTerminal(agent.AgentState(st.State))
+	}
+	if sess.EndState != nil {
+		switch *sess.EndState {
+		case "finished", "error", "interrupted", "deleted":
+			return true
+		}
+	}
+	return false
+}
+
+// CompareRunOutcome returns the spawn_outcome to display for sess: the
+// persisted spawn_outcome row when present, or — when the session has reached
+// a terminal state but no row has been written yet (the window between the
+// terminal transition and `prism cleanup`) — an on-the-fly computation via
+// ComputeSpawnOutcome. ComputeSpawnOutcome is the same aggregation
+// WriteSpawnOutcome uses internally, so the value agrees byte-for-byte with
+// the row cleanup will later persist. Returns nil for live sessions (the
+// renderer shows "—"). Issue #2102.
+func (d *DB) CompareRunOutcome(sess *Session) *SpawnOutcome {
+	if sess == nil {
+		return nil
+	}
+	if out, _ := d.SpawnOutcomeByInstanceID(sess.InstanceID); out != nil {
+		return out
+	}
+	if d.SessionIsTerminal(sess) {
+		if computed, err := d.ComputeSpawnOutcome(sess.InstanceID); err == nil && computed != nil {
+			return computed
+		}
+	}
+	return nil
+}
+
+// AssembleCompareRun gathers the per-run data the comparison renderer needs
+// for a single resolved session: the persisted-or-computed spawn_outcome and
+// the spawn_inputs row. spawn_inputs is best-effort — pre-#2087 sessions may
+// have no row, in which case Inputs stays nil and the renderer surfaces what
+// it can from the sessions row instead.
+func (d *DB) AssembleCompareRun(sess *Session) CompareRunData {
+	cr := CompareRunData{Session: sess}
+	cr.Outcome = d.CompareRunOutcome(sess)
+	if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil {
+		cr.Inputs = inputs
+	}
+	return cr
+}
+
+// AbtestGroupSessions resolves all members of a session group to their most
+// recent sessions rows, sorted by session_name for deterministic output.
+// Shared by `prism stats abtest <group_id>` on both the direct and proxy
+// paths so the resolved member set and ordering are identical (issue #2098).
+func (d *DB) AbtestGroupSessions(groupID string) ([]*Session, error) {
+	members, err := d.GroupResults(groupID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve group members: %w", err)
+	}
+	if len(members) == 0 {
+		return nil, fmt.Errorf("no members found for group %q", groupID)
+	}
+
+	var sessions []*Session
+	for _, m := range members {
+		sess, err := d.MostRecentSessionForName(m.SessionName)
+		if err != nil {
+			return nil, fmt.Errorf("resolve member %q: %w", m.SessionName, err)
+		}
+		if sess == nil {
+			return nil, fmt.Errorf("member session %q not found in sessions table", m.SessionName)
+		}
+		sessions = append(sessions, sess)
+	}
+	// Sort by session_name for deterministic output.
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].SessionName < sessions[j].SessionName
+	})
+	return sessions, nil
+}

--- a/modules/programs/prism/prism/internal/db/compare.go
+++ b/modules/programs/prism/prism/internal/db/compare.go
@@ -21,15 +21,43 @@ import (
 )
 
 // CompareRunData is the wire/render shape for one run in `prism stats compare`:
-// a resolved sessions row plus its assembled spawn_outcome and spawn_inputs.
-// It is the element type of the host-API /stats?view=compare and
-// view=abtest responses; the CLI renderer consumes the same struct on both
-// the direct and proxy paths. JSON tags are explicit so the proxy envelope is
-// stable across refactors of the underlying struct field names.
+// a resolved sessions row plus its assembled spawn_outcome and the slim,
+// non-sensitive spawn_inputs projection. It is the element type of the
+// host-API /stats?view=compare and view=abtest responses; the CLI renderer
+// consumes the same struct on both the direct and proxy paths. JSON tags are
+// explicit so the proxy envelope is stable across refactors of the underlying
+// struct field names.
+//
+// Inputs is CompareInputs, not the full *SpawnInputs, by design: /stats is the
+// all-roles "aggregate counts" surface, and the full spawn_inputs row carries
+// row-level conversation content (prompt_text, prompt_source, …) that must not
+// cross that boundary. See CompareInputs.
 type CompareRunData struct {
-	Session *Session      `json:"session"`
-	Outcome *SpawnOutcome `json:"outcome"`
-	Inputs  *SpawnInputs  `json:"inputs"`
+	Session *Session       `json:"session"`
+	Outcome *SpawnOutcome  `json:"outcome"`
+	Inputs  *CompareInputs `json:"inputs"`
+}
+
+// CompareInputs is the deliberately-slim projection of spawn_inputs that the
+// comparison renderer consumes. It contains only the six non-sensitive
+// provenance fields surfaced by `prism stats compare` (cmd/stats_compare.go
+// inputsValue). The conversation-bearing columns of SpawnInputs —
+// prompt_text, prompt_source, model_variant_overrides, extras — are
+// intentionally excluded so they never cross the all-roles host-API /stats
+// boundary.
+//
+// /stats is the "aggregate counts" surface; row-level conversation content
+// stays behind the coordinator-only /db/query and /checkin endpoints (see the
+// privilege boundary documented in internal/sidecar/host_api.go). This mirrors
+// the view=detail precedent, which returns only *Session and never the spawn
+// prompt (issue #2098, round-1 security review).
+type CompareInputs struct {
+	ProfileName   *string `json:"profile_name"`
+	HarnessFlag   *string `json:"harness_flag"`
+	IsolationFlag *string `json:"isolation_flag"`
+	AgentFlag     *string `json:"agent_flag"`
+	BranchFlag    *string `json:"branch_flag"`
+	AbtestPairID  *string `json:"abtest_pair_id"`
 }
 
 // ResolveSessionArg resolves a user-supplied argument to a sessions row.
@@ -134,14 +162,23 @@ func (d *DB) CompareRunOutcome(sess *Session) *SpawnOutcome {
 
 // AssembleCompareRun gathers the per-run data the comparison renderer needs
 // for a single resolved session: the persisted-or-computed spawn_outcome and
-// the spawn_inputs row. spawn_inputs is best-effort — pre-#2087 sessions may
-// have no row, in which case Inputs stays nil and the renderer surfaces what
-// it can from the sessions row instead.
+// the slim spawn_inputs projection. spawn_inputs is best-effort — pre-#2087
+// sessions may have no row, in which case Inputs stays nil and the renderer
+// surfaces what it can from the sessions row instead. The full row is
+// projected down to CompareInputs here so the sensitive conversation columns
+// never leave the DB layer (see CompareInputs).
 func (d *DB) AssembleCompareRun(sess *Session) CompareRunData {
 	cr := CompareRunData{Session: sess}
 	cr.Outcome = d.CompareRunOutcome(sess)
-	if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil {
-		cr.Inputs = inputs
+	if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil && inputs != nil {
+		cr.Inputs = &CompareInputs{
+			ProfileName:   inputs.ProfileName,
+			HarnessFlag:   inputs.HarnessFlag,
+			IsolationFlag: inputs.IsolationFlag,
+			AgentFlag:     inputs.AgentFlag,
+			BranchFlag:    inputs.BranchFlag,
+			AbtestPairID:  inputs.AbtestPairID,
+		}
 	}
 	return cr
 }

--- a/modules/programs/prism/prism/internal/db/compare_test.go
+++ b/modules/programs/prism/prism/internal/db/compare_test.go
@@ -1,0 +1,180 @@
+package db_test
+
+// Tests for the shared comparison-data helpers added in #2098:
+// ResolveSessionArg, SessionIsTerminal, CompareRunOutcome, AssembleCompareRun,
+// and AbtestGroupSessions. These back both the CLI direct path and the
+// host-API proxy path, so their behaviour is the single source of truth for
+// byte-identical `prism stats compare` / `abtest` output.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedSessionForCompare inserts agent_status + sessions rows for a session in
+// the given agent_status state, mirroring the cleanup-path end_state write for
+// terminal states.
+func seedSessionForCompare(t *testing.T, d *db.DB, sessionName, state string) (instanceID string) {
+	t.Helper()
+	instanceID = uuid.New().String()
+	if err := d.UpsertStatus(sessionName, "repo", "/wt/"+sessionName, state, nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("SetInstanceID %q: %v", sessionName, err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		Harness:     "pi",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	switch state {
+	case "finished", "error", "interrupted", "deleted":
+		if err := d.UpdateSessionEnded(instanceID, state); err != nil {
+			t.Fatalf("UpdateSessionEnded %q: %v", sessionName, err)
+		}
+	}
+	return instanceID
+}
+
+func TestResolveSessionArg(t *testing.T) {
+	d := openTestDB(t)
+	iid := seedSessionForCompare(t, d, "repo@feature", "finished")
+
+	t.Run("by full uuid", func(t *testing.T) {
+		sess, err := d.ResolveSessionArg(iid, false)
+		if err != nil || sess == nil {
+			t.Fatalf("ResolveSessionArg(uuid) = (%v, %v)", sess, err)
+		}
+		if sess.InstanceID != iid {
+			t.Errorf("instance = %q, want %q", sess.InstanceID, iid)
+		}
+	})
+
+	t.Run("by session name", func(t *testing.T) {
+		sess, err := d.ResolveSessionArg("repo@feature", false)
+		if err != nil || sess == nil {
+			t.Fatalf("ResolveSessionArg(name) = (%v, %v)", sess, err)
+		}
+		if sess.InstanceID != iid {
+			t.Errorf("instance = %q, want %q", sess.InstanceID, iid)
+		}
+	})
+
+	t.Run("by unambiguous prefix", func(t *testing.T) {
+		sess, err := d.ResolveSessionArg(iid[:8], false)
+		if err != nil || sess == nil {
+			t.Fatalf("ResolveSessionArg(prefix) = (%v, %v)", sess, err)
+		}
+		if sess.InstanceID != iid {
+			t.Errorf("instance = %q, want %q", sess.InstanceID, iid)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := d.ResolveSessionArg("definitely-not-a-real-arg", false)
+		if err == nil {
+			t.Fatal("expected error for unknown arg")
+		}
+		if !strings.Contains(err.Error(), "definitely-not-a-real-arg") {
+			t.Errorf("error should name the arg; got %v", err)
+		}
+	})
+
+	t.Run("missing full uuid", func(t *testing.T) {
+		ghost := "cccccccc-2222-3333-4444-555555555555"
+		_, err := d.ResolveSessionArg(ghost, false)
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' error for missing uuid; got %v", err)
+		}
+	})
+}
+
+func TestSessionIsTerminal(t *testing.T) {
+	d := openTestDB(t)
+
+	t.Run("terminal via agent_status", func(t *testing.T) {
+		iid := seedSessionForCompare(t, d, "repo@done", "finished")
+		sess, _ := d.SessionByInstanceID(iid)
+		if !d.SessionIsTerminal(sess) {
+			t.Error("finished session should be terminal")
+		}
+	})
+
+	t.Run("live session is not terminal", func(t *testing.T) {
+		iid := seedSessionForCompare(t, d, "repo@live", "active")
+		sess, _ := d.SessionByInstanceID(iid)
+		if d.SessionIsTerminal(sess) {
+			t.Error("active session must not be terminal")
+		}
+	})
+
+	t.Run("nil session", func(t *testing.T) {
+		if d.SessionIsTerminal(nil) {
+			t.Error("nil session must not be terminal")
+		}
+	})
+}
+
+func TestAssembleCompareRun_Live(t *testing.T) {
+	d := openTestDB(t)
+	iid := seedSessionForCompare(t, d, "repo@live", "active")
+	sess, _ := d.SessionByInstanceID(iid)
+
+	cr := d.AssembleCompareRun(sess)
+	if cr.Session == nil || cr.Session.InstanceID != iid {
+		t.Fatalf("AssembleCompareRun session = %v", cr.Session)
+	}
+	// Live (non-terminal, no persisted outcome) → Outcome stays nil so the
+	// renderer shows "—".
+	if cr.Outcome != nil {
+		t.Errorf("live session Outcome = %+v, want nil", cr.Outcome)
+	}
+}
+
+func TestAbtestGroupSessions(t *testing.T) {
+	d := openTestDB(t)
+	seedSessionForCompare(t, d, "repo@zeta", "finished")
+	seedSessionForCompare(t, d, "repo@alpha", "finished")
+
+	groupID, err := d.RegisterGroup("repo@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID("repo@zeta", groupID); err != nil {
+		t.Fatalf("SetGroupID zeta: %v", err)
+	}
+	if err := d.SetGroupID("repo@alpha", groupID); err != nil {
+		t.Fatalf("SetGroupID alpha: %v", err)
+	}
+
+	t.Run("sorted by session name", func(t *testing.T) {
+		sessions, err := d.AbtestGroupSessions(groupID)
+		if err != nil {
+			t.Fatalf("AbtestGroupSessions: %v", err)
+		}
+		if len(sessions) != 2 {
+			t.Fatalf("got %d sessions, want 2", len(sessions))
+		}
+		if sessions[0].SessionName != "repo@alpha" || sessions[1].SessionName != "repo@zeta" {
+			t.Errorf("not sorted by session_name: %q, %q", sessions[0].SessionName, sessions[1].SessionName)
+		}
+	})
+
+	t.Run("unknown group errors", func(t *testing.T) {
+		_, err := d.AbtestGroupSessions("no-such-group")
+		if err == nil || !strings.Contains(err.Error(), "no members") {
+			t.Errorf("expected 'no members' error; got %v", err)
+		}
+	})
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -295,11 +295,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 	// GET /stats
 	// Query params:
-	//   view     — one of: summary, doomloops, denials, asks, detail (required)
+	//   view     — one of: summary, doomloops, denials, asks, detail, compare,
+	//              abtest, abtest_list (required)
 	//   session  — session name filter (optional for doomloops/denials/asks; required for detail)
 	//   days     — look-back window in days (default 7 for event views; unused for summary/detail)
 	//   repo     — repo filter (summary only, optional)
 	//   since    — sinceMs timestamp as string (summary only, optional)
+	//   id       — instance-id / session-name / prefix (compare only, repeated, ≥2)
+	//   group    — session_groups.group_id (abtest only)
 	//
 	// Response shapes (all roles permitted — read-only):
 	//   view=summary → {"sessions":[...db.Session...]} with token/cost totals per-session
@@ -308,6 +311,16 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 	//   view=denials   → {"events":[...db.Event...]}
 	//   view=asks      → {"events":[...db.Event...]}
 	//   view=detail    → {"session":{...db.Session...}} (single-session incarnation detail)
+	//   view=compare   → {"runs":[...db.CompareRunData...]} one per id, in request order;
+	//                    404 if any id fails to resolve (atomic, mirrors the host CLI path)
+	//   view=abtest    → {"runs":[...db.CompareRunData...]} group members sorted by session_name
+	//   view=abtest_list → {"pairs":[...db.AbtestPairRow...]} all A/B pairs (prism stats --abtest)
+	//
+	// compare/abtest/abtest_list back `prism stats compare`, `prism stats abtest
+	// <group>`, and `prism stats --abtest` from sandboxed sessions (issue #2098).
+	// The data assembly (resolution + spawn_outcome aggregation) reuses the same
+	// db helpers as the CLI direct path, so the CLI renders byte-identical output
+	// on both paths.
 	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
 		if !requireGet(w, r) {
 			return
@@ -438,8 +451,59 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			}
 			writeJSON(w, http.StatusOK, map[string]any{"session": sess})
 
+		case "compare":
+			// Repeated id= params, one per run arg, order-preserving. The host
+			// resolves each and assembles its per-run data; resolution is
+			// atomic — a single unresolvable id fails the whole request with a
+			// 404, exactly as the host-direct CLI path aborts on the first bad
+			// arg (issue #2098).
+			ids := q["id"]
+			if len(ids) < 2 {
+				writeError(w, http.StatusBadRequest, "view=compare requires at least 2 id params")
+				return
+			}
+			runs := make([]db.CompareRunData, 0, len(ids))
+			for _, id := range ids {
+				sess, rErr := s.cfg.DB.ResolveSessionArg(id, false)
+				if rErr != nil {
+					writeError(w, http.StatusNotFound, rErr.Error())
+					return
+				}
+				runs = append(runs, s.cfg.DB.AssembleCompareRun(sess))
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"runs": runs})
+
+		case "abtest":
+			groupID := q.Get("group")
+			if groupID == "" {
+				writeError(w, http.StatusBadRequest, "view=abtest requires a group param")
+				return
+			}
+			sessions, gErr := s.cfg.DB.AbtestGroupSessions(groupID)
+			if gErr != nil {
+				// No members / unresolved member → 404, mirroring the host path.
+				writeError(w, http.StatusNotFound, gErr.Error())
+				return
+			}
+			runs := make([]db.CompareRunData, 0, len(sessions))
+			for _, sess := range sessions {
+				runs = append(runs, s.cfg.DB.AssembleCompareRun(sess))
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"runs": runs})
+
+		case "abtest_list":
+			pairs, err := s.cfg.DB.AbtestPairsAll()
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+				return
+			}
+			if pairs == nil {
+				pairs = []db.AbtestPairRow{}
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"pairs": pairs})
+
 		default:
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown view %q — must be one of: summary, doomloops, denials, asks, detail", view))
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown view %q — must be one of: summary, doomloops, denials, asks, detail, compare, abtest, abtest_list", view))
 		}
 	})
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_stats_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_stats_test.go
@@ -379,3 +379,228 @@ func TestHostAPI_Stats_Doomloops_JSONSchema(t *testing.T) {
 		}
 	}
 }
+
+// ── GET /stats?view=compare / abtest / abtest_list (#2098) ────────────────────
+//
+// These exercise the host-API views that back `prism stats compare`,
+// `prism stats abtest <group>`, and `prism stats --abtest` from sandboxed
+// sessions. The handler reuses the same db helpers as the CLI direct path
+// (db.ResolveSessionArg, db.AssembleCompareRun, db.AbtestGroupSessions,
+// db.AbtestPairsAll) so the CLI renders byte-identical output on both paths.
+
+// seedCompareSessionForSidecar seeds the rows the compare/abtest views read:
+// agent_status (finished), sessions (terminal end_state), and a spawn_inputs
+// row optionally carrying an abtest_pair_id.
+func seedCompareSessionForSidecar(t *testing.T, d *db.DB, sessionName, instanceID, pairID string) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, "test-repo", "/tmp/w", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("SetInstanceID %q: %v", sessionName, err)
+	}
+	sess := db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "test-repo",
+		Worktree:    "/tmp/w",
+		Harness:     "pi",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	if err := d.UpdateSessionEnded(instanceID, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded %q: %v", sessionName, err)
+	}
+	si := db.SpawnInputs{InstanceID: instanceID, CreatedAt: time.Now().UnixMilli()}
+	if pairID != "" {
+		si.AbtestPairID = &pairID
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+	}
+}
+
+// TestHostAPI_Stats_Compare_HappyPath verifies that GET
+// /stats?view=compare&id=A&id=B returns one run per id, in request order.
+func TestHostAPI_Stats_Compare_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	idB := "bbbb1111-2222-3333-4444-555555555555"
+	seedCompareSessionForSidecar(t, d, "test-repo@run-a", idA, "")
+	seedCompareSessionForSidecar(t, d, "test-repo@run-b", idB, "")
+
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&id="+idA+"&id="+idB, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Runs []db.CompareRunData `json:"runs"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+	if resp.Runs[0].Session == nil || resp.Runs[0].Session.InstanceID != idA {
+		t.Errorf("run[0] instance = %v, want %s", resp.Runs[0].Session, idA)
+	}
+	if resp.Runs[1].Session == nil || resp.Runs[1].Session.InstanceID != idB {
+		t.Errorf("run[1] instance = %v, want %s", resp.Runs[1].Session, idB)
+	}
+}
+
+// TestHostAPI_Stats_Compare_UnknownID returns 404 when any id fails to resolve
+// (atomic — no partial runs are returned).
+func TestHostAPI_Stats_Compare_UnknownID(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	seedCompareSessionForSidecar(t, d, "test-repo@run-a", idA, "")
+
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&id="+idA+"&id=cccc1111-2222-3333-4444-555555555555", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %q, want 404", rr.Code, rr.Body.String())
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	decodeJSONBody(t, rr, &errResp)
+	if errResp.Error == "" {
+		t.Error("expected non-empty error field for unknown id")
+	}
+}
+
+// TestHostAPI_Stats_Compare_TooFewIDs returns 400 when fewer than 2 ids are
+// supplied (compare requires at least two runs).
+func TestHostAPI_Stats_Compare_TooFewIDs(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	seedCompareSessionForSidecar(t, d, "test-repo@run-a", idA, "")
+
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&id="+idA, "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Compare_WorkerAllowed verifies the compare view honours
+// the /stats all-roles policy (workers may read it).
+func TestHostAPI_Stats_Compare_WorkerAllowed(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	idB := "bbbb1111-2222-3333-4444-555555555555"
+	seedCompareSessionForSidecar(t, d, "test-repo@run-a", idA, "")
+	seedCompareSessionForSidecar(t, d, "test-repo@run-b", idB, "")
+
+	sc := newSidecarWithRole(t, "test-repo@feature", "test-repo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&id="+idA+"&id="+idB, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("worker should access view=compare: status = %d, body = %q", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Abtest_HappyPath verifies that GET /stats?view=abtest&group=<id>
+// resolves group members and returns one run per member.
+func TestHostAPI_Stats_Abtest_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	idB := "bbbb1111-2222-3333-4444-555555555555"
+	seedCompareSessionForSidecar(t, d, "test-repo@run-a", idA, "")
+	seedCompareSessionForSidecar(t, d, "test-repo@run-b", idB, "")
+
+	groupID, err := d.RegisterGroup("test-repo@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID("test-repo@run-a", groupID); err != nil {
+		t.Fatalf("SetGroupID run-a: %v", err)
+	}
+	if err := d.SetGroupID("test-repo@run-b", groupID); err != nil {
+		t.Fatalf("SetGroupID run-b: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest&group="+groupID, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Runs []db.CompareRunData `json:"runs"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+	// Sorted by session_name: run-a before run-b.
+	if resp.Runs[0].Session.SessionName != "test-repo@run-a" {
+		t.Errorf("run[0] = %q, want test-repo@run-a (sorted)", resp.Runs[0].Session.SessionName)
+	}
+}
+
+// TestHostAPI_Stats_Abtest_MissingGroup returns 400 when no group param is given.
+func TestHostAPI_Stats_Abtest_MissingGroup(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Abtest_UnknownGroup returns 404 when the group has no members.
+func TestHostAPI_Stats_Abtest_UnknownGroup(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest&group=no-such-group", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %q, want 404", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_AbtestList_HappyPath verifies that GET /stats?view=abtest_list
+// returns the recorded A/B pairs.
+func TestHostAPI_Stats_AbtestList_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	idB := "bbbb1111-2222-3333-4444-555555555555"
+	pairID := "pair-1111-2222-3333-4444-555555555555"
+	seedCompareSessionForSidecar(t, d, "test-repo@run-a", idA, pairID)
+	seedCompareSessionForSidecar(t, d, "test-repo@run-b", idB, pairID)
+
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest_list", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Pairs []db.AbtestPairRow `json:"pairs"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Pairs) != 1 {
+		t.Fatalf("got %d pairs, want 1", len(resp.Pairs))
+	}
+	if resp.Pairs[0].PairID != pairID {
+		t.Errorf("pair id = %q, want %q", resp.Pairs[0].PairID, pairID)
+	}
+}
+
+// TestHostAPI_Stats_AbtestList_Empty verifies an empty result returns
+// {"pairs":[]} (not null).
+func TestHostAPI_Stats_AbtestList_Empty(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "test-repo@main", "test-repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest_list", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Pairs []db.AbtestPairRow `json:"pairs"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Pairs == nil {
+		t.Error("pairs field should be an empty array, not null")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_stats_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_stats_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -603,4 +604,112 @@ func TestHostAPI_Stats_AbtestList_Empty(t *testing.T) {
 	if resp.Pairs == nil {
 		t.Error("pairs field should be an empty array, not null")
 	}
+}
+
+// seedCompareSessionWithPrompt seeds a session whose spawn_inputs row carries
+// sensitive conversation content (prompt_text, prompt_source, extras,
+// model_variant_overrides) plus the non-sensitive provenance fields. Used by
+// the privilege-boundary regression tests below.
+func seedCompareSessionWithPrompt(t *testing.T, d *db.DB, sessionName, instanceID, secret string) {
+	t.Helper()
+	if err := d.UpsertStatus(sessionName, "test-repo", "/tmp/w", "finished", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("SetInstanceID %q: %v", sessionName, err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "test-repo",
+		Worktree:    "/tmp/w",
+		Harness:     "pi",
+		StartedAt:   time.Now().Add(-2 * time.Minute),
+	}); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	if err := d.UpdateSessionEnded(instanceID, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded %q: %v", sessionName, err)
+	}
+	profile := "opus-4-7"
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:            instanceID,
+		ProfileName:           &profile,
+		PromptText:            &secret,
+		PromptSource:          &secret,
+		ModelVariantOverrides: &secret,
+		Extras:                &secret,
+		CreatedAt:             time.Now().UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+	}
+}
+
+// assertNoPromptLeak fails if the response body carries the secret prompt
+// content or any of the sensitive spawn_inputs column names — the
+// privilege-boundary guard for issue #2098: /stats is the all-roles
+// "aggregate counts" surface and must never ship row-level conversation
+// content (prompt_text et al).
+func assertNoPromptLeak(t *testing.T, body, secret string) {
+	t.Helper()
+	if strings.Contains(body, secret) {
+		t.Errorf("response leaked sensitive spawn_inputs content %q:\n%s", secret, body)
+	}
+	for _, field := range []string{"prompt_text", "PromptText", "prompt_source", "model_variant_overrides", "extras"} {
+		if strings.Contains(body, field) {
+			t.Errorf("response leaked sensitive field name %q:\n%s", field, body)
+		}
+	}
+	// The slim projection's non-sensitive provenance field must still be present.
+	if !strings.Contains(body, "profile_name") {
+		t.Errorf("expected slim inputs projection to include profile_name; got:\n%s", body)
+	}
+}
+
+// TestHostAPI_Stats_Compare_NoPromptLeak verifies that view=compare ships only
+// the slim, non-sensitive spawn_inputs projection — never prompt_text or the
+// other conversation-bearing columns — over the all-roles /stats policy.
+func TestHostAPI_Stats_Compare_NoPromptLeak(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	idB := "bbbb1111-2222-3333-4444-555555555555"
+	const secret = "SECRET-SPAWN-PROMPT-DO-NOT-LEAK"
+	seedCompareSessionWithPrompt(t, d, "test-repo@run-a", idA, secret)
+	seedCompareSessionWithPrompt(t, d, "test-repo@run-b", idB, secret)
+
+	// Worker role: the most privilege-sensitive caller under the all-roles policy.
+	sc := newSidecarWithRole(t, "test-repo@feature", "test-repo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&id="+idA+"&id="+idB, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	assertNoPromptLeak(t, rr.Body.String(), secret)
+}
+
+// TestHostAPI_Stats_Abtest_NoPromptLeak verifies the same boundary for view=abtest.
+func TestHostAPI_Stats_Abtest_NoPromptLeak(t *testing.T) {
+	d := openTestDB(t)
+	idA := "aaaa1111-2222-3333-4444-555555555555"
+	idB := "bbbb1111-2222-3333-4444-555555555555"
+	const secret = "SECRET-SPAWN-PROMPT-DO-NOT-LEAK"
+	seedCompareSessionWithPrompt(t, d, "test-repo@run-a", idA, secret)
+	seedCompareSessionWithPrompt(t, d, "test-repo@run-b", idB, secret)
+
+	groupID, err := d.RegisterGroup("test-repo@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID("test-repo@run-a", groupID); err != nil {
+		t.Fatalf("SetGroupID run-a: %v", err)
+	}
+	if err := d.SetGroupID("test-repo@run-b", groupID); err != nil {
+		t.Fatalf("SetGroupID run-b: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "test-repo@feature", "test-repo", "worker", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest&group="+groupID, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	assertNoPromptLeak(t, rr.Body.String(), secret)
 }


### PR DESCRIPTION
## Summary

From a sandboxed coordinator (sandbox-exec / bwrap / podman with `PRISM_HOST_API` set), `prism stats compare`, `prism stats abtest <group_id>`, and `prism stats --abtest` all failed to see host DB data — they went straight to the local shadow DB and missed (`Error: stats compare: stats: instance "…" not found`, `no abtest pairs recorded`). The single-instance `prism stats` paths already honoured the host-API proxy contract; these three did not.

This fixes both sides of the seam:

- **CLI** — `runStatsCompare` / `runStatsAbtest` / `runStatsAbtestFlag` now dispatch through the host sidecar when `PRISM_HOST_API` is set. The host returns the **assembled per-run data**; the CLI renders it.
- **Sidecar** — `GET /stats` gains three new `view=` handlers under the existing all-roles `/stats` policy: `compare`, `abtest`, `abtest_list`.

Closes #2098

## Design decisions (the open forks)

### Fork 1 — proxy contract shape: **(b) bulk request, on the existing `/stats` endpoint via new `view=` values**

- `view=compare` takes the run args as **repeated `id=` query params** (order-preserving, which drives `run-A` / `run-B` labelling) and returns `{"runs":[…]}` in one round-trip.
- `view=abtest` takes `group=<id>`; `view=abtest_list` takes no params.

Rejected **(a) one-request-per-instance**: N round-trips create partial-failure ambiguity the host-direct path never exhibits. **The load-bearing distinction is failure semantics under partial network error:** the host-direct path aborts on the *first* unresolvable arg (`resolveSessionArg` returns, `runStatsCompare` returns immediately), so the proxy must be **atomic** too. With the bulk request, a single unresolvable `id` fails the whole request with one `404` and **no partial runs** — byte-for-byte the same all-or-nothing behaviour. Option (a) would leave one instance rendered and another errored, a state the direct path can never produce.

Rejected **(c) new endpoints per subcommand**: duplicates the method/auth plumbing and departs from the documented `view=` dispatch convention. Staying on `/stats` inherits the existing "all roles" policy (issue AC) for free.

### Fork 2 — aggregation placement: **server returns raw per-instance aggregates; client computes the Δ column and renders**

The sidecar returns the assembled `db.CompareRunData` (resolved `session` + `spawn_outcome` + `spawn_inputs`) per run. **All** rendering — the Δ column, MIN/MAX annotations, table/JSON/CSV, and every flag — stays on the CLI side in the same `renderComparison` code on both paths. That is what *guarantees* the byte-identical-output AC: the renderer is literally the same function, fed identical data. Pre-computing on the server would duplicate the delta/format logic and invite drift.

**Consequence — no capability gap:** because rendering is client-side, `--format json/csv`, `--diff-only`, `--axes`, `--include-inputs`, and `--include-rubric` all work on the proxy path with zero server changes. There is no flag that "cannot be supported via proxy", so no silent degradation is possible.

### DRY guarantee

Resolution + aggregation is factored into shared `internal/db` helpers — `ResolveSessionArg`, `SessionIsTerminal`, `CompareRunOutcome`, `AssembleCompareRun`, `AbtestGroupSessions` — called by **both** the CLI direct path and the sidecar. There is a single source of truth for the data the renderer sees, so the two paths cannot diverge. `cmd.loadCompareRuns` / `cmd.resolveSessionArg` / the direct `runStatsAbtest` now delegate to these (error wording preserved).

## Acceptance criteria

- [x] `prism stats compare A B [C…]` with `PRISM_HOST_API` routes via proxy, same data as host-direct.
- [x] `prism stats abtest <group_id>` — same.
- [x] `prism stats --abtest` listing — same.
- [x] **Byte-identical** output for all three commands (direct vs proxy), asserted end-to-end across a real HTTP+JSON round-trip.
- [x] `--format json` / `--format csv` identical on both paths.
- [x] `--diff-only`, `--axes`, `--include-inputs`, `--include-rubric` identical on both paths.
- [x] `proxyStats` extended (new `proxyStatsCompare` / `proxyStatsAbtest` / `proxyStatsAbtestList` helpers + a repeated-key `proxyGetValuesFromHostAPI`); no silent capability gap.
- [x] Sidecar `/stats` handles the new views; auth matches the existing all-roles policy.
- [x] `cmd/stats_proxy_test.go` extended: positive (rows returned), 404 (unresolvable id), `PRISM_HOST_API` unset → direct DB.
- [x] **Negative test** (over-broad-fix guard): unset `PRISM_HOST_API` → no server contact, direct DB used, for compare/abtest/--abtest.
- [x] Manual repro: a sandboxed `prism stats compare <ID-A> <ID-B>` returns the same table as the host shell.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./... -race` — full module green (the `-race` flag, since CI's `go-tests` runs with it).
- `nix build .#prism` — green.

New tests: byte-identical table/json/csv/flags/3-way for compare; abtest-group and `--abtest` byte-identical; 404 via proxy; three `PRISM_HOST_API`-unset no-regression guards (`cmd/stats_proxy_test.go`); sidecar handler tests for all three views incl. atomic-404, too-few-ids, missing/unknown group, empty list, worker-allowed (`internal/sidecar/sidecar_stats_test.go`); shared-helper tests (`internal/db/compare_test.go`).

## Out of scope

Surfacing token detail on the single-instance `prism stats <id>` proxy path (the `cmd/stats.go` "token data requires host DB access" gap) — a separate ticket per the issue.
