### PR TITLE
prism: proxy stats compare / abtest / --abtest via host-API (#2098)

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -242,6 +242,46 @@ func proxyStats(apiURL, view, sessionFilter string, days int, repoFilter string,
 	return proxyReadToHostAPI(apiURL, "/stats", params)
 }
 
+// proxyStatsCompare proxies a `prism stats compare` request to the host-API
+// sidecar. apiURL is the value of PRISM_HOST_API. ids is the list of
+// session-name / instance-id / UUID-prefix arguments passed on the command
+// line; they are joined with commas and forwarded verbatim so the server
+// resolves them with the same disambiguation rules the CLI uses on the
+// direct-DB path. Returns the raw {"runs":[...]} JSON envelope for the
+// caller to unmarshal and render. Added for issue #2098.
+//
+// We deliberately use a single bulk request rather than N per-instance
+// requests so partial-failure semantics are unambiguous: if any id fails
+// to resolve, the server returns a single 404 and the whole comparison
+// fails — matching the direct-DB behaviour where `resolveSessionArg`
+// aborts on the first miss. The single-request shape also keeps the
+// round-trip count at one regardless of how many ids the user passes.
+func proxyStatsCompare(apiURL string, ids []string) ([]byte, error) {
+	return proxyReadToHostAPI(apiURL, "/stats", map[string]string{
+		"view": "compare",
+		"ids":  strings.Join(ids, ","),
+	})
+}
+
+// proxyStatsAbtest proxies a `prism stats abtest <group_id>` request to the
+// host-API sidecar. Returns the same {"runs":[...]} envelope shape as
+// proxyStatsCompare. Added for issue #2098.
+func proxyStatsAbtest(apiURL, groupID string) ([]byte, error) {
+	return proxyReadToHostAPI(apiURL, "/stats", map[string]string{
+		"view":     "abtest",
+		"group_id": groupID,
+	})
+}
+
+// proxyStatsAbtestList proxies a `prism stats --abtest` request to the
+// host-API sidecar. Returns the raw {"pairs":[...db.AbtestPairRow...]}
+// JSON for the caller to unmarshal and render. Added for issue #2098.
+func proxyStatsAbtestList(apiURL string) ([]byte, error) {
+	return proxyReadToHostAPI(apiURL, "/stats", map[string]string{
+		"view": "abtest_list",
+	})
+}
+
 // proxyListSessions proxies a list-sessions request to the host-API sidecar.
 // apiURL is the value of PRISM_HOST_API. showAll controls whether the all=true
 // query parameter is sent. Returns the raw JSON output for the caller to render.

--- a/modules/programs/prism/prism/cmd/stats_abtest.go
+++ b/modules/programs/prism/prism/cmd/stats_abtest.go
@@ -10,18 +10,31 @@ package cmd
 //   - Outcome (both finished, one errored, one still running, etc.)
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar"
 )
 
 // runStatsAbtestFlag implements prism stats --abtest (the --abtest top-level flag,
 // distinct from `prism stats abtest <group_id>` which is runStatsAbtest in stats_compare.go).
+//
+// When PRISM_HOST_API is set the request is forwarded to the host sidecar's
+// GET /stats?view=abtest_list endpoint so an in-sandbox coordinator listing
+// pairs sees the host DB rather than the (empty / partial) shadow DB inside
+// the container (issue #2098). The empty-set helper line is rendered on the
+// CLI side on both paths so the user-facing output is byte-identical.
 func runStatsAbtestFlag() error {
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runStatsAbtestFlagProxy(apiURL)
+	}
+
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats --abtest: %w", err)
@@ -34,13 +47,39 @@ func runStatsAbtestFlag() error {
 	}
 
 	if len(pairs) == 0 {
-		fmt.Println("no abtest pairs recorded")
-		fmt.Println("  Use 'prism spawn --abtest <profileA> <profileB> --prompt \"...\"' to create a pair.")
+		printAbtestPairsEmpty()
 		return nil
 	}
 
 	renderAbtestPairsTable(pairs)
 	return nil
+}
+
+// runStatsAbtestFlagProxy handles the PRISM_HOST_API path for
+// `prism stats --abtest`. The host sidecar returns the raw
+// {"pairs":[...db.AbtestPairRow...]} envelope and the CLI renders.
+func runStatsAbtestFlagProxy(apiURL string) error {
+	raw, err := proxyStatsAbtestList(apiURL)
+	if err != nil {
+		return fmt.Errorf("stats --abtest: %w", err)
+	}
+	var resp sidecar.StatsAbtestListResponseWire
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("stats --abtest: unmarshal response: %w", err)
+	}
+	if len(resp.Pairs) == 0 {
+		printAbtestPairsEmpty()
+		return nil
+	}
+	renderAbtestPairsTable(resp.Pairs)
+	return nil
+}
+
+// printAbtestPairsEmpty prints the two-line "no pairs recorded" hint shared
+// between the direct-DB and proxy paths.
+func printAbtestPairsEmpty() {
+	fmt.Println("no abtest pairs recorded")
+	fmt.Println("  Use 'prism spawn --abtest <profileA> <profileB> --prompt \"...\"' to create a pair.")
 }
 
 // renderAbtestPairsTable renders the abtest pairs table to stdout.
@@ -53,14 +92,14 @@ func renderAbtestPairsTable(pairs []db.AbtestPairRow) {
 	fmt.Println()
 
 	const (
-		wPairID   = 12
-		wSession  = 36
-		wProfile  = 16
-		wTurns    = 6
-		wTokIn    = 9
-		wTokOut   = 9
-		wDur      = 9
-		wState    = 12
+		wPairID  = 12
+		wSession = 36
+		wProfile = 16
+		wTurns   = 6
+		wTokIn   = 9
+		wTokOut  = 9
+		wDur     = 9
+		wState   = 12
 	)
 
 	header := fmt.Sprintf("%-*s  %-*s  %-*s  %*s  %*s  %*s  %*s  %-*s",

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -201,6 +201,12 @@ func runStatsAbtestProxy(cmd *cobra.Command, groupID, apiURL string) error {
 // any payload is missing the required sessions row (defence-in-depth: the
 // sidecar always populates this field, but a malformed response would
 // otherwise NPE deep in axisValue).
+//
+// The wire-side spawn_inputs subset (StatsCompareInputsWire) is expanded
+// back into the partial db.SpawnInputs the renderer expects — the cmd-side
+// axisValue / inputsValue paths only read the six restricted fields, so
+// re-using db.SpawnInputs here costs nothing while keeping the renderer
+// type-stable across the direct-DB and proxy paths.
 func wireRunsToCompareRuns(wireRuns []sidecar.StatsCompareRunWire) ([]compareRun, error) {
 	runs := make([]compareRun, 0, len(wireRuns))
 	for i, w := range wireRuns {
@@ -214,11 +220,23 @@ func wireRunsToCompareRuns(wireRuns []sidecar.StatsCompareRunWire) ([]compareRun
 			// loadCompareRuns labelling.
 			label = "run-" + string(rune('A'+i))
 		}
+		var inputs *db.SpawnInputs
+		if w.Inputs != nil {
+			inputs = &db.SpawnInputs{
+				InstanceID:    w.Session.InstanceID,
+				ProfileName:   w.Inputs.ProfileName,
+				HarnessFlag:   w.Inputs.HarnessFlag,
+				IsolationFlag: w.Inputs.IsolationFlag,
+				AgentFlag:     w.Inputs.AgentFlag,
+				BranchFlag:    w.Inputs.BranchFlag,
+				AbtestPairID:  w.Inputs.AbtestPairID,
+			}
+		}
 		runs = append(runs, compareRun{
 			Label:   label,
 			Session: w.Session,
 			Outcome: w.Outcome,
-			Inputs:  w.Inputs,
+			Inputs:  inputs,
 		})
 	}
 	return runs, nil

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar"
 )
 
 // ---------- cobra command wiring ----------
@@ -82,6 +83,17 @@ func init() {
 // ---------- runner functions ----------
 
 func runStatsCompare(cmd *cobra.Command, args []string) error {
+	// PRISM_HOST_API proxy dispatch: in-sandbox sessions cannot reach the
+	// host DB directly, so forward the raw args verbatim to the host
+	// sidecar's GET /stats?view=compare endpoint. The server resolves each
+	// arg the same way `resolveSessionArg` does locally and returns the
+	// per-run (session, outcome, inputs) triples; the renderer below is
+	// unchanged so output is byte-identical to a host-direct invocation.
+	// Issue #2098.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runStatsCompareProxy(cmd, args, apiURL)
+	}
+
 	d, err := openDB()
 	if err != nil {
 		return fmt.Errorf("stats compare: %w", err)
@@ -103,6 +115,14 @@ func runStatsCompare(cmd *cobra.Command, args []string) error {
 
 func runStatsAbtest(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
+
+	// PRISM_HOST_API proxy dispatch (issue #2098). The server resolves the
+	// group members and returns the same {"runs":[...]} envelope as
+	// view=compare, sorted by session_name to match the direct-DB path's
+	// deterministic ordering.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		return runStatsAbtestProxy(cmd, groupID, apiURL)
+	}
 
 	d, err := openDB()
 	if err != nil {
@@ -139,6 +159,71 @@ func runStatsAbtest(cmd *cobra.Command, args []string) error {
 	return runComparison(cmd, d, sessions)
 }
 
+// runStatsCompareProxy handles the PRISM_HOST_API path for `prism stats
+// compare`. It forwards the raw args to the sidecar, unmarshals the per-run
+// payloads, and hands them to the same renderer the direct-DB path uses.
+func runStatsCompareProxy(cmd *cobra.Command, args []string, apiURL string) error {
+	raw, err := proxyStatsCompare(apiURL, args)
+	if err != nil {
+		return fmt.Errorf("stats compare: %w", err)
+	}
+	var resp sidecar.StatsCompareResponseWire
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("stats compare: unmarshal response: %w", err)
+	}
+	runs, err := wireRunsToCompareRuns(resp.Runs)
+	if err != nil {
+		return fmt.Errorf("stats compare: %w", err)
+	}
+	return renderComparison(cmd, runs)
+}
+
+// runStatsAbtestProxy handles the PRISM_HOST_API path for `prism stats abtest
+// <group_id>`.
+func runStatsAbtestProxy(cmd *cobra.Command, groupID, apiURL string) error {
+	raw, err := proxyStatsAbtest(apiURL, groupID)
+	if err != nil {
+		return fmt.Errorf("stats abtest: %w", err)
+	}
+	var resp sidecar.StatsCompareResponseWire
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("stats abtest: unmarshal response: %w", err)
+	}
+	runs, err := wireRunsToCompareRuns(resp.Runs)
+	if err != nil {
+		return fmt.Errorf("stats abtest: %w", err)
+	}
+	return renderComparison(cmd, runs)
+}
+
+// wireRunsToCompareRuns converts the server-side per-run payloads into the
+// cmd-local compareRun shape consumed by the renderer. Returns an error if
+// any payload is missing the required sessions row (defence-in-depth: the
+// sidecar always populates this field, but a malformed response would
+// otherwise NPE deep in axisValue).
+func wireRunsToCompareRuns(wireRuns []sidecar.StatsCompareRunWire) ([]compareRun, error) {
+	runs := make([]compareRun, 0, len(wireRuns))
+	for i, w := range wireRuns {
+		if w.Session == nil {
+			return nil, fmt.Errorf("proxy response: run %d missing session", i)
+		}
+		label := w.Label
+		if label == "" {
+			// Defensive fallback so an empty server-side label does not
+			// produce "run-" rendered cells. Matches the cmd-side
+			// loadCompareRuns labelling.
+			label = "run-" + string(rune('A'+i))
+		}
+		runs = append(runs, compareRun{
+			Label:   label,
+			Session: w.Session,
+			Outcome: w.Outcome,
+			Inputs:  w.Inputs,
+		})
+	}
+	return runs, nil
+}
+
 // ---------- comparison engine ----------
 
 // compareRun holds per-run data for the comparison.
@@ -164,8 +249,21 @@ type axisRow struct {
 	Values []string // one per run
 }
 
-// runComparison is the shared engine for compare and abtest.
+// runComparison is the shared engine for compare and abtest on the
+// direct-DB path. It loads the per-run data via loadCompareRuns and hands
+// off to renderComparison — the same renderer the proxy path uses, which
+// is how byte-identity between the two paths is guaranteed (issue #2098).
 func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
+	runs := loadCompareRuns(d, sessions)
+	return renderComparison(cmd, runs)
+}
+
+// renderComparison reads the comparison-engine flags (--format, --axes,
+// --diff-only, --include-inputs, --include-rubric) and renders the
+// provided runs in the chosen format. Shared between the direct-DB and
+// proxy paths so that --format json / --format csv / table output is
+// byte-identical between them.
+func renderComparison(cmd *cobra.Command, runs []compareRun) error {
 	format, _ := cmd.Flags().GetString("format")
 	diffOnly, _ := cmd.Flags().GetBool("diff-only")
 	includeRubric, _ := cmd.Flags().GetBool("include-rubric")
@@ -176,11 +274,8 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 	includeInputsVal, _ := cmd.Flags().GetBool("include-inputs")
 	includeInputs := includeInputsVal
 	if !includeInputsFlagSet {
-		includeInputs = len(sessions) == 2
+		includeInputs = len(runs) == 2
 	}
-
-	// Build run labels as run-A, run-B, run-C...
-	runs := loadCompareRuns(d, sessions)
 
 	// Collect desired axes.
 	wantAxes := defaultAxes()

--- a/modules/programs/prism/prism/cmd/stats_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/stats_proxy_test.go
@@ -427,12 +427,10 @@ func proxyCompareFixture() sidecar.StatsCompareResponseWire {
 		ToolCallCount:     5,
 		MsgAssistantCount: 4,
 	}
-	inA := &db.SpawnInputs{
-		InstanceID:  sessA.InstanceID,
+	inA := &sidecar.StatsCompareInputsWire{
 		ProfileName: &profA,
 	}
-	inB := &db.SpawnInputs{
-		InstanceID:  sessB.InstanceID,
+	inB := &sidecar.StatsCompareInputsWire{
 		ProfileName: &profB,
 	}
 	return sidecar.StatsCompareResponseWire{

--- a/modules/programs/prism/prism/cmd/stats_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/stats_proxy_test.go
@@ -16,7 +16,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar"
 )
 
 // fakeStatsServer is a minimal mock for the /stats endpoint.
@@ -256,7 +259,7 @@ func TestRunStatsProxy_SummaryJSON(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", apiURL)
 
-	statsCmd.Flags().Set("json", "true")      //nolint:errcheck
+	statsCmd.Flags().Set("json", "true")        //nolint:errcheck
 	defer statsCmd.Flags().Set("json", "false") //nolint:errcheck
 
 	out := captureStdout(t, func() {
@@ -294,7 +297,7 @@ func TestRunStatsProxy_GroupByFallsThrough(t *testing.T) {
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 
 	statsCmd.Flags().Set("group-by", "harness") //nolint:errcheck
-	defer statsCmd.Flags().Set("group-by", "") //nolint:errcheck
+	defer statsCmd.Flags().Set("group-by", "")  //nolint:errcheck
 
 	_ = captureStdout(t, func() {
 		// Uses local DB (empty) — should produce output from runStatsGroupBy,
@@ -322,7 +325,7 @@ func TestRunStatsProxy_DaysHistoricalFallsThrough(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", srv.apiURL())
 
-	statsCmd.Flags().Set("days", "7")  //nolint:errcheck
+	statsCmd.Flags().Set("days", "7")       //nolint:errcheck
 	defer statsCmd.Flags().Set("days", "0") //nolint:errcheck
 
 	_ = captureStdout(t, func() {
@@ -363,5 +366,596 @@ func TestRunStatsProxy_HostPathUnchanged(t *testing.T) {
 	}
 	if !strings.Contains(out, "Doom Loop Events") {
 		t.Errorf("output missing 'Doom Loop Events' heading for direct-DB path; got:\n%s", out)
+	}
+}
+
+// ── stats compare / abtest / --abtest proxy tests (#2098) ────────────────────
+
+// proxyCompareFixture builds a synthetic StatsCompareResponseWire payload —
+// the same shape the host sidecar emits for GET /stats?view=compare. Tests
+// hand this to a mock server so the proxy path can be exercised without
+// standing up a real sidecar.
+func proxyCompareFixture() sidecar.StatsCompareResponseWire {
+	startedA := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	startedB := time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC)
+	endedA := startedA.Add(2 * time.Minute)
+	endedB := startedB.Add(3 * time.Minute)
+
+	stateFinished := "finished"
+	durA := int64(120000)
+	durB := int64(180000)
+	profA := "anthropic-opus-max-4-7"
+	profB := "anthropic-opus-max-4-8"
+
+	sessA := &db.Session{
+		InstanceID:  "aaaaaaaa-1111-2222-3333-444444444444",
+		SessionName: "repo@run-a",
+		Repo:        "repo",
+		Worktree:    "/wt/run-a",
+		Harness:     "pi",
+		StartedAt:   startedA,
+		EndedAt:     &endedA,
+		EndState:    &stateFinished,
+	}
+	sessB := &db.Session{
+		InstanceID:  "bbbbbbbb-1111-2222-3333-444444444444",
+		SessionName: "repo@run-b",
+		Repo:        "repo",
+		Worktree:    "/wt/run-b",
+		Harness:     "pi",
+		StartedAt:   startedB,
+		EndedAt:     &endedB,
+		EndState:    &stateFinished,
+	}
+	outA := &db.SpawnOutcome{
+		InstanceID:        sessA.InstanceID,
+		EndState:          &stateFinished,
+		DurationMs:        &durA,
+		TokensInputTotal:  1500,
+		TokensOutputTotal: 700,
+		CostUSDTotal:      0.12,
+		ToolCallCount:     3,
+		MsgAssistantCount: 2,
+	}
+	outB := &db.SpawnOutcome{
+		InstanceID:        sessB.InstanceID,
+		EndState:          &stateFinished,
+		DurationMs:        &durB,
+		TokensInputTotal:  2000,
+		TokensOutputTotal: 900,
+		CostUSDTotal:      0.34,
+		ToolCallCount:     5,
+		MsgAssistantCount: 4,
+	}
+	inA := &db.SpawnInputs{
+		InstanceID:  sessA.InstanceID,
+		ProfileName: &profA,
+	}
+	inB := &db.SpawnInputs{
+		InstanceID:  sessB.InstanceID,
+		ProfileName: &profB,
+	}
+	return sidecar.StatsCompareResponseWire{
+		Runs: []sidecar.StatsCompareRunWire{
+			{Label: "run-A", Session: sessA, Outcome: outA, Inputs: inA},
+			{Label: "run-B", Session: sessB, Outcome: outB, Inputs: inB},
+		},
+	}
+}
+
+// resetCompareFlags returns compareCmd's flags to their declared defaults
+// between tests. Cobra-defined flags are package-global, so the
+// statsCmd-style "set, defer set" pattern must be applied per-test.
+func resetCompareFlags(t *testing.T) {
+	t.Helper()
+	_ = compareCmd.Flags().Set("format", "table")
+	_ = compareCmd.Flags().Set("diff-only", "false")
+	_ = compareCmd.Flags().Set("include-rubric", "false")
+	_ = compareCmd.Flags().Set("include-inputs", "false")
+	// Mark include-inputs as not-explicitly-set so the renderer applies its
+	// "on for 2-run, off for 3+" default. cobra.Flags has no public API for
+	// clearing Changed, so we rely on tests not depending on the prior state.
+}
+
+// resetAbtestFlags is the analogue of resetCompareFlags for abtestCmd.
+func resetAbtestFlags(t *testing.T) {
+	t.Helper()
+	_ = abtestCmd.Flags().Set("format", "table")
+	_ = abtestCmd.Flags().Set("diff-only", "false")
+	_ = abtestCmd.Flags().Set("include-rubric", "false")
+	_ = abtestCmd.Flags().Set("include-inputs", "false")
+}
+
+// ── proxyStats* helper signature tests ───────────────────────────────────────
+
+// TestProxyStatsCompare_SendsCorrectQueryParams verifies that proxyStatsCompare
+// sends GET /stats with view=compare and a comma-joined ids list.
+func TestProxyStatsCompare_SendsCorrectQueryParams(t *testing.T) {
+	respBody := `{"runs":[]}`
+	srv, apiURL := startFakeStatsServer(t, []byte(respBody))
+
+	_, err := proxyStatsCompare(apiURL, []string{"run-A", "run-B"})
+	if err != nil {
+		t.Fatalf("proxyStatsCompare: %v", err)
+	}
+	if srv.capturedPath != "/stats" {
+		t.Errorf("path = %q, want /stats", srv.capturedPath)
+	}
+	if !strings.Contains(srv.capturedQuery, "view=compare") {
+		t.Errorf("query %q missing view=compare", srv.capturedQuery)
+	}
+	if !strings.Contains(srv.capturedQuery, "ids=run-A%2Crun-B") {
+		t.Errorf("query %q missing ids=run-A%%2Crun-B", srv.capturedQuery)
+	}
+}
+
+// TestProxyStatsAbtest_SendsCorrectQueryParams verifies that proxyStatsAbtest
+// sends GET /stats with view=abtest and group_id.
+func TestProxyStatsAbtest_SendsCorrectQueryParams(t *testing.T) {
+	respBody := `{"runs":[]}`
+	srv, apiURL := startFakeStatsServer(t, []byte(respBody))
+
+	_, err := proxyStatsAbtest(apiURL, "grp-123")
+	if err != nil {
+		t.Fatalf("proxyStatsAbtest: %v", err)
+	}
+	if !strings.Contains(srv.capturedQuery, "view=abtest") {
+		t.Errorf("query %q missing view=abtest", srv.capturedQuery)
+	}
+	if !strings.Contains(srv.capturedQuery, "group_id=grp-123") {
+		t.Errorf("query %q missing group_id=grp-123", srv.capturedQuery)
+	}
+}
+
+// TestProxyStatsAbtestList_SendsCorrectQueryParams verifies the view=abtest_list
+// query is sent verbatim with no extra params.
+func TestProxyStatsAbtestList_SendsCorrectQueryParams(t *testing.T) {
+	respBody := `{"pairs":[]}`
+	srv, apiURL := startFakeStatsServer(t, []byte(respBody))
+
+	_, err := proxyStatsAbtestList(apiURL)
+	if err != nil {
+		t.Fatalf("proxyStatsAbtestList: %v", err)
+	}
+	if !strings.Contains(srv.capturedQuery, "view=abtest_list") {
+		t.Errorf("query %q missing view=abtest_list", srv.capturedQuery)
+	}
+}
+
+// ── runStatsCompare proxy integration tests ──────────────────────────────────
+
+// TestRunStatsCompare_ProxyHappyPath verifies that when PRISM_HOST_API is set,
+// the compare command pulls per-run data from the host-API proxy and renders
+// the labels and core axis values.
+func TestRunStatsCompare_ProxyHappyPath(t *testing.T) {
+	fixture := proxyCompareFixture()
+	respBody, _ := json.Marshal(fixture)
+
+	srv, apiURL := startFakeStatsServer(t, respBody)
+	t.Setenv("PRISM_HOST_API", apiURL)
+	resetCompareFlags(t)
+	defer resetCompareFlags(t)
+
+	args := []string{"repo@run-a", "repo@run-b"}
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, args); err != nil {
+			t.Errorf("runStatsCompare proxy: %v", err)
+		}
+	})
+
+	if !strings.Contains(srv.capturedQuery, "view=compare") {
+		t.Errorf("proxy did not receive view=compare; query=%q", srv.capturedQuery)
+	}
+	if !strings.Contains(srv.capturedQuery, "ids=repo%40run-a%2Crepo%40run-b") {
+		t.Errorf("proxy did not receive expected ids; query=%q", srv.capturedQuery)
+	}
+	if !strings.Contains(out, "run-A") || !strings.Contains(out, "run-B") {
+		t.Errorf("output missing run labels:\n%s", out)
+	}
+	if !strings.Contains(out, "finished") {
+		t.Errorf("output missing 'finished' end_state:\n%s", out)
+	}
+	// Token totals from the fixture should be visible in the rendered table.
+	if !strings.Contains(out, "1.5K") && !strings.Contains(out, "1500") {
+		t.Errorf("output missing run-A tokens_input (1.5K/1500):\n%s", out)
+	}
+}
+
+// TestRunStatsCompare_Proxy404Surface verifies that a 404 from the sidecar is
+// surfaced as an error containing the missing-id phrase.
+func TestRunStatsCompare_Proxy404Surface(t *testing.T) {
+	respBody := `{"error":"instance \"ghost\" not found"}`
+	srv := &fakeStatsServer{response: []byte(respBody), statusCode: http.StatusNotFound}
+	mock := newMockUnixServer(t, srv.handler().ServeHTTP)
+
+	t.Setenv("PRISM_HOST_API", mock.apiURL())
+	resetCompareFlags(t)
+	defer resetCompareFlags(t)
+
+	args := []string{"ghost", "repo@run-b"}
+	out := captureStdout(t, func() {
+		err := runStatsCompare(compareCmd, args)
+		if err == nil {
+			t.Fatal("expected error for 404 from proxy, got nil")
+		}
+		if !strings.Contains(err.Error(), "ghost") && !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error %q does not mention ghost or not found", err.Error())
+		}
+	})
+	_ = out
+}
+
+// TestRunStatsCompare_ProxyJSONFormat verifies that --format json with a proxy
+// response produces valid JSON containing the runs array.
+func TestRunStatsCompare_ProxyJSONFormat(t *testing.T) {
+	fixture := proxyCompareFixture()
+	respBody, _ := json.Marshal(fixture)
+
+	_, apiURL := startFakeStatsServer(t, respBody)
+	t.Setenv("PRISM_HOST_API", apiURL)
+	resetCompareFlags(t)
+	_ = compareCmd.Flags().Set("format", "json")
+	defer resetCompareFlags(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, []string{"repo@run-a", "repo@run-b"}); err != nil {
+			t.Errorf("runStatsCompare --format json proxy: %v", err)
+		}
+	})
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); err != nil {
+		t.Fatalf("--format json output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	if _, ok := parsed["runs"]; !ok {
+		t.Errorf("JSON output missing 'runs' key:\n%s", out)
+	}
+	if _, ok := parsed["diffs"]; !ok {
+		t.Errorf("JSON output missing 'diffs' key:\n%s", out)
+	}
+}
+
+// TestRunStatsCompare_ProxyCSVFormat verifies --format csv via proxy.
+func TestRunStatsCompare_ProxyCSVFormat(t *testing.T) {
+	fixture := proxyCompareFixture()
+	respBody, _ := json.Marshal(fixture)
+
+	_, apiURL := startFakeStatsServer(t, respBody)
+	t.Setenv("PRISM_HOST_API", apiURL)
+	resetCompareFlags(t)
+	_ = compareCmd.Flags().Set("format", "csv")
+	defer resetCompareFlags(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, []string{"repo@run-a", "repo@run-b"}); err != nil {
+			t.Errorf("runStatsCompare --format csv proxy: %v", err)
+		}
+	})
+
+	// CSV header must include axis,run-A,run-B,delta on a 2-run comparison.
+	if !strings.HasPrefix(strings.TrimSpace(out), "axis,run-A,run-B,delta") {
+		t.Errorf("CSV output missing expected header line; got:\n%s", out)
+	}
+}
+
+// TestRunStatsCompare_ProxyDiffOnly verifies that --diff-only is honoured on
+// the proxy path (filtering happens on the CLI side after unmarshaling).
+func TestRunStatsCompare_ProxyDiffOnly(t *testing.T) {
+	fixture := proxyCompareFixture()
+	respBody, _ := json.Marshal(fixture)
+
+	_, apiURL := startFakeStatsServer(t, respBody)
+	t.Setenv("PRISM_HOST_API", apiURL)
+	resetCompareFlags(t)
+	_ = compareCmd.Flags().Set("diff-only", "true")
+	defer resetCompareFlags(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, []string{"repo@run-a", "repo@run-b"}); err != nil {
+			t.Errorf("runStatsCompare --diff-only proxy: %v", err)
+		}
+	})
+
+	// end_state is "finished" for both runs in the fixture; with --diff-only
+	// the row must be filtered out.
+	if strings.Contains(out, "end_state:") {
+		t.Errorf("--diff-only should have filtered end_state row but it is present:\n%s", out)
+	}
+	// duration_ms differs between A (120000) and B (180000) — the row stays.
+	if !strings.Contains(out, "duration_ms:") {
+		t.Errorf("--diff-only should NOT filter duration_ms (values differ):\n%s", out)
+	}
+}
+
+// TestRunStatsCompare_HostPathUnchanged is the over-broad-fix guard required
+// by the issue's AC: with PRISM_HOST_API unset, runStatsCompare must hit the
+// direct-DB path and NOT contact any HTTP server.
+func TestRunStatsCompare_HostPathUnchanged(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+	iidA := seedCompareSession(t, d, "repo@run-a", startedAt, agent.StateFinished, nil)
+	iidB := seedCompareSession(t, d, "repo@run-b", startedAt.Add(time.Second), agent.StateFinished, nil)
+	_ = iidA
+	_ = iidB
+
+	requestCount := 0
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"runs":[]}`))
+	})
+	_ = srv
+	// openStatsTestDB has set PRISM_HOST_API="" already; do not override.
+
+	resetCompareFlags(t)
+	defer resetCompareFlags(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, []string{"repo@run-a", "repo@run-b"}); err != nil {
+			t.Errorf("runStatsCompare direct-DB: %v", err)
+		}
+	})
+
+	if requestCount > 0 {
+		t.Errorf("proxy server received %d request(s); should use direct DB", requestCount)
+	}
+	// Render at least produced something — the session labels are a good
+	// signal the renderer ran on real DB rows.
+	if !strings.Contains(out, "run-A") || !strings.Contains(out, "run-B") {
+		t.Errorf("direct-DB output missing run labels:\n%s", out)
+	}
+}
+
+// TestRunStatsCompare_ProxyByteIdentity verifies the core AC of #2098: the
+// proxy path renders byte-identically to the direct-DB path when the
+// underlying data is the same. We seed a DB with assistant turns, persist
+// the spawn_outcome rows (so neither path computes on the fly), capture
+// the direct-DB output, build the wire payload from the SAME DB rows,
+// serve it via mock, run the proxy path, and assert exact equality.
+//
+// Persisting the outcome rows is what keeps the test deterministic:
+// ComputeSpawnOutcome stamps ComputedAt = time.Now() on each call, so two
+// uncached invocations would differ in that field. Reading the persisted
+// row twice returns the same ComputedAt value, and the JSON roundtrip
+// preserves it.
+func TestRunStatsCompare_ProxyByteIdentity(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	const (
+		nameA = "repo@compare-a"
+		nameB = "repo@compare-b"
+	)
+	iidA := seedCompareSession(t, d, nameA, startedAt, agent.StateFinished, nil)
+	iidB := seedCompareSession(t, d, nameB, startedAt.Add(time.Second), agent.StateFinished, nil)
+
+	// Seed distinguishable per-run aggregates via msg_assistant events,
+	// then persist the computed spawn_outcome rows so subsequent reads
+	// are deterministic.
+	writeAssistantTurn(t, d, nameA, iidA, startedAt.Add(10*time.Second), 1500, 700, 300, 150, 0.12)
+	writeAssistantTurn(t, d, nameA, iidA, startedAt.Add(40*time.Second), 2000, 900, 400, 200, 0.34)
+	writeToolCall(t, d, nameA, iidA, "bash", startedAt.Add(20*time.Second))
+
+	writeAssistantTurn(t, d, nameB, iidB, startedAt.Add(15*time.Second), 1800, 800, 350, 175, 0.20)
+	writeAssistantTurn(t, d, nameB, iidB, startedAt.Add(50*time.Second), 2500, 1100, 500, 250, 0.40)
+	writeToolCall(t, d, nameB, iidB, "bash", startedAt.Add(25*time.Second))
+
+	if err := d.WriteSpawnOutcome(iidA); err != nil {
+		t.Fatalf("WriteSpawnOutcome A: %v", err)
+	}
+	if err := d.WriteSpawnOutcome(iidB); err != nil {
+		t.Fatalf("WriteSpawnOutcome B: %v", err)
+	}
+
+	resetCompareFlags(t)
+	defer resetCompareFlags(t)
+
+	// 1) Direct-DB path with PRISM_HOST_API empty.
+	directOut := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, []string{nameA, nameB}); err != nil {
+			t.Fatalf("direct compare: %v", err)
+		}
+	})
+
+	// 2) Build the wire payload using the SAME DB rows the direct path read,
+	// serve via mock, run proxy path.
+	sessA, _ := d.SessionByInstanceID(iidA)
+	sessB, _ := d.SessionByInstanceID(iidB)
+	persistedA, _ := d.SpawnOutcomeByInstanceID(iidA)
+	persistedB, _ := d.SpawnOutcomeByInstanceID(iidB)
+	wire := sidecar.StatsCompareResponseWire{
+		Runs: []sidecar.StatsCompareRunWire{
+			{Label: "run-A", Session: sessA, Outcome: persistedA},
+			{Label: "run-B", Session: sessB, Outcome: persistedB},
+		},
+	}
+	wireJSON, _ := json.Marshal(wire)
+	_, apiURL := startFakeStatsServer(t, wireJSON)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	proxyOut := captureStdout(t, func() {
+		if err := runStatsCompare(compareCmd, []string{nameA, nameB}); err != nil {
+			t.Fatalf("proxy compare: %v", err)
+		}
+	})
+
+	if directOut != proxyOut {
+		t.Errorf("proxy and direct outputs differ — byte-identity AC violated\n=== direct ===\n%s\n=== proxy ===\n%s", directOut, proxyOut)
+	}
+}
+
+// ── runStatsAbtest proxy integration tests ───────────────────────────────────
+
+// TestRunStatsAbtest_ProxyHappyPath verifies that `prism stats abtest
+// <group_id>` proxies via /stats?view=abtest&group_id=...
+func TestRunStatsAbtest_ProxyHappyPath(t *testing.T) {
+	fixture := proxyCompareFixture()
+	respBody, _ := json.Marshal(fixture)
+
+	srv, apiURL := startFakeStatsServer(t, respBody)
+	t.Setenv("PRISM_HOST_API", apiURL)
+	resetAbtestFlags(t)
+	defer resetAbtestFlags(t)
+
+	out := captureStdout(t, func() {
+		if err := runStatsAbtest(abtestCmd, []string{"grp-abcd"}); err != nil {
+			t.Errorf("runStatsAbtest proxy: %v", err)
+		}
+	})
+
+	if !strings.Contains(srv.capturedQuery, "view=abtest") {
+		t.Errorf("proxy did not receive view=abtest; query=%q", srv.capturedQuery)
+	}
+	if !strings.Contains(srv.capturedQuery, "group_id=grp-abcd") {
+		t.Errorf("proxy did not receive group_id=grp-abcd; query=%q", srv.capturedQuery)
+	}
+	if !strings.Contains(out, "run-A") || !strings.Contains(out, "run-B") {
+		t.Errorf("output missing run labels:\n%s", out)
+	}
+}
+
+// TestRunStatsAbtest_HostPathUnchanged is the over-broad-fix guard for the
+// abtest subcommand: PRISM_HOST_API unset → direct DB; no proxy request.
+func TestRunStatsAbtest_HostPathUnchanged(t *testing.T) {
+	d := openStatsTestDB(t)
+	_ = d
+
+	requestCount := 0
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"runs":[]}`))
+	})
+	_ = srv
+
+	resetAbtestFlags(t)
+	defer resetAbtestFlags(t)
+
+	// No group exists in the DB, so the direct-DB path returns an error.
+	// What we are guarding against is *contacting the mock server* on the
+	// direct-DB path — the command's own outcome is irrelevant here.
+	_ = captureStdout(t, func() {
+		_ = runStatsAbtest(abtestCmd, []string{"missing-group"})
+	})
+
+	if requestCount > 0 {
+		t.Errorf("proxy server received %d request(s); should use direct DB", requestCount)
+	}
+}
+
+// ── runStatsAbtestFlag (--abtest listing) proxy tests ────────────────────────
+
+// abtestPairFixture builds one synthetic AbtestPairRow for the listing.
+func abtestPairFixture() db.AbtestPairRow {
+	turnsA := 2
+	turnsB := 4
+	tokInA := int64(1500)
+	tokOutA := int64(700)
+	tokInB := int64(2000)
+	tokOutB := int64(900)
+	durA := int64(120000)
+	durB := int64(180000)
+	stateA := "finished"
+	stateB := "finished"
+	return db.AbtestPairRow{
+		PairID:        uuid.New().String(),
+		SessionNameA:  "repo@pair-a",
+		InstanceIDA:   "aaaaaaaa-1111-2222-3333-444444444444",
+		ProfileA:      "anthropic-opus-max-4-7",
+		StartedAtA:    time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC).UnixMilli(),
+		SessionNameB:  "repo@pair-b",
+		InstanceIDB:   "bbbbbbbb-1111-2222-3333-444444444444",
+		ProfileB:      "anthropic-opus-max-4-8",
+		StartedAtB:    time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC).UnixMilli(),
+		TurnsA:        &turnsA,
+		TurnsB:        &turnsB,
+		TokensInputA:  &tokInA,
+		TokensInputB:  &tokInB,
+		TokensOutputA: &tokOutA,
+		TokensOutputB: &tokOutB,
+		DurationMsA:   &durA,
+		DurationMsB:   &durB,
+		EndStateA:     &stateA,
+		EndStateB:     &stateB,
+	}
+}
+
+// TestRunStatsAbtestFlag_ProxyHappyPath verifies that --abtest (top-level
+// listing flag) routes via /stats?view=abtest_list and renders the table.
+func TestRunStatsAbtestFlag_ProxyHappyPath(t *testing.T) {
+	pairs := []db.AbtestPairRow{abtestPairFixture()}
+	respBody, _ := json.Marshal(sidecar.StatsAbtestListResponseWire{Pairs: pairs})
+
+	srv, apiURL := startFakeStatsServer(t, respBody)
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	statsCmd.Flags().Set("abtest", "true")        //nolint:errcheck
+	defer statsCmd.Flags().Set("abtest", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats --abtest proxy: %v", err)
+		}
+	})
+
+	if !strings.Contains(srv.capturedQuery, "view=abtest_list") {
+		t.Errorf("proxy did not receive view=abtest_list; query=%q", srv.capturedQuery)
+	}
+	if !strings.Contains(out, "A/B Test Pairs") {
+		t.Errorf("output missing 'A/B Test Pairs' heading:\n%s", out)
+	}
+	if !strings.Contains(out, "repo@pair-a") || !strings.Contains(out, "repo@pair-b") {
+		t.Errorf("output missing pair session names:\n%s", out)
+	}
+}
+
+// TestRunStatsAbtestFlag_ProxyEmpty verifies the empty-set hint is shared
+// between the direct-DB and proxy paths.
+func TestRunStatsAbtestFlag_ProxyEmpty(t *testing.T) {
+	respBody := `{"pairs":[]}`
+	_, apiURL := startFakeStatsServer(t, []byte(respBody))
+	t.Setenv("PRISM_HOST_API", apiURL)
+
+	statsCmd.Flags().Set("abtest", "true")        //nolint:errcheck
+	defer statsCmd.Flags().Set("abtest", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats --abtest proxy empty: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "no abtest pairs recorded") {
+		t.Errorf("output missing empty-set hint:\n%s", out)
+	}
+}
+
+// TestRunStatsAbtestFlag_HostPathUnchanged is the over-broad-fix guard for
+// the --abtest listing: PRISM_HOST_API unset → direct DB; no proxy request.
+func TestRunStatsAbtestFlag_HostPathUnchanged(t *testing.T) {
+	_ = openStatsTestDB(t) // clears PRISM_HOST_API via t.Setenv
+
+	requestCount := 0
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"pairs":[]}`))
+	})
+	_ = srv
+
+	statsCmd.Flags().Set("abtest", "true")        //nolint:errcheck
+	defer statsCmd.Flags().Set("abtest", "false") //nolint:errcheck
+
+	out := captureStdout(t, func() {
+		if err := runStats(statsCmd, nil); err != nil {
+			t.Errorf("runStats --abtest direct: %v", err)
+		}
+	})
+
+	if requestCount > 0 {
+		t.Errorf("proxy server received %d request(s); should use direct DB", requestCount)
+	}
+	if !strings.Contains(out, "no abtest pairs recorded") {
+		t.Errorf("direct-DB output missing empty-set hint:\n%s", out)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -295,19 +296,29 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 	// GET /stats
 	// Query params:
-	//   view     — one of: summary, doomloops, denials, asks, detail (required)
+	//   view     — one of: summary, doomloops, denials, asks, detail,
+	//              compare, abtest, abtest_list (required)
 	//   session  — session name filter (optional for doomloops/denials/asks; required for detail)
 	//   days     — look-back window in days (default 7 for event views; unused for summary/detail)
 	//   repo     — repo filter (summary only, optional)
 	//   since    — sinceMs timestamp as string (summary only, optional)
+	//   ids      — comma-separated list of session names / instance IDs / UUID prefixes
+	//              (compare only, required) — each id is resolved server-side the
+	//              same way `cmd.resolveSessionArg` resolves it locally
+	//   group_id — session_groups.group_id (abtest only, required)
 	//
 	// Response shapes (all roles permitted — read-only):
-	//   view=summary → {"sessions":[...db.Session...]} with token/cost totals per-session
+	//   view=summary    → {"sessions":[...db.Session...]} with token/cost totals per-session
 	//     when session is set: {"type":"detail","session":{...db.Session...}} (same as view=detail)
-	//   view=doomloops → {"events":[...db.Event...]}
-	//   view=denials   → {"events":[...db.Event...]}
-	//   view=asks      → {"events":[...db.Event...]}
-	//   view=detail    → {"session":{...db.Session...}} (single-session incarnation detail)
+	//   view=doomloops  → {"events":[...db.Event...]}
+	//   view=denials    → {"events":[...db.Event...]}
+	//   view=asks       → {"events":[...db.Event...]}
+	//   view=detail     → {"session":{...db.Session...}} (single-session incarnation detail)
+	//   view=compare    → {"runs":[StatsCompareRunWire,...]} for `prism stats compare`
+	//   view=abtest     → {"runs":[StatsCompareRunWire,...]} for `prism stats abtest <group>`
+	//                     (members are resolved and sorted by session_name, matching
+	//                     the direct-DB path in `cmd.runStatsAbtest`)
+	//   view=abtest_list → {"pairs":[...db.AbtestPairRow...]} for `prism stats --abtest`
 	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
 		if !requireGet(w, r) {
 			return
@@ -438,8 +449,104 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			}
 			writeJSON(w, http.StatusOK, map[string]any{"session": sess})
 
+		case "compare":
+			// Multi-instance comparison view. `ids` is a comma-separated
+			// list of session names / instance IDs / UUID prefixes — the
+			// same kinds of argument `prism stats compare` accepts on the
+			// host. We resolve each id and return the per-run
+			// (session, outcome, inputs) triples; the CLI computes the Δ /
+			// MIN / MAX columns and emits the table / JSON / CSV. Order is
+			// preserved so the rendered "run-A / run-B / ..." labels
+			// match the input order on both paths.
+			idsStr := q.Get("ids")
+			if idsStr == "" {
+				writeError(w, http.StatusBadRequest, "ids is required for view=compare (comma-separated list)")
+				return
+			}
+			var ids []string
+			for _, raw := range strings.Split(idsStr, ",") {
+				trimmed := strings.TrimSpace(raw)
+				if trimmed != "" {
+					ids = append(ids, trimmed)
+				}
+			}
+			if len(ids) < 2 {
+				writeError(w, http.StatusBadRequest, "view=compare requires at least 2 ids")
+				return
+			}
+			var sessions []*db.Session
+			for _, id := range ids {
+				sess, resolveErr := resolveStatsSessionArg(s.cfg.DB, id)
+				if resolveErr != nil {
+					if lookupErr, ok := asStatsLookupError(resolveErr); ok {
+						writeError(w, lookupErr.status, lookupErr.msg)
+					} else {
+						writeError(w, http.StatusInternalServerError, "db error: "+resolveErr.Error())
+					}
+					return
+				}
+				sessions = append(sessions, sess)
+			}
+			runs := buildStatsCompareRuns(s.cfg.DB, sessions)
+			writeJSON(w, http.StatusOK, StatsCompareResponseWire{Runs: runs})
+
+		case "abtest":
+			// Group-driven comparison: resolve every member of the
+			// session_groups.group_id and return the same {"runs":[...]}
+			// shape as view=compare. Members are sorted by session_name
+			// to match the direct-DB path's deterministic ordering.
+			groupID := q.Get("group_id")
+			if groupID == "" {
+				writeError(w, http.StatusBadRequest, "group_id is required for view=abtest")
+				return
+			}
+			members, err := s.cfg.DB.GroupResults(groupID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+				return
+			}
+			if len(members) == 0 {
+				writeError(w, http.StatusNotFound, fmt.Sprintf("no members found for group %q", groupID))
+				return
+			}
+			var sessions []*db.Session
+			for _, m := range members {
+				sess, err := s.cfg.DB.MostRecentSessionForName(m.SessionName)
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+					return
+				}
+				if sess == nil {
+					writeError(w, http.StatusNotFound,
+						fmt.Sprintf("member session %q not found in sessions table", m.SessionName))
+					return
+				}
+				sessions = append(sessions, sess)
+			}
+			sort.Slice(sessions, func(i, j int) bool {
+				return sessions[i].SessionName < sessions[j].SessionName
+			})
+			runs := buildStatsCompareRuns(s.cfg.DB, sessions)
+			writeJSON(w, http.StatusOK, StatsCompareResponseWire{Runs: runs})
+
+		case "abtest_list":
+			// Listing of every recorded A/B test pair, for
+			// `prism stats --abtest`. No filtering — same payload the
+			// host-direct path renders. The CLI handles the empty-set
+			// "no abtest pairs recorded" message so the wire stays a
+			// pure data envelope.
+			pairs, err := s.cfg.DB.AbtestPairsAll()
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "db error: "+err.Error())
+				return
+			}
+			if pairs == nil {
+				pairs = []db.AbtestPairRow{}
+			}
+			writeJSON(w, http.StatusOK, StatsAbtestListResponseWire{Pairs: pairs})
+
 		default:
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown view %q — must be one of: summary, doomloops, denials, asks, detail", view))
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown view %q — must be one of: summary, doomloops, denials, asks, detail, compare, abtest, abtest_list", view))
 		}
 	})
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_stats_compare_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_stats_compare_test.go
@@ -397,6 +397,120 @@ func TestHostAPI_Stats_AbtestList_HappyPath(t *testing.T) {
 	}
 }
 
+// ── privilege-boundary regression (PR #2107 review-security) ─────────────────
+
+// TestHostAPI_Stats_Compare_DoesNotLeakPromptText is the regression guard
+// for the review-security finding on PR #2107: the all-roles /stats
+// endpoint must NOT serialise db.SpawnInputs.PromptText (or any of the
+// other row-level conversation-content fields — PromptSource,
+// ModelVariantOverrides, Extras, SkillsManifestHash, AgentPromptHash) to
+// callers. The restricted StatsCompareInputsWire struct holds only the six
+// render-relevant fields; this test asserts that contract by inserting a
+// distinctive prompt body, issuing a worker-role request, and confirming
+// the secret is absent from both the parsed envelope and the raw response
+// bytes.
+//
+// AgentRole = "worker" exercises the path most likely to leak: a
+// container worker session with PRISM_HOST_API set, talking to its own
+// sidecar's /stats handler. The same data shape goes out for coordinator
+// callers as well, but the worker case is the boundary that matters.
+func TestHostAPI_Stats_Compare_DoesNotLeakPromptText(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+	iidA := seedSidecarStatsSession(t, d, "repo@secret-a", startedAt, "finished")
+	iidB := seedSidecarStatsSession(t, d, "repo@secret-b", startedAt.Add(time.Second), "finished")
+
+	profile := "anthropic-opus-max-4-7"
+	// Distinctive sentinel strings so a substring match is unambiguous.
+	promptText := "SECRET-PROMPT-do-not-leak-9d8f7a6b"
+	promptSource := "SECRET-SOURCE-also-do-not-leak"
+	modelOverrides := `{"SECRET-OVERRIDES":"do-not-leak"}`
+	extras := `{"SECRET-EXTRAS":"do-not-leak"}`
+	skillsHash := "SECRET-SKILLS-HASH"
+	agentHash := "SECRET-AGENT-PROMPT-HASH"
+	promptTemplateHash := "SECRET-PROMPT-TEMPLATE-HASH"
+	modelFlag := "SECRET-MODEL-FLAG"
+	variantFlag := "SECRET-VARIANT-FLAG"
+
+	for _, iid := range []string{iidA, iidB} {
+		if err := d.InsertSpawnInputs(db.SpawnInputs{
+			InstanceID:            iid,
+			ProfileName:           &profile,
+			PromptText:            &promptText,
+			PromptSource:          &promptSource,
+			ModelVariantOverrides: &modelOverrides,
+			Extras:                &extras,
+			SkillsManifestHash:    &skillsHash,
+			AgentPromptHash:       &agentHash,
+			PromptTemplateHash:    &promptTemplateHash,
+			ModelFlag:             &modelFlag,
+			VariantFlag:           &variantFlag,
+			CreatedAt:             startedAt.UnixMilli(),
+		}); err != nil {
+			t.Fatalf("InsertSpawnInputs %s: %v", iid, err)
+		}
+	}
+
+	sc := newSidecarWithRole(t, "repo@secret-worker", "repo", "worker", d)
+	url := fmt.Sprintf("/stats?view=compare&ids=%s,%s", iidA, iidB)
+	rr := doHostAPI(t, sc, http.MethodGet, url, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+
+	// Raw-byte check first: this is the strongest assertion because it
+	// catches a serialised field even if the wire struct gains a typo
+	// later (e.g. "prompttext" instead of "prompt_text").
+	body := rr.Body.String()
+	secrets := []string{
+		promptText, promptSource, modelOverrides, extras,
+		skillsHash, agentHash, promptTemplateHash,
+		modelFlag, variantFlag,
+	}
+	for _, secret := range secrets {
+		if strings.Contains(body, secret) {
+			t.Errorf("response body leaks %q to worker caller; full body:\n%s", secret, body)
+		}
+	}
+	// And the JSON field names themselves — belt and braces, so a future
+	// refactor that switches to a different secret value still trips this.
+	forbiddenFields := []string{
+		"prompt_text", "PromptText",
+		"prompt_source", "PromptSource",
+		"model_variant_overrides", "ModelVariantOverrides",
+		"extras", "Extras",
+		"skills_manifest_hash", "SkillsManifestHash",
+		"agent_prompt_hash", "AgentPromptHash",
+		"prompt_template_hash", "PromptTemplateHash",
+		"model_flag", "ModelFlag",
+		"variant_flag", "VariantFlag",
+	}
+	for _, field := range forbiddenFields {
+		if strings.Contains(body, field) {
+			t.Errorf("response body includes forbidden field key %q; full body:\n%s", field, body)
+		}
+	}
+
+	// Parsed-envelope check: the six render-relevant fields must still be
+	// present so the renderer works. ProfileName is the easiest to assert
+	// because the test seeds it on every run.
+	var resp StatsCompareResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+	for i, run := range resp.Runs {
+		if run.Inputs == nil {
+			t.Errorf("run %d: Inputs is nil; want populated render-only subset", i)
+			continue
+		}
+		if run.Inputs.ProfileName == nil || *run.Inputs.ProfileName != profile {
+			t.Errorf("run %d: ProfileName = %v, want %q", i, run.Inputs.ProfileName, profile)
+		}
+	}
+}
+
 // ── unknown view ──────────────────────────────────────────────────────────────
 
 // TestHostAPI_Stats_UnknownViewIncludesNewViews verifies the dispatcher's

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_stats_compare_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_stats_compare_test.go
@@ -1,0 +1,418 @@
+package sidecar
+
+// Tests for the host-API GET /stats compare/abtest/abtest_list views
+// added in #2098. These mirror the shape of sidecar_stats_test.go
+// (existing view=summary / view=detail / view=doomloops coverage).
+//
+// Each test seeds rows directly into the test DB, invokes the
+// hostAPIHandler() through the existing doHostAPI helper, and asserts
+// either the response shape (StatsCompareResponseWire / StatsAbtestList
+// ResponseWire) or the HTTP status code (404 / 400 / 409) for the
+// negative paths.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedSidecarStatsSession inserts the minimum rows needed to make a
+// session resolvable by view=compare/abtest. It mirrors
+// cmd/stats_compare_test.go::seedCompareSession but stays inside the
+// sidecar package (which cannot import cmd).
+func seedSidecarStatsSession(t *testing.T, d *db.DB, sessionName string, startedAt time.Time, endState string) (instanceID string) {
+	t.Helper()
+	instanceID = uuid.New().String()
+	state := "finished"
+	if endState != "" {
+		state = endState
+	}
+	if err := d.UpsertStatus(sessionName, "repo", "/wt/"+sessionName, state, nil, nil); err != nil {
+		t.Fatalf("UpsertStatus %q: %v", sessionName, err)
+	}
+	if err := d.SetInstanceID(sessionName, instanceID); err != nil {
+		t.Fatalf("SetInstanceID %q: %v", sessionName, err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		Harness:     "pi",
+		StartedAt:   startedAt,
+	}); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	if endState != "" {
+		if err := d.UpdateSessionEnded(instanceID, endState); err != nil {
+			t.Fatalf("UpdateSessionEnded %q: %v", sessionName, err)
+		}
+	}
+	return instanceID
+}
+
+// writeSidecarAssistantTurn writes a msg_assistant event tied to instanceID.
+func writeSidecarAssistantTurn(t *testing.T, d *db.DB, sessionName, instanceID string, ts time.Time, inputTokens, outputTokens int) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"messageId":%q,"text":"reply","agent":"pi","model":"anthropic/claude-sonnet-4-6","inputTokens":%d,"outputTokens":%d,"durationMs":5000}`,
+		uuid.New().String(), inputTokens, outputTokens)
+	ev := db.Event{
+		ID:          uuid.New().String(),
+		SessionName: sessionName,
+		Repo:        "repo",
+		Worktree:    "/wt/" + sessionName,
+		InstanceID:  &instanceID,
+		Type:        "msg_assistant",
+		Payload:     payload,
+		CreatedAt:   ts,
+	}
+	if err := d.WriteEvent(ev); err != nil {
+		t.Fatalf("WriteEvent: %v", err)
+	}
+}
+
+// ── view=compare ──────────────────────────────────────────────────────────────
+
+// TestHostAPI_Stats_Compare_HappyPath verifies the multi-id resolution
+// returns one StatsCompareRunWire per id, in input order, with labels
+// run-A and run-B.
+func TestHostAPI_Stats_Compare_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+	iidA := seedSidecarStatsSession(t, d, "repo@compare-a", startedAt, "finished")
+	iidB := seedSidecarStatsSession(t, d, "repo@compare-b", startedAt.Add(time.Second), "finished")
+
+	writeSidecarAssistantTurn(t, d, "repo@compare-a", iidA, startedAt.Add(10*time.Second), 1500, 700)
+	writeSidecarAssistantTurn(t, d, "repo@compare-b", iidB, startedAt.Add(20*time.Second), 2000, 900)
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	url := fmt.Sprintf("/stats?view=compare&ids=%s,%s", iidA, iidB)
+	rr := doHostAPI(t, sc, http.MethodGet, url, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsCompareResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+	if resp.Runs[0].Label != "run-A" || resp.Runs[1].Label != "run-B" {
+		t.Errorf("labels = (%q, %q), want (run-A, run-B)", resp.Runs[0].Label, resp.Runs[1].Label)
+	}
+	if resp.Runs[0].Session == nil || resp.Runs[0].Session.InstanceID != iidA {
+		t.Errorf("run-A session id mismatch: got %+v", resp.Runs[0].Session)
+	}
+	if resp.Runs[1].Session == nil || resp.Runs[1].Session.InstanceID != iidB {
+		t.Errorf("run-B session id mismatch: got %+v", resp.Runs[1].Session)
+	}
+}
+
+// TestHostAPI_Stats_Compare_TerminalFallbackToComputeSpawnOutcome verifies
+// that a terminal session with no persisted spawn_outcome row still gets
+// aggregates surfaced via on-the-fly ComputeSpawnOutcome. This is the
+// server-side analogue of cmd/stats_compare_test.go's Layer-1 coverage —
+// without this branch, proxy users would see "—" cells for sessions in
+// the gap between terminal-state and `prism cleanup`.
+func TestHostAPI_Stats_Compare_TerminalFallbackToComputeSpawnOutcome(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+	iidA := seedSidecarStatsSession(t, d, "repo@terminal-a", startedAt, "finished")
+	iidB := seedSidecarStatsSession(t, d, "repo@terminal-b", startedAt.Add(time.Second), "finished")
+	writeSidecarAssistantTurn(t, d, "repo@terminal-a", iidA, startedAt.Add(10*time.Second), 1500, 700)
+	writeSidecarAssistantTurn(t, d, "repo@terminal-b", iidB, startedAt.Add(20*time.Second), 2000, 900)
+	// Note: NO WriteSpawnOutcome call — outcomes must be computed on the fly.
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	url := fmt.Sprintf("/stats?view=compare&ids=%s,%s", iidA, iidB)
+	rr := doHostAPI(t, sc, http.MethodGet, url, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsCompareResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+	if resp.Runs[0].Outcome == nil || resp.Runs[0].Outcome.TokensInputTotal != 1500 {
+		t.Errorf("run-A outcome missing or wrong tokens_input: %+v", resp.Runs[0].Outcome)
+	}
+	if resp.Runs[1].Outcome == nil || resp.Runs[1].Outcome.TokensInputTotal != 2000 {
+		t.Errorf("run-B outcome missing or wrong tokens_input: %+v", resp.Runs[1].Outcome)
+	}
+}
+
+// TestHostAPI_Stats_Compare_LiveSessionOmitsOutcome verifies that a live
+// (non-terminal) session has Outcome == nil in the response — matching the
+// cmd-side renderer's "—" cells. This is the over-broad-fix guard for the
+// "terminal-only compute" branch.
+func TestHostAPI_Stats_Compare_LiveSessionOmitsOutcome(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+	// Seed one terminal session and one live session.
+	iidA := seedSidecarStatsSession(t, d, "repo@terminal-a", startedAt, "finished")
+	iidB := seedSidecarStatsSession(t, d, "repo@live-b", startedAt.Add(time.Second), "" /* no end state */)
+	writeSidecarAssistantTurn(t, d, "repo@terminal-a", iidA, startedAt.Add(10*time.Second), 1500, 700)
+	writeSidecarAssistantTurn(t, d, "repo@live-b", iidB, startedAt.Add(20*time.Second), 2000, 900)
+	// Reset the live session's status row to a non-terminal state so the
+	// terminal gate returns false.
+	if err := d.UpsertStatus("repo@live-b", "repo", "/wt/repo@live-b", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus active: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	url := fmt.Sprintf("/stats?view=compare&ids=%s,%s", iidA, iidB)
+	rr := doHostAPI(t, sc, http.MethodGet, url, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsCompareResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if resp.Runs[0].Outcome == nil {
+		t.Errorf("terminal session A should have outcome populated, got nil")
+	}
+	if resp.Runs[1].Outcome != nil {
+		t.Errorf("live session B should have outcome == nil; got %+v", resp.Runs[1].Outcome)
+	}
+}
+
+// TestHostAPI_Stats_Compare_MissingIdReturns404 verifies that an unresolvable
+// id surfaces as HTTP 404 with the "instance %q not found" message — the same
+// shape the cmd-side resolveSessionArg emits on the direct-DB path.
+func TestHostAPI_Stats_Compare_MissingIdReturns404(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	iidA := seedSidecarStatsSession(t, d, "repo@compare-a", startedAt, "finished")
+
+	ghost := "aaaaaaaa-1111-2222-3333-444444444444"
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	url := fmt.Sprintf("/stats?view=compare&ids=%s,%s", iidA, ghost)
+	rr := doHostAPI(t, sc, http.MethodGet, url, "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %q, want 404", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), ghost) {
+		t.Errorf("404 body does not mention %q: %s", ghost, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Compare_RequiresIds verifies the empty-ids 400.
+func TestHostAPI_Stats_Compare_RequiresIds(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Compare_RequiresAtLeastTwoIds guards against a single-id
+// proxy call slipping through (the comparison engine needs >= 2 runs).
+func TestHostAPI_Stats_Compare_RequiresAtLeastTwoIds(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	iid := seedSidecarStatsSession(t, d, "repo@compare-a", startedAt, "finished")
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&ids="+iid, "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Compare_ByName verifies that ids can also be raw
+// session_names (not just instance IDs), matching the cmd-side
+// resolveSessionArg precedence.
+func TestHostAPI_Stats_Compare_ByName(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	_ = seedSidecarStatsSession(t, d, "repo@by-name-a", startedAt, "finished")
+	_ = seedSidecarStatsSession(t, d, "repo@by-name-b", startedAt.Add(time.Second), "finished")
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=compare&ids=repo@by-name-a,repo@by-name-b", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsCompareResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+}
+
+// ── view=abtest ───────────────────────────────────────────────────────────────
+
+// TestHostAPI_Stats_Abtest_HappyPath verifies that GET /stats?view=abtest
+// resolves group members, sorts by session_name, and returns runs.
+func TestHostAPI_Stats_Abtest_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+	const nameA = "repo@group-aa"
+	const nameB = "repo@group-bb"
+	iidA := seedSidecarStatsSession(t, d, nameA, startedAt, "finished")
+	iidB := seedSidecarStatsSession(t, d, nameB, startedAt.Add(time.Second), "finished")
+	_ = iidA
+	_ = iidB
+
+	groupID, err := d.RegisterGroup("repo@main")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID(nameA, groupID); err != nil {
+		t.Fatalf("SetGroupID A: %v", err)
+	}
+	if err := d.SetGroupID(nameB, groupID); err != nil {
+		t.Fatalf("SetGroupID B: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	url := "/stats?view=abtest&group_id=" + groupID
+	rr := doHostAPI(t, sc, http.MethodGet, url, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsCompareResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Runs) != 2 {
+		t.Fatalf("got %d runs, want 2", len(resp.Runs))
+	}
+	// Sorted by session_name: group-aa comes before group-bb.
+	if resp.Runs[0].Session.SessionName != nameA || resp.Runs[1].Session.SessionName != nameB {
+		t.Errorf("sort order wrong: got (%q, %q), want (%q, %q)",
+			resp.Runs[0].Session.SessionName, resp.Runs[1].Session.SessionName, nameA, nameB)
+	}
+}
+
+// TestHostAPI_Stats_Abtest_MissingGroupReturns404 verifies that an unknown
+// group_id surfaces as 404 with a clear message.
+func TestHostAPI_Stats_Abtest_MissingGroupReturns404(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest&group_id=does-not-exist", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %q, want 404", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Stats_Abtest_RequiresGroupID verifies the missing-param 400.
+func TestHostAPI_Stats_Abtest_RequiresGroupID(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// ── view=abtest_list ──────────────────────────────────────────────────────────
+
+// TestHostAPI_Stats_AbtestList_Empty verifies that an empty DB returns the
+// envelope with an empty pairs array (not null) so the CLI's empty-set
+// hint path is exercised consistently.
+func TestHostAPI_Stats_AbtestList_Empty(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest_list", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsAbtestListResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if resp.Pairs == nil {
+		t.Errorf("Pairs is nil; want empty slice for stable JSON roundtrip")
+	}
+	if len(resp.Pairs) != 0 {
+		t.Errorf("got %d pairs, want 0", len(resp.Pairs))
+	}
+	// Verify the JSON envelope itself contains "pairs":[] not "pairs":null.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("raw unmarshal: %v", err)
+	}
+	if got := strings.TrimSpace(string(raw["pairs"])); got != "[]" {
+		t.Errorf(`pairs raw JSON = %q, want "[]"`, got)
+	}
+}
+
+// TestHostAPI_Stats_AbtestList_HappyPath seeds two abtest-paired sessions
+// and verifies they appear in the listing.
+func TestHostAPI_Stats_AbtestList_HappyPath(t *testing.T) {
+	d := openTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+	const (
+		nameA = "repo@pair-a"
+		nameB = "repo@pair-b"
+	)
+	iidA := seedSidecarStatsSession(t, d, nameA, startedAt, "finished")
+	iidB := seedSidecarStatsSession(t, d, nameB, startedAt.Add(time.Second), "finished")
+
+	pairID := uuid.New().String()
+	profA := "anthropic-opus-max-4-7"
+	profB := "anthropic-opus-max-4-8"
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:   iidA,
+		ProfileName:  &profA,
+		AbtestPairID: &pairID,
+		CreatedAt:    startedAt.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs A: %v", err)
+	}
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:   iidB,
+		ProfileName:  &profB,
+		AbtestPairID: &pairID,
+		CreatedAt:    startedAt.Add(time.Second).UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs B: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=abtest_list", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q, want 200", rr.Code, rr.Body.String())
+	}
+	var resp StatsAbtestListResponseWire
+	decodeJSONBody(t, rr, &resp)
+	if len(resp.Pairs) != 1 {
+		t.Fatalf("got %d pairs, want 1; body = %s", len(resp.Pairs), rr.Body.String())
+	}
+	if resp.Pairs[0].PairID != pairID {
+		t.Errorf("pair_id = %q, want %q", resp.Pairs[0].PairID, pairID)
+	}
+	if resp.Pairs[0].SessionNameA != nameA || resp.Pairs[0].SessionNameB != nameB {
+		t.Errorf("session names = (%q, %q), want (%q, %q)",
+			resp.Pairs[0].SessionNameA, resp.Pairs[0].SessionNameB, nameA, nameB)
+	}
+}
+
+// ── unknown view ──────────────────────────────────────────────────────────────
+
+// TestHostAPI_Stats_UnknownViewIncludesNewViews verifies the dispatcher's
+// "unknown view" 400 message names the new views in the allow-list,
+// guarding against drift between the doc comment and the actual switch.
+func TestHostAPI_Stats_UnknownViewIncludesNewViews(t *testing.T) {
+	d := openTestDB(t)
+	sc := newSidecarWithRole(t, "repo@main", "repo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/stats?view=bogus", "")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %q, want 400", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	for _, view := range []string{"compare", "abtest", "abtest_list"} {
+		if !strings.Contains(body, view) {
+			t.Errorf("unknown-view error %q does not mention %q", body, view)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/stats_compare.go
+++ b/modules/programs/prism/prism/internal/sidecar/stats_compare.go
@@ -1,0 +1,179 @@
+package sidecar
+
+// Server-side helpers for the host-API GET /stats compare/abtest views
+// (issue #2098).
+//
+// These helpers mirror the cmd-side `resolveSessionArg` and
+// `loadCompareRuns` so that the proxy path produces byte-identical
+// output to a host-direct `prism stats compare` / `prism stats abtest
+// <group>` invocation:
+//
+//   - resolveStatsSessionArg replicates the disambiguation rules from
+//     cmd/stats_render.go::resolveSessionArg (UUID > session_name >
+//     UUID-prefix > error).
+//   - statsSessionIsTerminal replicates cmd/stats_compare.go::
+//     sessionIsTerminal so that the on-the-fly ComputeSpawnOutcome gate
+//     matches between paths.
+//   - buildStatsCompareRuns is the server-side analogue of
+//     cmd/stats_compare.go::loadCompareRuns: for each session it reads
+//     spawn_outcome, falls back to ComputeSpawnOutcome when the session
+//     is terminal but no row has been persisted yet (issue #2102), and
+//     reads spawn_inputs best-effort.
+//
+// We intentionally keep these helpers small and inlined rather than
+// re-using the cmd-package implementations: cmd cannot be imported from
+// internal/sidecar (it would form an import cycle), and lifting the
+// logic into internal/db would force db to import internal/agent for
+// IsTerminal. The duplication is mechanical and is exercised by the
+// proxy-path tests in cmd/stats_proxy_test.go plus the sidecar
+// view-handler tests in internal/sidecar/sidecar_stats_compare_test.go.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// statsLookupError carries an HTTP status code alongside an error
+// message so the /stats handler can translate a missing-session
+// condition into a 404 (matching the CLI's "instance %q not found")
+// while still surfacing 500 for genuine DB failures.
+type statsLookupError struct {
+	status int
+	msg    string
+}
+
+func (e *statsLookupError) Error() string { return e.msg }
+
+// resolveStatsSessionArg resolves a single `prism stats compare` argument
+// (session name, full 36-char UUID, or unambiguous UUID prefix) to a
+// sessions row. Mirrors cmd/stats_render.go::resolveSessionArg with the
+// same precedence order so the proxy path and the direct-DB path return
+// the same row for the same input.
+//
+// Returns a *statsLookupError with status 404 when the arg cannot be
+// resolved, status 409 when a prefix is ambiguous, and a wrapped DB error
+// (statsLookupError with status 500 via the caller) for query failures.
+func resolveStatsSessionArg(d *db.DB, arg string) (*db.Session, error) {
+	// Step 1: full UUID (36 chars).
+	if len(arg) == 36 {
+		sess, err := d.SessionByInstanceID(arg)
+		if err != nil {
+			return nil, fmt.Errorf("lookup instance %q: %w", arg, err)
+		}
+		if sess != nil {
+			return sess, nil
+		}
+		return nil, &statsLookupError{
+			status: http.StatusNotFound,
+			msg:    fmt.Sprintf("instance %q not found", arg),
+		}
+	}
+
+	// Step 2: exact session_name match.
+	sess, err := d.MostRecentSessionForName(arg)
+	if err != nil {
+		return nil, fmt.Errorf("lookup session name %q: %w", arg, err)
+	}
+	if sess != nil {
+		return sess, nil
+	}
+
+	// Step 3: UUID prefix match.
+	matches, err := d.SessionsByInstanceIDPrefix(arg)
+	if err != nil {
+		return nil, fmt.Errorf("lookup instance prefix %q: %w", arg, err)
+	}
+	if len(matches) == 1 {
+		return &matches[0], nil
+	}
+	if len(matches) > 1 {
+		candidates := make([]string, 0, len(matches))
+		for _, m := range matches {
+			candidates = append(candidates, m.InstanceID)
+		}
+		return nil, &statsLookupError{
+			status: http.StatusConflict,
+			msg: fmt.Sprintf("%q is ambiguous — multiple incarnations match:\n  %s\nuse the full instance_id to disambiguate",
+				arg, strings.Join(candidates, "\n  ")),
+		}
+	}
+	return nil, &statsLookupError{
+		status: http.StatusNotFound,
+		msg:    fmt.Sprintf("%q is not a known instance_id or session_name", arg),
+	}
+}
+
+// statsSessionIsTerminal mirrors cmd/stats_compare.go::sessionIsTerminal:
+// the agent_status row is the live source of truth while it exists, with
+// a fallback to sess.EndState for sessions whose status row has already
+// been cleaned up.
+//
+// Returning true gates the on-the-fly ComputeSpawnOutcome call so a
+// session that has reached a terminal state but whose spawn_outcome row
+// has not yet been written (the window between terminal-state transition
+// and `prism cleanup`) still surfaces aggregates over the proxy.
+func statsSessionIsTerminal(d *db.DB, sess *db.Session) bool {
+	if sess == nil {
+		return false
+	}
+	if st, err := d.CurrentStatus(sess.SessionName); err == nil && st != nil {
+		return agent.IsTerminal(agent.AgentState(st.State))
+	}
+	if sess.EndState != nil {
+		switch *sess.EndState {
+		case "finished", "error", "interrupted", "deleted":
+			return true
+		}
+	}
+	return false
+}
+
+// buildStatsCompareRuns is the server-side analogue of
+// cmd/stats_compare.go::loadCompareRuns. For each session it reads the
+// persisted spawn_outcome row first; when the session is terminal but
+// has no persisted row yet it computes the outcome on the fly using the
+// canonical aggregation (db.ComputeSpawnOutcome). spawn_inputs is read
+// best-effort — pre-#2087 sessions have no row and the CLI renderer
+// surfaces what it can from sessions instead.
+//
+// Labels are assigned in input order so the CLI does not need to
+// re-derive ordering after unmarshaling. The caller is responsible for
+// any ordering policy (input-order for view=compare, session_name-sorted
+// for view=abtest).
+func buildStatsCompareRuns(d *db.DB, sessions []*db.Session) []StatsCompareRunWire {
+	runs := make([]StatsCompareRunWire, 0, len(sessions))
+	for i, sess := range sessions {
+		label := "run-" + string(rune('A'+i))
+		run := StatsCompareRunWire{
+			Label:   label,
+			Session: sess,
+		}
+		if out, _ := d.SpawnOutcomeByInstanceID(sess.InstanceID); out != nil {
+			run.Outcome = out
+		} else if statsSessionIsTerminal(d, sess) {
+			if computed, err := d.ComputeSpawnOutcome(sess.InstanceID); err == nil && computed != nil {
+				run.Outcome = computed
+			}
+		}
+		if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil {
+			run.Inputs = inputs
+		}
+		runs = append(runs, run)
+	}
+	return runs
+}
+
+// asStatsLookupError extracts a *statsLookupError from err, if present.
+// Tiny helper to keep the dispatcher's switch readable.
+func asStatsLookupError(err error) (*statsLookupError, bool) {
+	var lookupErr *statsLookupError
+	if errors.As(err, &lookupErr) {
+		return lookupErr, true
+	}
+	return nil, false
+}

--- a/modules/programs/prism/prism/internal/sidecar/stats_compare.go
+++ b/modules/programs/prism/prism/internal/sidecar/stats_compare.go
@@ -141,6 +141,16 @@ func statsSessionIsTerminal(d *db.DB, sess *db.Session) bool {
 // best-effort — pre-#2087 sessions have no row and the CLI renderer
 // surfaces what it can from sessions instead.
 //
+// spawn_inputs is converted to the restricted StatsCompareInputsWire
+// subset (six fields the CLI renderer actually consumes) before being
+// placed on the wire. The full db.SpawnInputs row carries row-level
+// conversation content (PromptText, PromptSource, ModelVariantOverrides,
+// Extras, manifest hashes) that the all-roles /stats endpoint must not
+// expose — see the architecture note on host_api.go's hostAPIHandler
+// stating "/stats is aggregate counts, /db/query is row-level
+// conversation content". restrictSpawnInputsForWire keeps those fields
+// off the wire entirely (review-security feedback on PR #2107).
+//
 // Labels are assigned in input order so the CLI does not need to
 // re-derive ordering after unmarshaling. The caller is responsible for
 // any ordering policy (input-order for view=compare, session_name-sorted
@@ -160,12 +170,33 @@ func buildStatsCompareRuns(d *db.DB, sessions []*db.Session) []StatsCompareRunWi
 				run.Outcome = computed
 			}
 		}
-		if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil {
-			run.Inputs = inputs
+		if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil && inputs != nil {
+			run.Inputs = restrictSpawnInputsForWire(inputs)
 		}
 		runs = append(runs, run)
 	}
 	return runs
+}
+
+// restrictSpawnInputsForWire copies the six render-relevant fields from a
+// full db.SpawnInputs row into a StatsCompareInputsWire so the prompt body,
+// prompt source, model-variant overrides JSON, extras blob, and manifest
+// hashes never appear on the all-roles /stats wire. The set of fields
+// mirrors cmd/stats_compare.go::inputsAxes exactly — every other field on
+// db.SpawnInputs is unused by the renderer and so has no reason to cross
+// the boundary.
+func restrictSpawnInputsForWire(in *db.SpawnInputs) *StatsCompareInputsWire {
+	if in == nil {
+		return nil
+	}
+	return &StatsCompareInputsWire{
+		ProfileName:   in.ProfileName,
+		HarnessFlag:   in.HarnessFlag,
+		IsolationFlag: in.IsolationFlag,
+		AgentFlag:     in.AgentFlag,
+		BranchFlag:    in.BranchFlag,
+		AbtestPairID:  in.AbtestPairID,
+	}
 }
 
 // asStatsLookupError extracts a *statsLookupError from err, if present.

--- a/modules/programs/prism/prism/internal/sidecar/stats_compare_wire.go
+++ b/modules/programs/prism/prism/internal/sidecar/stats_compare_wire.go
@@ -11,30 +11,68 @@ package sidecar
 // invite drift.
 //
 // The wire shape is intentionally raw: the server returns per-instance
-// db.Session, db.SpawnOutcome, and db.SpawnInputs rows and the client
-// renders. This keeps the Δ / MIN / MAX computation and all flag
-// behaviour (--diff-only, --axes, --include-inputs, --include-rubric)
-// on the CLI side, so the table/JSON/CSV output is byte-identical
-// between the direct-DB path and the proxy path. The render-time
-// rather than server-time aggregation choice is documented in the PR
-// body for #2098.
+// db.Session, db.SpawnOutcome, and a render-only subset of db.SpawnInputs
+// rows; the client renders. This keeps the Δ / MIN / MAX computation and
+// all flag behaviour (--diff-only, --axes, --include-inputs,
+// --include-rubric) on the CLI side, so the table / JSON / CSV output is
+// byte-identical between the direct-DB path and the proxy path. The
+// render-time rather than server-time aggregation choice is documented in
+// the PR body for #2098.
+//
+// Why SpawnInputs is exposed as a restricted struct rather than the raw
+// db.SpawnInputs row: /stats is an all-roles endpoint (it predates
+// /checkin's coordinator-only gate), and db.SpawnInputs carries
+// PromptText, PromptSource, ModelVariantOverrides, Extras, and the
+// skills / agent-prompt manifest hashes. None of those are read by the
+// cmd-side renderer (cmd/stats_compare.go::inputsAxes), but `db.SpawnInputs`
+// has no JSON tags so a raw embed would put the full row body — including
+// the first user-turn prompt — on the all-roles wire. The architecture
+// note next to the /stats handler in host_api.go states "/stats is
+// aggregate counts, /db/query is row-level conversation content" — the
+// prompt body is conversation content and crosses that boundary. The
+// restricted StatsCompareInputsWire struct holds only the six fields the
+// renderer actually consumes, so the all-roles policy AC from issue #2098
+// is preserved without leaking conversation content to worker callers.
 
 import "github.com/prismatic-koi/prism/internal/db"
 
+// StatsCompareInputsWire is the wire-safe subset of db.SpawnInputs surfaced
+// by view=compare and view=abtest. It carries exactly the fields the cmd-side
+// `prism stats compare` renderer reads via cmd/stats_compare.go::inputsAxes:
+// profile_name, harness_flag, isolation_flag, agent_flag, branch_flag, and
+// abtest_pair_id. PromptText, PromptSource, ModelVariantOverrides, Extras,
+// SkillsManifestHash, AgentPromptHash, ModelFlag, VariantFlag, PRNumber,
+// HostModeFlag, IgnoreConcurrencyCap, PromptTemplateHash, and CreatedAt are
+// intentionally excluded — they are not read by the renderer and would
+// otherwise leak to worker callers of the all-roles /stats endpoint.
+//
+// Fields use JSON-tagged pointers so the encoder emits them as null when
+// the underlying spawn_inputs column is NULL, matching the cmd-side
+// inputsValue "—" fallback for missing data.
+type StatsCompareInputsWire struct {
+	ProfileName   *string `json:"profile_name,omitempty"`
+	HarnessFlag   *string `json:"harness_flag,omitempty"`
+	IsolationFlag *string `json:"isolation_flag,omitempty"`
+	AgentFlag     *string `json:"agent_flag,omitempty"`
+	BranchFlag    *string `json:"branch_flag,omitempty"`
+	AbtestPairID  *string `json:"abtest_pair_id,omitempty"`
+}
+
 // StatsCompareRunWire is the per-run payload returned by the
 // view=compare and view=abtest handlers. Each run carries the raw
-// sessions / spawn_outcome / spawn_inputs rows that the comparison
-// engine needs; the renderer turns these into a labelled column.
+// sessions / spawn_outcome rows and the restricted spawn_inputs subset
+// (StatsCompareInputsWire) that the comparison engine needs; the
+// renderer turns these into a labelled column.
 //
 // Label is assigned by the server in input order ("run-A", "run-B", ...)
 // so the CLI does not need to know the input ordering after unmarshaling.
 // Outcome and Inputs may be nil — a live (non-terminal) session has no
 // outcome row, and pre-#2087 sessions have no spawn_inputs row.
 type StatsCompareRunWire struct {
-	Label   string           `json:"label"`
-	Session *db.Session      `json:"session"`
-	Outcome *db.SpawnOutcome `json:"outcome,omitempty"`
-	Inputs  *db.SpawnInputs  `json:"inputs,omitempty"`
+	Label   string                  `json:"label"`
+	Session *db.Session             `json:"session"`
+	Outcome *db.SpawnOutcome        `json:"outcome,omitempty"`
+	Inputs  *StatsCompareInputsWire `json:"inputs,omitempty"`
 }
 
 // StatsCompareResponseWire is the top-level response envelope for the

--- a/modules/programs/prism/prism/internal/sidecar/stats_compare_wire.go
+++ b/modules/programs/prism/prism/internal/sidecar/stats_compare_wire.go
@@ -1,0 +1,50 @@
+package sidecar
+
+// Wire types for the host-API GET /stats compare/abtest views (issue #2098).
+//
+// These types are the JSON-serialisable shapes exchanged between the
+// host sidecar and an in-sandbox `prism stats compare`, `prism stats abtest
+// <group_id>`, and `prism stats --abtest` invocation. They live in the
+// sidecar package because the `cmd` package already imports it for other
+// host-API plumbing (review sentinels, etc.) and the structs are the
+// authoritative wire contract — duplicating them in both packages would
+// invite drift.
+//
+// The wire shape is intentionally raw: the server returns per-instance
+// db.Session, db.SpawnOutcome, and db.SpawnInputs rows and the client
+// renders. This keeps the Δ / MIN / MAX computation and all flag
+// behaviour (--diff-only, --axes, --include-inputs, --include-rubric)
+// on the CLI side, so the table/JSON/CSV output is byte-identical
+// between the direct-DB path and the proxy path. The render-time
+// rather than server-time aggregation choice is documented in the PR
+// body for #2098.
+
+import "github.com/prismatic-koi/prism/internal/db"
+
+// StatsCompareRunWire is the per-run payload returned by the
+// view=compare and view=abtest handlers. Each run carries the raw
+// sessions / spawn_outcome / spawn_inputs rows that the comparison
+// engine needs; the renderer turns these into a labelled column.
+//
+// Label is assigned by the server in input order ("run-A", "run-B", ...)
+// so the CLI does not need to know the input ordering after unmarshaling.
+// Outcome and Inputs may be nil — a live (non-terminal) session has no
+// outcome row, and pre-#2087 sessions have no spawn_inputs row.
+type StatsCompareRunWire struct {
+	Label   string           `json:"label"`
+	Session *db.Session      `json:"session"`
+	Outcome *db.SpawnOutcome `json:"outcome,omitempty"`
+	Inputs  *db.SpawnInputs  `json:"inputs,omitempty"`
+}
+
+// StatsCompareResponseWire is the top-level response envelope for the
+// view=compare and view=abtest handlers.
+type StatsCompareResponseWire struct {
+	Runs []StatsCompareRunWire `json:"runs"`
+}
+
+// StatsAbtestListResponseWire is the response envelope for view=abtest_list,
+// used by `prism stats --abtest`.
+type StatsAbtestListResponseWire struct {
+	Pairs []db.AbtestPairRow `json:"pairs"`
+}


### PR DESCRIPTION
Closes #2098.

## Symptom

`prism stats compare <A> <B>`, `prism stats abtest <group>`, and `prism stats --abtest` all bypassed the existing `PRISM_HOST_API` proxy and went straight to `openDB()`. From an in-sandbox coordinator this meant lookups against an empty/partial shadow DB and the user-visible failures from the issue (`instance "..." not found`, `no abtest pairs recorded`).

`prism stats` (single-instance and bare-list) already had the right shape — `cmd/stats.go::runStatsProxy` dispatches into `proxyStats(apiURL, view, ...)` for one of five views (`summary`, `detail`, `doomloops`, `denials`, `asks`), all dispatched server-side from a single `view=` query parameter at `internal/sidecar/host_api.go::/stats`. This PR extends that seam — same endpoint, three new views (`compare`, `abtest`, `abtest_list`).

## Design forks (called explicitly per the spawn prompt)

### Fork 1 — proxy contract: chose **bulk request, one round-trip per command**

`proxyStatsCompare(apiURL, ids []string)` joins all ids into a single comma-separated `ids=` query param and posts one request:

```
GET /stats?view=compare&ids=run-A,run-B,run-C
```

Why not N-per-request:
- Partial-failure semantics get muddy. The direct-DB path (`cmd/stats_compare.go::runStatsCompare`) aborts the whole compare on the first missing id via `resolveSessionArg`. One-shot matches that behaviour exactly: a single 404 from the server fails the command with the same `"instance %q not found"` shape. N requests would force a decision ("render what we got, or fail?") that has no host-direct precedent.
- One round-trip regardless of how many ids — for >2 abtest groups this matters.
- UUIDs and `repo@session` names contain no commas, so the separator is safe; URL-encoding handles whitespace and weird chars.

Why not new endpoints (`/stats/compare`, `/stats/abtest`, `/stats/abtest/list`):
- Departs from the established `view=` dispatch pattern. The existing views all share auth (`/stats` is all-roles) and live in a single handler — splitting now would invite drift.
- More wire surface for no functional gain.

### Fork 2 — aggregation: chose **render-time on the CLI**

Server returns raw per-instance `(db.Session, *db.SpawnOutcome, *db.SpawnInputs)` triples in `StatsCompareResponseWire{Runs: [...]}`. The CLI computes the Δ column, MIN/MAX annotations, applies `--diff-only` filtering, honours `--axes`, etc.

Why:
- **Byte-identity is then trivially provable**: same renderer, two data sources. The new `renderComparison` helper is called from both `runComparison` (direct-DB) and `runStatsCompareProxy`/`runStatsAbtestProxy`.
- All compare-engine flags (`--diff-only`, `--axes`, `--include-inputs`, `--include-rubric`, `--format`) work on both paths without per-flag plumbing through the wire.
- The `ComputeSpawnOutcome` fallback for terminal-but-not-yet-cleaned sessions (issue #2102) is replicated on the server in `internal/sidecar/stats_compare.go::buildStatsCompareRuns`, so a proxy user sees aggregates for a session in the gap between `finished` and `prism cleanup` — the same fallback the direct path uses.

## Changes

**Sidecar (`internal/sidecar/`)**
- `stats_compare_wire.go` (new): `StatsCompareRunWire`, `StatsCompareResponseWire`, `StatsAbtestListResponseWire` — the wire contracts, importable by both `cmd` and `sidecar`.
- `stats_compare.go` (new): server-side `resolveStatsSessionArg` mirroring the cmd-side disambiguation (UUID → session_name → UUID-prefix), `statsSessionIsTerminal` mirroring `cmd/stats_compare.go::sessionIsTerminal`, and `buildStatsCompareRuns` which mirrors `loadCompareRuns`. The duplication is intentional and called out in the file header — the cmd package can't be imported from `internal/sidecar`, and lifting the logic into `internal/db` would force `db` to import `internal/agent` for `IsTerminal`.
- `host_api.go`: three new `case` arms on the existing `/stats` dispatcher (`compare`, `abtest`, `abtest_list`). All-roles auth inherited from the existing `/stats` handler. Doc comment and the "unknown view" error message both updated.

**CLI (`cmd/`)**
- `hostapi.go`: `proxyStatsCompare`, `proxyStatsAbtest`, `proxyStatsAbtestList` — thin wrappers over `proxyReadToHostAPI(apiURL, "/stats", ...)`.
- `stats_compare.go`: `runStatsCompare` and `runStatsAbtest` gain a `PRISM_HOST_API` env-var check that branches to `runStatsCompareProxy` / `runStatsAbtestProxy`. `runComparison` is split into `runComparison` (direct-DB) and `renderComparison` (path-agnostic) so the proxy path can hand pre-loaded runs to the same renderer.
- `stats_abtest.go`: `runStatsAbtestFlag` gains a `PRISM_HOST_API` branch that calls `runStatsAbtestFlagProxy`. The empty-set hint is factored into `printAbtestPairsEmpty` so both paths emit byte-identical "no abtest pairs recorded" output.

## Tests

All new tests run with `go test ./... -race`. Both the cmd suite and the sidecar suite pass.

**`cmd/stats_proxy_test.go`** (extended):
- `TestProxyStatsCompare_SendsCorrectQueryParams` / `..._SendsCorrectQueryParams` for abtest + abtest_list — verify the URL shape.
- `TestRunStatsCompare_ProxyHappyPath` — mock server, end-to-end render assertion.
- `TestRunStatsCompare_Proxy404Surface` — 404 from sidecar surfaces as an error containing the missing id.
- `TestRunStatsCompare_ProxyJSONFormat` / `_ProxyCSVFormat` — both alternate output formats round-trip through the proxy.
- `TestRunStatsCompare_ProxyDiffOnly` — `--diff-only` filters the matching-row case and keeps the differing-row case on the proxy path.
- `TestRunStatsCompare_HostPathUnchanged` — **negative test, over-broad-fix guard**: `PRISM_HOST_API` unset → proxy server is never contacted, render still works.
- `TestRunStatsCompare_ProxyByteIdentity` — seeds a real DB, persists spawn_outcome rows (so reads are deterministic), captures direct-DB output, builds the wire payload from the same DB rows, captures proxy output, asserts exact string equality.
- `TestRunStatsAbtest_ProxyHappyPath` / `_HostPathUnchanged` — same shape for the abtest subcommand.
- `TestRunStatsAbtestFlag_ProxyHappyPath` / `_ProxyEmpty` / `_HostPathUnchanged` — same shape for the `--abtest` listing flag.

**`internal/sidecar/sidecar_stats_compare_test.go`** (new file):
- `TestHostAPI_Stats_Compare_HappyPath` / `_TerminalFallbackToComputeSpawnOutcome` / `_LiveSessionOmitsOutcome` / `_MissingIdReturns404` / `_RequiresIds` / `_RequiresAtLeastTwoIds` / `_ByName` — the `view=compare` handler tested through `hostAPIHandler()` against a real test DB.
- `TestHostAPI_Stats_Abtest_HappyPath` / `_MissingGroupReturns404` / `_RequiresGroupID` — the `view=abtest` handler, including the session-name sort order that matches `runStatsAbtest`'s direct-DB sort.
- `TestHostAPI_Stats_AbtestList_Empty` / `_HappyPath` — the `view=abtest_list` handler, including the empty-array (not `null`) JSON envelope guarantee.
- `TestHostAPI_Stats_UnknownViewIncludesNewViews` — guards against drift between the dispatcher's `default:` message and the actual switch arms.

## Manual repro (from the issue)

Setup is identical to the bug report: an in-sandbox coordinator session with `PRISM_HOST_API=unix://...` and two ended sessions on the host. The byte-identity test (`TestRunStatsCompare_ProxyByteIdentity`) exercises the same code path against a synthetic DB inside the test runner — direct render and proxy render produce string-equal output. A live manual repro requires a sandbox-with-coordinator setup which I have not stood up; the byte-identity test covers the contract a manual repro would verify.

## Out of scope

Out-of-scope items listed in the issue (single-instance token-detail proxy gap at `cmd/stats.go:348`, new comparison axes, table layout changes) are unchanged here.