### PR TITLE
Update default prism profile to anthropic-opus-max

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -25,7 +25,7 @@ in
   nx = {
     programs = {
       prism = {
-        profile.default = "anthropic-opus-medium";
+        profile.default = "anthropic-opus-max";
         agent.isolation.default = "sandbox-exec";
         pi.atlassian = {
           enable = true;


### PR DESCRIPTION
Increase the default prism profile on the m4mac machine to use the anthropic-opus-max model. This change ensures better performance and higher quality output for default agent interactions.