### PR TITLE
prism investigate: pre-compute HarnessPipeSockPath for host-mode invokers

### DIFF
--- a/modules/programs/prism/prism/cmd/investigate.go
+++ b/modules/programs/prism/prism/cmd/investigate.go
@@ -26,11 +26,19 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
+	"github.com/prismatic-koi/prism/internal/proglog"
 	"github.com/prismatic-koi/prism/internal/session"
 )
+
+// investigateSpawnSessionFn is the function used to actually spawn the
+// investigator session. It defaults to session.SpawnSession; tests can swap
+// it out to capture the SpawnOpts that would be passed to SpawnSession
+// without performing the (tmux + sidecar) side-effects.
+var investigateSpawnSessionFn = session.SpawnSession
 
 var investigateCmd = &cobra.Command{
 	Use:   "investigate",
@@ -118,7 +126,13 @@ func spawnInvestigateSession(invokerSession, promptText, suppliedName string) er
 		return fmt.Errorf("open db: %w", err)
 	}
 	defer database.Close()
+	return spawnInvestigateSessionWithDB(database, invokerSession, promptText, suppliedName)
+}
 
+// spawnInvestigateSessionWithDB is the DB-injected core of spawnInvestigateSession,
+// extracted so tests can drive the SpawnOpts construction against an isolated DB
+// (sidecartest.NewIsolated) without going through openDB() / a real prism.db.
+func spawnInvestigateSessionWithDB(database *db.DB, invokerSession, promptText, suppliedName string) error {
 	status, err := database.CurrentStatus(invokerSession)
 	if err != nil {
 		return fmt.Errorf("prism investigate: read invoker status: %w", err)
@@ -178,7 +192,21 @@ func spawnInvestigateSession(invokerSession, promptText, suppliedName string) er
 		PIExtensionDir: cfg.PIExtensionDir,
 	}
 
-	if err := session.SpawnSession(database, spawnOpts); err != nil {
+	// For socket-pipe harnesses (e.g. "pi") in host isolation mode, pre-compute
+	// the Unix socket path so agentPaneEnvVars can inject PRISM_HARNESS_PIPE
+	// into the tmux pane. bwrap and sandbox-exec set PRISM_HARNESS_PIPE via
+	// their own paths (bwrap.go --setenv, sandbox-exec profile, podman --env);
+	// only inject here for host mode. Mirrors the same block in spawn.go,
+	// switch.go, and restore.go (issue #2111).
+	if hShape, hShapeOK := harness.ShapeOf(harnessName); hShapeOK && hShape == harness.TransportSocketPipe && string(isoMode) == "host" {
+		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
+			spawnOpts.HarnessPipeSockPath = pipePath
+		} else {
+			proglog.Warnf("[prism investigate] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
+		}
+	}
+
+	if err := investigateSpawnSessionFn(database, spawnOpts); err != nil {
 		return fmt.Errorf("prism investigate: spawn session: %w", err)
 	}
 

--- a/modules/programs/prism/prism/cmd/investigate_harness_pipe_test.go
+++ b/modules/programs/prism/prism/cmd/investigate_harness_pipe_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+// Regression tests for issue #2111 — `prism investigate` must pre-compute
+// SpawnOpts.HarnessPipeSockPath for host-mode pi invokers, mirroring the
+// same gate that lives in cmd/spawn.go, cmd/switch.go, and cmd/restore.go.
+//
+// For host-mode invokers, the PI extension only learns where to reach the
+// sidecar via PRISM_HARNESS_PIPE in the tmux pane env. That env var is only
+// emitted by agentPaneEnvVars when opts.HarnessPipeSockPath != "". Before
+// the fix, cmd/investigate.go::spawnInvestigateSession built SpawnOpts with
+// HarnessPipeSockPath left empty unconditionally, which made the PI extension
+// no-op out, the `--agent` flag never register, and pi reject
+// `--agent investigate --prompt "..."` as `Unknown options`.
+//
+// The two tests below intercept the SpawnSession call via the
+// investigateSpawnSessionFn package var and assert on the captured SpawnOpts:
+//
+//   - TestSpawnInvestigateSession_HostMode_PopulatesHarnessPipeSockPath
+//     proves the gate fires for host-mode invokers.
+//   - TestSpawnInvestigateSession_BwrapMode_LeavesHarnessPipeSockPathEmpty
+//     proves the gate does real work — for container-mode invokers
+//     HarnessPipeSockPath stays empty, so the existing container-mode
+//     injection paths (bwrap --setenv, sandbox-exec profile, podman --env)
+//     remain responsible for PRISM_HARNESS_PIPE.
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608):
+//   - sidecartest.NewIsolated redirects $XDG_STATE_HOME to a t.TempDir() and
+//     sets the PRISM_TEST_MODE_RESTRICT_HOSTAPI guard.
+//   - Session names use the "prism-test@" prefix.
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// seedInvestigateInvoker inserts an active invoker row for the given session
+// and explicitly stamps the requested isolation_mode. The invoker row must
+// exist before spawnInvestigateSessionWithDB can call CurrentStatus.
+func seedInvestigateInvoker(t *testing.T, d *db.DB, sessionName, isolationMode string) {
+	t.Helper()
+	agentName := "coordinator"
+	if err := d.UpsertStatusWithRootAgent(
+		sessionName,
+		"prism-test",
+		"/tmp/test-worktree",
+		"active",
+		nil, nil,
+		&agentName, nil,
+	); err != nil {
+		t.Fatalf("seedInvestigateInvoker: UpsertStatusWithRootAgent: %v", err)
+	}
+	if err := d.SetIsolationMode(sessionName, isolationMode); err != nil {
+		t.Fatalf("seedInvestigateInvoker: SetIsolationMode(%q): %v", isolationMode, err)
+	}
+}
+
+// TestSpawnInvestigateSession_HostMode_PopulatesHarnessPipeSockPath verifies
+// AC: when the invoker's resolved isolation mode is "host" and the harness
+// is "pi" (socket-pipe transport), spawnOpts.HarnessPipeSockPath equals
+// session.SidecarHarnessPipePath(<new-session-name>).
+//
+// This is the failure case in #2111: before the fix HarnessPipeSockPath was
+// left empty for host-mode invokers, the PI extension no-op'd, and pi
+// rejected --agent/--prompt as unknown flags.
+func TestSpawnInvestigateSession_HostMode_PopulatesHarnessPipeSockPath(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+
+	invoker := "prism-test@coord-" + t.Name()
+	seedInvestigateInvoker(t, bus.DB, invoker, "host")
+
+	var captured *session.SpawnOpts
+	prev := investigateSpawnSessionFn
+	investigateSpawnSessionFn = func(_ *db.DB, opts session.SpawnOpts) error {
+		clone := opts
+		captured = &clone
+		return nil
+	}
+	t.Cleanup(func() { investigateSpawnSessionFn = prev })
+
+	const promptText = "trace the call chain for SSH auth"
+	const suppliedName = "ssh-auth-trace"
+	if err := spawnInvestigateSessionWithDB(bus.DB, invoker, promptText, suppliedName); err != nil {
+		t.Fatalf("spawnInvestigateSessionWithDB: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("investigateSpawnSessionFn was never invoked — SpawnOpts not captured")
+	}
+
+	wantSessionName := invoker + "~investigate-" + suppliedName
+	if captured.SessionName != wantSessionName {
+		t.Fatalf("SpawnOpts.SessionName = %q, want %q", captured.SessionName, wantSessionName)
+	}
+
+	// Sanity: investigate hard-codes the pi harness.
+	if captured.HarnessName != "pi" {
+		t.Errorf("SpawnOpts.HarnessName = %q, want %q", captured.HarnessName, "pi")
+	}
+	// Sanity: the invoker's host isolation mode propagated into spawnOpts.
+	if captured.IsolationMode != "host" {
+		t.Errorf("SpawnOpts.IsolationMode = %q, want %q", captured.IsolationMode, "host")
+	}
+
+	wantPath, err := session.SidecarHarnessPipePath(wantSessionName)
+	if err != nil {
+		t.Fatalf("session.SidecarHarnessPipePath(%q): %v", wantSessionName, err)
+	}
+	if captured.HarnessPipeSockPath != wantPath {
+		t.Errorf("SpawnOpts.HarnessPipeSockPath = %q, want %q (issue #2111: host-mode pi invoker must populate the harness pipe sock path so agentPaneEnvVars emits PRISM_HARNESS_PIPE)",
+			captured.HarnessPipeSockPath, wantPath)
+	}
+}
+
+// TestSpawnInvestigateSession_BwrapMode_LeavesHarnessPipeSockPathEmpty
+// verifies the gate does real work: when the invoker's resolved isolation
+// mode is not "host" (here bwrap), SpawnOpts.HarnessPipeSockPath stays empty
+// so the existing container-mode injection paths (bwrap --setenv, sandbox-exec
+// profile, podman --env) remain responsible for PRISM_HARNESS_PIPE.
+//
+// Without this assertion a buggy fix that unconditionally set
+// HarnessPipeSockPath for all isolation modes would pass the host-mode test
+// — this is the negative half of the gate-correctness proof.
+func TestSpawnInvestigateSession_BwrapMode_LeavesHarnessPipeSockPathEmpty(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+
+	invoker := "prism-test@coord-" + t.Name()
+	seedInvestigateInvoker(t, bus.DB, invoker, "bwrap")
+
+	var captured *session.SpawnOpts
+	prev := investigateSpawnSessionFn
+	investigateSpawnSessionFn = func(_ *db.DB, opts session.SpawnOpts) error {
+		clone := opts
+		captured = &clone
+		return nil
+	}
+	t.Cleanup(func() { investigateSpawnSessionFn = prev })
+
+	const promptText = "trace the call chain for SSH auth"
+	const suppliedName = "ssh-auth-trace"
+	if err := spawnInvestigateSessionWithDB(bus.DB, invoker, promptText, suppliedName); err != nil {
+		t.Fatalf("spawnInvestigateSessionWithDB: %v", err)
+	}
+	if captured == nil {
+		t.Fatal("investigateSpawnSessionFn was never invoked — SpawnOpts not captured")
+	}
+
+	if captured.IsolationMode != "bwrap" {
+		t.Errorf("SpawnOpts.IsolationMode = %q, want %q", captured.IsolationMode, "bwrap")
+	}
+
+	if captured.HarnessPipeSockPath != "" {
+		t.Errorf("SpawnOpts.HarnessPipeSockPath = %q, want \"\" for bwrap invokers — container-mode injection paths (bwrap --setenv, sandbox-exec profile, podman --env) own PRISM_HARNESS_PIPE for container sessions; pre-computing the sock path here would double-inject (issue #2111 AC).",
+			captured.HarnessPipeSockPath)
+	}
+}


### PR DESCRIPTION
## Summary

`cmd/investigate.go::spawnInvestigateSession` was missing the harness-pipe pre-computation block that `cmd/spawn.go` (twice), `cmd/switch.go`, and `cmd/restore.go` all have. For host-mode pi invokers this meant `PRISM_HARNESS_PIPE` was never injected into the spawned investigator's pi pane env, the prism PI extension hit its no-op early-return, the `--agent` CLI flag was never registered, and pi rejected `--agent investigate --prompt "..."` with `Unknown options: --agent, --prompt`.

## Failure chain (before this fix)

1. Invoker session is host-mode (e.g. `ProjectIsolationOverrides["~/documents/obsidian"] = "host"`).
2. `prism investigate --prompt "..."` builds `SpawnOpts` with `HarnessPipeSockPath == ""`.
3. `agentPaneEnvVars` returns `nil` (host mode + empty pipe path).
4. The new tmux pane launches pi with no `PRISM_HARNESS_PIPE` in its env.
5. The prism PI extension hits its early-return no-op, so `pi.registerFlag("agent", ...)` never runs.
6. Pi parses CLI args, sees `--agent investigate --prompt "..."`, rejects both flags as unknown, exits non-zero.
7. The sidecar never receives a `hello` from pi → `HarnessSessionID` never populated → state stays `idle` → no per-turn notifications.

Container-mode invokers (`bwrap` / `sandbox-exec` / `podman`) were unaffected because they route `PRISM_HARNESS_PIPE` through their own paths (`bwrap.go --setenv`, sandbox-exec profile, podman `--env`).

## Fix

Add the same socket-pipe + host-mode gate after `spawnOpts` is constructed, populating `spawnOpts.HarnessPipeSockPath` via `session.SidecarHarnessPipePath(sessionName)`. Log prefix is `[prism investigate]` to match the existing convention across the four sibling call sites:

- `cmd/spawn.go:797-805` (`prism spawn`)
- `cmd/spawn.go:1346-1352` (`--abtest` leg)
- `cmd/switch.go:219-225` (re-attach)
- `cmd/restore.go:372-380` (restore)

## Refactor for testability

Extracted `spawnInvestigateSessionWithDB` so tests can drive SpawnOpts construction against `sidecartest.NewIsolated` without going through `openDB()` / a real `prism.db`. Introduced `investigateSpawnSessionFn` as a package-level swappable hook (default: `session.SpawnSession`) so tests can capture the SpawnOpts that would be passed without performing the (tmux + sidecar) side-effects.

## Regression tests

`cmd/investigate_harness_pipe_test.go` adds two tests:

- **`TestSpawnInvestigateSession_HostMode_PopulatesHarnessPipeSockPath`** — proves the gate fires: for a host-mode invoker the captured `spawnOpts.HarnessPipeSockPath` equals `session.SidecarHarnessPipePath(<new-session-name>)`.
- **`TestSpawnInvestigateSession_BwrapMode_LeavesHarnessPipeSockPathEmpty`** — proves the gate does real work (negative-mutation half): for a bwrap invoker `HarnessPipeSockPath` stays empty, so the container-mode injection paths continue to own `PRISM_HARNESS_PIPE`.

Both tests use `sidecartest.NewIsolated(t, ...)` and the `prism-test@` session-name prefix per AGENTS.md "Test-suite isolation (issue #1608)".

Negative-mutation check performed locally: temporarily deleting the new gate block from the production file causes `TestSpawnInvestigateSession_HostMode_PopulatesHarnessPipeSockPath` to fail (`HarnessPipeSockPath = "", want "<pipe-sock-path>"`), confirming the test is not a no-op.

## Verification

- `go build ./...` (from `modules/programs/prism/prism/`) — passes.
- `go test -run 'Investigate' ./cmd/` — all investigate tests pass (existing + 2 new).
- `go vet ./cmd/` — clean.
- Full `go test ./...` has pre-existing environmental failures (tmux `fork failed: Operation not permitted` under the worker sandbox) that also reproduce on `main`; unrelated to this change. CI exercises the homeless-shelter signal via `nix-build-prism-checked`.

Closes #2111
