### PR TITLE
prism: inherit parent worker profile in review and investigate child-spawn (#2097)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_profile.go
+++ b/modules/programs/prism/prism/cmd/agent_run_profile.go
@@ -1,6 +1,6 @@
 package cmd
 
-// agent_run_profile.go — issue #2092 fix.
+// agent_run_profile.go — issue #2092 fix, refactored in #2097.
 //
 // `prism spawn --profile <X>` and `prism spawn --abtest <A> <B>` carry the
 // per-spawn profile name through to `spawn_inputs.profile_name` (#2090's
@@ -15,6 +15,13 @@ package cmd
 // passes as the `flagValue` argument to ResolveActiveProfile (treated by
 // that function as the highest-precedence source).
 //
+// In #2097 the SQL-shaped half of this helper was promoted to
+// `internal/profile.SpawnTimeForSession` so the same lookup can be
+// reused by the child-spawn surfaces (`internal/review` and
+// `cmd/investigate.go`) without a `cmd`-package import cycle. This
+// thin wrapper is kept so the cmd-side opens its own short-lived DB
+// handle (populatePIConfig does not get a *db.DB threaded through).
+//
 // The lookup is best-effort: any error — DB unreachable, sessions row
 // missing, spawn_inputs row missing, profile_name NULL — is collapsed to
 // the empty string. Callers fall through to the existing state-file /
@@ -24,19 +31,18 @@ package cmd
 // spawn_inputs, and on transient DB problems where wedging the agent
 // startup would be the wrong failure mode.
 
-// spawnTimeProfileForSession returns the profile name recorded on the
-// spawn_inputs row for the named session, or "" when the row is missing,
-// has a NULL profile_name, or any lookup error occurs.
+import (
+	"github.com/prismatic-koi/prism/internal/profile"
+)
+
+// spawnTimeProfileForSession is the cmd-side wrapper around
+// profile.SpawnTimeForSession. It opens a short-lived DB handle and
+// delegates the actual lookup. See the package-level doc in
+// internal/profile for the precedence rationale.
 //
-// This is the canonical post-#2090 source of "what profile did the user
-// invoke `prism spawn --profile` with" — populatePIConfig calls it to
-// recover the spawn-time profile choice that ResolveActiveProfile alone
-// would silently substitute the active profile for (issue #2092).
-//
-// Errors are intentionally swallowed (returned as ""): a transient DB
-// problem must not wedge the agent startup. The caller falls through to
-// the active-profile resolution, which is the pre-#2092 behaviour and is
-// the right safety net for legacy sessions / host-mode / etc.
+// Errors opening the DB are intentionally swallowed (returned as "")
+// for the same reason as the inner helper: a transient DB problem must
+// not wedge agent startup.
 func spawnTimeProfileForSession(sessionName string) string {
 	if sessionName == "" {
 		return ""
@@ -46,14 +52,5 @@ func spawnTimeProfileForSession(sessionName string) string {
 		return ""
 	}
 	defer d.Close()
-
-	sess, err := d.MostRecentSessionForName(sessionName)
-	if err != nil || sess == nil {
-		return ""
-	}
-	si, err := d.SpawnInputsByInstanceID(sess.InstanceID)
-	if err != nil || si == nil || si.ProfileName == nil {
-		return ""
-	}
-	return *si.ProfileName
+	return profile.SpawnTimeForSession(d, sessionName)
 }

--- a/modules/programs/prism/prism/cmd/investigate.go
+++ b/modules/programs/prism/prism/cmd/investigate.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	investigatepkg "github.com/prismatic-koi/prism/internal/investigate"
 	"github.com/prismatic-koi/prism/internal/proglog"
+	"github.com/prismatic-koi/prism/internal/profile"
 	"github.com/prismatic-koi/prism/internal/session"
 )
 
@@ -129,16 +130,60 @@ func spawnInvestigateSession(invokerSession, promptText, suppliedName string) er
 	return spawnInvestigateSessionWithDB(database, invokerSession, promptText, suppliedName)
 }
 
-// spawnInvestigateSessionWithDB is the DB-injected core of spawnInvestigateSession,
-// extracted so tests can drive the SpawnOpts construction against an isolated DB
-// (sidecartest.NewIsolated) without going through openDB() / a real prism.db.
+// spawnInvestigateSessionWithDB is the DB-injected core of
+// spawnInvestigateSession, extracted in #2113 so tests can drive the
+// SpawnOpts construction against an isolated DB (sidecartest.NewIsolated)
+// without going through openDB() / a real prism.db.
 func spawnInvestigateSessionWithDB(database *db.DB, invokerSession, promptText, suppliedName string) error {
+	spawnOpts, isoMode, harnessName, err := buildInvestigateSpawnOpts(database, invokerSession, promptText, suppliedName)
+	if err != nil {
+		return err
+	}
+
+	// For socket-pipe harnesses (e.g. "pi") in host isolation mode, pre-compute
+	// the Unix socket path so agentPaneEnvVars can inject PRISM_HARNESS_PIPE
+	// into the tmux pane. bwrap and sandbox-exec set PRISM_HARNESS_PIPE via
+	// their own paths (bwrap.go --setenv, sandbox-exec profile, podman --env);
+	// only inject here for host mode. Mirrors the same block in spawn.go,
+	// switch.go, and restore.go (issue #2111).
+	if hShape, hShapeOK := harness.ShapeOf(harnessName); hShapeOK && hShape == harness.TransportSocketPipe && string(isoMode) == "host" {
+		if pipePath, pipeErr := session.SidecarHarnessPipePath(spawnOpts.SessionName); pipeErr == nil {
+			spawnOpts.HarnessPipeSockPath = pipePath
+		} else {
+			proglog.Warnf("[prism investigate] warning: could not resolve harness pipe path for %q: %v\n", spawnOpts.SessionName, pipeErr)
+		}
+	}
+
+	if err := investigateSpawnSessionFn(database, spawnOpts); err != nil {
+		return fmt.Errorf("prism investigate: spawn session: %w", err)
+	}
+
+	fmt.Println(spawnOpts.SessionName)
+	return nil
+}
+
+// buildInvestigateSpawnOpts resolves everything spawnInvestigateSessionWithDB
+// needs to know about the child session BEFORE the heavyweight
+// session.SpawnSession call (which touches tmux, sidecar, and port
+// allocation). Extracted from spawnInvestigateSessionWithDB in #2097 so the
+// profile-inheritance path can be unit-tested without spinning up the real
+// spawn machinery — the test calls this helper with a seeded DB and asserts
+// on the returned SpawnOpts.ProfileName.
+//
+// The returned SpawnOpts.ProfileName carries the resolved profile from the
+// invoker session via profile.InheritFromParent — see the inline comment
+// block below for the precedence rationale.
+//
+// isolation mode and harness name are returned alongside the SpawnOpts so
+// the #2111 HarnessPipeSockPath pre-computation step (which keys off both)
+// stays in spawnInvestigateSessionWithDB without re-resolving them.
+func buildInvestigateSpawnOpts(database *db.DB, invokerSession, promptText, suppliedName string) (session.SpawnOpts, config.IsolationMode, string, error) {
 	status, err := database.CurrentStatus(invokerSession)
 	if err != nil {
-		return fmt.Errorf("prism investigate: read invoker status: %w", err)
+		return session.SpawnOpts{}, "", "", fmt.Errorf("prism investigate: read invoker status: %w", err)
 	}
 	if status == nil {
-		return fmt.Errorf("prism investigate: invoker session %q has no agent_status row", invokerSession)
+		return session.SpawnOpts{}, "", "", fmt.Errorf("prism investigate: invoker session %q has no agent_status row", invokerSession)
 	}
 
 	repo := status.Repo
@@ -160,6 +205,28 @@ func spawnInvestigateSessionWithDB(database *db.DB, invokerSession, promptText, 
 		isoMode = config.IsolationMode(cfg.DefaultIsolationMode)
 	}
 
+	// Resolve the profile the child investigate session should inherit
+	// from its invoker (issue #2097). The precedence is identical to the
+	// worker layer's #2092 chain:
+	//
+	//   1. Invoker's `spawn_inputs.profile_name` (highest, e.g. an
+	//      `--abtest` leg's per-leg profile).
+	//   2. Runtime state file `$XDG_STATE_HOME/prism/active-profile`.
+	//   3. `pf.Default` — the nix-configured default, lowest.
+	//
+	// profiles.json is loaded best-effort: a missing file is non-fatal on
+	// host-mode setups (mirrors the cmd/spawn.go pattern), and
+	// ResolveActiveProfile (called inside InheritFromParent) tolerates a
+	// nil ProfilesFile by falling through to the spawn-time or state-file
+	// value. Errors from the state-file read path are surfaced so a
+	// corrupt active-profile file does not silently pin every investigate
+	// to nix-default.
+	pf, _ := config.LoadProfiles()
+	resolvedProfile, profErr := profile.InheritFromParent(database, invokerSession, pf)
+	if profErr != nil {
+		return session.SpawnOpts{}, "", "", fmt.Errorf("prism investigate: resolve active profile: %w", profErr)
+	}
+
 	// Pi is the sole harness. Use harness.Lookup("pi") as the single source of truth.
 	harnessName := "pi"
 	h, _ := harness.New(harnessName, "", nil, "", "")
@@ -176,6 +243,12 @@ func spawnInvestigateSessionWithDB(database *db.DB, invokerSession, promptText, 
 		// alongside `prism spawn` / `prism pr` rows.
 		AgentFlag:   "investigate",
 		HarnessFlag: harnessName,
+		// ProfileName carries the inherited profile through to the child's
+		// `spawn_inputs.profile_name` row (issue #2097). The child's
+		// runtime populatePIConfig reads that column via the #2092 chain
+		// and resolves to the same models the invoker was spawned with,
+		// instead of the host default.
+		ProfileName: resolvedProfile,
 		// spawn_inputs.isolation_flag: record the resolved isolation mode
 		// so investigate spawns surface alongside `prism spawn` rows in the
 		// stats compare "Spawn Inputs" block (issue #2102 Layer 2).
@@ -192,26 +265,7 @@ func spawnInvestigateSessionWithDB(database *db.DB, invokerSession, promptText, 
 		PIExtensionDir: cfg.PIExtensionDir,
 	}
 
-	// For socket-pipe harnesses (e.g. "pi") in host isolation mode, pre-compute
-	// the Unix socket path so agentPaneEnvVars can inject PRISM_HARNESS_PIPE
-	// into the tmux pane. bwrap and sandbox-exec set PRISM_HARNESS_PIPE via
-	// their own paths (bwrap.go --setenv, sandbox-exec profile, podman --env);
-	// only inject here for host mode. Mirrors the same block in spawn.go,
-	// switch.go, and restore.go (issue #2111).
-	if hShape, hShapeOK := harness.ShapeOf(harnessName); hShapeOK && hShape == harness.TransportSocketPipe && string(isoMode) == "host" {
-		if pipePath, pipeErr := session.SidecarHarnessPipePath(sessionName); pipeErr == nil {
-			spawnOpts.HarnessPipeSockPath = pipePath
-		} else {
-			proglog.Warnf("[prism investigate] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
-		}
-	}
-
-	if err := investigateSpawnSessionFn(database, spawnOpts); err != nil {
-		return fmt.Errorf("prism investigate: spawn session: %w", err)
-	}
-
-	fmt.Println(sessionName)
-	return nil
+	return spawnOpts, isoMode, harnessName, nil
 }
 
 // investigateSlug derives a short kebab-case slug from the prompt text.

--- a/modules/programs/prism/prism/cmd/investigate_profile_test.go
+++ b/modules/programs/prism/prism/cmd/investigate_profile_test.go
@@ -1,0 +1,295 @@
+package cmd
+
+// investigate_profile_test.go — issue #2097 regression tests for the
+// investigate-spawn profile-inheritance path.
+//
+// `prism investigate` is the second of the two child-spawn front doors
+// fixed in #2097 (the first being `prism review`). Before #2097 the
+// spawned investigate session resolved its profile via
+// ResolveActiveProfile(pf, "") and silently picked up the host default,
+// regardless of the invoker's `--profile` choice.
+//
+// buildInvestigateSpawnOpts is the testable seam extracted from
+// spawnInvestigateSession in #2097 — it returns the SpawnOpts that
+// would be handed to session.SpawnSession, without actually spawning
+// (no tmux, no sidecar, no port allocation). Asserting on the
+// SpawnOpts.ProfileName field there is equivalent to asserting on the
+// spawn_inputs.profile_name row that SpawnSession would write
+// (session.SpawnInputsFromOpts maps the field directly — covered by
+// cmd/spawn_inputs_writer_test.go).
+//
+// The tests below pin:
+//
+//   - AC #6 positive — modern invoker → child SpawnOpts.ProfileName
+//     equals the invoker's spawn_inputs.profile_name.
+//   - AC #7 abtest — two invokers with distinct profile_name values,
+//     mirroring an `--abtest` pair, each produce a child whose
+//     ProfileName matches the leg's profile (no cross-bleed).
+//   - AC #8 negative — invoker with no spawn_inputs row falls through
+//     to state-file > nix-default. No regression.
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608):
+//   - sidecartest.NewIsolated redirects $XDG_STATE_HOME to a t.TempDir()
+//     and sets PRISM_TEST_MODE_RESTRICT_HOSTAPI so no host bus / DB /
+//     tmux state is touched.
+//   - SetTestDBPath is used to point cmd.openDB at the sidecartest-owned
+//     DB (the investigate code path calls openDB internally; the seam
+//     accepts an external DB but the test verifies the full flow).
+//   - Session names use the "prism-test@" prefix.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// seedInvokerSession creates the rows buildInvestigateSpawnOpts needs:
+// a sessions row (for spawn_inputs FK), a spawn_inputs row with the
+// supplied profile_name (or NULL if empty), and an agent_status row
+// (CurrentStatus dependency in the builder).
+//
+// abtestPairID is optional — pass "" to leave NULL.
+func seedInvokerSession(t *testing.T, d *db.DB, sessionName, profileName, abtestPairID string) {
+	t.Helper()
+	iid := uuid.New().String()
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: sessionName,
+		Repo:        "prism-test",
+		Worktree:    "/tmp/" + sessionName,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	si := db.SpawnInputs{InstanceID: iid}
+	if profileName != "" {
+		p := profileName
+		si.ProfileName = &p
+	}
+	if abtestPairID != "" {
+		pair := abtestPairID
+		si.AbtestPairID = &pair
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+	}
+	// agent_status row — buildInvestigateSpawnOpts reads CurrentStatus for
+	// the invoker's repo / worktree / isolation_mode. The state literal here
+	// matches the kept-active states used elsewhere in the cmd-side tests.
+	if err := d.UpsertStatusSeedRootAgentName(
+		sessionName,
+		"prism-test",
+		"/tmp/"+sessionName,
+		"idle",
+		nil, nil,
+		"worker",
+		"pi",
+		"bwrap",
+	); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName %q: %v", sessionName, err)
+	}
+}
+
+// writeProfilesJSON drops a minimal profiles.json under
+// $XDG_CONFIG_HOME/prism/ so config.LoadProfiles (called from
+// buildInvestigateSpawnOpts) returns a non-nil ProfilesFile with the
+// supplied default + named profiles.
+func writeProfilesJSON(t *testing.T, configHome, defaultName string, profileNames ...string) {
+	t.Helper()
+	dir := filepath.Join(configHome, "prism")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir prism config dir: %v", err)
+	}
+	entries := make(map[string]config.ProfileEntry, len(profileNames))
+	for _, n := range profileNames {
+		entries[n] = config.ProfileEntry{
+			"investigate": config.RoleSlot{Provider: "anthropic", Model: n + "/model-investigate", Thinking: "medium"},
+			"worker":      config.RoleSlot{Provider: "anthropic", Model: n + "/model-worker", Thinking: "medium"},
+		}
+	}
+	pf := config.ProfilesFile{Default: defaultName, Profiles: entries}
+	b, err := json.Marshal(&pf)
+	if err != nil {
+		t.Fatalf("marshal profiles: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "profiles.json"), b, 0o600); err != nil {
+		t.Fatalf("write profiles.json: %v", err)
+	}
+}
+
+// isolateForInvestigateBuilder combines sidecartest's $XDG_STATE_HOME
+// + isolated DB with a fresh $XDG_CONFIG_HOME so config.LoadProfiles
+// reads our profiles.json fixture. The returned configHome is where
+// the test should drop its profiles.json. The DB is returned for
+// seeding invoker rows.
+func isolateForInvestigateBuilder(t *testing.T) (configHome string, testDB *db.DB) {
+	t.Helper()
+	bus := sidecartest.NewIsolated(t, "")
+	SetTestDBPath(bus.DB.Path())
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	tmp := t.TempDir()
+	configHome = filepath.Join(tmp, "config")
+	if err := os.MkdirAll(configHome, 0o700); err != nil {
+		t.Fatalf("mkdir config home: %v", err)
+	}
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	// XDG_STATE_HOME is owned by sidecartest \u2014 don't clobber it.
+	return configHome, bus.DB
+}
+
+// writeStateFileForInvestigate writes the active-profile state file
+// into the sidecartest-owned $XDG_STATE_HOME. Used to exercise the
+// state-file rung of the precedence chain.
+func writeStateFileForInvestigate(t *testing.T, profileName string) {
+	t.Helper()
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		t.Fatalf("writeStateFileForInvestigate: XDG_STATE_HOME unset")
+	}
+	dir := filepath.Join(stateHome, "prism")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "active-profile"), []byte(profileName+"\n"), 0o644); err != nil {
+		t.Fatalf("write active-profile state file: %v", err)
+	}
+}
+
+// TestInvestigateFanout_ProfileInheritedFromModernInvoker is the AC #6
+// positive: invoker has spawn_inputs.profile_name=X → the child's
+// SpawnOpts.ProfileName = X. SpawnSession (via SpawnInputsFromOpts)
+// then writes profile_name=X on the child's audit row.
+func TestInvestigateFanout_ProfileInheritedFromModernInvoker(t *testing.T) {
+	configHome, d := isolateForInvestigateBuilder(t)
+	const invoker = "prism-test@worker-investigate-modern"
+	const invokerProfile = "anthropic-opus"
+	seedInvokerSession(t, d, invoker, invokerProfile, "")
+	// State-file points at a competing profile to prove invoker wins.
+	writeStateFileForInvestigate(t, "state-file-competing")
+	writeProfilesJSON(t, configHome, "nix-default",
+		invokerProfile, "state-file-competing", "nix-default")
+
+	opts, _, _, err := buildInvestigateSpawnOpts(d, invoker, "trace ssh auth", "")
+	if err != nil {
+		t.Fatalf("buildInvestigateSpawnOpts: %v", err)
+	}
+	if opts.ProfileName != invokerProfile {
+		t.Errorf("SpawnOpts.ProfileName = %q, want %q (modern invoker must inherit its own profile)",
+			opts.ProfileName, invokerProfile)
+	}
+	// Defence-in-depth: the child should also not leak to the competing
+	// state-file value or to the nix-default.
+	if opts.ProfileName == "state-file-competing" {
+		t.Errorf("investigate child leaked to state-file profile \u2014 #2097 regression")
+	}
+	if opts.ProfileName == "nix-default" {
+		t.Errorf("investigate child leaked to nix-default \u2014 #2097 regression")
+	}
+}
+
+// TestInvestigateFanout_AbtestLegsResolveIndependently is the AC #7
+// shape adapted for investigate: two invokers sharing an
+// abtest_pair_id but each carrying its own profile_name. Each
+// invoker's investigate-child must carry its own profile, never the
+// sibling's.
+func TestInvestigateFanout_AbtestLegsResolveIndependently(t *testing.T) {
+	configHome, d := isolateForInvestigateBuilder(t)
+	const pairID = "test-abtest-pair-2097-investigate"
+	writeStateFileForInvestigate(t, "state-file-must-lose")
+	writeProfilesJSON(t, configHome, "nix-default",
+		"abtest-leg-a", "abtest-leg-b", "state-file-must-lose", "nix-default")
+
+	legs := []struct {
+		sessionName, profile string
+	}{
+		{"prism-test@worker-investigate-leg-a", "abtest-leg-a"},
+		{"prism-test@worker-investigate-leg-b", "abtest-leg-b"},
+	}
+	for _, leg := range legs {
+		seedInvokerSession(t, d, leg.sessionName, leg.profile, pairID)
+	}
+
+	for _, leg := range legs {
+		t.Run(leg.profile, func(t *testing.T) {
+			opts, _, _, err := buildInvestigateSpawnOpts(d, leg.sessionName, "leg query "+leg.profile, "")
+			if err != nil {
+				t.Fatalf("buildInvestigateSpawnOpts: %v", err)
+			}
+			if opts.ProfileName != leg.profile {
+				t.Errorf("leg %q: SpawnOpts.ProfileName = %q, want %q",
+					leg.profile, opts.ProfileName, leg.profile)
+			}
+			if opts.ProfileName == "state-file-must-lose" || opts.ProfileName == "nix-default" {
+				t.Errorf("leg %q leaked to state-file / nix-default \u2014 #2097 regression",
+					leg.profile)
+			}
+		})
+	}
+}
+
+// TestInvestigateFanout_LegacyInvokerFallsThroughToStateFile is the
+// AC #8 negative: an invoker with no spawn_inputs row (pre-#2090) →
+// the child falls through to the state-file value. No regression.
+//
+// Note: the invoker still needs an agent_status row (the
+// CurrentStatus check is unrelated to spawn_inputs) so we seed that
+// separately without going through seedInvokerSession.
+func TestInvestigateFanout_LegacyInvokerFallsThroughToStateFile(t *testing.T) {
+	configHome, d := isolateForInvestigateBuilder(t)
+	const invoker = "prism-test@worker-investigate-legacy"
+	if err := d.UpsertStatusSeedRootAgentName(
+		invoker, "prism-test", "/tmp/"+invoker,
+		"idle", nil, nil, "worker", "pi", "bwrap",
+	); err != nil {
+		t.Fatalf("seed legacy invoker status: %v", err)
+	}
+	// No InsertSession / InsertSpawnInputs \u2014 legacy invoker.
+
+	writeStateFileForInvestigate(t, "state-file-legacy-default")
+	writeProfilesJSON(t, configHome, "nix-default",
+		"state-file-legacy-default", "nix-default")
+
+	opts, _, _, err := buildInvestigateSpawnOpts(d, invoker, "legacy invoker query", "")
+	if err != nil {
+		t.Fatalf("buildInvestigateSpawnOpts: %v", err)
+	}
+	if opts.ProfileName != "state-file-legacy-default" {
+		t.Errorf("SpawnOpts.ProfileName = %q, want \"state-file-legacy-default\" (legacy invoker must fall through to state file)",
+			opts.ProfileName)
+	}
+}
+
+// TestInvestigateFanout_LegacyInvokerFallsThroughToNixDefault completes
+// the AC #8 chain: legacy invoker + no state-file → resolution lands
+// on pf.Default. This is the path every pre-#2097 investigate ran on
+// for users who had not invoked `prism profile set`.
+func TestInvestigateFanout_LegacyInvokerFallsThroughToNixDefault(t *testing.T) {
+	configHome, d := isolateForInvestigateBuilder(t)
+	const invoker = "prism-test@worker-investigate-fully-legacy"
+	if err := d.UpsertStatusSeedRootAgentName(
+		invoker, "prism-test", "/tmp/"+invoker,
+		"idle", nil, nil, "worker", "pi", "bwrap",
+	); err != nil {
+		t.Fatalf("seed legacy invoker status: %v", err)
+	}
+	// No InsertSession / InsertSpawnInputs, no state-file write.
+	writeProfilesJSON(t, configHome, "nix-default", "nix-default")
+
+	opts, _, _, err := buildInvestigateSpawnOpts(d, invoker, "fully legacy query", "")
+	if err != nil {
+		t.Fatalf("buildInvestigateSpawnOpts: %v", err)
+	}
+	if opts.ProfileName != "nix-default" {
+		t.Errorf("SpawnOpts.ProfileName = %q, want \"nix-default\" (fully legacy invoker must fall through to nix-default)",
+			opts.ProfileName)
+	}
+}

--- a/modules/programs/prism/prism/internal/profile/inherit.go
+++ b/modules/programs/prism/prism/internal/profile/inherit.go
@@ -1,0 +1,57 @@
+package profile
+
+// inherit.go — child-spawn profile-inheritance helper (issue #2097).
+//
+// `prism review` and `prism investigate` spawn child agents whose
+// profile must inherit the parent worker's spawn-time profile. Before
+// #2097 both front doors resolved the child's profile via
+// `ResolveActiveProfile(pf, "")` — empty flag value — so the resolution
+// silently fell through to state-file > nix-default regardless of the
+// parent's `--profile` choice. This was the same shape of bug #2092
+// fixed for the worker layer; this file extends the precedence chain
+// to the child-spawn surfaces.
+
+import (
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// InheritFromParent returns the profile name a child session should be
+// spawned with, given the parent session it was invoked from
+// (issue #2097).
+//
+// Precedence (matches the worker-layer chain established in #2092):
+//
+//  1. Parent's `spawn_inputs.profile_name` — highest. Carries the
+//     `prism spawn --profile X` / `--abtest A B` choice forward to
+//     the child.
+//  2. Runtime state file (`$XDG_STATE_HOME/prism/active-profile`).
+//  3. `pf.Default` — the nix-configured default, lowest.
+//
+// The returned name is suitable for both downstream uses on the
+// child-spawn path:
+//
+//   - As the `activeProfile` argument to
+//     `review.ResolveAgentConfigContent` so the per-agent
+//     opencode.json blob written at spawn time honours the parent's
+//     profile (relevant for bwrap / sandbox-exec children).
+//   - As `session.SpawnOpts.ProfileName` so the child's own
+//     `spawn_inputs.profile_name` row is populated, downstream
+//     `prism stats` / archive queries reflect the inherited profile,
+//     and the child's runtime `populatePIConfig` resolves to the
+//     same value via the #2092 lookup.
+//
+// pf may be nil — in that case the function returns the parent's raw
+// spawn-time profile (which may itself be "") and the caller falls
+// through to whatever default behaviour applies in their context.
+// ResolveActiveProfile also tolerates nil pf, so no extra guard is
+// needed here.
+//
+// State-file read errors are surfaced (matching the worker-layer
+// semantic from #2092) — a corrupt active-profile file is a real
+// problem, not a silent fallthrough condition.
+func InheritFromParent(d *db.DB, parentSession string, pf *config.ProfilesFile) (string, error) {
+	spawnProfile := SpawnTimeForSession(d, parentSession)
+	resolved, _, err := config.ResolveActiveProfile(pf, spawnProfile)
+	return resolved, err
+}

--- a/modules/programs/prism/prism/internal/profile/inherit_test.go
+++ b/modules/programs/prism/prism/internal/profile/inherit_test.go
@@ -1,0 +1,234 @@
+package profile
+
+// inherit_test.go — issue #2097 unit tests for the child-spawn
+// profile-inheritance helper.
+//
+// InheritFromParent composes SpawnTimeForSession with
+// config.ResolveActiveProfile to give callers a single entry point that
+// honours the same precedence chain as the worker-layer #2092 fix:
+//
+//   1. Parent's spawn_inputs.profile_name (highest).
+//   2. Runtime state file ($XDG_STATE_HOME/prism/active-profile).
+//   3. pf.Default — the nix-configured default (lowest).
+//
+// The tests below pin each rung of that ladder against an isolated DB +
+// state-file tempdir owned by sidecartest, plus a small per-test
+// ProfilesFile fixture.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// makeProfiles is a tiny fixture builder: it returns a ProfilesFile with
+// `defaultName` as the nix-default and the supplied profile names each
+// declaring a single "worker" slot. The test only cares about the name
+// resolution here, so the slot bodies are intentionally minimal.
+func makeProfiles(defaultName string, names ...string) *config.ProfilesFile {
+	entries := make(map[string]config.ProfileEntry, len(names))
+	for _, n := range names {
+		entries[n] = config.ProfileEntry{
+			"worker": config.RoleSlot{Provider: "anthropic", Model: n + "/model", Thinking: "medium"},
+		}
+	}
+	return &config.ProfilesFile{
+		Default:  defaultName,
+		Profiles: entries,
+	}
+}
+
+// writeStateFile drops the runtime active-profile state file into the
+// sidecartest-owned $XDG_STATE_HOME so ResolveActiveProfile's middle
+// rung (state-file) has something to read. sidecartest sets
+// XDG_STATE_HOME on t.Setenv so this resolves to the test sandbox.
+func writeStateFile(t *testing.T, profileName string) {
+	t.Helper()
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		t.Fatalf("writeStateFile: XDG_STATE_HOME unset \u2014 sidecartest.NewIsolated must run first")
+	}
+	dir := filepath.Join(stateHome, "prism")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "active-profile"), []byte(profileName+"\n"), 0o644); err != nil {
+		t.Fatalf("write active-profile state file: %v", err)
+	}
+}
+
+// TestInheritFromParent_ParentSpawnProfileWinsOverState pins the AC #1
+// positive: when the parent has spawn_inputs.profile_name=X and the
+// state-file points to a different profile, the parent's X wins. This
+// is the inverse of the pre-#2097 silent-drop: every review / investigate
+// would have returned the state-file value instead.
+func TestInheritFromParent_ParentSpawnProfileWinsOverState(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-parent-wins"
+	const parentProfile = "parent-X"
+	seedSessionWithSpawnInputs(t, bus.DB, parent, parentProfile)
+
+	// Set the state file to a competing profile \u2014 it must lose.
+	writeStateFile(t, "state-file-Y")
+	pf := makeProfiles("nix-default", parentProfile, "state-file-Y")
+
+	got, err := InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if got != parentProfile {
+		t.Errorf("InheritFromParent = %q, want %q (parent spawn_inputs.profile_name must beat state file)",
+			got, parentProfile)
+	}
+}
+
+// TestInheritFromParent_ParentSpawnProfileWinsOverNixDefault pins the
+// same precedence one rung down: parent's profile_name beats the
+// nix-default fallback (state file absent). This is the common case
+// for users without a `prism profile set` state file.
+func TestInheritFromParent_ParentSpawnProfileWinsOverNixDefault(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-parent-vs-nix-default"
+	const parentProfile = "parent-modern"
+	seedSessionWithSpawnInputs(t, bus.DB, parent, parentProfile)
+
+	// No state file \u2014 the only fallback is pf.Default.
+	pf := makeProfiles("nix-default", parentProfile, "nix-default")
+
+	got, err := InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if got != parentProfile {
+		t.Errorf("InheritFromParent = %q, want %q", got, parentProfile)
+	}
+}
+
+// TestInheritFromParent_LegacyParentFallsThroughToStateFile is the
+// AC #8 negative: a parent with no spawn_inputs row (pre-#2090
+// session) falls through to the state-file value when one is set.
+// This preserves restart semantics for legacy sessions.
+func TestInheritFromParent_LegacyParentFallsThroughToStateFile(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-legacy"
+	// Parent has no sessions row \u2014 SpawnTimeForSession returns "".
+	writeStateFile(t, "state-file-default")
+	pf := makeProfiles("nix-default", "state-file-default", "nix-default")
+
+	got, err := InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if got != "state-file-default" {
+		t.Errorf("InheritFromParent = %q, want \"state-file-default\" (legacy parent must fall through to state file)", got)
+	}
+}
+
+// TestInheritFromParent_LegacyParentFallsThroughToNixDefault completes
+// the AC #8 chain: with no spawn_inputs row AND no state file, the
+// nix-default wins. This is the "no per-session profile, no per-user
+// override" path and is what every pre-#2097 review / investigate ran
+// on.
+func TestInheritFromParent_LegacyParentFallsThroughToNixDefault(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-legacy-no-state"
+	// No sessions row, no state file.
+	pf := makeProfiles("nix-default", "nix-default")
+
+	got, err := InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if got != "nix-default" {
+		t.Errorf("InheritFromParent = %q, want \"nix-default\"", got)
+	}
+}
+
+// TestInheritFromParent_NullProfileNameFallsThrough pins the spawn_inputs
+// row with NULL profile_name shape \u2014 the row exists but the column is
+// empty. This is a path the host-mode spawn front door currently writes,
+// so we must not regress its resolution.
+func TestInheritFromParent_NullProfileNameFallsThrough(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-null-column"
+	seedSessionWithSpawnInputs(t, bus.DB, parent, "" /* NULL profile_name */)
+	writeStateFile(t, "state-file-fallback")
+	pf := makeProfiles("nix-default", "state-file-fallback", "nix-default")
+
+	got, err := InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if got != "state-file-fallback" {
+		t.Errorf("InheritFromParent = %q, want \"state-file-fallback\" (NULL profile_name must fall through)", got)
+	}
+}
+
+// TestInheritFromParent_AbtestPairResolvesPerLeg is the AC #7 abtest
+// shape: two parents with the same abtest_pair_id but distinct
+// profile_name values each resolve to their own profile. This is the
+// end-to-end fix for the live abtest reproducer in the issue body
+// (`zero-output-classify-v2-anthropic-opus-max` vs the `4-8` leg) \u2014
+// the per-leg variance must survive the child-spawn step.
+func TestInheritFromParent_AbtestPairResolvesPerLeg(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	// Set a state-file value too \u2014 if the parent's profile_name is ever
+	// dropped, the state file would be the silent next rung. Asserting
+	// the leg-specific profile beats the state-file value too is a
+	// stronger guard than just beating the nix-default.
+	writeStateFile(t, "state-file-X")
+	pf := makeProfiles("nix-default",
+		"abtest-leg-a", "abtest-leg-b", "state-file-X", "nix-default")
+
+	legs := []struct {
+		sessionName, profile string
+	}{
+		{"prism-test@worker-abtest-leg-a", "abtest-leg-a"},
+		{"prism-test@worker-abtest-leg-b", "abtest-leg-b"},
+	}
+	for _, leg := range legs {
+		seedSessionWithSpawnInputs(t, bus.DB, leg.sessionName, leg.profile)
+	}
+
+	for _, leg := range legs {
+		t.Run(leg.profile, func(t *testing.T) {
+			got, err := InheritFromParent(bus.DB, leg.sessionName, pf)
+			if err != nil {
+				t.Fatalf("InheritFromParent: %v", err)
+			}
+			if got != leg.profile {
+				t.Errorf("InheritFromParent(%q) = %q, want %q (per-leg profile must survive child-spawn)",
+					leg.sessionName, got, leg.profile)
+			}
+			if got == "state-file-X" || got == "nix-default" {
+				t.Errorf("InheritFromParent(%q) leaked state/nix-default \u2014 issue #2097 regression",
+					leg.sessionName)
+			}
+		})
+	}
+}
+
+// TestInheritFromParent_NilProfilesFile pins the nil-pf tolerance:
+// when no profiles.json is loaded, the helper still works \u2014 it
+// returns the parent's spawn-time profile verbatim. This is the
+// host-mode investigate path that may run without profiles.json
+// present on disk; ResolveActiveProfile's nil-tolerant behaviour
+// must propagate through unchanged.
+func TestInheritFromParent_NilProfilesFile(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-nil-pf"
+	const parentProfile = "raw-spawn-time"
+	seedSessionWithSpawnInputs(t, bus.DB, parent, parentProfile)
+
+	got, err := InheritFromParent(bus.DB, parent, nil)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if got != parentProfile {
+		t.Errorf("InheritFromParent(nil pf) = %q, want %q (nil pf must propagate the parent's profile)",
+			got, parentProfile)
+	}
+}

--- a/modules/programs/prism/prism/internal/profile/spawn_time.go
+++ b/modules/programs/prism/prism/internal/profile/spawn_time.go
@@ -1,0 +1,56 @@
+// Package profile centralises the spawn-time profile lookup that connects
+// the #2090 audit row (`spawn_inputs.profile_name`) to the #2092 runtime
+// resolution chain.
+//
+// The helper here is the canonical "what profile did the user spawn this
+// session with" reader. It is shared by:
+//
+//   - cmd/agent_run.go::populatePIConfig (runtime resolution, #2092)
+//   - internal/review.Run / RunAsync     (review fan-out, #2097)
+//   - cmd/investigate.go                 (investigate fan-out, #2097)
+//
+// Originally lived as `spawnTimeProfileForSession` in
+// `cmd/agent_run_profile.go` (#2092). Promoted to internal/ in #2097
+// so the two child-spawn front doors (review, investigate) can read the
+// same audit column without taking an `internal/cmd` dependency (no such
+// thing) or duplicating the SQL.
+package profile
+
+import (
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// SpawnTimeForSession returns the profile name recorded on the
+// `spawn_inputs` row for the named session, or "" when the row is
+// missing, has a NULL `profile_name`, or any lookup error occurs.
+//
+// This is the canonical post-#2090 source of "what profile did the user
+// invoke `prism spawn --profile` with" — callers feed the value as the
+// `flagValue` argument to `config.ResolveActiveProfile` (treated by
+// that function as the highest-precedence source, beating the
+// state-file > nix-default fallback).
+//
+// d may be nil — in that case the function returns "" without touching
+// any DB. sessionName may be empty for the same short-circuit.
+//
+// Errors are intentionally swallowed (returned as ""). A transient DB
+// problem, a missing sessions row (legacy / pre-#2090), a missing
+// spawn_inputs row, or a NULL `profile_name` all collapse to "". The
+// caller is expected to fall through to `config.ResolveActiveProfile`'s
+// existing state-file > nix-default chain, which is the pre-#2092
+// behaviour and the right safety net for legacy sessions and host-mode
+// paths that never wrote a `spawn_inputs` row in the first place.
+func SpawnTimeForSession(d *db.DB, sessionName string) string {
+	if d == nil || sessionName == "" {
+		return ""
+	}
+	sess, err := d.MostRecentSessionForName(sessionName)
+	if err != nil || sess == nil {
+		return ""
+	}
+	si, err := d.SpawnInputsByInstanceID(sess.InstanceID)
+	if err != nil || si == nil || si.ProfileName == nil {
+		return ""
+	}
+	return *si.ProfileName
+}

--- a/modules/programs/prism/prism/internal/profile/spawn_time_test.go
+++ b/modules/programs/prism/prism/internal/profile/spawn_time_test.go
@@ -1,0 +1,184 @@
+package profile
+
+// spawn_time_test.go — issue #2097 unit tests for the lifted lookup helper.
+//
+// SpawnTimeForSession was originally an unexported cmd-side function
+// (`cmd/agent_run_profile.go::spawnTimeProfileForSession`, #2092). It
+// was promoted into this package so the child-spawn surfaces
+// (`internal/review`, `cmd/investigate.go`) can read the same column
+// without an import cycle. The tests here pin the lookup behaviour and
+// the best-effort error swallowing contract.
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608):
+//   - sidecartest.NewIsolated redirects $XDG_STATE_HOME to a t.TempDir()
+//     and sets PRISM_TEST_MODE_RESTRICT_HOSTAPI so no host bus / DB /
+//     tmux state is touched.
+//   - Session names use the "prism-test@" prefix.
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// seedSessionWithSpawnInputs is a small fixture helper: it inserts a
+// sessions row + a spawn_inputs row for the given session name. When
+// profileName is "", the spawn_inputs row is still written but with NULL
+// profile_name — exercising the negative path where the row exists but
+// the column is empty.
+func seedSessionWithSpawnInputs(t *testing.T, d *db.DB, sessionName, profileName string) string {
+	t.Helper()
+	instanceID := uuid.New().String()
+	if err := d.InsertSession(db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "prism-test",
+		Worktree:    "/tmp/" + sessionName,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("seedSessionWithSpawnInputs InsertSession %q: %v", sessionName, err)
+	}
+	si := db.SpawnInputs{InstanceID: instanceID}
+	if profileName != "" {
+		p := profileName
+		si.ProfileName = &p
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("seedSessionWithSpawnInputs InsertSpawnInputs %q: %v", sessionName, err)
+	}
+	return instanceID
+}
+
+// TestSpawnTimeForSession_Positive is the core lookup happy path: a
+// session with spawn_inputs.profile_name=X returns X.
+func TestSpawnTimeForSession_Positive(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const sessionName = "prism-test@worker-positive"
+	const wantProfile = "anthropic-opus"
+	seedSessionWithSpawnInputs(t, bus.DB, sessionName, wantProfile)
+
+	got := SpawnTimeForSession(bus.DB, sessionName)
+	if got != wantProfile {
+		t.Errorf("SpawnTimeForSession = %q, want %q", got, wantProfile)
+	}
+}
+
+// TestSpawnTimeForSession_NullProfileName is the AC #8 negative path:
+// the spawn_inputs row exists but profile_name is NULL → "". Callers
+// fall through to ResolveActiveProfile's state-file > nix-default chain
+// unchanged (no regression for legacy / host-mode sessions that record
+// the audit row without a profile).
+func TestSpawnTimeForSession_NullProfileName(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const sessionName = "prism-test@worker-null-profile"
+	seedSessionWithSpawnInputs(t, bus.DB, sessionName, "" /* NULL profile_name */)
+
+	if got := SpawnTimeForSession(bus.DB, sessionName); got != "" {
+		t.Errorf("SpawnTimeForSession = %q, want \"\" (NULL profile_name must collapse to empty)", got)
+	}
+}
+
+// TestSpawnTimeForSession_MissingSpawnInputs covers a sessions row
+// that has no spawn_inputs row (pre-#2090 legacy). The lookup must
+// short-circuit without error.
+func TestSpawnTimeForSession_MissingSpawnInputs(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const sessionName = "prism-test@worker-legacy-no-spawn-inputs"
+	if err := bus.DB.InsertSession(db.Session{
+		InstanceID:  uuid.New().String(),
+		SessionName: sessionName,
+		Repo:        "prism-test",
+		Worktree:    "/tmp/" + sessionName,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	// No InsertSpawnInputs call → the row is absent.
+
+	if got := SpawnTimeForSession(bus.DB, sessionName); got != "" {
+		t.Errorf("SpawnTimeForSession = %q, want \"\" (missing spawn_inputs row must collapse to empty)", got)
+	}
+}
+
+// TestSpawnTimeForSession_MissingSession covers the case where the
+// session name is not in the DB at all. The lookup must return ""
+// rather than erroring — this is the contract that lets a transient DB
+// problem or an unknown session-name not wedge the spawn path.
+func TestSpawnTimeForSession_MissingSession(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	if got := SpawnTimeForSession(bus.DB, "prism-test@no-such-session"); got != "" {
+		t.Errorf("SpawnTimeForSession = %q, want \"\" (unknown session must collapse to empty)", got)
+	}
+}
+
+// TestSpawnTimeForSession_NilDB exercises the explicit nil-d guard:
+// passing a nil *db.DB must short-circuit before any I/O and return ""
+// rather than panic on nil-dereference. This is the contract callers
+// rely on when they want to call the helper unconditionally and let
+// the empty return drive the fallback chain.
+func TestSpawnTimeForSession_NilDB(t *testing.T) {
+	if got := SpawnTimeForSession(nil, "prism-test@anything"); got != "" {
+		t.Errorf("SpawnTimeForSession(nil, ...) = %q, want \"\"", got)
+	}
+}
+
+// TestSpawnTimeForSession_EmptySession is the empty-string-session
+// short-circuit. The helper must not touch the DB at all.
+func TestSpawnTimeForSession_EmptySession(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	if got := SpawnTimeForSession(bus.DB, ""); got != "" {
+		t.Errorf("SpawnTimeForSession(d, \"\") = %q, want \"\"", got)
+	}
+}
+
+// TestSpawnTimeForSession_AbtestPair pins the AC #7 abtest-leg shape:
+// two sessions with distinct profile_name values each resolve to their
+// own value. The pair_id is also set to mirror the on-disk shape
+// `prism spawn --abtest` produces; the lookup keys off instance_id (via
+// session name) so the pair_id is informational here, but its presence
+// guards against an accidental aggregate-by-pair regression.
+func TestSpawnTimeForSession_AbtestPair(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const pairID = "test-abtest-pair-2097"
+	legs := []struct {
+		sessionName string
+		profile     string
+	}{
+		{"prism-test@worker-abtest-leg-a", "abtest-leg-a"},
+		{"prism-test@worker-abtest-leg-b", "abtest-leg-b"},
+	}
+
+	for _, leg := range legs {
+		iid := uuid.New().String()
+		if err := bus.DB.InsertSession(db.Session{
+			InstanceID:  iid,
+			SessionName: leg.sessionName,
+			Repo:        "prism-test",
+			Worktree:    "/tmp/" + leg.sessionName,
+			Harness:     "pi",
+		}); err != nil {
+			t.Fatalf("InsertSession %q: %v", leg.sessionName, err)
+		}
+		p := leg.profile
+		pair := pairID
+		if err := bus.DB.InsertSpawnInputs(db.SpawnInputs{
+			InstanceID:   iid,
+			ProfileName:  &p,
+			AbtestPairID: &pair,
+		}); err != nil {
+			t.Fatalf("InsertSpawnInputs %q: %v", leg.sessionName, err)
+		}
+	}
+
+	for _, leg := range legs {
+		t.Run(leg.profile, func(t *testing.T) {
+			if got := SpawnTimeForSession(bus.DB, leg.sessionName); got != leg.profile {
+				t.Errorf("SpawnTimeForSession(%q) = %q, want %q (abtest legs must not bleed across)",
+					leg.sessionName, got, leg.profile)
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/review/export_test.go
+++ b/modules/programs/prism/prism/internal/review/export_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/session"
 )
 
 // RunGHForTest is an exported wrapper around runGH for use in timeout tests.
@@ -113,6 +115,58 @@ const MaxProgressMsgBytesForTest = maxProgressMsgBytes
 // for use in external test packages (#1512).
 func BuildLoopLimitFooterForTest(cycles int, prNumber string) string {
 	return buildLoopLimitFooter(cycles, prNumber)
+}
+
+// ReviewerSpawnInputForTest mirrors the unexported reviewerSpawnInput
+// struct (spawn_opts.go) so external tests in package review_test can
+// drive newReviewerSpawnOpts via NewReviewerSpawnOptsForTest. Fields
+// match 1:1 with the production struct; see spawn_opts.go for the
+// field-level rationale.
+type ReviewerSpawnInputForTest struct {
+	AgentName          string
+	AgentSession       string
+	Prompt             string
+	AgentConfigContent string
+	Repo               string
+	Worktree           string
+	PromptTemplateHash string
+	IsolationMode      string
+	PluginHostPath     string
+	GroupID            string
+	HarnessName        string
+	HarnessHandle      harness.Harness
+	ModelsByRole       map[string]string
+	PIExtensionDir     string
+	ProfileName        string
+}
+
+// NewReviewerSpawnOptsForTest is an exported wrapper around
+// newReviewerSpawnOpts (spawn_opts.go) for use in external test
+// packages verifying the #2097 ProfileName-inheritance wiring.
+//
+// Tests construct a ReviewerSpawnInputForTest, pass it through this
+// shim, and assert on the returned session.SpawnOpts.ProfileName.
+// The shim mirrors the production call signature so a regression in
+// the field mapping (e.g. accidentally dropping ProfileName from the
+// returned literal) is caught immediately.
+func NewReviewerSpawnOptsForTest(in ReviewerSpawnInputForTest) session.SpawnOpts {
+	return newReviewerSpawnOpts(reviewerSpawnInput{
+		AgentName:          in.AgentName,
+		AgentSession:       in.AgentSession,
+		Prompt:             in.Prompt,
+		AgentConfigContent: in.AgentConfigContent,
+		Repo:               in.Repo,
+		Worktree:           in.Worktree,
+		PromptTemplateHash: in.PromptTemplateHash,
+		IsolationMode:      in.IsolationMode,
+		PluginHostPath:     in.PluginHostPath,
+		GroupID:            in.GroupID,
+		HarnessName:        in.HarnessName,
+		HarnessHandle:      in.HarnessHandle,
+		ModelsByRole:       in.ModelsByRole,
+		PIExtensionDir:     in.PIExtensionDir,
+		ProfileName:        in.ProfileName,
+	})
 }
 
 // CurrentCycleProducedVerdictsForTest is an exported wrapper around

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/prismatic-koi/prism/internal/agent"
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
@@ -25,6 +24,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/proglog"
+	"github.com/prismatic-koi/prism/internal/profile"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -77,7 +77,16 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 	// agent in this fan-out spawns with the same models (#1207). Errors are
 	// surfaced — a corrupt state file would otherwise silently leak the
 	// pf.Default profile into review agents.
-	activeProfile, _, profErr := config.ResolveActiveProfile(opts.ProfilesFile, "")
+	//
+	// Issue #2097: the parent worker's spawn-time profile (recorded on
+	// `spawn_inputs.profile_name` by #2090) is fed as the highest-precedence
+	// input via profile.InheritFromParent. Before #2097 we passed "" here,
+	// so the resolution silently fell through to state-file > nix-default —
+	// every review fan-out since `--abtest` (#1216) shipped ran on the host
+	// default regardless of the parent's `--profile` choice. The #1207
+	// single-resolve-per-round invariant is preserved: this call happens
+	// once, outside the agent loop, so all 5 reviewers share one profile.
+	activeProfile, profErr := profile.InheritFromParent(d, opts.ParentSession, opts.ProfilesFile)
 	if profErr != nil {
 		return nil, fmt.Errorf("resolve active profile: %w", profErr)
 	}
@@ -229,38 +238,28 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 			}
 			continue
 		}
-		spawnOpts := session.SpawnOpts{
-			InstanceID:         uuid.New().String(),
-			SessionName:        agentSession,
+		// Build the per-reviewer SpawnOpts via the shared builder so the
+		// audit-row shape, isolation-mode propagation, and #2097
+		// ProfileName inheritance are guaranteed identical between Run
+		// (sync) and RunAsync (async monitor). See spawn_opts.go for the
+		// field-level rationale.
+		spawnOpts := newReviewerSpawnOpts(reviewerSpawnInput{
+			AgentName:          ag.Name,
+			AgentSession:       agentSession,
+			Prompt:             prompt,
+			AgentConfigContent: agentConfigContent,
 			Repo:               repo,
 			Worktree:           worktree,
-			AgentRole:          ag.Name,
-			Prompt:             prompt,
-			PromptSource:       "review-fanout",
 			PromptTemplateHash: ReviewPromptTemplateHash(),
-			ConfigContent:      agentConfigContent,
-			Layout:             session.LayoutAgentOnly,
 			IsolationMode:      opts.IsolationMode,
 			PluginHostPath:     opts.PluginHostPath,
-			WorktreeReadOnly:   true,
 			GroupID:            groupID,
-			ConfigEnvVarName:   agentH.ConfigEnvVar(),
-			RuntimeEnvVars:     agentH.RuntimeEnv(),
 			HarnessName:        agentHarnessName,
+			HarnessHandle:      agentH,
 			ModelsByRole:       opts.ModelsByRole,
-			// PIExtensionDir for host-mode pi launches (#2065).
-			PIExtensionDir: opts.PIExtensionDir,
-			// spawn_inputs audit (#2087): record the per-agent role and the
-			// harness so review fan-out rows are queryable alongside other
-			// spawn front doors. PromptSource / PromptTemplateHash above
-			// already feed the centralised SpawnSession writer.
-			// IsolationFlag mirrors the resolved isolation mode so the
-			// `prism stats compare` Spawn Inputs block surfaces it for
-			// review-fan-out rows too (issue #2102 Layer 2).
-			AgentFlag:     ag.Name,
-			HarnessFlag:   agentHarnessName,
-			IsolationFlag: opts.IsolationMode,
-		}
+			PIExtensionDir:     opts.PIExtensionDir,
+			ProfileName:        activeProfile,
+		})
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
 				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnSessErr)))
@@ -429,8 +428,9 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 	repo := deriveRepo(opts.ParentSession)
 
 	// Resolve the runtime active profile once for the round (#1207). See
-	// the matching block in Run() above for rationale.
-	activeProfile, _, profErr := config.ResolveActiveProfile(opts.ProfilesFile, "")
+	// the matching block in Run() above for rationale, including the
+	// #2097 inheritance of the parent worker's spawn-time profile.
+	activeProfile, profErr := profile.InheritFromParent(d, opts.ParentSession, opts.ProfilesFile)
 	if profErr != nil {
 		return nil, fmt.Errorf("resolve active profile: %w", profErr)
 	}
@@ -535,33 +535,26 @@ func RunAsync(opts Opts, prismBinary string) (*AsyncResult, error) {
 			}
 			continue
 		}
-		spawnOpts := session.SpawnOpts{
-			InstanceID:         uuid.New().String(),
-			SessionName:        agentSession,
+		// Build the per-reviewer SpawnOpts via the shared builder so
+		// RunAsync and Run produce structurally identical SpawnOpts.
+		// See spawn_opts.go for the field-level rationale.
+		spawnOpts := newReviewerSpawnOpts(reviewerSpawnInput{
+			AgentName:          ag.Name,
+			AgentSession:       agentSession,
+			Prompt:             prompt,
+			AgentConfigContent: agentConfigContent,
 			Repo:               repo,
 			Worktree:           worktree,
-			AgentRole:          ag.Name,
-			Prompt:             prompt,
-			PromptSource:       "review-fanout",
 			PromptTemplateHash: ReviewPromptTemplateHash(),
-			ConfigContent:      agentConfigContent,
-			Layout:             session.LayoutAgentOnly,
 			IsolationMode:      opts.IsolationMode,
 			PluginHostPath:     opts.PluginHostPath,
-			WorktreeReadOnly:   true,
 			GroupID:            groupID,
-			ConfigEnvVarName:   asyncAgentH.ConfigEnvVar(),
-			RuntimeEnvVars:     asyncAgentH.RuntimeEnv(),
 			HarnessName:        asyncAgentHarnessName,
+			HarnessHandle:      asyncAgentH,
 			ModelsByRole:       opts.ModelsByRole,
-			// PIExtensionDir for host-mode pi launches (#2065).
-			PIExtensionDir: opts.PIExtensionDir,
-			// spawn_inputs audit (#2087): mirror the sync fan-out block.
-			// IsolationFlag mirrors the resolved isolation mode (#2102 Layer 2).
-			AgentFlag:     ag.Name,
-			HarnessFlag:   asyncAgentHarnessName,
-			IsolationFlag: opts.IsolationMode,
-		}
+			PIExtensionDir:     opts.PIExtensionDir,
+			ProfileName:        activeProfile,
+		})
 		if spawnSessErr := session.SpawnSession(d, spawnOpts); spawnSessErr != nil {
 			if opts.OnProgress != nil {
 				opts.OnProgress(fmt.Sprintf("%s failed to start: %s", FormatAgentDisplayName(ag.Name), sanitizeSpawnError(opts.PRNumber, ag.Name, spawnSessErr)))

--- a/modules/programs/prism/prism/internal/review/run_profile_test.go
+++ b/modules/programs/prism/prism/internal/review/run_profile_test.go
@@ -1,0 +1,384 @@
+package review_test
+
+// run_profile_test.go — issue #2097 regression tests for the review
+// fan-out's profile-inheritance path.
+//
+// The child-spawn surfaces (review fan-out, investigate) previously
+// resolved their child profile via ResolveActiveProfile(pf, "") — empty
+// flag — so every review and investigate session since `--abtest`
+// (#1216) shipped ran on the host default regardless of the parent
+// worker's `--profile` choice. PR #2093 fixed this for the worker
+// layer; #2097 extends the same precedence chain to review and
+// investigate by feeding the parent's spawn_inputs.profile_name through
+// profile.InheritFromParent.
+//
+// These tests don't drive the full review.Run / RunAsync (those spin
+// up tmux / sidecar / a real agent); they exercise the resolution +
+// SpawnOpts construction step that closes the inheritance loop. Three
+// behaviours are pinned:
+//
+//  1. Modern parent → child SpawnOpts.ProfileName = parent's value,
+//     spawn_inputs row would record it (AC #5).
+//  2. Abtest legs → each leg's children get their own profile,
+//     never the sibling's or the state-file value (AC #7).
+//  3. Legacy parent → child falls through to state-file > nix-default
+//     (AC #8). No regression for pre-#2090 sessions.
+//
+// Plus a #1207-invariant pin: profile.InheritFromParent is called
+// exactly once per round inside review.Run / review.RunAsync, so all
+// 5 reviewers in a single round share the same resolved profile. The
+// inline call-site comments in run.go assert this in code; this test
+// asserts it through behaviour by resolving once and treating the
+// result as the value used by every reviewer's SpawnOpts.
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608):
+//   - sidecartest.NewIsolated redirects $XDG_STATE_HOME to a t.TempDir()
+//     and sets PRISM_TEST_MODE_RESTRICT_HOSTAPI so no host bus / DB /
+//     tmux state is touched.
+//   - Session names use the "prism-test@" prefix.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/config"
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/harness"
+	_ "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/profile"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// seedParentSession inserts the minimal pair of rows (sessions,
+// spawn_inputs) needed for profile.InheritFromParent to find the
+// parent's spawn-time profile. Passing profileName="" exercises the
+// negative path (row exists, column NULL).
+func seedParentSession(t *testing.T, d *db.DB, sessionName, profileName string) string {
+	t.Helper()
+	iid := uuid.New().String()
+	if err := d.InsertSession(db.Session{
+		InstanceID:  iid,
+		SessionName: sessionName,
+		Repo:        "prism-test",
+		Worktree:    "/tmp/" + sessionName,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("InsertSession %q: %v", sessionName, err)
+	}
+	si := db.SpawnInputs{InstanceID: iid}
+	if profileName != "" {
+		p := profileName
+		si.ProfileName = &p
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs %q: %v", sessionName, err)
+	}
+	return iid
+}
+
+// writeStateFile drops the runtime active-profile state file into the
+// sidecartest-owned $XDG_STATE_HOME so the state-file rung of the
+// precedence chain has something to read.
+func writeStateFile(t *testing.T, profileName string) {
+	t.Helper()
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		t.Fatalf("writeStateFile: XDG_STATE_HOME unset")
+	}
+	dir := filepath.Join(stateHome, "prism")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "active-profile"), []byte(profileName+"\n"), 0o644); err != nil {
+		t.Fatalf("write active-profile state file: %v", err)
+	}
+}
+
+// makeProfilesWithReviewSlots builds a ProfilesFile whose every named
+// profile defines slots for the canonical review agents (review-goal,
+// review-code, review-security, review-qa, review-context). This lets a
+// downstream BuildConfigContent / RequireSlot call resolve to a real
+// model without surprising "missing slot" errors.
+func makeProfilesWithReviewSlots(defaultName string, profileNames ...string) *config.ProfilesFile {
+	pf := &config.ProfilesFile{
+		Default:  defaultName,
+		Profiles: make(map[string]config.ProfileEntry, len(profileNames)),
+	}
+	reviewSlots := []string{"review-goal", "review-code", "review-security", "review-qa", "review-context", "worker", "investigate"}
+	for _, name := range profileNames {
+		entry := make(config.ProfileEntry, len(reviewSlots))
+		for _, slot := range reviewSlots {
+			entry[slot] = config.RoleSlot{
+				Provider: "anthropic",
+				Model:    name + "/model-" + slot,
+				Thinking: "medium",
+			}
+		}
+		pf.Profiles[name] = entry
+	}
+	return pf
+}
+
+// resolvedSpawnInputsForReviewer drives the *production* builder
+// review.NewReviewerSpawnOptsForTest (re-exported via export_test.go)
+// to produce the same SpawnOpts that Run / RunAsync would hand to
+// SpawnSession. We then map that to a db.SpawnInputs row via
+// session.SpawnInputsFromOpts so the assertion is exactly the row that
+// SpawnSession would write.
+//
+// This is the critical seam for issue #2097: by driving the real
+// builder (rather than constructing a SpawnOpts literal in the test),
+// a regression where the production code drops ProfileName from the
+// builder output is caught here — the test cannot pass vacuously.
+func resolvedSpawnInputsForReviewer(t *testing.T, activeProfile, agentName, parentSession string) db.SpawnInputs {
+	t.Helper()
+	h, err := harness.New("pi", "", nil, "", "")
+	if err != nil {
+		t.Fatalf("harness.New(pi): %v", err)
+	}
+	opts := review.NewReviewerSpawnOptsForTest(review.ReviewerSpawnInputForTest{
+		AgentName:          agentName,
+		AgentSession:       parentSession + "~review-1-" + agentName,
+		Prompt:             "unused-in-this-test",
+		AgentConfigContent: "",
+		Repo:               "prism-test",
+		Worktree:           "/tmp/" + parentSession,
+		PromptTemplateHash: "test-template-hash",
+		IsolationMode:      "bwrap",
+		HarnessName:        "pi",
+		HarnessHandle:      h,
+		ProfileName:        activeProfile,
+	})
+	return session.SpawnInputsFromOpts(opts)
+}
+
+// TestReviewFanout_ProfileInheritedFromModernParent is the AC #5
+// positive: parent has spawn_inputs.profile_name=X → every reviewer's
+// SpawnOpts.ProfileName = X (so the child's audit row records X and
+// the child's runtime populatePIConfig resolves to X's models via the
+// #2092 chain).
+func TestReviewFanout_ProfileInheritedFromModernParent(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-modern-parent"
+	const parentProfile = "anthropic-opus"
+	seedParentSession(t, bus.DB, parent, parentProfile)
+
+	// State-file points at a competing profile to prove parent wins.
+	writeStateFile(t, "state-file-competing")
+	pf := makeProfilesWithReviewSlots("nix-default", parentProfile, "state-file-competing", "nix-default")
+
+	resolved, err := profile.InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if resolved != parentProfile {
+		t.Fatalf("InheritFromParent = %q, want %q", resolved, parentProfile)
+	}
+
+	// Mirror the in-Run loop: build a SpawnOpts row for each canonical
+	// reviewer using the resolved profile, and assert the audit row
+	// would carry profile_name=parentProfile.
+	for _, ag := range review.Agents() {
+		si := resolvedSpawnInputsForReviewer(t, resolved, ag.Name, parent)
+		if si.ProfileName == nil {
+			t.Errorf("agent %s: spawn_inputs.profile_name is NULL, want %q",
+				ag.Name, parentProfile)
+			continue
+		}
+		if *si.ProfileName != parentProfile {
+			t.Errorf("agent %s: spawn_inputs.profile_name = %q, want %q",
+				ag.Name, *si.ProfileName, parentProfile)
+		}
+	}
+}
+
+// TestReviewFanout_AbtestLegsResolveIndependently is the AC #7 abtest
+// shape: two parents sharing an abtest_pair_id but each carrying its
+// own spawn_inputs.profile_name produce review fan-outs that record
+// the leg-specific profile on every reviewer's audit row. No leg's
+// reviewers bleed across to the sibling leg's profile, and neither
+// leg's reviewers leak to the state-file or nix-default rung.
+func TestReviewFanout_AbtestLegsResolveIndependently(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const pairID = "test-abtest-pair-2097-review"
+	writeStateFile(t, "state-file-must-lose")
+	pf := makeProfilesWithReviewSlots("nix-default",
+		"abtest-leg-a", "abtest-leg-b", "state-file-must-lose", "nix-default")
+
+	legs := []struct {
+		sessionName, profile string
+	}{
+		{"prism-test@worker-abtest-leg-a-review", "abtest-leg-a"},
+		{"prism-test@worker-abtest-leg-b-review", "abtest-leg-b"},
+	}
+	for _, leg := range legs {
+		iid := uuid.New().String()
+		if err := bus.DB.InsertSession(db.Session{
+			InstanceID:  iid,
+			SessionName: leg.sessionName,
+			Repo:        "prism-test",
+			Worktree:    "/tmp/" + leg.sessionName,
+			Harness:     "pi",
+		}); err != nil {
+			t.Fatalf("InsertSession %q: %v", leg.sessionName, err)
+		}
+		p := leg.profile
+		pair := pairID
+		if err := bus.DB.InsertSpawnInputs(db.SpawnInputs{
+			InstanceID:   iid,
+			ProfileName:  &p,
+			AbtestPairID: &pair,
+		}); err != nil {
+			t.Fatalf("InsertSpawnInputs %q: %v", leg.sessionName, err)
+		}
+	}
+
+	for _, leg := range legs {
+		t.Run(leg.profile, func(t *testing.T) {
+			resolved, err := profile.InheritFromParent(bus.DB, leg.sessionName, pf)
+			if err != nil {
+				t.Fatalf("InheritFromParent: %v", err)
+			}
+			if resolved != leg.profile {
+				t.Fatalf("InheritFromParent = %q, want %q (per-leg profile must survive)",
+					resolved, leg.profile)
+			}
+			if resolved == "state-file-must-lose" || resolved == "nix-default" {
+				t.Fatalf("leg %q leaked to state-file / nix-default \u2014 #2097 regression",
+					leg.profile)
+			}
+
+			// Every canonical reviewer's SpawnOpts.ProfileName must
+			// carry this leg's profile, not the sibling's or the
+			// state-file fallback.
+			for _, ag := range review.Agents() {
+				si := resolvedSpawnInputsForReviewer(t, resolved, ag.Name, leg.sessionName)
+				if si.ProfileName == nil || *si.ProfileName != leg.profile {
+					var got string
+					if si.ProfileName != nil {
+						got = *si.ProfileName
+					}
+					t.Errorf("leg %q agent %s: spawn_inputs.profile_name = %q, want %q",
+						leg.profile, ag.Name, got, leg.profile)
+				}
+			}
+		})
+	}
+}
+
+// TestReviewFanout_LegacyParentFallsThroughToStateFile is the AC #8
+// negative: parent has no spawn_inputs row (pre-#2090) → resolution
+// falls through to the state-file value → no regression for legacy
+// sessions. The child's audit row records the resolved state-file
+// value, and the child's runtime populatePIConfig resolves to that
+// same value via the #2092 chain (so behaviour matches the pre-#2097
+// world where legacy parents ran on whatever state-file pointed at).
+func TestReviewFanout_LegacyParentFallsThroughToStateFile(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-legacy-review"
+	// No InsertSession / InsertSpawnInputs \u2014 the parent is fully legacy.
+	writeStateFile(t, "state-file-legacy-default")
+	pf := makeProfilesWithReviewSlots("nix-default",
+		"state-file-legacy-default", "nix-default")
+
+	resolved, err := profile.InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if resolved != "state-file-legacy-default" {
+		t.Fatalf("InheritFromParent = %q, want \"state-file-legacy-default\"", resolved)
+	}
+
+	for _, ag := range review.Agents() {
+		si := resolvedSpawnInputsForReviewer(t, resolved, ag.Name, parent)
+		if si.ProfileName == nil || *si.ProfileName != "state-file-legacy-default" {
+			var got string
+			if si.ProfileName != nil {
+				got = *si.ProfileName
+			}
+			t.Errorf("legacy parent agent %s: spawn_inputs.profile_name = %q, want \"state-file-legacy-default\"",
+				ag.Name, got)
+		}
+	}
+}
+
+// TestReviewFanout_LegacyParentFallsThroughToNixDefault completes the
+// AC #8 chain: legacy parent + no state-file → resolution lands on
+// pf.Default. This is the path every pre-#2097 review ran on for users
+// who had not invoked `prism profile set`.
+func TestReviewFanout_LegacyParentFallsThroughToNixDefault(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-fully-legacy-review"
+	// No InsertSession / InsertSpawnInputs, and no state-file write.
+	pf := makeProfilesWithReviewSlots("nix-default", "nix-default")
+
+	resolved, err := profile.InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+	if resolved != "nix-default" {
+		t.Fatalf("InheritFromParent = %q, want \"nix-default\"", resolved)
+	}
+
+	for _, ag := range review.Agents() {
+		si := resolvedSpawnInputsForReviewer(t, resolved, ag.Name, parent)
+		if si.ProfileName == nil || *si.ProfileName != "nix-default" {
+			var got string
+			if si.ProfileName != nil {
+				got = *si.ProfileName
+			}
+			t.Errorf("agent %s: spawn_inputs.profile_name = %q, want \"nix-default\"",
+				ag.Name, got)
+		}
+	}
+}
+
+// TestReviewFanout_RoundLevelConsistency_Issue1207 is the regression
+// pin for the #1207 invariant referenced in
+// internal/review/run.go (the resolution-once-per-round comment).
+// Even though the parent's profile_name could change between two
+// review rounds for the same parent (e.g. a `prism profile set` in
+// between), within a single round every reviewer must share the same
+// resolved profile.
+//
+// We assert this by treating InheritFromParent as a pure function of
+// (parent, state, pf) and confirming every reviewer in a single
+// "round snapshot" sees the same value. The production code calls
+// InheritFromParent exactly once outside the agent loop in both Run
+// and RunAsync \u2014 the snapshot here mirrors that pattern.
+func TestReviewFanout_RoundLevelConsistency_Issue1207(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	const parent = "prism-test@worker-round-consistency"
+	const parentProfile = "round-consistent-profile"
+	seedParentSession(t, bus.DB, parent, parentProfile)
+	pf := makeProfilesWithReviewSlots("nix-default", parentProfile, "nix-default")
+
+	// One resolution for the round (mirrors the inline call site in Run).
+	resolved, err := profile.InheritFromParent(bus.DB, parent, pf)
+	if err != nil {
+		t.Fatalf("InheritFromParent: %v", err)
+	}
+
+	// Every reviewer in the round must see this exact value.
+	seen := make(map[string]int, len(review.Agents()))
+	for _, ag := range review.Agents() {
+		si := resolvedSpawnInputsForReviewer(t, resolved, ag.Name, parent)
+		if si.ProfileName == nil {
+			t.Fatalf("agent %s: spawn_inputs.profile_name is NULL, want %q",
+				ag.Name, parentProfile)
+		}
+		seen[*si.ProfileName]++
+	}
+	if len(seen) != 1 {
+		t.Fatalf("round-level consistency broken: reviewers resolved to %d distinct profiles %v",
+			len(seen), seen)
+	}
+	if _, ok := seen[parentProfile]; !ok {
+		t.Errorf("round resolved to profiles %v, want a single %q entry", seen, parentProfile)
+	}
+}

--- a/modules/programs/prism/prism/internal/review/spawn_opts.go
+++ b/modules/programs/prism/prism/internal/review/spawn_opts.go
@@ -1,0 +1,104 @@
+package review
+
+// spawn_opts.go — extracted SpawnOpts builder shared by Run / RunAsync.
+//
+// Before #2097 the per-reviewer session.SpawnOpts literal was duplicated
+// inline in both the sync `Run` and async `RunAsync` loops. The two
+// literals were structurally identical except for the harness handle
+// variable name (`agentH` vs `asyncAgentH`). Lifting them into a single
+// builder lets:
+//
+//   - the production code stay DRY (one source of truth for the audit
+//     fields, the layout, and the isolation flags);
+//   - the #2097 ProfileName-inheritance wiring be unit-tested directly
+//     without spinning up tmux / sidecar / a real DB write (the test
+//     calls newReviewerSpawnOpts with a known activeProfile and asserts
+//     the returned SpawnOpts.ProfileName matches).
+//
+// The builder is intentionally exhaustive: every field that
+// SpawnSession reads must be present here so the production code does
+// not need a second SpawnOpts literal anywhere.
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/harness"
+	"github.com/prismatic-koi/prism/internal/session"
+)
+
+// reviewerSpawnInput bundles the per-agent and round-level inputs that
+// drive a single reviewer's SpawnOpts. Round-level fields are constant
+// across the 5 agents in one fan-out; per-agent fields vary.
+type reviewerSpawnInput struct {
+	// Per-agent.
+	AgentName          string
+	AgentSession       string
+	Prompt             string
+	AgentConfigContent string
+
+	// Round-level (constant across all 5 reviewers).
+	Repo               string
+	Worktree           string
+	PromptTemplateHash string
+	IsolationMode      string
+	PluginHostPath     string
+	GroupID            string
+	HarnessName        string
+	HarnessHandle      harness.Harness
+	ModelsByRole       map[string]string
+	PIExtensionDir     string
+
+	// ProfileName is the resolved active profile for this round
+	// (issue #2097). Set once via profile.InheritFromParent before the
+	// agent loop and propagated identically to every reviewer in the
+	// round — preserving the #1207 single-resolve-per-round invariant.
+	ProfileName string
+}
+
+// newReviewerSpawnOpts returns the SpawnOpts that drives one reviewer
+// session's creation. Both `Run` (sync) and `RunAsync` (async monitor
+// path) call this helper so the audit row shape (spawn_inputs columns
+// derived from the *Flag fields), the isolation-mode propagation, and
+// the #2097 ProfileName inheritance are guaranteed identical between
+// the two fan-out paths.
+func newReviewerSpawnOpts(in reviewerSpawnInput) session.SpawnOpts {
+	return session.SpawnOpts{
+		InstanceID:         uuid.New().String(),
+		SessionName:        in.AgentSession,
+		Repo:               in.Repo,
+		Worktree:           in.Worktree,
+		AgentRole:          in.AgentName,
+		Prompt:             in.Prompt,
+		PromptSource:       "review-fanout",
+		PromptTemplateHash: in.PromptTemplateHash,
+		ConfigContent:      in.AgentConfigContent,
+		Layout:             session.LayoutAgentOnly,
+		IsolationMode:      in.IsolationMode,
+		PluginHostPath:     in.PluginHostPath,
+		WorktreeReadOnly:   true,
+		GroupID:            in.GroupID,
+		ConfigEnvVarName:   in.HarnessHandle.ConfigEnvVar(),
+		RuntimeEnvVars:     in.HarnessHandle.RuntimeEnv(),
+		HarnessName:        in.HarnessName,
+		ModelsByRole:       in.ModelsByRole,
+		// PIExtensionDir for host-mode pi launches (#2065).
+		PIExtensionDir: in.PIExtensionDir,
+		// spawn_inputs audit (#2087): record the per-agent role and the
+		// harness so review fan-out rows are queryable alongside other
+		// spawn front doors. PromptSource / PromptTemplateHash above
+		// already feed the centralised SpawnSession writer.
+		// IsolationFlag mirrors the resolved isolation mode so the
+		// `prism stats compare` Spawn Inputs block surfaces it for
+		// review-fan-out rows too (issue #2102 Layer 2).
+		AgentFlag:     in.AgentName,
+		HarnessFlag:   in.HarnessName,
+		IsolationFlag: in.IsolationMode,
+		// ProfileName carries the resolved active profile through to
+		// the child's own `spawn_inputs.profile_name` row (issue
+		// #2097). The child's runtime populatePIConfig reads
+		// spawn_inputs.profile_name via the #2092 chain and resolves
+		// to the same profile the parent worker was spawned with,
+		// instead of the host default.
+		ProfileName: in.ProfileName,
+	}
+}


### PR DESCRIPTION
## Summary

Before this change \`prism review\` and \`prism investigate\` resolved the
spawned child's profile via \`ResolveActiveProfile(opts.ProfilesFile, \"\")\`
— empty flag value — so the resolution silently fell through to
state-file > nix-default regardless of the parent worker's \`--profile\`
choice. Every review fan-out and investigate spawn since \`--abtest\`
(#1216) shipped had been running on the host default; live A/B
experiments could not measure per-leg variance end-to-end.

This is the sibling fix to #2092 / #2093 (which threaded the
spawn_inputs.profile_name → ResolveActiveProfile chain through the
worker layer. The same precedence chain is extended one layer down to
the two child-spawn surfaces.

## Fix

- Lift `spawnTimeProfileForSession` (cmd/agent_run_profile.go, #2092)
  into a new `internal/profile` package as
  `SpawnTimeForSession(d, sessionName)`. The cmd-side wrapper is kept
  as a thin shim that opens its own DB handle, so the existing call
  site (populatePIConfig) is unchanged.
- Add `profile.InheritFromParent(d, parentSession, pf)` that composes
  the lookup with `config.ResolveActiveProfile`, giving callers a
  single entry point that honours the worker-layer precedence chain:
  spawn_inputs.profile_name > state-file > nix-default.
- Wire the new helper into both review fan-out paths
  (`internal/review/run.go::Run` and `RunAsync`) and the investigate
  spawn (`cmd/investigate.go::spawnInvestigateSessionWithDB`).
- Set `SpawnOpts.ProfileName` on every spawned child so the child's
  own `spawn_inputs.profile_name` row carries the inherited profile.
  The child's runtime populatePIConfig (via #2092) then resolves to
  the same models the parent was spawned with, and downstream
  `prism stats` / archive queries reflect the actual profile used.
- Extract a shared `newReviewerSpawnOpts` builder (internal/review/
  spawn_opts.go) so Run and RunAsync produce structurally identical
  SpawnOpts. Apart from removing duplication, the seam makes the
  #2097 ProfileName-inheritance wiring testable without spinning up
  tmux / sidecar / a real spawn.
- Extract `buildInvestigateSpawnOpts` from
  spawnInvestigateSessionWithDB for the same reason on the investigate
  side. Coordinates cleanly with #2113's existing
  `investigateSpawnSessionFn` test-injection seam.

The #1207 single-resolve-per-round invariant for review fan-out is
preserved: `profile.InheritFromParent` is called once outside the
agent loop in both Run and RunAsync, so all 5 reviewers in a round
share the same resolved profile.

## Tests

- `internal/profile/spawn_time_test.go` — unit tests for the lifted
  helper: positive lookup, NULL profile_name, missing spawn_inputs row,
  missing sessions row, nil DB, empty session name, abtest-pair shape.
- `internal/profile/inherit_test.go` — unit tests for the
  child-spawn precedence chain: parent wins over state, parent wins
  over nix-default, legacy parent falls through to state, legacy
  parent falls through to nix-default, NULL profile_name falls
  through, abtest legs resolve independently, nil ProfilesFile
  tolerance.
- `internal/review/run_profile_test.go` — review fan-out integration
  tests driving the production `newReviewerSpawnOpts` builder (via an
  `export_test.go` shim): modern parent, abtest legs, legacy parent
  to state-file, legacy parent to nix-default, plus an explicit
  #1207-invariant pin (all 5 reviewers share one profile).
- `cmd/investigate_profile_test.go` — investigate spawn tests
  driving the production `buildInvestigateSpawnOpts` builder:
  modern invoker, abtest legs, legacy invoker to state-file, legacy
  invoker to nix-default.

All tests use `sidecartest.NewIsolated` and the `prism-test@`
session-name prefix per AGENTS.md "Test-suite isolation (issue
#1608)".

I confirmed the new tests **fail without the fix** for both fan-out
surfaces (stashed the `ProfileName: in.ProfileName` field on
spawn_opts.go's builder — the review tests' abtest, legacy, and
#1207-consistency assertions all flip to FAIL; stashed
`ProfileName: resolvedProfile` on investigate.go's builder — every
investigate test flips to FAIL).

## Local self-check

From `modules/programs/prism/prism/`:
- `go build ./...` ✅
- `go test ./internal/profile/ ./internal/review/ -race` ✅
- `go test ./cmd/ -race -run "PopulatePIConfig|SpawnInputs|InvestigateFanout|InvestigateSlug|ValidateInvestigateName"` ✅
  (pre-existing tmux-fork failures in cleanup / restore / switch tests
  are unrelated and reproduce on main in this Darwin sandbox)

From the repo root:
- `nix build .#prism` ✅
- `nix build --impure --no-link --expr '(builtins.getFlake (toString
  ./.)).packages.aarch64-darwin.prism.override { runChecks = true; }'`
  ✅ (homeless-shelter sandbox)

The full homeless-shelter signal is also re-exercised by CI's
`nix-build-prism-checked` job on the PR.

Closes #2097
EOF
)