### PR TITLE
worker.md: add 'match CI locally' and 'verify tests aren't no-ops' discipline sections

### DIFF
--- a/modules/programs/prism/agents/worker.md
+++ b/modules/programs/prism/agents/worker.md
@@ -88,6 +88,44 @@ After each meaningful code change, run the quality gates described in the repo's
 AGENTS.md (tests, linters, builds). Do not batch these up — run them as you go
 so problems are caught early.
 
+### Match CI's test invocation locally
+
+Before declaring finished, run the **same** test invocation CI uses — not a
+simpler local-shorthand variant. The repo's `AGENTS.md` should point at the
+canonical command; if it doesn't, read the CI workflow files directly
+(`.github/workflows/`, `.gitlab-ci.yml`, etc.) and mirror the exact command
+and flags. Common failure modes this catches:
+
+- **Concurrency analysers** — race detectors, model checkers, or loom-style
+  scheduling explorers change which interleavings get explored. A test that
+  passes without them may fail with them.
+- **Sandbox / isolation flags** — your local environment usually has fewer
+  restrictions than CI. Tests that touch the user's home directory, network,
+  or filesystem may pass locally and fail in CI's sandbox.
+- **Coverage / lint / strictness flags** — `--strict`, `-Werror`,
+  `clippy::all`, deny-warnings configurations, etc. — change which checks
+  fire.
+- **Integration vs unit suites** — CI may run both; your habit may be to run
+  only one.
+
+This complements the AGENTS.md delegation above rather than replacing it —
+AGENTS.md names the canonical command for the repo; the workflow files are
+the source of truth when AGENTS.md is silent or stale.
+
+### Verify your tests aren't no-ops
+
+When you write a new test for a fix, briefly verify the test actually catches
+the bug it's meant to catch. The minimal discipline:
+
+1. Revert your fix locally (e.g. `git stash`, or comment out the change).
+2. Re-run only the new test. Confirm it **FAILS**.
+3. Re-apply your fix. Confirm the new test **PASSES**.
+
+This is a one-minute check that catches "vacuous pass" tests — tests that
+pass equally before and after the fix and therefore provide no actual signal.
+It's especially important for regression tests on subtle bugs, where the test
+scaffolding may not reproduce the failure path correctly.
+
 ## Opening your PR
 
 When your work is complete and quality gates pass:


### PR DESCRIPTION
Doc-only change to `modules/programs/prism/agents/worker.md`. Codifies two discipline lessons surfaced in PR #2104 and demonstrated in #2113 and #2115.

## What changed

Two new H3 subsections under the existing `## Quality gates` H2, placed before `## Opening your PR`:

- **Match CI's test invocation locally** — workers should run the same test command CI runs (e.g. `-race` for Go), not a simpler local-shorthand variant. Calls out four failure modes: concurrency analysers, sandbox/isolation flags, coverage/lint/strictness flags, integration-vs-unit suite drift. Points at `AGENTS.md` as the primary source and CI workflow files (`.github/workflows/`, `.gitlab-ci.yml`, etc.) as the fallback.
- **Verify your tests aren't no-ops** — three-step procedure: (1) revert the fix locally, (2) re-run the new test, confirm it FAILS, (3) re-apply the fix, confirm it PASSES. Guards against vacuous-pass regression tests.

## Why at the worker-agent layer, not AGENTS.md

- `-race` is Go-specific and would pollute the global worker prompt for sessions spawned in non-Go repos (`home-ops`, `obsidian`, etc.).
- The deeper lesson ("run the same command CI runs") generalises across Go, Rust, Python, TypeScript, C++ and any future stack. The principle belongs in the global worker agent; the language-specific incantation stays in the repo's `AGENTS.md`.
- The "test isn't a no-op" pattern is also language-agnostic — revert-and-rerun works in any test framework.

## Integration

- The two new sections nest as H3 under the existing `## Quality gates` H2, so the AGENTS.md delegation remains the primary hand-off and the new guidance complements rather than replaces it (the "Match CI's test invocation locally" section explicitly says so in its closing paragraph).
- No changes to `AGENTS.md`, `review-qa.md`, `coordinator.md`, `pi.nix`, or any other Nix module surface — the agent file is loaded at runtime, so the next worker spawned in any prism-enabled repo will see the new sections after this PR lands and the user runs `nh switch`.

## Adjacency

- **#2104** — closed PR (opus-4-8 leg of #2102 A/B test) that exhibited the gap this ticket addresses by shipping red CI on a `-race` failure that local `go test ./...` missed.
- **#2113, #2115** — recently-merged PRs that explicitly demonstrated the revert-and-rerun discipline in their PR bodies; this PR formalises what they were already exhibiting.
- **#2096, #2101** — opus-4-7 PRs that established the revert-and-rerun / stash-and-rerun pattern this ticket codifies.

Closes #2109
