### PR TITLE
prism stats compare: fix table alignment, add --json, fix JSON error envelope

### DIFF
--- a/modules/programs/prism/prism/cmd/json_error_envelope.go
+++ b/modules/programs/prism/prism/cmd/json_error_envelope.go
@@ -1,0 +1,49 @@
+package cmd
+
+// json_error_envelope.go — shared helper for the prism `--json` error
+// contract (issue #2099). Subcommands that expose a `--json` (or
+// `--format json`) surface MUST emit errors as a single-line JSON object
+// `{"error":"<message>"}` on stderr, leaving stdout empty and exiting
+// non-zero. This file centralises the helper so the contract is
+// implemented identically across `prism stats compare`, `prism escalate`,
+// and any future subcommand that opts in.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// emitJSONErrorEnvelope writes a single-line JSON object of the form
+// `{"error":"<message>"}` to stderr and returns a quietExitErr wrapping the
+// original error so main's fallback error printer does not duplicate it on
+// stderr. The returned error still satisfies the exitCoder interface (exit
+// code 1), preserving the non-zero exit-code contract.
+//
+// Callers typically pair this with cobra's SilenceUsage/SilenceErrors flags
+// so cobra does not also dump the usage block on the error path — see the
+// `compareCmd` / `abtestCmd` init() in stats_compare.go for the canonical
+// pattern.
+func emitJSONErrorEnvelope(err error) error {
+	return emitJSONErrorEnvelopeTo(os.Stderr, err)
+}
+
+// emitJSONErrorEnvelopeTo is the writer-injectable variant used by tests.
+// It is otherwise identical to emitJSONErrorEnvelope.
+func emitJSONErrorEnvelopeTo(stderr io.Writer, err error) error {
+	if err == nil {
+		return nil
+	}
+	payload := map[string]string{"error": err.Error()}
+	if b, mErr := json.Marshal(payload); mErr == nil {
+		fmt.Fprintln(stderr, string(b))
+	} else {
+		// json.Marshal of a string map should never fail in practice;
+		// the fallback below preserves the contract (single JSON line on
+		// stderr) for the pathological case so callers still get a
+		// parseable envelope rather than a panic / dropped error.
+		fmt.Fprintf(stderr, "{\"error\":%q}\n", err.Error())
+	}
+	return &quietExitErr{inner: err}
+}

--- a/modules/programs/prism/prism/cmd/stats.go
+++ b/modules/programs/prism/prism/cmd/stats.go
@@ -153,9 +153,11 @@ func runStats(cmd *cobra.Command, args []string) error {
 	// --abtest: list all A/B test pairs with summary metrics. runStatsAbtestFlag
 	// performs its own PRISM_HOST_API proxy dispatch (issue #2098) so a
 	// sandboxed session lists pairs from the host DB rather than the empty
-	// shadow DB.
+	// shadow DB. The jsonMode arg honours the prism-wide --json convention
+	// (issue #2099 Bug 2): on success the function emits a single JSON
+	// document mirroring the /stats?view=abtest_list shape.
 	if abtest {
-		return runStatsAbtestFlag()
+		return runStatsAbtestFlag(jsonMode)
 	}
 
 	// Validate --group-by early so we fail fast on bad input.

--- a/modules/programs/prism/prism/cmd/stats_abtest.go
+++ b/modules/programs/prism/prism/cmd/stats_abtest.go
@@ -23,7 +23,13 @@ import (
 
 // runStatsAbtestFlag implements prism stats --abtest (the --abtest top-level flag,
 // distinct from `prism stats abtest <group_id>` which is runStatsAbtest in stats_compare.go).
-func runStatsAbtestFlag() error {
+//
+// When jsonMode is true, emits the abtest_list payload to stdout as a single
+// JSON document on the success path (issue #2099 Bug 2 — sibling surface
+// of `prism stats compare --json`). The shape mirrors the host-API
+// /stats?view=abtest_list response so the direct-DB and proxy paths are
+// byte-identical.
+func runStatsAbtestFlag(jsonMode bool) error {
 	// PRISM_HOST_API proxy dispatch (issue #2098): inside a sandbox the local
 	// shadow DB carries no abtest pairs, so list them from the host DB via the
 	// sidecar /stats?view=abtest_list endpoint. Rendering stays on the CLI side
@@ -32,6 +38,9 @@ func runStatsAbtestFlag() error {
 		pairs, err := proxyStatsAbtestList(apiURL)
 		if err != nil {
 			return fmt.Errorf("stats --abtest: %w", err)
+		}
+		if jsonMode {
+			return emitAbtestPairsJSON(pairs)
 		}
 		renderAbtestPairs(pairs)
 		return nil
@@ -48,8 +57,30 @@ func runStatsAbtestFlag() error {
 		return fmt.Errorf("stats --abtest: %w", err)
 	}
 
+	if jsonMode {
+		return emitAbtestPairsJSON(pairs)
+	}
 	renderAbtestPairs(pairs)
 	return nil
+}
+
+// emitAbtestPairsJSON writes the abtest pairs list as a single JSON
+// document on stdout. Shape: {"pairs":[...]} — a top-level object with one
+// `pairs` array of db.AbtestPairRow entries, matching the host-API
+// /stats?view=abtest_list response so consumers see the same shape on the
+// direct-DB and proxy paths.
+func emitAbtestPairsJSON(pairs []db.AbtestPairRow) error {
+	// Nil-safe: an empty list emits {"pairs":[]} rather than {"pairs":null},
+	// so consumers can `.pairs | length` without a null-check.
+	if pairs == nil {
+		pairs = []db.AbtestPairRow{}
+	}
+	payload := struct {
+		Pairs []db.AbtestPairRow `json:"pairs"`
+	}{Pairs: pairs}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
 }
 
 // proxyStatsAbtestList proxies `prism stats --abtest` to the host sidecar's

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -42,15 +42,27 @@ agent-level, and per-axis aggregation metrics.
 Each argument is a session name, a full 36-character instance_id, or an
 unambiguous instance_id prefix. You may mix session names and instance IDs.
 
-Output is a formatted table by default. Use --format json to emit the
-machine-readable contract format or --format csv for spreadsheet import.
+Output is a formatted table by default. Use --json (preferred) or the
+equivalent --format json to emit the machine-readable contract format, or
+--format csv for spreadsheet import. --json and --format json are
+byte-identical aliases on the success path; on the error path both emit a
+single-line JSON object {"error":"<message>"} to stderr and exit non-zero.
 
 Examples:
   prism stats compare run-A run-B
   prism stats compare --diff-only run-A run-B run-C
-  prism stats compare --format json run-A run-B | jq .`,
+  prism stats compare --json run-A run-B | jq .`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: runStatsCompare,
+	// SilenceUsage / SilenceErrors keep the JSON error contract clean:
+	// on a bad ID we emit a single-line `{"error":"..."}` envelope to
+	// stderr (see runStatsCompare) and let main.go drive the non-zero
+	// exit code. Cobra's default behaviour would dump the usage block
+	// and a duplicate "Error: ..." line, both of which violate the
+	// documented `--json` output contract for `prism stats compare`
+	// (issue #2099 Bug 3).
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 var abtestCmd = &cobra.Command{
@@ -61,26 +73,68 @@ resolves all group members automatically.
 
 Example:
   prism stats abtest <group_id>`,
-	Args: cobra.ExactArgs(1),
-	RunE: runStatsAbtest,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runStatsAbtest,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 func init() {
 	for _, cmd := range []*cobra.Command{compareCmd, abtestCmd} {
 		cmd.Flags().StringSlice("axes", nil, "Comma-separated axes to display (default: all). Names: end_state, duration_ms, interrupted_count, compaction_count, error_event_count, permission_ask_count, permission_denied_count, doom_loop_count, pr_number, pr_merged_at, review_verdict, review_pass_count, review_fail_count, tokens_input, tokens_output, tokens_cache_read, tokens_cache_write, cost_usd, tool_call, tool_error, msg_assistant, time_to_first_event, time_to_finished")
-		cmd.Flags().String("format", "table", "Output format: table, json, csv")
+		cmd.Flags().String("format", "table", "Output format: table, json, csv. --format json is equivalent to the top-level --json flag.")
 		cmd.Flags().Bool("diff-only", false, "Hide rows where every run has the same value")
 		cmd.Flags().String("sort", "", "Sort columns by this axis value descending (reserved; renderer details deferred per C3 §6.5)")
 		cmd.Flags().Bool("include-inputs", false, "Prepend spawn_inputs block (default: on for 2-run, off for 3+)")
 		cmd.Flags().Bool("include-rubric", false, "Include rubric_* columns (hidden by default)")
+		// Top-level `--json` flag honours the prism-wide convention that
+		// every list/lookup subcommand accepts `--json` (issue #2099 Bug 2).
+		// It is byte-equivalent to `--format json` on stdout for the success
+		// path; on the error path both surfaces emit `{"error":"..."}` on
+		// stderr per the prism `--json` contract (issue #2099 Bug 3).
+		cmd.Flags().Bool("json", false, "Emit a single JSON document to stdout (alias for --format json). On error, emits {\"error\":\"...\"} to stderr.")
 	}
 	statsCmd.AddCommand(compareCmd)
 	statsCmd.AddCommand(abtestCmd)
 }
 
+// jsonOutputRequested reports whether the caller asked for the JSON
+// output contract via either the top-level `--json` flag (issue #2099
+// Bug 2) or the legacy `--format json`. The two surfaces are equivalent
+// — see compareCmd.Long for the documented contract.
+func jsonOutputRequested(cmd *cobra.Command) bool {
+	if j, _ := cmd.Flags().GetBool("json"); j {
+		return true
+	}
+	if f, _ := cmd.Flags().GetString("format"); f == "json" {
+		return true
+	}
+	return false
+}
+
+// reportCompareError implements the JSON-or-passthrough error contract
+// shared by runStatsCompare and runStatsAbtest. When the caller asked for
+// JSON output (via --json or --format json), the error is rendered as a
+// single-line JSON envelope on stderr and a quietExitErr is returned so
+// main does not double-print. Otherwise the original error is returned
+// unchanged.
+func reportCompareError(cmd *cobra.Command, err error) error {
+	if err == nil {
+		return nil
+	}
+	if jsonOutputRequested(cmd) {
+		return emitJSONErrorEnvelope(err)
+	}
+	return err
+}
+
 // ---------- runner functions ----------
 
 func runStatsCompare(cmd *cobra.Command, args []string) error {
+	return reportCompareError(cmd, runStatsCompareInner(cmd, args))
+}
+
+func runStatsCompareInner(cmd *cobra.Command, args []string) error {
 	// PRISM_HOST_API proxy dispatch: inside a sandbox the local shadow DB does
 	// not carry the host's data, so the resolution + aggregation must run on the
 	// host. The sidecar returns the assembled per-run data and the rendering
@@ -114,6 +168,10 @@ func runStatsCompare(cmd *cobra.Command, args []string) error {
 }
 
 func runStatsAbtest(cmd *cobra.Command, args []string) error {
+	return reportCompareError(cmd, runStatsAbtestInner(cmd, args))
+}
+
+func runStatsAbtestInner(cmd *cobra.Command, args []string) error {
 	groupID := args[0]
 
 	// PRISM_HOST_API proxy dispatch (issue #2098): same contract as compare —
@@ -242,6 +300,15 @@ func runComparison(cmd *cobra.Command, d *db.DB, sessions []*db.Session) error {
 // none of them can silently degrade on the proxy path.
 func renderComparison(cmd *cobra.Command, runs []compareRun) error {
 	format, _ := cmd.Flags().GetString("format")
+	// The top-level `--json` flag (issue #2099 Bug 2) is an alias for
+	// `--format json`. Both surfaces must produce byte-identical stdout,
+	// so collapse them to the same renderer dispatch here. If both are
+	// set with conflicting values (e.g. `--json --format csv`), --json
+	// wins — it is the documented prism-wide convention and the more
+	// explicit signal.
+	if j, _ := cmd.Flags().GetBool("json"); j {
+		format = "json"
+	}
 	diffOnly, _ := cmd.Flags().GetBool("diff-only")
 	includeRubric, _ := cmd.Flags().GetBool("include-rubric")
 	axesFlag, _ := cmd.Flags().GetStringSlice("axes")
@@ -616,13 +683,45 @@ func buildAxisRows(axes []string, runs []compareRun, diffOnly bool) []axisRow {
 }
 
 // ---------- table renderer ----------
+//
+// Issue #2099 Bug 1 — the previous renderer used `fmt.Sprintf("%-*s", wLabel,
+// styleLabel.Render(row.Name+":"))` which mixes byte-count padding with ANSI
+// escape sequences from lipgloss. Escape codes contribute bytes but zero
+// visible width, so the visible column anchor drifted by (raw_bytes - visible)
+// on every row, breaking vertical alignment between value cells and the
+// header row's run-A / run-B / Δ positions.
+//
+// The new renderer:
+//   - assembles every section (Session, Spawn Inputs, Process-level, ...)
+//     into a flat list of (section-title, rows[]) entries up front,
+//   - performs a single pass over the full dataset to compute the label
+//     column width and per-run value column widths from the actual data
+//     (rather than guessing fixed constants),
+//   - pads with `padRightVisible`, which measures visible width via
+//     `lipgloss.Width` so styled labels and unstyled values share the
+//     same column anchors,
+//   - applies `truncateStr` per column using the column's measured width,
+//     so a long value (e.g. a multi-line PR title or a full instance_id)
+//     stays inside its own column instead of pushing later columns right.
+
+// compareTableSection groups one rendered block of the compare table. The
+// header is fully-rendered text ("Session", "Process-level outcomes:", "").
+// emptyMsg, when non-empty, is printed in place of rows for the Spawn Inputs
+// no-data fallback. showDelta is true only for the outcome / aggregation
+// sections in a 2-run comparison.
+type compareTableSection struct {
+	title    string
+	suffix   string // ":" for outcome sections, empty for the Session block
+	rows     []axisRow
+	emptyMsg string
+	showDelta bool
+}
 
 func renderCompareTable(runs []compareRun, axes []string, includeInputs, includeRubric, diffOnly bool) error {
 	styleHeader := lipgloss.NewStyle().Bold(true)
 	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 	styleDim := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSecondary))
 
-	// Effective axes.
 	effectiveAxes := axes
 	if includeRubric {
 		effectiveAxes = append(effectiveAxes, rubricAxes...)
@@ -630,92 +729,213 @@ func renderCompareTable(runs []compareRun, axes []string, includeInputs, include
 
 	isPairwise := len(runs) == 2
 
-	// Column widths.
-	const wLabel = 28
-	wVal := 26
+	// --- Build sections ------------------------------------------------------
+	var sections []compareTableSection
 
-	// Header row: axis label + run labels.
-	headerCols := fmt.Sprintf("%-*s", wLabel, "")
-	for _, r := range runs {
-		headerCols += fmt.Sprintf("  %-*s", wVal, r.Label)
-	}
-	if isPairwise {
-		headerCols += fmt.Sprintf("  %s", "Δ")
-	}
-	fmt.Println(styleHeader.Render(headerCols))
-	fmt.Println(styleDim.Render(fmt.Sprintf("%-*s", wLabel, "") +
-		strings.Repeat("  "+strings.Repeat("─", wVal), len(runs))))
+	// Session block — always shown, no Δ column.
+	sections = append(sections, compareTableSection{
+		title: "Session",
+		rows: []axisRow{
+			{Name: "instance_id", Values: valsFromRuns(runs, func(r compareRun) string { return r.Session.InstanceID })},
+			{Name: "session_name", Values: valsFromRuns(runs, func(r compareRun) string { return r.Session.SessionName })},
+			{Name: "started_at", Values: valsFromRuns(runs, func(r compareRun) string { return r.Session.StartedAt.Format("2006-01-02 15:04:05") })},
+		},
+	})
 
-	// Session metadata block.
-	fmt.Println()
-	fmt.Println(styleHeader.Render("Session"))
-	for _, row := range []struct {
-		label string
-		fn    func(compareRun) string
-	}{
-		{"instance_id", func(r compareRun) string { return r.Session.InstanceID }},
-		{"session_name", func(r compareRun) string { return r.Session.SessionName }},
-		{"started_at", func(r compareRun) string { return r.Session.StartedAt.Format("2006-01-02 15:04:05") }},
-	} {
-		line := fmt.Sprintf("%-*s", wLabel, styleLabel.Render(row.label+":"))
-		for _, r := range runs {
-			v := truncateStr(row.fn(r), wVal)
-			line += fmt.Sprintf("  %-*s", wVal, v)
-		}
-		fmt.Println(line)
-	}
-
-	// Spawn inputs block: render the actual values written at spawn time by
-	// SpawnSession (#2087) and the `prism pr` writer. The renderer reads
-	// profile_name, isolation, harness, branch, agent_role, and the abtest
-	// pair id. Partial data is rendered as-is — missing fields collapse to
-	// “—” rather than treating the row as absent (issue #2102, Layer 2).
+	// Spawn Inputs block — optional, no Δ column.
 	if includeInputs {
-		fmt.Println()
-		fmt.Println(styleHeader.Render("Spawn Inputs"))
+		inputsSection := compareTableSection{title: "Spawn Inputs"}
 		if !anyInputsPresent(runs) {
-			// Best-effort placeholder for sessions that pre-date the
-			// spawn_inputs writer (#2087). The old “C.1” placeholder is
-			// gone — the writer is live for every front door, so the only
-			// reason a row is missing today is that the session is from
-			// before #2087 merged.
-			fmt.Println(styleDim.Render("  (no spawn_inputs rows for the runs being compared)"))
+			inputsSection.emptyMsg = "  (no spawn_inputs rows for the runs being compared)"
 		} else {
-			for _, row := range inputsAxisRows(runs, diffOnly) {
-				line := fmt.Sprintf("%-*s", wLabel, styleLabel.Render(row.Name+":"))
-				for _, v := range row.Values {
-					line += fmt.Sprintf("  %-*s", wVal, truncateStr(v, wVal))
-				}
-				fmt.Println(line)
-			}
+			inputsSection.rows = inputsAxisRows(runs, diffOnly)
 		}
+		sections = append(sections, inputsSection)
 	}
 
-	// Section: process-level.
+	// Outcome sections — deltas only meaningful for pairwise.
 	processAxes := []string{
 		"end_state", "duration_ms", "interrupted_count", "compaction_count",
 		"error_event_count", "permission_ask_count", "permission_denied_count", "doom_loop_count",
 	}
-	renderSection(styleHeader, styleLabel, styleDim, "Process-level outcomes", processAxes, effectiveAxes, runs, wLabel, wVal, isPairwise, diffOnly)
-
-	// Section: agent-level.
 	agentAxes := []string{
 		"pr_number", "pr_merged_at", "review_verdict", "review_pass_count", "review_fail_count",
 	}
-	renderSection(styleHeader, styleLabel, styleDim, "Agent-level outcomes", agentAxes, effectiveAxes, runs, wLabel, wVal, isPairwise, diffOnly)
-
-	// Section: per-axis aggregations.
 	aggregateAxes := []string{
 		"tokens_input", "tokens_output", "tokens_cache_read", "tokens_cache_write",
 		"cost_usd", "tool_call", "tool_error", "msg_assistant",
 		"time_to_first_event", "time_to_finished",
 	}
-	renderSection(styleHeader, styleLabel, styleDim, "Per-axis aggregations", aggregateAxes, effectiveAxes, runs, wLabel, wVal, isPairwise, diffOnly)
+	wantSet := make(map[string]bool, len(effectiveAxes))
+	for _, a := range effectiveAxes {
+		wantSet[a] = true
+	}
+	filterRequested := func(axes []string) []string {
+		var out []string
+		for _, a := range axes {
+			if wantSet[a] {
+				out = append(out, a)
+			}
+		}
+		return out
+	}
 
-	// Section: rubric.
+	appendOutcomeSection := func(title string, axes []string) {
+		filtered := filterRequested(axes)
+		if len(filtered) == 0 {
+			return
+		}
+		rows := buildAxisRows(filtered, runs, diffOnly)
+		if len(rows) == 0 {
+			return
+		}
+		sections = append(sections, compareTableSection{
+			title:     title,
+			suffix:    ":",
+			rows:      rows,
+			showDelta: isPairwise,
+		})
+	}
+	appendOutcomeSection("Process-level outcomes", processAxes)
+	appendOutcomeSection("Agent-level outcomes", agentAxes)
+	appendOutcomeSection("Per-axis aggregations", aggregateAxes)
 	if includeRubric {
-		renderSection(styleHeader, styleLabel, styleDim, "Rubric-level outcomes", rubricAxes, effectiveAxes, runs, wLabel, wVal, isPairwise, diffOnly)
-	} else {
+		appendOutcomeSection("Rubric-level outcomes", rubricAxes)
+	}
+
+	// --- Single-pass width calculation across ALL rows ----------------------
+	//
+	// labelW is the max axis-name length plus the trailing ":".
+	// valW[i] is the max visible width of any value in column i, including
+	// run header labels and any "[MIN]" / "[MAX]" annotation that will be
+	// appended in the 3+ run case. We use lipgloss.Width so that styled
+	// strings contribute their *visible* width, not their raw byte length.
+	labelW := 0
+	for _, s := range sections {
+		for _, r := range s.rows {
+			if w := lipgloss.Width(r.Name) + 1; w > labelW { // +1 for ":"
+				labelW = w
+			}
+		}
+	}
+	if labelW < 12 {
+		labelW = 12
+	}
+
+	valW := make([]int, len(runs))
+	for i, r := range runs {
+		if w := lipgloss.Width(r.Label); w > valW[i] {
+			valW[i] = w
+		}
+	}
+	for _, s := range sections {
+		for _, row := range s.rows {
+			for i, v := range row.Values {
+				if i >= len(valW) {
+					break
+				}
+				candidate := v
+				if !isPairwise {
+					if ann := minMaxAnnotation(row.Name, i, runs); ann != "" {
+						candidate = candidate + " [" + ann + "]"
+					}
+				}
+				if w := lipgloss.Width(candidate); w > valW[i] {
+					valW[i] = w
+				}
+			}
+		}
+	}
+	const maxValW = 40
+	for i := range valW {
+		if valW[i] > maxValW {
+			valW[i] = maxValW
+		}
+		if valW[i] < len("run-A") {
+			valW[i] = len("run-A")
+		}
+	}
+
+	const colGap = "  "
+
+	// --- Render: header + separator ----------------------------------------
+	var sb strings.Builder
+	sb.WriteString(strings.Repeat(" ", labelW))
+	for i, r := range runs {
+		sb.WriteString(colGap)
+		sb.WriteString(padRightVisible(r.Label, valW[i]))
+	}
+	if isPairwise {
+		sb.WriteString(colGap)
+		sb.WriteString("Δ")
+	}
+	fmt.Println(styleHeader.Render(sb.String()))
+
+	sb.Reset()
+	sb.WriteString(strings.Repeat(" ", labelW))
+	for i := range runs {
+		sb.WriteString(colGap)
+		sb.WriteString(strings.Repeat("─", valW[i]))
+	}
+	fmt.Println(styleDim.Render(sb.String()))
+
+	// --- Render: per-section bodies ----------------------------------------
+	renderRow := func(name string, values []string, showDelta bool, deltaVal string) {
+		var sb strings.Builder
+		labelStr := name + ":"
+		sb.WriteString(styleLabel.Render(labelStr))
+		// Pad the label column to labelW using *visible* width — escape
+		// codes from styleLabel.Render must not push the value column right.
+		if pad := labelW - lipgloss.Width(labelStr); pad > 0 {
+			sb.WriteString(strings.Repeat(" ", pad))
+		}
+		for i, v := range values {
+			sb.WriteString(colGap)
+			cell := truncateStr(v, valW[i])
+			sb.WriteString(padRightVisible(cell, valW[i]))
+		}
+		if showDelta {
+			sb.WriteString(colGap)
+			sb.WriteString(deltaVal)
+		}
+		fmt.Println(sb.String())
+	}
+
+	for _, sec := range sections {
+		fmt.Println()
+		fmt.Println(styleHeader.Render(sec.title + sec.suffix))
+		if sec.emptyMsg != "" {
+			fmt.Println(styleDim.Render(sec.emptyMsg))
+			continue
+		}
+		for _, row := range sec.rows {
+			// Build the per-cell display values — for 3+ runs, append
+			// the MIN/MAX annotation BEFORE truncation/padding so the
+			// width pass above already accounted for it.
+			vals := make([]string, len(row.Values))
+			for i, v := range row.Values {
+				if !sec.showDelta && !isPairwise {
+					if ann := minMaxAnnotation(row.Name, i, runs); ann != "" {
+						vals[i] = v + " [" + ann + "]"
+						continue
+					}
+				}
+				vals[i] = v
+			}
+
+			deltaVal := ""
+			if sec.showDelta {
+				d := deltaStr(row.Name, runs[0], runs[1])
+				if d == "" {
+					d = "—"
+				}
+				deltaVal = d
+			}
+			renderRow(row.Name, vals, sec.showDelta, deltaVal)
+		}
+	}
+
+	if !includeRubric {
 		fmt.Println()
 		fmt.Println(styleDim.Render("Rubric-level outcomes: (none recorded; pass --include-rubric to show NULLs)"))
 	}
@@ -723,67 +943,27 @@ func renderCompareTable(runs []compareRun, axes []string, includeInputs, include
 	return nil
 }
 
-// renderSection prints a named section of the comparison table.
-// Only axes that are in both sectionAxes and wantAxes are shown.
-func renderSection(
-	styleHeader, styleLabel, styleDim lipgloss.Style,
-	title string,
-	sectionAxes, wantAxes []string,
-	runs []compareRun,
-	wLabel, wVal int,
-	isPairwise, diffOnly bool,
-) {
-	// Intersect: only axes requested by the user.
-	wantSet := make(map[string]bool, len(wantAxes))
-	for _, a := range wantAxes {
-		wantSet[a] = true
+// valsFromRuns is a small helper that materialises a per-run value slice
+// from a projection function. Used to build the Session block rows without
+// repeating the boilerplate `make + for` loop at each call site.
+func valsFromRuns(runs []compareRun, fn func(compareRun) string) []string {
+	out := make([]string, len(runs))
+	for i, r := range runs {
+		out[i] = fn(r)
 	}
+	return out
+}
 
-	var filtered []string
-	for _, a := range sectionAxes {
-		if wantSet[a] {
-			filtered = append(filtered, a)
-		}
+// padRightVisible right-pads s with spaces so its visible width is at
+// least width. Visible width is measured by lipgloss.Width so ANSI escape
+// sequences (from lipgloss.Style.Render) contribute zero to the width
+// budget. If s is already >= width visibly, it is returned unchanged.
+func padRightVisible(s string, width int) string {
+	w := lipgloss.Width(s)
+	if w >= width {
+		return s
 	}
-	if len(filtered) == 0 {
-		return
-	}
-
-	rows := buildAxisRows(filtered, runs, diffOnly)
-	if len(rows) == 0 {
-		return
-	}
-
-	fmt.Println()
-	fmt.Println(styleHeader.Render(title + ":"))
-	for _, row := range rows {
-		var line string
-		if isPairwise {
-			// 2 runs: plain values + Δ column.
-			line = fmt.Sprintf("%-*s", wLabel, styleLabel.Render(row.Name+":"))
-			for _, v := range row.Values {
-				line += fmt.Sprintf("  %-*s", wVal, truncateStr(v, wVal))
-			}
-			delta := deltaStr(row.Name, runs[0], runs[1])
-			if delta != "" {
-				line += fmt.Sprintf("  %s", delta)
-			} else {
-				line += "  —"
-			}
-		} else {
-			// 3+ runs: MIN/MAX annotation per cell; no Δ column.
-			line = fmt.Sprintf("%-*s", wLabel, styleLabel.Render(row.Name+":"))
-			for i, v := range row.Values {
-				ann := minMaxAnnotation(row.Name, i, runs)
-				cellStr := truncateStr(v, wVal)
-				if ann != "" {
-					cellStr = fmt.Sprintf("%s [%s]", truncateStr(v, wVal-len(ann)-3), ann)
-				}
-				line += fmt.Sprintf("  %-*s", wVal, cellStr)
-			}
-		}
-		fmt.Println(line)
-	}
+	return s + strings.Repeat(" ", width-w)
 }
 
 // ---------- spawn_inputs renderer helpers ----------

--- a/modules/programs/prism/prism/cmd/stats_compare_output_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_output_test.go
@@ -1,0 +1,595 @@
+package cmd
+
+// Tests for prism stats compare output-contract fixes (issue #2099):
+//
+//   Bug 1 — `--format table` column alignment uses a single-pass
+//   width calculation across all rows; value cells line up vertically
+//   with the run-A / run-B / Δ header anchors, regardless of label or
+//   value byte length.
+//
+//   Bug 2 — top-level `--json` flag is accepted; emits the same JSON
+//   document as `--format json` on the success path (byte-identical
+//   stdout). Sibling commands `stats abtest <group_id>` and
+//   `stats --abtest` honour the same convention.
+//
+//   Bug 3 — on error, `--json` / `--format json` emits a single-line
+//   JSON envelope `{"error":"..."}` to stderr (no cobra usage dump);
+//   stdout is empty; exit code non-zero. Other formats (table, csv)
+//   are not affected.
+//
+// Tests use the seedCompareSession / writeAssistantTurn helpers defined
+// in stats_compare_test.go and the captureStdout/captureStdoutStderr
+// helpers defined in checkin_test.go / escalate_idempotency_test.go.
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// forceLipglossANSI forces lipgloss to emit ANSI escape sequences for
+// the duration of the test. Without this, lipgloss auto-detects that
+// stdout is not a TTY (test environment) and emits plain text, which
+// would hide the issue #2099 Bug 1 mis-alignment that depends on
+// `len(styled_bytes) > visible_width`. The cleanup restores the Ascii
+// profile so concurrent / subsequent tests are unaffected.
+//
+// See internal/dashboard/review_summary_test.go for the established
+// in-tree precedent.
+func forceLipglossANSI(t *testing.T) {
+	t.Helper()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(termenv.Ascii)
+	})
+}
+
+// ── Bug 1 — table column alignment ───────────────────────────────────────────
+
+// ansiEscapeRE matches CSI/SGR escape sequences emitted by lipgloss.
+// Used to strip styling for column-position assertions.
+var ansiEscapeRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+// stripANSI removes ANSI escape sequences from s so the result reflects
+// the *visible* characters that would land in the user's terminal. This
+// is the right primitive for column-alignment assertions because the
+// alignment bug (#2099 Bug 1) was specifically that lipgloss escape
+// codes contributed bytes but zero visible width, breaking the renderer's
+// `%-*s` byte-count padding.
+func stripANSI(s string) string { return ansiEscapeRE.ReplaceAllString(s, "") }
+
+// dataRowRE matches lines of the form `<axis_name>: <value>...` — i.e.
+// lines whose first colon is preceded by an axis-name-shaped identifier
+// (lowercase letters, digits, underscores). This deliberately excludes
+// section titles ("Process-level outcomes:", "Spawn Inputs", "Session")
+// and the dim-styled Rubric fallback line ("Rubric-level outcomes:
+// (none recorded; ...)") whose label has spaces and a hyphen.
+var dataRowRE = regexp.MustCompile(`^\s*[a-z][a-z0-9_]*:\s+\S`)
+
+func isDataRowLine(line string) bool { return dataRowRE.MatchString(line) }
+
+// findValueColumnAnchors returns the *visible* offset of the first
+// non-space rune after the label-column gap on each data row. Visible
+// offset is the rune count of the prefix, matching what the user sees in
+// a terminal regardless of UTF-8 byte width.
+func findValueColumnAnchors(t *testing.T, plain string) []int {
+	t.Helper()
+	var anchors []int
+	for _, line := range strings.Split(plain, "\n") {
+		if !isDataRowLine(line) {
+			continue
+		}
+		colonIdx := strings.Index(line, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		i := colonIdx + 1
+		for i < len(line) && line[i] == ' ' {
+			i++
+		}
+		// Convert byte index to rune index for the visible anchor.
+		anchors = append(anchors, len([]rune(line[:i])))
+	}
+	return anchors
+}
+
+// TestRenderCompareTable_ValueColumnsAlignAcrossRows is the primary
+// alignment guard for issue #2099 Bug 1: every "label: value..." row
+// must place its first value cell at the same column anchor as every
+// other data row's first value cell. The old renderer drifted by
+// (raw_bytes_of_styled_label - visible_width) per row, so rows with
+// longer axis names sat further right than rows with short names.
+func TestRenderCompareTable_ValueColumnsAlignAcrossRows(t *testing.T) {
+	forceLipglossANSI(t)
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+
+	inputsA := &db.SpawnInputs{
+		ProfileName:   strPtr("anthropic-sonnet"),
+		HarnessFlag:   strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"),
+		AgentFlag:     strPtr("worker"),
+	}
+	inputsB := &db.SpawnInputs{
+		ProfileName:   strPtr("google-gemini-3"),
+		HarnessFlag:   strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"),
+		AgentFlag:     strPtr("worker"),
+	}
+	iidA := seedCompareSession(t, d, "repo@align-a", startedAt, agent.StateFinished, inputsA)
+	iidB := seedCompareSession(t, d, "repo@align-b", startedAt, agent.StateFinished, inputsB)
+	writeAssistantTurn(t, d, "repo@align-a", iidA, startedAt.Add(10*time.Second), 1500, 700, 300, 150, 0.12)
+	writeAssistantTurn(t, d, "repo@align-b", iidB, startedAt.Add(10*time.Second), 2000, 900, 400, 200, 0.34)
+
+	sessA, _ := d.SessionByInstanceID(iidA)
+	sessB, _ := d.SessionByInstanceID(iidB)
+	runs := loadCompareRuns(d, []*db.Session{sessA, sessB})
+
+	out := captureStdout(t, func() {
+		if err := renderCompareTable(runs, defaultAxes(), true, false, false); err != nil {
+			t.Fatalf("renderCompareTable: %v", err)
+		}
+	})
+
+	plain := stripANSI(out)
+
+	anchors := findValueColumnAnchors(t, plain)
+	if len(anchors) < 6 {
+		t.Fatalf("expected ≥6 data rows for alignment check, got %d\n--- plain output ---\n%s", len(anchors), plain)
+	}
+	first := anchors[0]
+	for i, a := range anchors {
+		if a != first {
+			lines := strings.Split(plain, "\n")
+			t.Errorf("data row %d anchor = %d, want %d (matches row 0)\n  row 0: %q\n  row %d: %q",
+				i, a, first, firstDataLine(lines, isDataRowLine), i, ithDataLine(lines, isDataRowLine, i))
+		}
+	}
+
+	// Cross-check: the header's "run-A" / "run-B" anchors must match the
+	// data anchors. Find the header line — the first line that contains
+	// both "run-A" and "run-B". Use rune index for visible alignment.
+	var headerLine string
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "run-A") && strings.Contains(line, "run-B") {
+			headerLine = line
+			break
+		}
+	}
+	if headerLine == "" {
+		t.Fatalf("did not find run-A/run-B header line in output:\n%s", plain)
+	}
+	runAByte := strings.Index(headerLine, "run-A")
+	runAIdx := len([]rune(headerLine[:runAByte]))
+	if runAIdx != first {
+		t.Errorf("run-A header anchor = %d, but data rows anchor at %d\n  header: %q", runAIdx, first, headerLine)
+	}
+}
+
+// TestRenderCompareTable_ThreeRunsAlign verifies the alignment property
+// holds for an N-run comparison (no Δ column, MIN/MAX annotations).
+func TestRenderCompareTable_ThreeRunsAlign(t *testing.T) {
+	forceLipglossANSI(t)
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+
+	inputs := func(profile string) *db.SpawnInputs {
+		return &db.SpawnInputs{
+			ProfileName:   strPtr(profile),
+			HarnessFlag:   strPtr("pi"),
+			IsolationFlag: strPtr("bwrap"),
+		}
+	}
+	iidA := seedCompareSession(t, d, "repo@three-a", startedAt, agent.StateFinished, inputs("sonnet"))
+	iidB := seedCompareSession(t, d, "repo@three-b", startedAt, agent.StateFinished, inputs("opus"))
+	iidC := seedCompareSession(t, d, "repo@three-c", startedAt, agent.StateFinished, inputs("haiku"))
+	writeAssistantTurn(t, d, "repo@three-a", iidA, startedAt.Add(5*time.Second), 1000, 500, 0, 0, 0.05)
+	writeAssistantTurn(t, d, "repo@three-b", iidB, startedAt.Add(5*time.Second), 1500, 700, 0, 0, 0.10)
+	writeAssistantTurn(t, d, "repo@three-c", iidC, startedAt.Add(5*time.Second), 800, 400, 0, 0, 0.04)
+
+	sessA, _ := d.SessionByInstanceID(iidA)
+	sessB, _ := d.SessionByInstanceID(iidB)
+	sessC, _ := d.SessionByInstanceID(iidC)
+	runs := loadCompareRuns(d, []*db.Session{sessA, sessB, sessC})
+
+	out := captureStdout(t, func() {
+		if err := renderCompareTable(runs, defaultAxes(), false, false, false); err != nil {
+			t.Fatalf("renderCompareTable: %v", err)
+		}
+	})
+
+	plain := stripANSI(out)
+	anchors := findValueColumnAnchors(t, plain)
+	if len(anchors) < 6 {
+		t.Fatalf("expected ≥6 data rows, got %d:\n%s", len(anchors), plain)
+	}
+	first := anchors[0]
+	for i, a := range anchors {
+		if a != first {
+			t.Errorf("3-run data row %d anchor = %d, want %d", i, a, first)
+		}
+	}
+	// Header anchor (run-A) must equal the data anchor too — visible runes.
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "run-A") && strings.Contains(line, "run-B") && strings.Contains(line, "run-C") {
+			runAByte := strings.Index(line, "run-A")
+			runAIdx := len([]rune(line[:runAByte]))
+			if runAIdx != first {
+				t.Errorf("3-run header anchor = %d, want %d (matches data rows)", runAIdx, first)
+			}
+			break
+		}
+	}
+}
+
+// TestRenderCompareTable_LongValueTruncates verifies the edge-case AC:
+// long values must wrap/truncate inside their column and never push later
+// columns right. We exercise this with a long session_name (longer than
+// the maxValW cap) and assert the value cell visible width does not
+// exceed the column width and the next column anchor is unchanged.
+func TestRenderCompareTable_LongValueTruncates(t *testing.T) {
+	forceLipglossANSI(t)
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+
+	longName := "repo@" + strings.Repeat("very-long-leg-name-segment-", 4) // ~110 chars
+	inputs := &db.SpawnInputs{ProfileName: strPtr("p"), HarnessFlag: strPtr("pi")}
+	iidA := seedCompareSession(t, d, longName, startedAt, agent.StateFinished, inputs)
+	iidB := seedCompareSession(t, d, "repo@short", startedAt, agent.StateFinished, inputs)
+	writeAssistantTurn(t, d, longName, iidA, startedAt.Add(time.Second), 100, 50, 0, 0, 0.01)
+	writeAssistantTurn(t, d, "repo@short", iidB, startedAt.Add(time.Second), 200, 100, 0, 0, 0.02)
+
+	sessA, _ := d.SessionByInstanceID(iidA)
+	sessB, _ := d.SessionByInstanceID(iidB)
+	runs := loadCompareRuns(d, []*db.Session{sessA, sessB})
+
+	out := captureStdout(t, func() {
+		if err := renderCompareTable(runs, defaultAxes(), true, false, false); err != nil {
+			t.Fatalf("renderCompareTable: %v", err)
+		}
+	})
+
+	plain := stripANSI(out)
+	// No line's *visible* width should exceed the per-column truncation
+	// budget (label + 2 columns + delta + gaps). lipgloss.Width counts
+	// visible columns, so multi-byte runes like "─" count as 1 each.
+	const sanityMaxVisible = 200
+	for _, line := range strings.Split(plain, "\n") {
+		if lipgloss.Width(line) > sanityMaxVisible {
+			t.Errorf("line visible width %d > sanity max %d (long value not truncated?): %q",
+				lipgloss.Width(line), sanityMaxVisible, line)
+		}
+	}
+
+	// The session_name row must still be present and the long name must
+	// appear in truncated form (with the truncateStr "..." marker).
+	foundSessionRow := false
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "session_name:") {
+			foundSessionRow = true
+			if !strings.Contains(line, "...") {
+				t.Errorf("long session_name not truncated in row: %q", line)
+			}
+		}
+	}
+	if !foundSessionRow {
+		t.Errorf("expected session_name: row in output:\n%s", plain)
+	}
+}
+
+// ── Bug 2 — top-level --json flag accepted and equivalent to --format json ───
+
+// TestStatsCompare_JSONFlagAccepted is the headline AC for Bug 2:
+// `prism stats compare --json <runs>` must be accepted by cobra (no
+// "unknown flag" error) and emit a single JSON document on stdout.
+func TestStatsCompare_JSONFlagAccepted(t *testing.T) {
+	d := openStatsTestDB(t)
+	resetRootCmdFlags(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+	iidA := seedCompareSession(t, d, "repo@json-a", startedAt, agent.StateFinished,
+		&db.SpawnInputs{ProfileName: strPtr("sonnet"), HarnessFlag: strPtr("pi")})
+	iidB := seedCompareSession(t, d, "repo@json-b", startedAt, agent.StateFinished,
+		&db.SpawnInputs{ProfileName: strPtr("opus"), HarnessFlag: strPtr("pi")})
+	writeAssistantTurn(t, d, "repo@json-a", iidA, startedAt.Add(time.Second), 100, 50, 0, 0, 0.01)
+	writeAssistantTurn(t, d, "repo@json-b", iidB, startedAt.Add(time.Second), 200, 100, 0, 0, 0.02)
+
+	rootCmd.SetArgs([]string{"stats", "compare", iidA, iidB, "--json"})
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("rootCmd.Execute(): %v", err)
+		}
+	})
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatalf("--json produced empty stdout")
+	}
+	var parsed compareJSONOutput
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("--json stdout is not parseable JSON: %v\nstdout:\n%s", err, stdout)
+	}
+	if len(parsed.Runs) != 2 {
+		t.Errorf("--json runs count = %d, want 2", len(parsed.Runs))
+	}
+}
+
+// TestStatsCompare_JSONFlagEquivalentToFormatJSON asserts the byte-identical
+// stdout contract between `--json` and `--format json` on the success path.
+// Both surfaces MUST produce the same output (one shape, two surface flags).
+func TestStatsCompare_JSONFlagEquivalentToFormatJSON(t *testing.T) {
+	d := openStatsTestDB(t)
+	resetRootCmdFlags(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+	iidA := seedCompareSession(t, d, "repo@equiv-a", startedAt, agent.StateFinished,
+		&db.SpawnInputs{ProfileName: strPtr("p1")})
+	iidB := seedCompareSession(t, d, "repo@equiv-b", startedAt, agent.StateFinished,
+		&db.SpawnInputs{ProfileName: strPtr("p2")})
+	writeAssistantTurn(t, d, "repo@equiv-a", iidA, startedAt.Add(time.Second), 100, 50, 0, 0, 0.01)
+	writeAssistantTurn(t, d, "repo@equiv-b", iidB, startedAt.Add(time.Second), 200, 100, 0, 0, 0.02)
+
+	runOnce := func(args []string) string {
+		resetRootCmdFlags(t)
+		rootCmd.SetArgs(args)
+		out, _ := captureStdoutStderr(t, func() {
+			if err := rootCmd.Execute(); err != nil {
+				t.Fatalf("rootCmd.Execute(%v): %v", args, err)
+			}
+		})
+		return out
+	}
+	a := runOnce([]string{"stats", "compare", iidA, iidB, "--json"})
+	b := runOnce([]string{"stats", "compare", iidA, iidB, "--format", "json"})
+	if a != b {
+		t.Errorf("--json and --format json are not byte-identical\n--- --json ---\n%s\n--- --format json ---\n%s", a, b)
+	}
+}
+
+// TestStatsAbtest_JSONFlagAccepted is the sibling-surface AC for Bug 2:
+// `prism stats abtest <group_id> --json` must also accept --json and emit
+// JSON, sharing the engine with `stats compare`. The members are
+// associated with the group via agent_status.group_id (the column
+// AbtestGroupSessions reads) using SetGroupID.
+func TestStatsAbtest_JSONFlagAccepted(t *testing.T) {
+	d := openStatsTestDB(t)
+	resetRootCmdFlags(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+	inputsA := &db.SpawnInputs{ProfileName: strPtr("sonnet")}
+	inputsB := &db.SpawnInputs{ProfileName: strPtr("opus")}
+	iidA := seedCompareSession(t, d, "repo@grp-a", startedAt, agent.StateFinished, inputsA)
+	iidB := seedCompareSession(t, d, "repo@grp-b", startedAt.Add(time.Second), agent.StateFinished, inputsB)
+	writeAssistantTurn(t, d, "repo@grp-a", iidA, startedAt.Add(2*time.Second), 100, 50, 0, 0, 0.01)
+	writeAssistantTurn(t, d, "repo@grp-b", iidB, startedAt.Add(2*time.Second), 200, 100, 0, 0, 0.02)
+
+	groupID, err := d.RegisterGroup("repo@parent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+	if err := d.SetGroupID("repo@grp-a", groupID); err != nil {
+		t.Fatalf("SetGroupID a: %v", err)
+	}
+	if err := d.SetGroupID("repo@grp-b", groupID); err != nil {
+		t.Fatalf("SetGroupID b: %v", err)
+	}
+
+	rootCmd.SetArgs([]string{"stats", "abtest", groupID, "--json"})
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("rootCmd.Execute(): %v", err)
+		}
+	})
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatalf("stats abtest --json produced empty stdout")
+	}
+	var parsed compareJSONOutput
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("--json stdout not parseable: %v\n%s", err, stdout)
+	}
+	if len(parsed.Runs) != 2 {
+		t.Errorf("expected 2 runs in JSON output, got %d", len(parsed.Runs))
+	}
+}
+
+// TestStatsAbtestFlag_JSON verifies the top-level `prism stats --abtest --json`
+// surface emits the abtest_list payload as JSON (shape {"pairs":[...]}).
+func TestStatsAbtestFlag_JSON(t *testing.T) {
+	d := openStatsTestDB(t)
+	resetRootCmdFlags(t)
+	// Reuse the seedAbtestPair helper from stats_proxy_test.go.
+	seedAbtestPair(t, d, "pair-2099-aaaa-bbbb-cccc-dddddddddddd")
+
+	rootCmd.SetArgs([]string{"stats", "--abtest", "--json"})
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("rootCmd.Execute(): %v", err)
+		}
+	})
+
+	var parsed struct {
+		Pairs []db.AbtestPairRow `json:"pairs"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("--abtest --json stdout not parseable JSON: %v\n%s", err, stdout)
+	}
+	if len(parsed.Pairs) != 1 {
+		t.Errorf("expected 1 abtest pair in JSON output, got %d:\n%s", len(parsed.Pairs), stdout)
+	}
+}
+
+// ── Bug 3 — JSON error envelope contract ─────────────────────────────────────
+
+// TestStatsCompare_JSONErrorEnvelope is the headline AC for Bug 3:
+// on a bad instance ID, stdout MUST be empty, stderr MUST carry a single
+// parseable JSON object with an `error` field, and the exit code MUST be
+// non-zero. No cobra usage block.
+func TestStatsCompare_JSONErrorEnvelope(t *testing.T) {
+	_ = openStatsTestDB(t)
+	resetRootCmdFlags(t)
+
+	rootCmd.SetArgs([]string{"stats", "compare", "bogus-id-1", "bogus-id-2", "--json"})
+	stdout, stderr := captureStdoutStderr(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("expected non-nil error for bad instance ID")
+		}
+	})
+
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout = %q, want empty on --json error path", stdout)
+	}
+
+	// stderr must contain exactly one parseable JSON object with an
+	// "error" field; no cobra usage dump.
+	if strings.Contains(stderr, "Usage:") {
+		t.Errorf("stderr contains cobra usage dump (forbidden on --json error path):\n%s", stderr)
+	}
+	stderrLines := splitNonEmpty(stderr)
+	var jsonLine string
+	for _, ln := range stderrLines {
+		if strings.HasPrefix(strings.TrimSpace(ln), "{") {
+			if jsonLine != "" {
+				t.Errorf("stderr carries multiple JSON envelopes (must be exactly one):\n%s", stderr)
+			}
+			jsonLine = strings.TrimSpace(ln)
+		}
+	}
+	if jsonLine == "" {
+		t.Fatalf("no JSON envelope on stderr:\n%s", stderr)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(jsonLine), &payload); err != nil {
+		t.Fatalf("stderr JSON envelope not parseable: %v\nline: %q", err, jsonLine)
+	}
+	msg, ok := payload["error"]
+	if !ok || msg == "" {
+		t.Errorf("JSON envelope missing 'error' field or empty: %v", payload)
+	}
+	// The exact error message phrasing is owned by resolveSessionArg —
+	// the contract this test enforces is that the *underlying* error is
+	// surfaced (not swallowed by the cobra usage handler), which we
+	// verify by checking that the message at minimum identifies the bad
+	// arg by name.
+	if !strings.Contains(msg, "bogus-id-1") {
+		t.Errorf("error message %q does not name the bad arg (was the underlying error swallowed?)", msg)
+	}
+}
+
+// TestStatsCompare_FormatJSONErrorEnvelope verifies the same contract is
+// honoured via the legacy `--format json` surface (one shape, two flags).
+func TestStatsCompare_FormatJSONErrorEnvelope(t *testing.T) {
+	_ = openStatsTestDB(t)
+	resetRootCmdFlags(t)
+
+	rootCmd.SetArgs([]string{"stats", "compare", "bogus-id-1", "bogus-id-2", "--format", "json"})
+	stdout, stderr := captureStdoutStderr(t, func() {
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("expected non-nil error for bad instance ID")
+		}
+	})
+	if strings.TrimSpace(stdout) != "" {
+		t.Errorf("stdout non-empty on --format json error path: %q", stdout)
+	}
+	if strings.Contains(stderr, "Usage:") {
+		t.Errorf("stderr carries cobra usage dump on --format json error path:\n%s", stderr)
+	}
+	var jsonLine string
+	for _, ln := range splitNonEmpty(stderr) {
+		if strings.HasPrefix(strings.TrimSpace(ln), "{") {
+			jsonLine = strings.TrimSpace(ln)
+		}
+	}
+	if jsonLine == "" {
+		t.Fatalf("no JSON envelope on stderr:\n%s", stderr)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(jsonLine), &payload); err != nil {
+		t.Fatalf("JSON envelope not parseable: %v", err)
+	}
+	if payload["error"] == "" {
+		t.Errorf("envelope missing error field: %v", payload)
+	}
+}
+
+// ── CSV negative — the fix must NOT over-broad to the CSV format ─────────────
+
+// TestStatsCompare_CSVFormatStillWorks is the negative AC for the
+// renderer/error-envelope refactor: --format csv must continue to emit a
+// parseable CSV document on stdout, with the existing column order and
+// header row. No JSON envelope. No regression in the CSV writer.
+func TestStatsCompare_CSVFormatStillWorks(t *testing.T) {
+	d := openStatsTestDB(t)
+	resetRootCmdFlags(t)
+	startedAt := time.Now().Add(-2 * time.Minute)
+	iidA := seedCompareSession(t, d, "repo@csv-a", startedAt, agent.StateFinished,
+		&db.SpawnInputs{ProfileName: strPtr("sonnet")})
+	iidB := seedCompareSession(t, d, "repo@csv-b", startedAt, agent.StateFinished,
+		&db.SpawnInputs{ProfileName: strPtr("opus")})
+	writeAssistantTurn(t, d, "repo@csv-a", iidA, startedAt.Add(time.Second), 100, 50, 0, 0, 0.01)
+	writeAssistantTurn(t, d, "repo@csv-b", iidB, startedAt.Add(time.Second), 200, 100, 0, 0, 0.02)
+
+	rootCmd.SetArgs([]string{"stats", "compare", iidA, iidB, "--format", "csv"})
+	stdout, _ := captureStdoutStderr(t, func() {
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("--format csv failed: %v", err)
+		}
+	})
+	if strings.TrimSpace(stdout) == "" {
+		t.Fatalf("--format csv produced empty stdout")
+	}
+
+	r := csv.NewReader(strings.NewReader(stdout))
+	rows, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("--format csv output is not parseable CSV: %v\nstdout:\n%s", err, stdout)
+	}
+	if len(rows) < 2 {
+		t.Fatalf("--format csv produced too few rows: %d", len(rows))
+	}
+	// Header: axis,run-A,run-B,delta
+	header := rows[0]
+	if len(header) < 4 || header[0] != "axis" || header[1] != "run-A" || header[2] != "run-B" || header[3] != "delta" {
+		t.Errorf("--format csv header = %v, want [axis run-A run-B delta]", header)
+	}
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// splitNonEmpty splits s on newlines and returns only the non-empty lines.
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.TrimSpace(ln) != "" {
+			out = append(out, ln)
+		}
+	}
+	return out
+}
+
+func firstDataLine(lines []string, isData func(string) bool) string {
+	for _, ln := range lines {
+		if isData(ln) {
+			return ln
+		}
+	}
+	return ""
+}
+
+func ithDataLine(lines []string, isData func(string) bool, idx int) string {
+	n := 0
+	for _, ln := range lines {
+		if isData(ln) {
+			if n == idx {
+				return ln
+			}
+			n++
+		}
+	}
+	return ""
+}

--- a/modules/programs/prism/prism/cmd/stats_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/stats_proxy_test.go
@@ -646,13 +646,13 @@ func TestStatsAbtestFlagProxy_ByteIdentical(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", "")
 	direct := captureStdout(t, func() {
-		if err := runStatsAbtestFlag(); err != nil {
+		if err := runStatsAbtestFlag(false); err != nil {
 			t.Fatalf("runStatsAbtestFlag (direct): %v", err)
 		}
 	})
 	t.Setenv("PRISM_HOST_API", apiURL)
 	proxy := captureStdout(t, func() {
-		if err := runStatsAbtestFlag(); err != nil {
+		if err := runStatsAbtestFlag(false); err != nil {
 			t.Fatalf("runStatsAbtestFlag (proxy): %v", err)
 		}
 	})
@@ -672,7 +672,7 @@ func TestStatsAbtestFlagProxy_Empty(t *testing.T) {
 
 	t.Setenv("PRISM_HOST_API", apiURL)
 	out := captureStdout(t, func() {
-		if err := runStatsAbtestFlag(); err != nil {
+		if err := runStatsAbtestFlag(false); err != nil {
 			t.Fatalf("runStatsAbtestFlag (proxy, empty): %v", err)
 		}
 	})
@@ -762,7 +762,7 @@ func TestStatsAbtestFlagProxy_UnsetUsesDirectDB(t *testing.T) {
 	_ = srv
 
 	out := captureStdout(t, func() {
-		if err := runStatsAbtestFlag(); err != nil {
+		if err := runStatsAbtestFlag(false); err != nil {
 			t.Fatalf("runStatsAbtestFlag (direct): %v", err)
 		}
 	})

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -569,6 +569,8 @@ The workflow is:
    prism stats compare <instance-id-A> <instance-id-B>
    # or, if you minted the pair via --abtest, by the shared pair id:
    prism stats abtest <pair-id>
+   # machine-readable when scripting the winner decision:
+   prism stats compare <instance-id-A> <instance-id-B> --json | jq .
    ```
 
    The output carries the `Spawn Inputs` block (profile, harness, isolation, agent role, branch, abtest_pair_id) plus per-axis aggregates (tokens, cost, tool calls, durations, end_state). The aggregates are available *between* terminal-state transition and `prism cleanup` — they no longer require cleanup to materialise (issue #2102). Use the cost / duration / msg_assistant axes alongside the quality of the produced PRs to pick a winner.
@@ -579,7 +581,7 @@ Notes:
 
 - `prism stats compare` shows `—` for aggregate axes while a session is still in progress (state `active`, `idle`, or `reviewing`). The aggregates only stabilise at terminal transition.
 - The `Spawn Inputs` block surfaces whatever the writer captured at spawn time. Pre-#2087 sessions may have a partial row — missing columns render as `—` rather than collapsing the whole block.
-- Use `--format json` for machine-readable output (e.g. when scripting the winner decision); the `spawn_inputs` object carries the same fields shown in the table.
+- Use `--json` (preferred) or the equivalent `--format json` for machine-readable output (e.g. when scripting the winner decision); the `spawn_inputs` object carries the same fields shown in the table. On error, both surfaces emit a single-line `{"error":"..."}` JSON envelope to stderr (no cobra usage dump) — script the failure path against the JSON contract too, not by parsing human-readable text (issue #2099).
 
 ## Querying prism state — prefer `--json` for scripting
 
@@ -591,6 +593,9 @@ Every list-style and lookup-style prism subcommand supports a `--json` flag that
 | `prism sessions list --all --json` | array of session-status objects across all repos |
 | `prism checkin <session> --json` | session + events object |
 | `prism stats --json` (and `prism stats <id> --json`) | rows mirroring the host-API |
+| `prism stats compare --json <runs...>` (alias for `--format json`) | `{runs:[...], diffs:{spawn_inputs:[...], spawn_outcome:[...]}}` |
+| `prism stats abtest <group_id> --json` | same shape as `stats compare --json` |
+| `prism stats --abtest --json` | `{pairs:[...]}` — abtest pair listing |
 | `prism merges --json` (and `prism merges list --json`, `--failed --json`, `--abandoned --json`, `--all --json`) | array of merge-queue entries |
 | `prism audit --json` | object with `events` array, `truncated` bool, optional `hint` |
 | `prism sessions status --json` | object keyed by state (`active`, `waiting`, `idle`, `finished`, `error`) with integer counts (mutually exclusive with `--tmux-format`) |


### PR DESCRIPTION
Closes #2099.

## What changed

Three related output-format-contract bugs in `prism stats compare` (and the sibling `stats abtest <group_id>` / `stats --abtest` surfaces).

### Bug 1 — table column alignment

The previous renderer used `fmt.Sprintf("%-*s", wLabel, styleLabel.Render(row.Name+":"))` which mixes byte-count padding with ANSI escape sequences from lipgloss. Escape codes contributed bytes but zero visible width, so the value-cell column anchor drifted by `(raw_bytes - visible_width)` on every row — exactly the misalignment seen in the issue body.

Replaced with a two-stage renderer in `cmd/stats_compare.go`:

1. Build every section (`Session`, `Spawn Inputs`, `Process-level outcomes`, `Agent-level outcomes`, `Per-axis aggregations`, optionally `Rubric-level outcomes`) into a flat list of `(title, rows[])` entries.
2. Single-pass column-width calculation across all rows, using `lipgloss.Width` so styled labels contribute their *visible* width, not their raw byte length. Per-column widths are capped at `maxValW = 40` with `truncateStr` truncation.
3. Per-row rendering uses `padRightVisible(s, width)` which pads with spaces based on visible width, never byte length. Label and value cells share the same column anchors regardless of styling.

### Bug 2 — top-level `--json` flag

Added `--json` to both `compareCmd` and `abtestCmd` (`cmd/stats_compare.go`). `--json` is byte-identical to `--format json` — `renderComparison` collapses both surfaces to the same renderer dispatch.

For the sibling surface `prism stats --abtest`, `runStatsAbtestFlag` now takes a `jsonMode bool` and emits the abtest_list payload as a single JSON document `{"pairs":[...]}` (shape mirrors the host-API `/stats?view=abtest_list` response) when set.

### Bug 3 — JSON output contract on error

Added a generic `emitJSONErrorEnvelope` helper in `cmd/json_error_envelope.go` that writes a single-line `{"error":"<message>"}` JSON object to stderr and returns a `quietExitErr` (reused from `cmd/escalate.go`) so `main` does not duplicate the error.

Both `compareCmd` and `abtestCmd` now have `SilenceUsage: true` and `SilenceErrors: true` so cobra does not print the usage block or a duplicate `Error: ...` line on the JSON error path. RunE wrappers `runStatsCompare` / `runStatsAbtest` delegate to inner functions and pipe any returned error through `reportCompareError`, which only emits the JSON envelope when the caller actually asked for JSON (via `--json` or `--format json`); table/csv error paths print the raw error to stderr per `main.go`'s fallback.

## Acceptance criteria

### Bug 1 — table format

- ✅ `--format table` (default) renders columns with consistent vertical alignment across every section.
- ✅ Implementation uses a single-pass column-width calculation across the full dataset (`renderCompareTable` in `cmd/stats_compare.go`).
- ✅ Three-run comparison and N-run comparison render with the same alignment property.
- ✅ Long values truncate within their column (capped at `maxValW = 40` per column).

### Bug 2 — top-level `--json` flag

- ✅ `prism stats compare --json <runs...>` is accepted and emits a single JSON document on stdout.
- ✅ The JSON shape matches `--format json` (byte-identical).
- ✅ Documented as equivalent in `compareCmd.Long` and the flag help text.
- ✅ Same fix applied to `prism stats abtest <group_id> --json` and `prism stats --abtest --json`.

### Bug 3 — JSON output contract

- ✅ On error, `--format json` / `--json` emits `{"error":"..."}` to stderr in the documented prism shape.
- ✅ Stdout empty on error; no cobra usage dump.
- ✅ Exit code non-zero on error.
- ✅ Success path unchanged.
- ✅ Shape consistent with `prism escalate --json` (shares the `quietExitErr` type).

### Tests

10 new tests in `cmd/stats_compare_output_test.go`, plus the existing tests in `cmd/stats_compare_test.go`, `cmd/stats_proxy_test.go`, and `internal/db/compare_test.go` continue to pass.

Alignment tests force `lipgloss.SetColorProfile(termenv.TrueColor)` so the bug manifests in tests — without this, lipgloss auto-detects the non-TTY `go test` environment and omits ANSI, hiding the very bug we're guarding against. This is the same pattern used in `internal/dashboard/review_summary_test.go`.

## Negative-mutation verification

All three behavioural fixes confirmed via mutation (FAIL → revert → PASS):

| Bug | Mutation | Test result |
|-----|----------|-------------|
| 1 | Replace visible-width label padding with byte-count `%-*s` | 26+ rows fail with "anchor = X, want Y" misalignment messages |
| 2 | Remove `cmd.Flags().Bool("json", ...)` registration | `--json` tests fail with the documented `unknown flag: --json` error |
| 3 | Bypass `reportCompareError`, return raw err | Envelope tests fail with "no JSON envelope on stderr" |

After reverting each mutation, all 10 new tests pass under `-race`.

## Discipline gates

- ✅ `go build ./...` from `modules/programs/prism/prism/` — passes.
- ✅ `go test ./... -race` from `modules/programs/prism/prism/` for cmd, internal/db, and other prism-touching packages — passes.
- ✅ `nix build .#prism` from the repo root — passes.

Tmux-fork and sandbox-exec test failures in `internal/{tmux,container,integration,sidecar}` and `cmd/{cleanup,restore,switch,dashboard}` are pre-existing Darwin sandbox environment limitations (confirmed by running the same tests on `main` with `git stash`); they are not related to this change.

## Adjacency

Next PRs in the stream (per issue):
- #2110 — write paths for the `Agent-level outcomes` block (currently always empty).
- #2105 — populate `isolation_mode` effective value; cleanup stale `C.1` references.

Doing #2099 first means #2110's new rows land on a working renderer rather than re-litigating alignment when new rows arrive.
