### PR TITLE
prism quick pr: pi --print + Claude Sonnet 4.6 via anthropic-oauth

### DIFF
--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -90,13 +90,17 @@ type ContainerResources struct {
 	PidsLimit int `json:"pidsLimit,omitempty"`
 }
 
-// QuickProfile holds the model and provider routing config for a prism quick
-// subcommand (e.g. "pr").
+// QuickProfile holds the model config for a prism quick subcommand (e.g. "pr").
+//
+// As of #2118, prism quick pr invokes `pi --print` instead of OpenRouter
+// over HTTP; Model is now a pi model specifier (e.g.
+// "anthropic/claude-sonnet-4-6") and the legacy ProviderOrder field is
+// dropped. Unknown fields in profiles.json are ignored by Go's JSON
+// decoder, so loading a profiles.json that still carries a `providerOrder`
+// key (e.g. an older system rebuild) is silently tolerated.
 type QuickProfile struct {
-	// Model is the OpenRouter model slug (e.g. "google/gemini-3.1-flash-lite-preview").
+	// Model is the pi model specifier passed to `pi --model`.
 	Model string `json:"model"`
-	// ProviderOrder is the ordered list of OpenRouter provider slugs to try.
-	ProviderOrder []string `json:"providerOrder,omitempty"`
 }
 
 // profilesFilePath returns the path to profiles.json.

--- a/modules/programs/prism/prism/internal/quick/pr.go
+++ b/modules/programs/prism/prism/internal/quick/pr.go
@@ -1,17 +1,21 @@
-// Package quickpr implements the "prism quick pr" command.
+// Package quick implements the "prism quick pr" command.
 //
-// It generates a PR description from staged git changes using the OpenRouter
-// API, then creates a branch, commits, pushes, and opens a GitHub PR —
-// all from main. On success it switches back to main and opens the PR in
-// the system browser.
+// It generates a PR description from staged git changes by invoking the
+// `pi` binary (with the anthropic-oauth extension for auth), then creates
+// a branch, commits, pushes, and opens a GitHub PR — all from main.
+// On success it switches back to main and opens the PR in the system browser.
+//
+// History (#2118): this used to call a third-party HTTP API directly with
+// google/gemini-3.1-flash-lite and an API-key env var. The HTTP path
+// produced inconsistent output and bypassed pi's prompt scaffolding. It
+// now shells out to `pi --print --mode json` with claude-sonnet-4-6 via
+// pi's anthropic-oauth extension. No API key plumbing remains.
 package quick
 
 import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -21,21 +25,193 @@ import (
 	"github.com/prismatic-koi/prism/internal/config"
 )
 
-const (
-	openrouterURL = "https://openrouter.ai/api/v1/chat/completions"
+// titleMaxLen is the maximum PR title length enforced by the existing
+// convention. Pi is instructed to respect this in the system prompt; we
+// truncate (and warn) as a defensive fallback if the model overruns.
+const titleMaxLen = 72
 
-	// Token thresholds for max_tokens selection.
-	smallLines  = 50
-	mediumLines = 200
+// ── Test seams ─────────────────────────────────────────────────────────────
+//
+// The package-level function vars below mirror the pattern from PR #2113's
+// investigateSpawnSessionFn seam (cmd/investigate.go). Tests override these
+// to drive Run() without actually exec'ing pi / git / gh / a browser.
+//
+// piLookPathFn   — pre-flight check that `pi` is on PATH.
+// piExecFn       — runs `pi <args>` with the given stdin and returns the
+//                  captured stdout/stderr plus run error.
+// gitRunFn       — runs `git <args>` streaming to the user's stdout/stderr.
+// gitOutputFn    — runs `git <args>` capturing stdout.
+// ghRunFn        — runs `gh <args>` streaming to the user's stdout/stderr.
+// ghOutputFn     — runs `gh <args>` capturing stdout.
+// openBrowserFn  — opens a URL in the system browser.
 
-	smallTokens  = 128
-	mediumTokens = 256
-	largeTokens  = 512
+type piResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+var (
+	piLookPathFn  = realPiLookPath
+	piExecFn      = realPiExec
+	gitRunFn      = realGitRun
+	gitOutputFn   = realGitOutput
+	ghRunFn       = realGhRun
+	ghOutputFn    = realGhOutput
+	openBrowserFn = realOpenBrowser
 )
+
+func realPiLookPath() error {
+	if _, err := exec.LookPath("pi"); err != nil {
+		return fmt.Errorf("pi binary not found on PATH (install the pi CLI or add it to PATH): %w", err)
+	}
+	return nil
+}
+
+func realPiExec(args []string, stdin string) piResult {
+	cmd := exec.Command("pi", args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return piResult{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+	}
+}
+
+func realGitRun(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func realGitOutput(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func realGhRun(args ...string) error {
+	cmd := exec.Command("gh", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func realGhOutput(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func realOpenBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	default: // linux and others
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
+// ── System prompt ──────────────────────────────────────────────────────────
+//
+// Materially expanded vs the previous 5-line template (issue #2118). Defines
+// the role, codifies the output structure, includes worked examples for the
+// "quick pr" tactical use case (NOT long-form worker-agent PRs), and
+// emphasises "why" over diff-recital.
+
+const quickPRSystemPrompt = `You are writing a tactical pull request title and body for a single-commit change.
+
+ROLE & SCOPE
+
+The user is invoking ` + "`prism quick pr`" + ` — a fast path for small, focused changes:
+dotfile tweaks, README edits, version bumps, small refactors, config tweaks,
+comment fixes, lint-rule adjustments. This is NOT the long-form worker-agent PR
+style; do NOT produce sections like "## Summary", "## Failure chain", or
+"## Acceptance Criteria". Plain, tight, conversational prose only.
+
+OUTPUT FORMAT (STRICT)
+
+Respond with exactly ONE JSON object and nothing else — no prose preamble, no
+markdown code fences, no trailing commentary. The shape is:
+
+{"title": "<title>", "body": "<body>"}
+
+If you wrap the JSON in markdown fences or add explanatory text, the caller's
+parser will fail. JSON only.
+
+TITLE RULES
+
+- Imperative mood: "Fix...", "Add...", "Drop...", "Bump...", "Switch...".
+- ≤ 72 characters. Hard limit.
+- No trailing period.
+- No conventional-commit prefix (no "feat:", "fix:", "chore:").
+- Lead with the action and the affected component or behaviour.
+
+BODY RULES
+
+- Plain text. No markdown headers. Backticks for code identifiers are fine.
+- Focus on WHY the change is needed: what problem does it solve, what was the
+  motivating observation. Do NOT recite the diff file-by-file — the reviewer
+  can read the diff themselves.
+- 1–4 sentences for normal changes. May be empty ("") for trivial changes
+  (typo fixes, single-character corrections) where the title is fully
+  self-explanatory.
+- For purely mechanical changes (version bumps, dependency updates), keep
+  it brief — one sentence naming the upstream change is plenty.
+
+REPO AWARENESS
+
+You have access to the project's AGENTS.md / CLAUDE.md / CONTRIBUTING.md if
+they exist in the working directory. Use them to match the project's
+conventions (commit style, terminology, focus areas) — but only where it
+adds value. Do not parrot the AGENTS.md verbatim.
+
+WORKED EXAMPLES
+
+Example 1 — small dotfile tweak:
+Diff context: a one-line change in a neovim config replacing
+` + "`set number relativenumber`" + ` with ` + "`set number nornu`" + `.
+Output:
+{"title":"Disable relative line numbers in neovim","body":"Relative numbers were adding visual noise during long reading sessions and the jump-by-count workflow is now handled by leap.nvim, so rnu is redundant."}
+
+Example 2 — version bump:
+Diff context: package.json updates ` + "`\"react\": \"^18.2.0\"`" + ` to ` + "`\"react\": \"^18.3.1\"`" + `.
+Output:
+{"title":"Bump react to 18.3.1","body":"Picks up the upstream useId fix and the deprecation-warning suppression on Suspense boundaries. No app-side changes needed."}
+
+Example 3 — typo fix:
+Diff context: a README sentence changes "recieve" to "receive".
+Output:
+{"title":"Fix \"recieve\" typo in README","body":""}
+
+Now produce the JSON response for the diff the user is about to send.`
+
+// ── Run ────────────────────────────────────────────────────────────────────
 
 // Run executes the quick pr workflow.
 func Run() error {
 	// ── Pre-flight checks ──────────────────────────────────────────────────
+
+	// Pi-on-PATH check is FIRST so that a missing pi binary fails cleanly
+	// before any git/gh side effects.
+	if err := piLookPathFn(); err != nil {
+		return fmt.Errorf("quick pr: %w", err)
+	}
 
 	branch, err := currentBranch()
 	if err != nil {
@@ -59,11 +235,6 @@ func Run() error {
 		)
 	}
 
-	apiKey := os.Getenv("OPENROUTER_API_KEY")
-	if apiKey == "" {
-		return fmt.Errorf("OPENROUTER_API_KEY is not set")
-	}
-
 	// ── Load configuration ─────────────────────────────────────────────────
 
 	pf, err := config.LoadProfiles()
@@ -75,6 +246,9 @@ func Run() error {
 	if !ok {
 		return fmt.Errorf("quick pr: no 'pr' entry in quick_profiles — rebuild system config")
 	}
+	if qp.Model == "" {
+		return fmt.Errorf("quick pr: quick_profiles.pr.model is empty — rebuild system config")
+	}
 
 	// ── Git diff analysis ──────────────────────────────────────────────────
 
@@ -83,31 +257,38 @@ func Run() error {
 		return err
 	}
 
-	lineCount := countDiffLines(diff)
-	maxTokens := tokenBudget(lineCount)
+	// ── Generate PR description via pi ─────────────────────────────────────
 
-	// ── Generate PR description via OpenRouter ─────────────────────────────
-
-	description, err := generateDescription(apiKey, qp, diff, maxTokens)
+	title, body, err := generateDescription(qp, diff)
 	if err != nil {
 		return err
 	}
 
-	// Extract title (first line) and body (rest).
-	title, body := splitDescription(description)
+	// Defensive title truncation: pi is instructed to respect the 72-char
+	// limit, but warn-and-trim if it overruns.
+	if len(title) > titleMaxLen {
+		fmt.Fprintf(os.Stderr,
+			"warning: pi returned a %d-char title (max %d) — truncating\n",
+			len(title), titleMaxLen)
+		title = title[:titleMaxLen]
+	}
+
+	if title == "" {
+		return fmt.Errorf("quick pr: pi returned an empty title")
+	}
 
 	// ── Git operations ─────────────────────────────────────────────────────
 
 	newBranch := fmt.Sprintf("quick/pr-%d", time.Now().Unix())
 	fmt.Printf("Creating branch %s...\n", newBranch)
 
-	if err := gitRun("switch", "-c", newBranch); err != nil {
+	if err := gitRunFn("switch", "-c", newBranch); err != nil {
 		return fmt.Errorf("git switch -c: %w", err)
 	}
 
 	// Ensure we switch back to main even if something fails after this point.
 	defer func() {
-		_ = gitRun("switch", "main")
+		_ = gitRunFn("switch", "main")
 	}()
 
 	// Build commit args: always include title; include body as a separate -m
@@ -118,12 +299,12 @@ func Run() error {
 	if body != "" {
 		commitArgs = append(commitArgs, "-m", body)
 	}
-	if err := gitRun(commitArgs...); err != nil {
+	if err := gitRunFn(commitArgs...); err != nil {
 		return fmt.Errorf("git commit: %w", err)
 	}
 
 	fmt.Println("Pushing branch...")
-	if err := gitRun("push", "-u", "origin", newBranch); err != nil {
+	if err := gitRunFn("push", "-u", "origin", newBranch); err != nil {
 		return fmt.Errorf("git push: %w", err)
 	}
 
@@ -136,13 +317,13 @@ func Run() error {
 	} else {
 		prArgs = append(prArgs, "--body", "")
 	}
-	if err := ghRun(prArgs...); err != nil {
+	if err := ghRunFn(prArgs...); err != nil {
 		return fmt.Errorf("gh pr create: %w", err)
 	}
 
 	// ── Fetch PR URL ───────────────────────────────────────────────────────
 
-	prURL, err := ghOutput("pr", "view", "--json", "url", "-q", ".url")
+	prURL, err := ghOutputFn("pr", "view", "--json", "url", "-q", ".url")
 	if err != nil {
 		return fmt.Errorf("gh pr view: %w", err)
 	}
@@ -153,14 +334,14 @@ func Run() error {
 	// ── Switch back to main ────────────────────────────────────────────────
 	// The deferred switch handles the actual switch; we cancel it here so we
 	// can print a clean message, then let the defer run anyway (no-op on main).
-	if err := gitRun("switch", "main"); err != nil {
+	if err := gitRunFn("switch", "main"); err != nil {
 		return fmt.Errorf("git switch main: %w", err)
 	}
 
 	// ── Open browser ───────────────────────────────────────────────────────
 
 	if prURL != "" {
-		if err := openBrowser(prURL); err != nil {
+		if err := openBrowserFn(prURL); err != nil {
 			// Non-fatal: just print the URL so the user can open it manually.
 			fmt.Fprintf(os.Stderr, "warning: could not open browser: %v\n", err)
 		}
@@ -172,7 +353,7 @@ func Run() error {
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 func currentBranch() (string, error) {
-	out, err := gitOutput("rev-parse", "--abbrev-ref", "HEAD")
+	out, err := gitOutputFn("rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse: %w", err)
 	}
@@ -180,7 +361,7 @@ func currentBranch() (string, error) {
 }
 
 func stagedFiles() ([]string, error) {
-	out, err := gitOutput("diff", "--cached", "--name-only")
+	out, err := gitOutputFn("diff", "--cached", "--name-only")
 	if err != nil {
 		return nil, fmt.Errorf("git diff --cached: %w", err)
 	}
@@ -192,196 +373,222 @@ func stagedFiles() ([]string, error) {
 }
 
 func stagedDiff() (string, error) {
-	out, err := gitOutput("diff", "--cached")
+	out, err := gitOutputFn("diff", "--cached")
 	if err != nil {
 		return "", fmt.Errorf("git diff --cached: %w", err)
 	}
 	return out, nil
 }
 
-// countDiffLines counts the number of added + removed lines in a unified diff.
-func countDiffLines(diff string) int {
-	count := 0
-	for _, line := range strings.Split(diff, "\n") {
-		if len(line) == 0 {
+// generateDescription invokes pi to produce a PR title and body for the
+// given staged diff. It uses pi's `--print --mode json` non-interactive
+// path with `--no-tools --no-skills`, leaving AGENTS.md auto-discovery
+// enabled (no `--no-context-files`) for repo-style awareness.
+//
+// Output extraction strategy (chosen for issue #2118): JSON-in-JSON.
+//
+//  1. Pi emits NDJSON (one JSON object per line) when --mode json is set.
+//  2. We scan for the final `agent_end` event; its `messages` array contains
+//     the assistant's full reply.
+//  3. The assistant text is itself a JSON object {"title":"...","body":"..."}
+//     per the system prompt, which we parse to extract the two fields.
+//
+// Rejected alternative: fenced sentinels like <title>...</title>. JSON is
+// chosen because Sonnet 4.6 is highly reliable with structured JSON output
+// and the parse path is unambiguous (no regex on free-form text).
+func generateDescription(qp config.QuickProfile, diff string) (title, body string, err error) {
+	// Pi's `--print --mode json` non-interactive path. Flags chosen per
+	// the issue ACs:
+	//   --print           one-shot completion
+	//   --mode json       NDJSON output for structured parse
+	//   --no-tools        no tool calls
+	//   --no-skills       no skill loading
+	//   --system-prompt   our role/format/example prompt
+	//   --model/--provider — drives the anthropic-oauth route via pi
+	//
+	// AGENTS.md auto-discovery is intentionally left enabled (we do NOT
+	// pass --no-context-files), so pi picks up the repo's conventions.
+	provider := "anthropic" // single-source-of-truth for the anthropic-oauth route
+	args := []string{
+		"--print",
+		"--mode", "json",
+		"--no-tools",
+		"--no-skills",
+		"--system-prompt", quickPRSystemPrompt,
+		"--model", qp.Model,
+		"--provider", provider,
+	}
+
+	// User message: a short framing line plus the diff. Passed as the
+	// final positional arg so it becomes the initial user message body.
+	userMsg := "Generate a PR title and body in the required JSON shape for the following staged git diff:\n\n" + diff
+	args = append(args, userMsg)
+
+	res := piExecFn(args, "")
+	if res.err != nil {
+		// Surface pi's stderr verbatim so OAuth errors, model errors, etc.
+		// reach the user; wrap with a `quick pr:` prefix for clarity.
+		stderr := strings.TrimSpace(res.stderr)
+		if stderr == "" {
+			return "", "", fmt.Errorf("quick pr: pi exec failed: %w", res.err)
+		}
+		return "", "", fmt.Errorf("quick pr: pi exec failed: %w\npi stderr:\n%s", res.err, stderr)
+	}
+
+	return extractTitleBody(res.stdout)
+}
+
+// extractTitleBody parses pi's NDJSON --mode json stdout and pulls the
+// title/body from the assistant's reply (which is itself a JSON object
+// per the system prompt).
+//
+// Returns a clear error including a snippet of the raw stdout if any
+// stage of the parse fails.
+func extractTitleBody(piStdout string) (title, body string, err error) {
+	if strings.TrimSpace(piStdout) == "" {
+		return "", "", fmt.Errorf("quick pr: pi returned empty stdout")
+	}
+
+	assistantText, err := assistantTextFromNDJSON(piStdout)
+	if err != nil {
+		return "", "", fmt.Errorf("quick pr: %w\npi stdout (truncated):\n%s", err, truncate(piStdout, 2000))
+	}
+
+	// The assistant text is supposed to be JSON; strip any surrounding
+	// markdown fences (defensive — the system prompt forbids them, but
+	// models occasionally add them anyway).
+	jsonText := stripCodeFences(strings.TrimSpace(assistantText))
+
+	var parsed struct {
+		Title string `json:"title"`
+		Body  string `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(jsonText), &parsed); err != nil {
+		return "", "", fmt.Errorf(
+			"quick pr: could not parse pi assistant text as JSON {title,body}: %w\nassistant text:\n%s\npi stdout (truncated):\n%s",
+			err, truncate(assistantText, 2000), truncate(piStdout, 2000),
+		)
+	}
+
+	title = strings.TrimSpace(parsed.Title)
+	body = strings.TrimSpace(parsed.Body)
+	return title, body, nil
+}
+
+// piContentBlock is one block of an assistant message's content array.
+type piContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type piMessage struct {
+	Role    string           `json:"role"`
+	Content []piContentBlock `json:"content"`
+}
+
+type piEnvelope struct {
+	Type     string      `json:"type"`
+	Messages []piMessage `json:"messages,omitempty"`
+	Message  *piMessage  `json:"message,omitempty"`
+}
+
+// assistantTextFromNDJSON walks pi's NDJSON --mode json stream and returns
+// the assistant's final reply text. It prefers the `agent_end` event (which
+// carries the full message history) and falls back to the final `turn_end`
+// or assistant `message_end` event if `agent_end` is absent.
+func assistantTextFromNDJSON(stream string) (string, error) {
+	// Event shapes (minimal — we ignore everything else pi emits):
+	//   {"type":"agent_end","messages":[ {role,content:[{type:"text",text}] }, ... ]}
+	//   {"type":"turn_end","message":{role:"assistant",content:[{type:"text",text}]}}
+	//   {"type":"message_end","message":{role:"assistant",content:[{type:"text",text}]}}
+	var (
+		fromAgentEnd     string
+		fromTurnEnd      string
+		fromMessageEnd   string
+		anyEventObserved bool
+	)
+
+	for _, line := range strings.Split(stream, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
-		if line[0] == '+' || line[0] == '-' {
-			// Skip the +++ / --- header lines.
-			if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") {
-				continue
+		var env piEnvelope
+		if err := json.Unmarshal([]byte(line), &env); err != nil {
+			// Non-JSON lines are tolerated — pi may emit ordinary log lines
+			// in some modes. Skip them.
+			continue
+		}
+		anyEventObserved = true
+		switch env.Type {
+		case "agent_end":
+			// Walk messages in reverse for the last assistant message.
+			for i := len(env.Messages) - 1; i >= 0; i-- {
+				if env.Messages[i].Role == "assistant" {
+					fromAgentEnd = concatText(env.Messages[i].Content)
+					break
+				}
 			}
-			count++
+		case "turn_end":
+			if env.Message != nil && env.Message.Role == "assistant" {
+				fromTurnEnd = concatText(env.Message.Content)
+			}
+		case "message_end":
+			if env.Message != nil && env.Message.Role == "assistant" {
+				fromMessageEnd = concatText(env.Message.Content)
+			}
 		}
 	}
-	return count
-}
 
-// tokenBudget returns the max_tokens value based on the number of diff lines.
-func tokenBudget(lines int) int {
+	if !anyEventObserved {
+		return "", fmt.Errorf("pi stdout contained no JSON events")
+	}
+
 	switch {
-	case lines <= smallLines:
-		return smallTokens
-	case lines <= mediumLines:
-		return mediumTokens
+	case fromAgentEnd != "":
+		return fromAgentEnd, nil
+	case fromTurnEnd != "":
+		return fromTurnEnd, nil
+	case fromMessageEnd != "":
+		return fromMessageEnd, nil
 	default:
-		return largeTokens
+		return "", fmt.Errorf("pi stdout contained no assistant message text")
 	}
 }
 
-// splitDescription splits the generated text into a title (first line) and
-// body (remaining lines). The title is truncated to 72 characters.
-func splitDescription(desc string) (title, body string) {
-	desc = strings.TrimSpace(desc)
-	idx := strings.Index(desc, "\n")
-	if idx == -1 {
-		title = desc
-		body = ""
-	} else {
-		title = strings.TrimSpace(desc[:idx])
-		body = strings.TrimSpace(desc[idx+1:])
-	}
-	if len(title) > 72 {
-		title = title[:72]
-	}
-	return title, body
-}
-
-// openRouterRequest is the JSON body sent to OpenRouter.
-type openRouterRequest struct {
-	Model     string              `json:"model"`
-	MaxTokens int                 `json:"max_tokens"`
-	Messages  []map[string]string `json:"messages"`
-	Provider  *providerConfig     `json:"provider,omitempty"`
-}
-
-type providerConfig struct {
-	Order          []string `json:"order,omitempty"`
-	AllowFallbacks bool     `json:"allow_fallbacks"`
-}
-
-type openRouterResponse struct {
-	Choices []struct {
-		Message struct {
-			Content string `json:"content"`
-		} `json:"message"`
-	} `json:"choices"`
-	Error *struct {
-		Message string `json:"message"`
-		Code    int    `json:"code"`
-	} `json:"error,omitempty"`
-}
-
-var prPromptTemplate = `You are a concise technical writer. Given the following git diff of staged changes, write a pull request title and description.
-
-Format your response as:
-<title> (one line, imperative mood, max 72 chars, no period)
-
-<body> (2-4 sentences describing what changed and why, plain text, no markdown headers)
-
-Git diff:
-%s`
-
-func generateDescription(apiKey string, qp config.QuickProfile, diff string, maxTokens int) (string, error) {
-	prompt := fmt.Sprintf(prPromptTemplate, diff)
-
-	reqBody := openRouterRequest{
-		Model:     qp.Model,
-		MaxTokens: maxTokens,
-		Messages: []map[string]string{
-			{"role": "user", "content": prompt},
-		},
-	}
-
-	if len(qp.ProviderOrder) > 0 {
-		reqBody.Provider = &providerConfig{
-			Order:          qp.ProviderOrder,
-			AllowFallbacks: true,
+func concatText(blocks []piContentBlock) string {
+	var sb strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" {
+			sb.WriteString(b.Text)
 		}
 	}
-
-	bodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", fmt.Errorf("quick pr: marshal request: %w", err)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, openrouterURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return "", fmt.Errorf("quick pr: build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("quick pr: OpenRouter request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("quick pr: read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("quick pr: OpenRouter API error (HTTP %d): %s", resp.StatusCode, string(respBytes))
-	}
-
-	var orResp openRouterResponse
-	if err := json.Unmarshal(respBytes, &orResp); err != nil {
-		return "", fmt.Errorf("quick pr: parse response: %w", err)
-	}
-
-	if orResp.Error != nil {
-		return "", fmt.Errorf("quick pr: OpenRouter API error (code %d): %s", orResp.Error.Code, orResp.Error.Message)
-	}
-
-	if len(orResp.Choices) == 0 || orResp.Choices[0].Message.Content == "" {
-		return "", fmt.Errorf("quick pr: empty response from OpenRouter")
-	}
-
-	return orResp.Choices[0].Message.Content, nil
+	return sb.String()
 }
 
-func gitRun(args ...string) error {
-	cmd := exec.Command("git", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func gitOutput(args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
+// stripCodeFences removes a single surrounding ```json ... ``` or ``` ... ```
+// fence if present. Pi's system prompt forbids fences, but some model
+// completions still emit them — be defensive.
+func stripCodeFences(s string) string {
+	if !strings.HasPrefix(s, "```") {
+		return s
 	}
-	return string(out), nil
-}
-
-func ghRun(args ...string) error {
-	cmd := exec.Command("gh", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func ghOutput(args ...string) (string, error) {
-	cmd := exec.Command("gh", args...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
+	// Drop the leading fence (and optional language tag).
+	first := strings.IndexByte(s, '\n')
+	if first == -1 {
+		return s
 	}
-	return string(out), nil
+	s = s[first+1:]
+	// Drop the trailing fence.
+	if i := strings.LastIndex(s, "```"); i != -1 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
 }
 
-func openBrowser(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	default: // linux and others
-		cmd = exec.Command("xdg-open", url)
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
 	}
-	return cmd.Start()
+	return s[:n] + "…(truncated)"
 }

--- a/modules/programs/prism/prism/internal/quick/pr_test.go
+++ b/modules/programs/prism/prism/internal/quick/pr_test.go
@@ -1,0 +1,624 @@
+// Tests for the "prism quick pr" command (issue #2118).
+//
+// The seam pattern mirrors PR #2113 (cmd/investigate.go's
+// investigateSpawnSessionFn). Test bodies swap the package-level
+// piLookPathFn / piExecFn / gitRunFn / gitOutputFn / ghRunFn / ghOutputFn
+// / openBrowserFn function vars with stubs, exercise Run() (or the
+// helpers it calls), then assert on captured calls and returned errors.
+//
+// These tests do NOT exec real binaries — they verify Run()'s control
+// flow, the structured-output parse, the >72-char title truncation,
+// and the legacy-profiles.json JSON unmarshal compatibility.
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608): these tests do
+// not touch the host bus, DB, tmux, or HOME. profiles.json is loaded from
+// XDG_CONFIG_HOME, which we redirect to t.TempDir().
+
+package quick
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// ── Test-seam helpers ──────────────────────────────────────────────────────
+
+// piCall records one invocation of piExecFn.
+type piCall struct {
+	args  []string
+	stdin string
+}
+
+// callRecorder captures the call order across all seams so we can assert
+// (e.g.) "git/gh were never called" after a pi-missing error.
+type callRecorder struct {
+	mu        sync.Mutex
+	piCalls   []piCall
+	gitCalls  [][]string // each call: argv after "git "
+	ghCalls   [][]string // each call: argv after "gh "
+	browser   []string   // URLs opened
+	piLookErr error
+}
+
+func newRecorder() *callRecorder { return &callRecorder{} }
+
+// installSeams swaps every package-level seam in this package with a stub
+// recording into r. Returns a cleanup function the test should call via
+// t.Cleanup. The stubs read scripted behaviour from r — happy-path tests
+// can override individual stubs by re-assigning the package var.
+func installSeams(t *testing.T, r *callRecorder) {
+	t.Helper()
+
+	prevPiLook := piLookPathFn
+	prevPiExec := piExecFn
+	prevGitRun := gitRunFn
+	prevGitOut := gitOutputFn
+	prevGhRun := ghRunFn
+	prevGhOut := ghOutputFn
+	prevBrowser := openBrowserFn
+
+	piLookPathFn = func() error {
+		return r.piLookErr
+	}
+
+	// Default piExec: not used directly; tests that need it override the
+	// var after calling installSeams.
+	piExecFn = func(args []string, stdin string) piResult {
+		r.mu.Lock()
+		r.piCalls = append(r.piCalls, piCall{args: append([]string(nil), args...), stdin: stdin})
+		r.mu.Unlock()
+		return piResult{err: fmt.Errorf("piExecFn not configured in this test")}
+	}
+
+	gitRunFn = func(args ...string) error {
+		r.mu.Lock()
+		r.gitCalls = append(r.gitCalls, append([]string(nil), args...))
+		r.mu.Unlock()
+		return nil
+	}
+	gitOutputFn = func(args ...string) (string, error) {
+		r.mu.Lock()
+		r.gitCalls = append(r.gitCalls, append([]string(nil), args...))
+		r.mu.Unlock()
+		// Default canned outputs for the read-only pre-flight calls.
+		switch {
+		case len(args) >= 2 && args[0] == "rev-parse" && args[1] == "--abbrev-ref":
+			return "main\n", nil
+		case len(args) >= 3 && args[0] == "diff" && args[1] == "--cached" && args[2] == "--name-only":
+			return "some/file.go\n", nil
+		case len(args) >= 2 && args[0] == "diff" && args[1] == "--cached":
+			return "diff --git a/x b/x\n+hello\n", nil
+		}
+		return "", nil
+	}
+	ghRunFn = func(args ...string) error {
+		r.mu.Lock()
+		r.ghCalls = append(r.ghCalls, append([]string(nil), args...))
+		r.mu.Unlock()
+		return nil
+	}
+	ghOutputFn = func(args ...string) (string, error) {
+		r.mu.Lock()
+		r.ghCalls = append(r.ghCalls, append([]string(nil), args...))
+		r.mu.Unlock()
+		// Default: gh pr view --json url -q .url returns a fake URL.
+		return "https://example/pr/1\n", nil
+	}
+	openBrowserFn = func(url string) error {
+		r.mu.Lock()
+		r.browser = append(r.browser, url)
+		r.mu.Unlock()
+		return nil
+	}
+
+	t.Cleanup(func() {
+		piLookPathFn = prevPiLook
+		piExecFn = prevPiExec
+		gitRunFn = prevGitRun
+		gitOutputFn = prevGitOut
+		ghRunFn = prevGhRun
+		ghOutputFn = prevGhOut
+		openBrowserFn = prevBrowser
+	})
+}
+
+// writeProfilesJSON writes a minimal profiles.json into a temp config home
+// and points XDG_CONFIG_HOME at it for the duration of the test.
+func writeProfilesJSON(t *testing.T, body string) {
+	t.Helper()
+	cfgHome := t.TempDir()
+	prismDir := filepath.Join(cfgHome, "prism")
+	if err := os.MkdirAll(prismDir, 0o755); err != nil {
+		t.Fatalf("mkdir prism: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(prismDir, "profiles.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write profiles.json: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+}
+
+// piNDJSON builds a minimal pi --mode json stdout stream containing a
+// single agent_end event with the given assistant text.
+func piNDJSON(assistantText string) string {
+	type contentBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type message struct {
+		Role    string         `json:"role"`
+		Content []contentBlock `json:"content"`
+	}
+	type envelope struct {
+		Type     string    `json:"type"`
+		Messages []message `json:"messages"`
+	}
+	env := envelope{
+		Type: "agent_end",
+		Messages: []message{
+			{
+				Role: "user",
+				Content: []contentBlock{
+					{Type: "text", Text: "diff goes here"},
+				},
+			},
+			{
+				Role: "assistant",
+				Content: []contentBlock{
+					{Type: "text", Text: assistantText},
+				},
+			},
+		},
+	}
+	// Prepend a couple of unrelated events to look more realistic.
+	prefix := `{"type":"session","id":"abc"}` + "\n" +
+		`{"type":"agent_start"}` + "\n" +
+		`{"type":"turn_start"}` + "\n"
+	body, err := json.Marshal(env)
+	if err != nil {
+		panic(err)
+	}
+	return prefix + string(body) + "\n"
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+// TestRun_HappyPath verifies that with a well-formed pi response Run()
+// produces a branch, commit, push, and gh pr create with the expected
+// title and body, and opens the browser at the gh-returned URL.
+func TestRun_HappyPath(t *testing.T) {
+	writeProfilesJSON(t, `{
+		"default":"anthropic","profiles":{},
+		"quick_profiles":{"pr":{"model":"anthropic/claude-sonnet-4-6"}}
+	}`)
+	r := newRecorder()
+	installSeams(t, r)
+
+	wantTitle := "Fix typo in README"
+	wantBody := "Recieve was spelled wrong; corrected to receive."
+	piExecFn = func(args []string, stdin string) piResult {
+		r.mu.Lock()
+		r.piCalls = append(r.piCalls, piCall{args: append([]string(nil), args...), stdin: stdin})
+		r.mu.Unlock()
+		return piResult{
+			stdout: piNDJSON(fmt.Sprintf(`{"title":%q,"body":%q}`, wantTitle, wantBody)),
+		}
+	}
+
+	if err := Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Pi must have been invoked.
+	if len(r.piCalls) != 1 {
+		t.Fatalf("piExecFn called %d times, want 1", len(r.piCalls))
+	}
+	got := r.piCalls[0].args
+	// Required flags (issue #2118 ACs).
+	requireFlag(t, got, "--print")
+	requireFlagValue(t, got, "--mode", "json")
+	requireFlag(t, got, "--no-tools")
+	requireFlag(t, got, "--no-skills")
+	requireFlagValue(t, got, "--model", "anthropic/claude-sonnet-4-6")
+	requireFlagValue(t, got, "--provider", "anthropic")
+	// AGENTS.md auto-discovery must be enabled (no --no-context-files).
+	for _, a := range got {
+		if a == "--no-context-files" || a == "-nc" {
+			t.Errorf("pi args contain %q — AGENTS.md auto-discovery must remain enabled (issue #2118)", a)
+		}
+	}
+	// System prompt must be present and materially expanded vs the old
+	// 5-line template. The old template was 5 lines including blank
+	// separators; the new one is several hundred chars with worked
+	// examples. Assert on length + presence of a representative phrase.
+	sp := flagValue(t, got, "--system-prompt")
+	if len(sp) < 500 {
+		t.Errorf("--system-prompt is only %d chars — expected the materially expanded prompt", len(sp))
+	}
+	if !strings.Contains(sp, "WORKED EXAMPLES") {
+		t.Errorf("--system-prompt missing WORKED EXAMPLES section — prompt may have regressed to short template")
+	}
+	if !strings.Contains(strings.ToLower(sp), "imperative") {
+		t.Errorf("--system-prompt does not mention imperative-mood title rule")
+	}
+	if !strings.Contains(sp, "72") {
+		t.Errorf("--system-prompt does not mention the 72-char title constraint")
+	}
+
+	// gh pr create must have been invoked with the parsed title and body.
+	var prCreateArgs []string
+	for _, c := range r.ghCalls {
+		if len(c) >= 2 && c[0] == "pr" && c[1] == "create" {
+			prCreateArgs = c
+			break
+		}
+	}
+	if prCreateArgs == nil {
+		t.Fatalf("gh pr create was never invoked; ghCalls=%v", r.ghCalls)
+	}
+	if v := flagValue(t, prCreateArgs, "--title"); v != wantTitle {
+		t.Errorf("gh pr create --title = %q, want %q", v, wantTitle)
+	}
+	if v := flagValue(t, prCreateArgs, "--body"); v != wantBody {
+		t.Errorf("gh pr create --body = %q, want %q", v, wantBody)
+	}
+
+	// Browser opened with the URL gh returned.
+	if len(r.browser) != 1 || r.browser[0] != "https://example/pr/1" {
+		t.Errorf("openBrowser not invoked correctly: %v", r.browser)
+	}
+}
+
+// TestRun_PiNotOnPath verifies that when piLookPathFn returns ENOENT,
+// Run() exits with a clear error naming the missing binary and does NOT
+// invoke any destructive git/gh operations.
+//
+// Negative-mutation check (issue #2118 discipline): if you delete the
+// piLookPathFn() pre-flight from Run(), the test below produces a
+// different error (something like "exec: \"pi\": file not found") and
+// destructive git/gh seams MAY be called — assertions fail.
+func TestRun_PiNotOnPath(t *testing.T) {
+	writeProfilesJSON(t, `{
+		"default":"anthropic","profiles":{},
+		"quick_profiles":{"pr":{"model":"anthropic/claude-sonnet-4-6"}}
+	}`)
+	r := newRecorder()
+	installSeams(t, r)
+	// Simulate ENOENT for pi.
+	r.piLookErr = fmt.Errorf("simulated lookup: %w", &exec.Error{Name: "pi", Err: exec.ErrNotFound})
+
+	err := Run()
+	if err == nil {
+		t.Fatal("Run() should have returned an error when pi is missing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "quick pr:") {
+		t.Errorf("error %q missing 'quick pr:' prefix", msg)
+	}
+	if !strings.Contains(msg, "pi") {
+		t.Errorf("error %q does not name the missing binary 'pi'", msg)
+	}
+
+	// Destructive git/gh calls must NOT have happened. Read-only git
+	// pre-flight (rev-parse, diff --cached) must also not have run since
+	// LookPath is the very first check.
+	if len(r.gitCalls) != 0 {
+		t.Errorf("git was called %d times despite pi-missing; calls=%v", len(r.gitCalls), r.gitCalls)
+	}
+	if len(r.ghCalls) != 0 {
+		t.Errorf("gh was called %d times despite pi-missing; calls=%v", len(r.ghCalls), r.ghCalls)
+	}
+	if len(r.piCalls) != 0 {
+		t.Errorf("pi was exec'd %d times despite LookPath failure; calls=%v", len(r.piCalls), r.piCalls)
+	}
+}
+
+// TestRun_PiReturnsMalformedOutput verifies that an unparseable pi stdout
+// yields an error that includes the raw output for diagnosis.
+//
+// Negative-mutation check: if you replace extractTitleBody's JSON parse
+// with a "first line is title" fallback, this test fails — the malformed
+// blob would be silently accepted as the title.
+func TestRun_PiReturnsMalformedOutput(t *testing.T) {
+	writeProfilesJSON(t, `{
+		"default":"anthropic","profiles":{},
+		"quick_profiles":{"pr":{"model":"anthropic/claude-sonnet-4-6"}}
+	}`)
+	r := newRecorder()
+	installSeams(t, r)
+
+	// Pi emits an agent_end event whose assistant text is NOT valid JSON.
+	malformed := piNDJSON("this is not a valid json object at all !!!")
+	piExecFn = func(args []string, stdin string) piResult {
+		r.mu.Lock()
+		r.piCalls = append(r.piCalls, piCall{args: append([]string(nil), args...), stdin: stdin})
+		r.mu.Unlock()
+		return piResult{stdout: malformed}
+	}
+
+	err := Run()
+	if err == nil {
+		t.Fatal("Run() should have errored on malformed pi output")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "quick pr:") {
+		t.Errorf("error %q missing 'quick pr:' prefix", msg)
+	}
+	// Error must include enough of the raw output for diagnosis.
+	if !strings.Contains(msg, "not a valid json object") {
+		t.Errorf("error does not include the raw pi output for diagnosis: %v", msg)
+	}
+
+	// Destructive git/gh ops must not have run (we never got a title).
+	for _, c := range r.gitCalls {
+		if len(c) > 0 && (c[0] == "commit" || c[0] == "push") {
+			t.Errorf("destructive git %v ran despite parse failure", c)
+		}
+		if len(c) >= 2 && c[0] == "switch" && c[1] == "-c" {
+			t.Errorf("git switch -c ran despite parse failure: %v", c)
+		}
+	}
+	if len(r.ghCalls) != 0 {
+		t.Errorf("gh was called despite parse failure: %v", r.ghCalls)
+	}
+}
+
+// TestRun_PiExecError verifies that a pi exec failure (e.g. OAuth expired,
+// non-zero exit) is propagated to the user with the pi stderr preserved
+// and a "quick pr:" prefix.
+func TestRun_PiExecError(t *testing.T) {
+	writeProfilesJSON(t, `{
+		"default":"anthropic","profiles":{},
+		"quick_profiles":{"pr":{"model":"anthropic/claude-sonnet-4-6"}}
+	}`)
+	r := newRecorder()
+	installSeams(t, r)
+
+	wantStderr := "ERROR: anthropic-oauth credentials expired; run /login in pi"
+	piExecFn = func(args []string, stdin string) piResult {
+		r.mu.Lock()
+		r.piCalls = append(r.piCalls, piCall{args: append([]string(nil), args...), stdin: stdin})
+		r.mu.Unlock()
+		return piResult{stdout: "", stderr: wantStderr, err: errors.New("exit status 1")}
+	}
+
+	err := Run()
+	if err == nil {
+		t.Fatal("Run() should have errored on pi exec failure")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "quick pr:") {
+		t.Errorf("error %q missing 'quick pr:' prefix", msg)
+	}
+	if !strings.Contains(msg, wantStderr) {
+		t.Errorf("error does not preserve pi stderr %q; got %q", wantStderr, msg)
+	}
+	if !strings.Contains(msg, "exit status 1") {
+		t.Errorf("error does not preserve underlying exec error: %q", msg)
+	}
+}
+
+// TestRun_TitleTruncatedAt72Chars verifies that an over-long title from
+// pi is truncated to 72 chars and a warning is printed to stderr.
+//
+// Negative-mutation check: if you remove the truncate-and-warn block, the
+// gh pr create --title length will be > 72 — fails len assertion.
+func TestRun_TitleTruncatedAt72Chars(t *testing.T) {
+	writeProfilesJSON(t, `{
+		"default":"anthropic","profiles":{},
+		"quick_profiles":{"pr":{"model":"anthropic/claude-sonnet-4-6"}}
+	}`)
+	r := newRecorder()
+	installSeams(t, r)
+
+	// Build a 100-char title.
+	longTitle := strings.Repeat("A", 100)
+	piExecFn = func(args []string, stdin string) piResult {
+		r.mu.Lock()
+		r.piCalls = append(r.piCalls, piCall{args: append([]string(nil), args...), stdin: stdin})
+		r.mu.Unlock()
+		return piResult{stdout: piNDJSON(fmt.Sprintf(`{"title":%q,"body":"body"}`, longTitle))}
+	}
+
+	// Capture stderr to assert the warning was emitted. We drain the
+	// pipe concurrently per the stdout-capture-testing convention
+	// (issue #1798).
+	origStderr := os.Stderr
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = wPipe
+	doneCh := make(chan []byte, 1)
+	go func() {
+		data, _ := io.ReadAll(rPipe)
+		doneCh <- data
+	}()
+	t.Cleanup(func() {
+		os.Stderr = origStderr
+	})
+
+	runErr := Run()
+
+	// Close the write end so the reader goroutine sees EOF.
+	_ = wPipe.Close()
+	os.Stderr = origStderr
+	stderrBytes := <-doneCh
+
+	if runErr != nil {
+		t.Fatalf("Run: %v", runErr)
+	}
+	stderr := string(stderrBytes)
+	if !strings.Contains(stderr, "warning") || !strings.Contains(stderr, "truncat") {
+		t.Errorf("expected truncation warning on stderr; got %q", stderr)
+	}
+
+	// Find the gh pr create call and assert title length.
+	var prCreate []string
+	for _, c := range r.ghCalls {
+		if len(c) >= 2 && c[0] == "pr" && c[1] == "create" {
+			prCreate = c
+			break
+		}
+	}
+	if prCreate == nil {
+		t.Fatalf("gh pr create not invoked; ghCalls=%v", r.ghCalls)
+	}
+	got := flagValue(t, prCreate, "--title")
+	if len(got) != 72 {
+		t.Errorf("gh pr create --title length = %d, want 72 (got %q)", len(got), got)
+	}
+}
+
+// TestLegacyProfilesJSONUnmarshal locks in the schema-compatibility
+// promise (issue #2118): loading a profiles.json that still carries a
+// `providerOrder` field on the pr entry must NOT fail unmarshalling.
+//
+// Negative-mutation check: if QuickProfile ever gets a
+// `json:",disallowunknown"` tag or the decoder is switched to
+// DisallowUnknownFields, this test fails — the legacy field would be
+// rejected.
+func TestLegacyProfilesJSONUnmarshal(t *testing.T) {
+	const legacy = `{
+		"default":"anthropic",
+		"profiles":{},
+		"quick_profiles":{
+			"pr":{
+				"model":"google/gemini-3.1-flash-lite-preview",
+				"providerOrder":["google","google-vertex"]
+			}
+		}
+	}`
+	writeProfilesJSON(t, legacy)
+
+	pf, err := config.LoadProfiles()
+	if err != nil {
+		t.Fatalf("LoadProfiles must tolerate legacy providerOrder field: %v", err)
+	}
+	qp, ok := pf.QuickProfiles["pr"]
+	if !ok {
+		t.Fatal("pr entry missing after unmarshal")
+	}
+	if qp.Model != "google/gemini-3.1-flash-lite-preview" {
+		t.Errorf("model = %q, want google/gemini-3.1-flash-lite-preview", qp.Model)
+	}
+}
+
+// TestNoOpenRouterReferences guards against accidental re-introduction of
+// the OPENROUTER_API_KEY env var or openrouter.ai URL in the quick
+// package — both must be gone per issue #2118.
+//
+// Negative-mutation check: re-add either string and this test fails.
+func TestNoOpenRouterReferences(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no .go files found in this package")
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		body := string(data)
+		if strings.Contains(body, "OPENROUTER_API_KEY") {
+			t.Errorf("%s still references OPENROUTER_API_KEY", f)
+		}
+		if strings.Contains(body, "openrouter.ai") {
+			t.Errorf("%s still references openrouter.ai", f)
+		}
+	}
+}
+
+// ── Direct extractTitleBody tests ──────────────────────────────────────────
+
+func TestExtractTitleBody_WellFormed(t *testing.T) {
+	stdout := piNDJSON(`{"title":"Bump react to 18.3.1","body":"upstream useId fix"}`)
+	title, body, err := extractTitleBody(stdout)
+	if err != nil {
+		t.Fatalf("extractTitleBody: %v", err)
+	}
+	if title != "Bump react to 18.3.1" {
+		t.Errorf("title = %q", title)
+	}
+	if body != "upstream useId fix" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestExtractTitleBody_WrappedInJSONFence(t *testing.T) {
+	// Defensive parse path: model occasionally wraps the JSON in a fence
+	// despite the system-prompt prohibition.
+	fenced := "```json\n{\"title\":\"Add a thing\",\"body\":\"because\"}\n```"
+	stdout := piNDJSON(fenced)
+	title, body, err := extractTitleBody(stdout)
+	if err != nil {
+		t.Fatalf("extractTitleBody: %v", err)
+	}
+	if title != "Add a thing" || body != "because" {
+		t.Errorf("got (%q, %q)", title, body)
+	}
+}
+
+func TestExtractTitleBody_EmptyStdout(t *testing.T) {
+	_, _, err := extractTitleBody("   \n  \n")
+	if err == nil {
+		t.Fatal("expected error on empty stdout")
+	}
+	if !strings.Contains(err.Error(), "empty stdout") {
+		t.Errorf("error %q does not name the failure mode", err)
+	}
+}
+
+func TestExtractTitleBody_NoAssistantMessage(t *testing.T) {
+	// Valid NDJSON but no assistant message anywhere.
+	stdout := `{"type":"session"}` + "\n" + `{"type":"agent_start"}` + "\n"
+	_, _, err := extractTitleBody(stdout)
+	if err == nil {
+		t.Fatal("expected error when no assistant message present")
+	}
+}
+
+// ── Small assertion helpers ────────────────────────────────────────────────
+
+func requireFlag(t *testing.T, argv []string, flag string) {
+	t.Helper()
+	for _, a := range argv {
+		if a == flag {
+			return
+		}
+	}
+	t.Errorf("argv missing required flag %q; argv=%v", flag, argv)
+}
+
+func requireFlagValue(t *testing.T, argv []string, flag, want string) {
+	t.Helper()
+	got := flagValue(t, argv, flag)
+	if got != want {
+		t.Errorf("%s = %q, want %q", flag, got, want)
+	}
+}
+
+func flagValue(t *testing.T, argv []string, flag string) string {
+	t.Helper()
+	for i, a := range argv {
+		if a == flag && i+1 < len(argv) {
+			return argv[i+1]
+		}
+	}
+	return ""
+}

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -191,11 +191,9 @@
 
           quickProfiles = {
             pr = {
-              model = "google/gemini-3.1-flash-lite";
-              providerOrder = [
-                "google"
-                "google-vertex"
-              ];
+              # prism quick pr invokes `pi --print` (anthropic-oauth route).
+              # See modules/programs/prism/prism/internal/quick/pr.go (#2118).
+              model = "anthropic/claude-sonnet-4-6";
             };
           };
 


### PR DESCRIPTION
Closes #2118

Replace the OpenRouter HTTP path in `prism quick pr` with `exec.Command("pi", ...)` in non-interactive `--print` mode, switching the underlying model from `google/gemini-3.1-flash-lite` to `anthropic/claude-sonnet-4-6` routed through pi's already-installed anthropic-oauth extension. **No API key plumbing remains.**

## Why

Per the issue, three compounding sources of inconsistency:

1. **Model layer** — flash-lite drifts on structured-output instructions. Sonnet 4.6 is the largest single quality lever.
2. **Prompt layer** — the previous 5-line template had no examples, no output-shape discipline, no repo awareness.
3. **Architecture layer** — rolling our own HTTP LLM client bypassed pi's prompt scaffolding, output-mode plumbing, and OAuth credential handling.

This PR addresses all three.

## What changed

### `internal/quick/pr.go`

- `openrouterURL` const, `openRouterRequest` / `openRouterResponse` / `providerConfig` types, and the entire HTTP body in `generateDescription` are **deleted**.
- New pi invocation:
  ```
  pi --print --mode json --no-tools --no-skills \
     --system-prompt "<role/format/examples>" \
     --model anthropic/claude-sonnet-4-6 --provider anthropic \
     "<framing + diff>"
  ```
  `--no-context-files` is intentionally **not** passed so pi auto-discovers `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` (the "repo-aware" lever).
- The `OPENROUTER_API_KEY` env-var check is gone. A `piLookPathFn` pre-flight is added as the first gate — a missing `pi` binary fails before any git/gh side effects.
- `splitDescription` (first-line-is-title) is **replaced** by `extractTitleBody`. See "Output extraction" below.
- Defensive title-truncation at 72 chars with a stderr warning if pi overruns.

### `internal/config/profiles.go`

- `QuickProfile.ProviderOrder` field **removed**. `Model` retained.
- Legacy `profiles.json` files carrying `providerOrder` still unmarshal cleanly (standard Go JSON behaviour; locked in by `TestLegacyProfilesJSONUnmarshal`).

### `modules/programs/prism/profiles.nix`

- `quickProfiles.pr.model` now reads `"anthropic/claude-sonnet-4-6"`.
- `providerOrder` emission **removed**.

The Go struct change and the Nix-emitted JSON move together — `nix build .#prism` (CI `nix-build-prism-checked` job) is the homeless-shelter signal that they stay aligned.

## Output extraction — JSON-in-JSON

Chose **JSON-in-JSON** over fenced sentinels:

1. Pi emits NDJSON on `--mode json` (one event per line).
2. `extractTitleBody` walks the stream for the final `agent_end` event (falls back to `turn_end` / assistant `message_end`).
3. The assistant text is itself `{"title":"...","body":"..."}` per the system prompt; parsed via `json.Unmarshal`.
4. Defensive triple-backtick fence-stripping handles the case where the model wraps the JSON despite the prompt forbidding it.

JSON was chosen because Sonnet 4.6 is highly reliable with structured JSON and the parse path is unambiguous (no regex on free-form text).

## System prompt structure

The new system prompt (defined as a const in `pr.go::quickPRSystemPrompt`) covers:

- **ROLE & SCOPE** — tactical "quick pr" use case (dotfile tweaks, version bumps, README fixes), explicitly distinguished from long-form worker-agent PR style.
- **OUTPUT FORMAT (STRICT)** — exact JSON shape, no prose preamble, no fences.
- **TITLE RULES** — imperative mood, ≤72 chars, no trailing period, no conventional-commit prefix.
- **BODY RULES** — focus on *why*, not file-by-file recital; 1–4 sentences; may be empty for trivial diffs.
- **REPO AWARENESS** — note that `AGENTS.md` etc. are auto-loaded.
- **WORKED EXAMPLES** — three worked title/body pairs (small dotfile tweak, version bump, typo fix). The typo-fix example demonstrates the empty-body case.

## Tests

New `internal/quick/pr_test.go` mirrors PR #2113's seam pattern.

Package-level function vars swapped by `installSeams(t, r)`:

| Var | Real fn | Test stub |
|---|---|---|
| `piLookPathFn` | `exec.LookPath` | returns canned error or nil |
| `piExecFn` | `pi --print ...` | returns canned stdout/stderr/err |
| `gitRunFn` / `gitOutputFn` | `git ...` | records calls, returns canned outputs |
| `ghRunFn` / `ghOutputFn` | `gh ...` | records calls, returns canned outputs |
| `openBrowserFn` | `open` / `xdg-open` | records URL |

Tests added:

- `TestRun_HappyPath` — well-formed pi response → title/body propagate to `gh pr create`, browser opens to the gh-returned URL. Also asserts on **every** required pi flag (`--print`, `--mode json`, `--no-tools`, `--no-skills`, `--model`, `--provider`, presence of `--system-prompt`) and that `--no-context-files` / `-nc` is **absent**.
- `TestRun_PiNotOnPath` — `piLookPathFn` returns ENOENT → error names "pi", and **no git/gh/pi calls are made**.
- `TestRun_PiExecError` — pi exits non-zero with stderr → error wrapped with `quick pr:` prefix; both stderr **and** underlying exec error preserved.
- `TestRun_PiReturnsMalformedOutput` — assistant text isn't JSON → error contains the raw output; **no destructive git/gh ops run**.
- `TestRun_TitleTruncatedAt72Chars` — 100-char title from pi → truncated to 72, warning on stderr. Stderr capture drains the pipe concurrently per the issue #1798 stdout-capture-testing convention.
- `TestLegacyProfilesJSONUnmarshal` — `profiles.json` carrying legacy `providerOrder` field unmarshals cleanly.
- `TestNoOpenRouterReferences` — guards against accidental re-introduction of `OPENROUTER_API_KEY` or `openrouter.ai` in any non-test `.go` file in the package.
- `TestExtractTitleBody_{WellFormed,WrappedInJSONFence,EmptyStdout,NoAssistantMessage}` — direct coverage of the parse helper.

## Negative-mutation checks

All five mutations were performed manually and verified to make the targeted test FAIL; reverting restores PASS.

| # | Mutation | Targeted test | Result on mutation |
|---|---|---|---|
| 1 | Replace `"--model", qp.Model,` with hardcoded `"--model", "google/gemini-3.1-flash-lite",` | `TestRun_HappyPath` | FAIL: `--model = "google/gemini-3.1-flash-lite", want "anthropic/claude-sonnet-4-6"` |
| 2 | Re-add an `OPENROUTER_API_KEY` env-var check at the top of `Run()` | `TestNoOpenRouterReferences` | FAIL: `pr.go still references OPENROUTER_API_KEY` |
| 3 | Replace `extractTitleBody` JSON parse with first-line-is-title heuristic | `TestRun_PiReturnsMalformedOutput` | FAIL: `Run() should have errored on malformed pi output` |
| 4 | Delete the title-truncation `if len(title) > titleMaxLen { ... }` block | `TestRun_TitleTruncatedAt72Chars` | FAIL: `expected truncation warning on stderr; got ""` and `--title length = 100, want 72` |
| 5 | Delete the `piLookPathFn()` pre-flight at the top of `Run()` | `TestRun_PiNotOnPath` | FAIL (Run() proceeds past missing-pi guard; destructive ops attempted) |

## Local gates

- `go build ./...` from `modules/programs/prism/prism/` — passes.
- `go test ./internal/quick/... ./internal/config/... -race -count=1` — passes.
- `nix build .#prism` from the repo root — **could not be run** from inside this worker sandbox (sandbox-exec blocks writes to `~/.local/share/nix/trusted-settings.json`). CI's `nix-build-prism-checked` job is the canonical homeless-shelter signal and will gate the merge.
- The broader `go test ./... -race` run inside this worker session shows pre-existing tmux-fork failures unrelated to this change (sandbox blocks `fork` for tmux test fixtures); verified by reproducing on a stashed-clean working tree. CI's `go-tests` job runs on a Linux runner without that restriction.

## Out of scope (per the issue)

- No new `prism quick` subcommands.
- No telemetry / observability of the pi exec call.
- No repo-style learning beyond pi's existing context-file auto-discovery.
