### PR TITLE
prism stats compare: capture effective isolation_mode in spawn_inputs (#2105)

### DIFF
--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -263,6 +263,7 @@ var prCmd = &cobra.Command{
 			agentFlag:            agentFlag,
 			harnessFlag:          effectiveHarness,
 			isolationFlag:        isolationFlag,
+			isolationMode:        string(isoMode),
 			prNumber:             prNumber,
 			ignoreConcurrencyCap: ignoreConcurrencyCapFlag,
 			modelsByRole:         modelsByRole,
@@ -279,15 +280,20 @@ var prCmd = &cobra.Command{
 // ensureAndSwitch → session.Create), and we need to mirror SpawnSession's
 // column mapping without duplicating the SpawnOpts struct.
 type prSpawnInputsArgs struct {
-	worktreePath         string
-	bareRoot             string
-	agentRole            string
-	profileName          string
-	modelFlag            string
-	variantFlag          string
-	agentFlag            string
-	harnessFlag          string
-	isolationFlag        string
+	worktreePath  string
+	bareRoot      string
+	agentRole     string
+	profileName   string
+	modelFlag     string
+	variantFlag   string
+	agentFlag     string
+	harnessFlag   string
+	isolationFlag string
+	// isolationMode is the resolved effective isolation mode for the
+	// session — always populated (#2105) so spawn_inputs.isolation_mode
+	// reflects what the session actually ran under, even when --isolation
+	// was omitted and isolationFlag is therefore "".
+	isolationMode        string
 	prNumber             string
 	ignoreConcurrencyCap bool
 	modelsByRole         map[string]string
@@ -327,9 +333,22 @@ func writeSpawnInputsForPR(cmd *cobra.Command, a prSpawnInputsArgs) {
 		agentPromptHash = ""
 	}
 
+	si := buildPRSpawnInputs(a, *st.InstanceID, skillsManifestHash, agentPromptHash, time.Now().UnixMilli())
+	if err := d.InsertSpawnInputs(si); err != nil {
+		proglog.Warnf("[prism pr] warning: could not write spawn_inputs: %v\n", err)
+	}
+}
+
+// buildPRSpawnInputs builds the db.SpawnInputs row written by the `prism pr`
+// path from its audit-field args. Factored out of writeSpawnInputsForPR so
+// the flag-to-column mapping is testable without spinning up tmux / git /
+// the cobra command. Mirrors spawnInputsFromOpts in internal/session/spawn.go
+// — the two writers must stay in sync because both front doors share the
+// same spawn_inputs schema. Issue #2105.
+func buildPRSpawnInputs(a prSpawnInputsArgs, instanceID, skillsManifestHash, agentPromptHash string, createdAt int64) db.SpawnInputs {
 	si := db.SpawnInputs{
-		InstanceID: *st.InstanceID,
-		CreatedAt:  time.Now().UnixMilli(),
+		InstanceID: instanceID,
+		CreatedAt:  createdAt,
 	}
 	if a.profileName != "" {
 		si.ProfileName = &a.profileName
@@ -348,6 +367,14 @@ func writeSpawnInputsForPR(cmd *cobra.Command, a prSpawnInputsArgs) {
 	}
 	if a.isolationFlag != "" {
 		si.IsolationFlag = &a.isolationFlag
+	}
+	// isolationMode mirrors spawn_inputs.isolation_mode — the resolved
+	// effective mode the session ran under, distinct from the raw
+	// --isolation flag value. Always populated post-#2105 so the
+	// `prism stats compare` Spawn Inputs block surfaces a meaningful value
+	// even when --isolation was omitted (the common case).
+	if a.isolationMode != "" {
+		si.IsolationMode = &a.isolationMode
 	}
 	if a.prNumber != "" {
 		if n, convErr := strconv.Atoi(a.prNumber); convErr == nil {
@@ -373,10 +400,7 @@ func writeSpawnInputsForPR(cmd *cobra.Command, a prSpawnInputsArgs) {
 	if a.promptSource != "" {
 		si.PromptSource = &a.promptSource
 	}
-
-	if err := d.InsertSpawnInputs(si); err != nil {
-		proglog.Warnf("[prism pr] warning: could not write spawn_inputs: %v\n", err)
-	}
+	return si
 }
 
 func init() {

--- a/modules/programs/prism/prism/cmd/pr_spawn_inputs_test.go
+++ b/modules/programs/prism/prism/cmd/pr_spawn_inputs_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+// Tests for buildPRSpawnInputs — the `prism pr` flag-to-column mapping for
+// the spawn_inputs audit row. Issue #2105.
+//
+// `prism pr` does not flow through SpawnSession (it uses ensureAndSwitch →
+// session.Create), so it has its own writer that mirrors
+// internal/session/spawn.go::spawnInputsFromOpts. These tests pin the
+// audit-vs-effective split for isolation_mode / isolation_flag on the PR
+// path so the two writers stay in sync.
+//
+// Test-suite isolation: buildPRSpawnInputs is a pure builder — no DB / no
+// tmux / no env reads — so it is safe to call without sidecartest.
+
+import (
+	"testing"
+)
+
+// TestBuildPRSpawnInputs_IsolationModeDefaultsWhenFlagOmitted mirrors
+// TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted for the
+// `prism pr` writer. When --isolation is omitted (isolationFlag == ""),
+// the writer must still populate isolation_mode with the resolved mode.
+func TestBuildPRSpawnInputs_IsolationModeDefaultsWhenFlagOmitted(t *testing.T) {
+	const resolved = "sandbox-exec"
+	args := prSpawnInputsArgs{
+		isolationFlag: "", // user did not pass --isolation
+		isolationMode: resolved,
+		promptText:    "do the mahi",
+		promptSource:  "cli-positional",
+	}
+	si := buildPRSpawnInputs(args, "iid-123", "", "", 12345)
+
+	// isolation_mode must be the resolved effective mode — the bug-fix
+	// pivot. Without this, the renderer shows "—" for nearly every
+	// session because users rarely pass --isolation explicitly.
+	if si.IsolationMode == nil || *si.IsolationMode != resolved {
+		t.Errorf("IsolationMode: got %v, want %q", si.IsolationMode, resolved)
+	}
+	// isolation_flag must stay NULL because the raw flag was not passed —
+	// that is the audit trail.
+	if si.IsolationFlag != nil {
+		t.Errorf("IsolationFlag: got %q, want nil (raw flag was not passed)", *si.IsolationFlag)
+	}
+}
+
+// TestBuildPRSpawnInputs_IsolationModeMatchesFlagWhenPassed verifies
+// that when --isolation is explicitly passed on `prism pr`, BOTH
+// columns are populated with that value.
+func TestBuildPRSpawnInputs_IsolationModeMatchesFlagWhenPassed(t *testing.T) {
+	const mode = "bwrap"
+	args := prSpawnInputsArgs{
+		isolationFlag: mode, // user passed --isolation bwrap
+		isolationMode: mode, // resolver agrees
+		promptText:    "do the mahi",
+		promptSource:  "cli-positional",
+	}
+	si := buildPRSpawnInputs(args, "iid-456", "", "", 12345)
+
+	if si.IsolationMode == nil || *si.IsolationMode != mode {
+		t.Errorf("IsolationMode: got %v, want %q", si.IsolationMode, mode)
+	}
+	if si.IsolationFlag == nil || *si.IsolationFlag != mode {
+		t.Errorf("IsolationFlag: got %v, want %q", si.IsolationFlag, mode)
+	}
+}

--- a/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_inputs_writer_test.go
@@ -397,6 +397,106 @@ func TestSpawnInputsFromOpts_AbtestPairCarriesRendererFields(t *testing.T) {
 	}
 }
 
+// TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted is the
+// issue #2105 writer-level AC. When --isolation is omitted (the common
+// case where the user relies on the resolved default), the writer must
+// still populate spawn_inputs.isolation_mode with the resolved effective
+// mode the session is about to run under. isolation_flag stays NULL
+// because the raw flag was not passed — that is the audit trail.
+//
+// Without this, `prism stats compare`'s Spawn Inputs block shows "—"
+// for the isolation_mode axis on nearly every session (every session
+// where the user did not pass --isolation), defeating the
+// A/B-comparison workflow's ability to confirm both legs ran under the
+// same sandbox shape.
+func TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-iso-mode-default"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	// SpawnOpts mimics the shape `prism spawn` builds when the user runs
+	// `prism spawn "do the mahi"` without --isolation: IsolationFlag is
+	// empty (no raw flag), IsolationMode holds the resolved effective
+	// mode the resolver picked (here "sandbox-exec" for the test host).
+	const resolvedMode = "sandbox-exec"
+	opts := session.SpawnOpts{
+		InstanceID:    instanceID,
+		Prompt:        "do the mahi",
+		PromptSource:  "cli-positional",
+		IsolationMode: resolvedMode,
+		// IsolationFlag deliberately empty — the user did not pass --isolation.
+	}
+
+	si := session.SpawnInputsFromOpts(opts)
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil row, want non-nil")
+	}
+
+	// isolation_mode must carry the resolved effective mode — the bug
+	// fix in #2105 hinges on this not being NULL.
+	assertStringPtr(t, "IsolationMode", got.IsolationMode, resolvedMode)
+
+	// isolation_flag must stay NULL because no raw --isolation flag was
+	// passed. This is the audit trail: it records that the user relied
+	// on the default rather than naming a specific mode.
+	if got.IsolationFlag != nil {
+		t.Errorf("IsolationFlag: got %q, want nil (raw flag was not passed)",
+			*got.IsolationFlag)
+	}
+}
+
+// TestSpawnInputsFromOpts_IsolationModeMatchesFlagWhenPassed verifies that
+// when --isolation is explicitly passed, BOTH spawn_inputs.isolation_mode
+// (the resolved effective mode) and spawn_inputs.isolation_flag (the raw
+// flag value as audit trail) are populated with that value. The two
+// columns serve different roles — mode is what the renderer reads, flag
+// is what the audit trail preserves — but in this case they agree because
+// the explicit flag IS the resolved mode.
+func TestSpawnInputsFromOpts_IsolationModeMatchesFlagWhenPassed(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-iso-mode-explicit"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	const mode = "bwrap"
+	opts := session.SpawnOpts{
+		InstanceID:    instanceID,
+		Prompt:        "do the mahi",
+		PromptSource:  "cli-positional",
+		IsolationFlag: mode, // user passed --isolation bwrap
+		IsolationMode: mode, // resolver agrees with the flag
+	}
+
+	si := session.SpawnInputsFromOpts(opts)
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil row, want non-nil")
+	}
+
+	assertStringPtr(t, "IsolationMode", got.IsolationMode, mode)
+	assertStringPtr(t, "IsolationFlag", got.IsolationFlag, mode)
+}
+
 // assertStringPtr fails the test if got is nil or *got != want. Used to keep
 // the per-field assertions in the tests above concise.
 func assertStringPtr(t *testing.T, name string, got *string, want string) {

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -1000,6 +1000,15 @@ func inputsValue(axis string, run compareRun) string {
 			return run.Session.Harness
 		}
 	case "isolation_mode":
+		// Prefer the resolved effective mode (#2105 — always populated for
+		// new rows post-fix) so the renderer surfaces a meaningful value
+		// even when --isolation was omitted at spawn time. Fall back to the
+		// raw --isolation flag value for back-compat with pre-#2105 rows
+		// (where isolation_mode is NULL) so we never crash or misreport on
+		// historical data.
+		if in != nil && in.IsolationMode != nil && *in.IsolationMode != "" {
+			return *in.IsolationMode
+		}
 		if in != nil && in.IsolationFlag != nil && *in.IsolationFlag != "" {
 			return *in.IsolationFlag
 		}

--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -390,6 +390,87 @@ func TestInputsValue_PullsFromSpawnInputs(t *testing.T) {
 	}
 }
 
+// TestInputsValue_IsolationModePreferredOverFlag is the issue #2105
+// renderer AC. When a row has BOTH isolation_mode and isolation_flag set
+// (the new post-fix shape), the renderer must surface isolation_mode —
+// the resolved effective mode is what the operator wants to see for
+// A/B leg comparisons. isolation_flag is the raw audit trail.
+func TestInputsValue_IsolationModePreferredOverFlag(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-iso-mode-preferred"
+	inputs := &db.SpawnInputs{
+		ProfileName:   strPtr("anthropic"),
+		HarnessFlag:   strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"),
+		IsolationMode: strPtr("sandbox-exec"),
+		AgentFlag:     strPtr("worker"),
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("isolation_mode", runs[0]); got != "sandbox-exec" {
+		t.Errorf("inputsValue(isolation_mode) = %q, want %q (resolved mode wins over raw flag)",
+			got, "sandbox-exec")
+	}
+}
+
+// TestInputsValue_IsolationModeFallsBackToFlagForLegacyRow is the
+// issue #2105 over-broad-fix guard. Pre-#2105 rows have isolation_mode
+// NULL (the column did not yet exist or the writer did not yet populate
+// it) but isolation_flag set to the resolved mode (the old shim). The
+// renderer must surface the legacy isolation_flag value gracefully
+// rather than "—" — historical sessions should still display sensibly
+// in stats compare output.
+func TestInputsValue_IsolationModeFallsBackToFlagForLegacyRow(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-iso-mode-legacy"
+	inputs := &db.SpawnInputs{
+		ProfileName:   strPtr("anthropic"),
+		HarnessFlag:   strPtr("pi"),
+		IsolationFlag: strPtr("bwrap"),
+		// IsolationMode deliberately nil — simulating a pre-#2105 row.
+		AgentFlag: strPtr("worker"),
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("isolation_mode", runs[0]); got != "bwrap" {
+		t.Errorf("inputsValue(isolation_mode) on legacy row = %q, want %q (fallback to isolation_flag)",
+			got, "bwrap")
+	}
+}
+
+// TestInputsValue_IsolationModeAbsentRendersDash guards the empty-row
+// branch: when neither isolation_mode nor isolation_flag is set (e.g. a
+// pre-spawn_inputs row from a test fixture), the renderer must return
+// "—" rather than crash on a nil pointer dereference.
+func TestInputsValue_IsolationModeAbsentRendersDash(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-iso-mode-absent"
+	inputs := &db.SpawnInputs{
+		ProfileName: strPtr("anthropic"),
+		// Both IsolationFlag and IsolationMode deliberately nil.
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("isolation_mode", runs[0]); got != "—" {
+		t.Errorf("inputsValue(isolation_mode) on empty row = %q, want %q", got, "—")
+	}
+}
+
 // TestInputsValue_PartialRowSurfacesWhatExists guards the Layer 2 AC: a row
 // with only profile_name set (the #2092/#2093 case) must surface that field
 // rather than treating the whole row as absent.

--- a/modules/programs/prism/prism/internal/db/compare.go
+++ b/modules/programs/prism/prism/internal/db/compare.go
@@ -52,9 +52,18 @@ type CompareRunData struct {
 // the view=detail precedent, which returns only *Session and never the spawn
 // prompt (issue #2098, round-1 security review).
 type CompareInputs struct {
-	ProfileName   *string `json:"profile_name"`
-	HarnessFlag   *string `json:"harness_flag"`
+	ProfileName *string `json:"profile_name"`
+	HarnessFlag *string `json:"harness_flag"`
+	// IsolationFlag is the raw --isolation CLI value (nil = flag omitted).
+	// Preserved as the audit trail; consumers that want the actual mode the
+	// session ran under should read IsolationMode instead. Issue #2105.
 	IsolationFlag *string `json:"isolation_flag"`
+	// IsolationMode is the resolved effective isolation mode the session
+	// actually ran under (podman/bwrap/sandbox-exec/host), captured at
+	// spawn time post profile/config/Nix-default resolution. Always
+	// populated for sessions spawned post-#2105; nil only on pre-#2105 rows
+	// (the renderer falls back to IsolationFlag for those).
+	IsolationMode *string `json:"isolation_mode"`
 	AgentFlag     *string `json:"agent_flag"`
 	BranchFlag    *string `json:"branch_flag"`
 	AbtestPairID  *string `json:"abtest_pair_id"`
@@ -175,6 +184,7 @@ func (d *DB) AssembleCompareRun(sess *Session) CompareRunData {
 			ProfileName:   inputs.ProfileName,
 			HarnessFlag:   inputs.HarnessFlag,
 			IsolationFlag: inputs.IsolationFlag,
+			IsolationMode: inputs.IsolationMode,
 			AgentFlag:     inputs.AgentFlag,
 			BranchFlag:    inputs.BranchFlag,
 			AbtestPairID:  inputs.AbtestPairID,

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -29,7 +29,7 @@ const (
 	// It must be bumped whenever a new migrateVNtoVN+1 function is added.
 	// A meta-test in db_test.go asserts that this constant equals the count of
 	// migration functions, so forgetting to bump it will fail CI.
-	currentSchemaVersion = 34
+	currentSchemaVersion = 35
 )
 
 // DB wraps a SQLite connection.
@@ -203,11 +203,22 @@ CREATE TABLE IF NOT EXISTS spawn_inputs (
     variant_flag           TEXT,
     agent_flag             TEXT,
     harness_flag           TEXT,
+    -- Raw --isolation flag value as the user passed it (NULL = flag omitted,
+    -- default in effect). Preserved as audit trail; the actual mode the
+    -- session ran under lives in isolation_mode (below). Added pre-#2105.
     isolation_flag         TEXT,
     host_mode_flag         INTEGER NOT NULL DEFAULT 0,
     pr_number              INTEGER,
     branch_flag            TEXT,
     ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+
+    -- Resolved effective isolation mode the session actually ran under
+    -- (podman/bwrap/sandbox-exec/host), captured at spawn time post profile/
+    -- config/Nix-default resolution. Added in #2105 so stats compare surfaces
+    -- a meaningful value even when --isolation was omitted. NULLABLE for
+    -- back-compat with pre-#2105 rows; new rows are always populated by the
+    -- centralised writer in internal/session/spawn.go.
+    isolation_mode         TEXT,
 
     -- C.2: per-role model-variant overrides (JSON; NULL if no overrides).
     model_variant_overrides TEXT,
@@ -350,8 +361,9 @@ CREATE INDEX IF NOT EXISTS idx_harness_frames_session_dir ON harness_frames(sess
 // 'podman'. The WHERE clause makes the migration idempotent: rows already set
 // are skipped on any subsequent open. This is the Phase A prerequisite for the
 // A4 deprecation-removal sequence (#1129).
-// v23→v24 drops sessions.outcome_summary (reserved by C.1 as a JSON
-// placeholder with zero writers) and adds the spawn_outcome table (C.3 §4).
+// v23→v24 drops sessions.outcome_summary (a JSON placeholder column with
+// zero writers) and adds the spawn_outcome table (#1130 — the discrete-event
+// aggregation row that supersedes outcome_summary).
 // The outcome_summary column is dropped with a rebuild-via-rename strategy
 // because SQLite does not support ALTER TABLE ... DROP COLUMN on columns with
 // foreign-key references (and to maintain compatibility with older SQLite
@@ -360,7 +372,8 @@ CREATE INDEX IF NOT EXISTS idx_harness_frames_session_dir ON harness_frames(sess
 // the migration idempotent. Fresh databases skip the column-drop (the column
 // never existed in the declarative schema) and the table creation is a no-op
 // because the schema block above already created it.
-// v24→v25 adds the spawn_inputs table (C.1/C.4 §4.1) and the agent_prompt_hash
+// v24→v25 adds the spawn_inputs table (#2087 introduced the table; #2092 /
+// #2093 fixed the profile_name write path) and the agent_prompt_hash
 // column within it (C4.AP). The table is created with CREATE TABLE IF NOT
 // EXISTS and its indexes with CREATE INDEX IF NOT EXISTS, making the migration
 // idempotent. Fresh databases already have the table from the declarative
@@ -393,6 +406,14 @@ CREATE INDEX IF NOT EXISTS idx_harness_frames_session_dir ON harness_frames(sess
 //   - idx_agent_status_{active,group_id,instance_id,repo_active} on agent_status
 // Each CREATE INDEX uses IF NOT EXISTS so the migration is idempotent on a
 // fresh DB (which already has the indexes via the declarative schema block).
+// v34→v35 adds spawn_inputs.isolation_mode (issue #2105). The column carries
+// the resolved effective isolation mode the session ran under — distinct
+// from isolation_flag, which is the raw --isolation CLI value (NULL when the
+// user relied on the resolved default). The ALTER TABLE is guarded by a
+// pragma_table_info check so the migration is idempotent on fresh databases
+// where the declarative schema block above already includes the column. No
+// backfill: pre-#2105 rows keep their NULL isolation_mode and the renderer
+// falls back to isolation_flag for them.
 //
 func Open(path string) (*DB, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -633,6 +654,9 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV33ToV34(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV34ToV35(conn, &version); err != nil {
+		return err
+	}
 	if version > currentSchemaVersion {
 		return fmt.Errorf(
 			"db schema version %d is newer than this prism binary (max %d); "+
@@ -680,6 +704,44 @@ func runMigrations(conn *sql.DB) error {
 // The partial WHERE (harness_port IS NOT NULL AND ended_at IS NULL) excludes
 // both NULL/released ports and ended sessions, so that ended sessions' ports
 // can be reclaimed by new sessions without triggering a constraint error.
+// migrateV34ToV35 adds the `isolation_mode` column to spawn_inputs
+// (issue #2105). The new column carries the resolved effective isolation
+// mode the session ran under, captured at spawn time after profile /
+// config / Nix-default resolution — distinct from `isolation_flag`, which
+// preserves the raw --isolation CLI flag value (NULL when omitted) purely
+// as an audit trail.
+//
+// Pre-#2105 rows keep NULL `isolation_mode`; no backfill is performed.
+// The `prism stats compare` renderer falls back to `isolation_flag` for
+// those rows so they continue to display whatever was originally recorded.
+//
+// The ALTER TABLE is guarded by a pragma_table_info check so the migration
+// is idempotent on fresh databases where the base schema already includes
+// the column.
+func migrateV34ToV35(conn *sql.DB, version *int) error {
+	if *version >= 35 {
+		return nil
+	}
+	var exists int
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('spawn_inputs') WHERE name = 'isolation_mode'`,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("db: migration v34\u2192v35: check isolation_mode column: %w", err)
+	}
+	if exists == 0 {
+		if _, err := conn.Exec(
+			`ALTER TABLE spawn_inputs ADD COLUMN isolation_mode TEXT`,
+		); err != nil {
+			return fmt.Errorf("db: migration v34\u2192v35: add isolation_mode: %w", err)
+		}
+	}
+	if _, err := conn.Exec(`UPDATE schema_version SET version = 35`); err != nil {
+		return fmt.Errorf("db: migration v34\u2192v35: %w", err)
+	}
+	*version = 35
+	return nil
+}
+
 // migrateV33ToV34 adds the `muted` column to agent_status (issue #2013).
 // The column is `INTEGER NOT NULL DEFAULT 0` so existing rows are
 // initialised as unmuted (false). The ALTER TABLE is guarded by a
@@ -1618,9 +1680,10 @@ func migrateV23toV24(conn *sql.DB, version *int) error {
 	if *version != 23 {
 		return nil
 	}
-	// Migration v23 → v24: drop sessions.outcome_summary (reserved by C.1
-	// as a JSON placeholder with zero writers) and add the spawn_outcome
-	// table (C.3 §4, issue #1130).
+	// Migration v23 → v24: drop sessions.outcome_summary (a JSON
+	// placeholder column with zero writers) and add the spawn_outcome
+	// table (issue #1130 — the discrete-event aggregation row that
+	// supersedes outcome_summary).
 	//
 	// Dropping a column from sessions requires recreating the table because
 	// SQLite < 3.35 does not support ALTER TABLE ... DROP COLUMN and because
@@ -1753,7 +1816,8 @@ func migrateV24toV25(conn *sql.DB, version *int) error {
 	if *version != 24 {
 		return nil
 	}
-	// Migration v24 → v25: add the spawn_inputs table (C.1/C.4 §4.1).
+	// Migration v24 → v25: add the spawn_inputs table (#2087 introduced
+	// the table; #2092 / #2093 fixed the profile_name write path).
 	// The table holds the intent of a spawn — every flag value the user
 	// passed — keyed on instance_id (FK → sessions). Also includes
 	// agent_prompt_hash (C4.AP) and skills_manifest_hash (C4.SK) columns.
@@ -2048,7 +2112,18 @@ type SpawnInputs struct {
 	VariantFlag   *string
 	AgentFlag     *string
 	HarnessFlag   *string
+	// IsolationFlag is the raw --isolation flag value as the user passed
+	// it. nil when the flag was omitted (the common case). Preserved as an
+	// audit trail; downstream readers that want the actual mode the
+	// session ran under should consult IsolationMode (below) instead.
 	IsolationFlag *string
+	// IsolationMode is the resolved effective isolation mode the session
+	// actually ran under ("podman", "bwrap", "sandbox-exec", "host"),
+	// captured at spawn time after profile / config / Nix-default
+	// resolution. Always populated by the centralised writer post-#2105 so
+	// the `prism stats compare` Spawn Inputs block can surface it. nil only
+	// on pre-#2105 rows or when a writer somehow omits it.
+	IsolationMode *string
 	HostModeFlag  bool
 	PRNumber      *int
 	BranchFlag    *string
@@ -2095,6 +2170,7 @@ INSERT OR IGNORE INTO spawn_inputs (
     profile_name, model_flag, variant_flag, agent_flag, harness_flag,
     isolation_flag, host_mode_flag,
     pr_number, branch_flag, ignore_concurrency_cap,
+    isolation_mode,
     model_variant_overrides,
     skills_manifest_hash, prompt_template_hash, agent_prompt_hash,
     prompt_text, prompt_source, abtest_pair_id, extras,
@@ -2105,6 +2181,7 @@ INSERT OR IGNORE INTO spawn_inputs (
     ?, ?,
     ?, ?, ?,
     ?,
+    ?,
     ?, ?, ?,
     ?, ?, ?, ?,
     ?
@@ -2113,6 +2190,7 @@ INSERT OR IGNORE INTO spawn_inputs (
 		si.ProfileName, si.ModelFlag, si.VariantFlag, si.AgentFlag, si.HarnessFlag,
 		si.IsolationFlag, boolToInt(si.HostModeFlag),
 		si.PRNumber, si.BranchFlag, boolToInt(si.IgnoreConcurrencyCap),
+		si.IsolationMode,
 		si.ModelVariantOverrides,
 		si.SkillsManifestHash, si.PromptTemplateHash, si.AgentPromptHash,
 		si.PromptText, si.PromptSource, si.AbtestPairID, si.Extras,
@@ -2133,6 +2211,7 @@ SELECT
     profile_name, model_flag, variant_flag, agent_flag, harness_flag,
     isolation_flag, host_mode_flag,
     pr_number, branch_flag, ignore_concurrency_cap,
+    isolation_mode,
     model_variant_overrides,
     skills_manifest_hash, prompt_template_hash, agent_prompt_hash,
     prompt_text, prompt_source, abtest_pair_id, extras,
@@ -2142,6 +2221,7 @@ WHERE instance_id = ?`
 	row := d.conn.QueryRow(q, instanceID)
 	var si SpawnInputs
 	var profileName, modelFlag, variantFlag, agentFlag, harnessFlag, isolationFlag sql.NullString
+	var isolationMode sql.NullString
 	var prNumber sql.NullInt64
 	var branchFlag, modelVariantOverrides, skillsManifestHash, promptTemplateHash, agentPromptHash sql.NullString
 	var promptText, promptSource, abtestPairID, extras sql.NullString
@@ -2151,6 +2231,7 @@ WHERE instance_id = ?`
 		&profileName, &modelFlag, &variantFlag, &agentFlag, &harnessFlag,
 		&isolationFlag, &hostModeFlag,
 		&prNumber, &branchFlag, &ignoreConcurrencyCap,
+		&isolationMode,
 		&modelVariantOverrides,
 		&skillsManifestHash, &promptTemplateHash, &agentPromptHash,
 		&promptText, &promptSource, &abtestPairID, &extras,
@@ -2179,6 +2260,9 @@ WHERE instance_id = ?`
 	}
 	if isolationFlag.Valid {
 		si.IsolationFlag = &isolationFlag.String
+	}
+	if isolationMode.Valid {
+		si.IsolationMode = &isolationMode.String
 	}
 	si.HostModeFlag = hostModeFlag != 0
 	if prNumber.Valid {

--- a/modules/programs/prism/prism/internal/db/db_migration_v34_v35_test.go
+++ b/modules/programs/prism/prism/internal/db/db_migration_v34_v35_test.go
@@ -1,0 +1,250 @@
+package db_test
+
+// Tests for the v34→v35 migration that adds spawn_inputs.isolation_mode
+// (issue #2105). The new column carries the resolved effective isolation
+// mode the session ran under — distinct from isolation_flag (the raw
+// --isolation CLI value, NULL when omitted).
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedV34DB creates a v34 DB with the pre-v35 spawn_inputs shape (no
+// isolation_mode column). If withIsoMode is true, spawn_inputs already has
+// the column (simulates a DB whose declarative schema block added it — the
+// migration's pragma guard must detect this and skip the ALTER TABLE).
+func seedV34DB(t *testing.T, dbPath string, withIsoMode bool) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open v34 db: %v", err)
+	}
+	defer rawConn.Close()
+
+	isoModeCol := ""
+	if withIsoMode {
+		isoModeCol = "isolation_mode TEXT,"
+	}
+
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, harness_session_id TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL,
+		  instance_id TEXT
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		  pr_number INTEGER,
+		  round INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  isolation_mode TEXT,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'pi',
+		  harness_session_id TEXT, harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  muted INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS sessions (
+		  instance_id        TEXT PRIMARY KEY,
+		  session_name       TEXT NOT NULL,
+		  agent_role         TEXT,
+		  root_agent_name    TEXT,
+		  repo               TEXT NOT NULL,
+		  worktree           TEXT NOT NULL,
+		  harness            TEXT NOT NULL,
+		  harness_session_id TEXT,
+		  group_id           TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  started_at         INTEGER NOT NULL,
+		  ended_at           INTEGER,
+		  end_state          TEXT,
+		  archive_path       TEXT,
+		  prism_version      TEXT
+		);
+		CREATE TABLE IF NOT EXISTS pending_merges (
+		  pr INTEGER PRIMARY KEY, session_name TEXT NOT NULL, instance_id TEXT NOT NULL,
+		  queue_position INTEGER NOT NULL, status TEXT NOT NULL, title TEXT, error TEXT,
+		  queued_at INTEGER NOT NULL, last_checked_at INTEGER, merged_at INTEGER, ended_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS spawn_inputs (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    profile_name TEXT, model_flag TEXT, variant_flag TEXT, agent_flag TEXT,
+		    harness_flag TEXT, isolation_flag TEXT, host_mode_flag INTEGER NOT NULL DEFAULT 0,
+		    pr_number INTEGER, branch_flag TEXT, ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+		    ` + isoModeCol + `
+		    model_variant_overrides TEXT, skills_manifest_hash TEXT, prompt_template_hash TEXT,
+		    agent_prompt_hash TEXT, prompt_text TEXT, prompt_source TEXT,
+		    abtest_pair_id TEXT,
+		    extras TEXT,
+		    created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS spawn_outcome (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    end_state TEXT,
+		    exit_code INTEGER,
+		    duration_ms INTEGER,
+		    interrupted_count INTEGER NOT NULL DEFAULT 0,
+		    compaction_count INTEGER NOT NULL DEFAULT 0,
+		    error_event_count INTEGER NOT NULL DEFAULT 0,
+		    permission_ask_count INTEGER NOT NULL DEFAULT 0,
+		    permission_denied_count INTEGER NOT NULL DEFAULT 0,
+		    doom_loop_count INTEGER NOT NULL DEFAULT 0,
+		    pr_number INTEGER,
+		    pr_merged_at INTEGER,
+		    review_group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		    review_verdict TEXT,
+		    review_pass_count INTEGER,
+		    review_fail_count INTEGER,
+		    review_none_count INTEGER,
+		    rubric_verdict TEXT,
+		    rubric_score REAL,
+		    rubric_breakdown TEXT,
+		    rubric_grader TEXT,
+		    tokens_input_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_output_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_cache_read_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_cache_write_total INTEGER NOT NULL DEFAULT 0,
+		    cost_usd_total REAL NOT NULL DEFAULT 0,
+		    tool_call_count INTEGER NOT NULL DEFAULT 0,
+		    tool_error_count INTEGER NOT NULL DEFAULT 0,
+		    msg_assistant_count INTEGER NOT NULL DEFAULT 0,
+		    time_to_first_event_ms INTEGER,
+		    time_to_finished_ms INTEGER,
+		    computed_at INTEGER NOT NULL,
+		    schema_version INTEGER NOT NULL DEFAULT 1
+		);
+		CREATE TABLE IF NOT EXISTS harness_frames (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, instance_id TEXT,
+		  direction TEXT NOT NULL, type TEXT, payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (34);
+	`)
+	if err != nil {
+		t.Fatalf("seed v34 db: %v", err)
+	}
+}
+
+// TestMigration_V34ToV35_BodyRuns_AddsIsolationMode exercises the
+// body-runs branch of the v34→v35 migration (issue #2105): a v34 DB
+// without the spawn_inputs.isolation_mode column. The pragma_table_info
+// guard returns 0 and the ALTER TABLE ADD COLUMN executes.
+func TestMigration_V34ToV35_BodyRuns_AddsIsolationMode(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v34_body_runs.db")
+	seedV34DB(t, dbPath, false /*withIsoMode*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
+	}
+
+	var n int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('spawn_inputs') WHERE name = 'isolation_mode'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info isolation_mode: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("spawn_inputs.isolation_mode missing after v34→v35 (body-runs branch): got %d, want 1", n)
+	}
+}
+
+// TestMigration_V34ToV35_BodySkips_PreExistingColumn exercises the
+// body-skips branch: a v34 DB that ALREADY has the spawn_inputs.isolation_mode
+// column (simulating a DB whose declarative schema block added it). The
+// pragma_table_info guard returns 1 and the ALTER TABLE ADD COLUMN is
+// skipped. The end state is still v35 with the column present (not
+// duplicated by a re-ADD).
+func TestMigration_V34ToV35_BodySkips_PreExistingColumn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v34_body_skips.db")
+	seedV34DB(t, dbPath, true /*withIsoMode*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
+	}
+
+	var n int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('spawn_inputs') WHERE name = 'isolation_mode'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info isolation_mode: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("spawn_inputs.isolation_mode count after v34→v35 (body-skips branch): got %d, want 1", n)
+	}
+}
+
+// TestMigration_V34ToV35_Idempotent verifies that re-opening a DB already
+// at v35+ does not error and the column remains.
+func TestMigration_V34ToV35_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v34_idem.db")
+	seedV34DB(t, dbPath, false)
+
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first db.Open: %v", err)
+	}
+	d1.Close()
+
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	var version int
+	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version after second open: %v", err)
+	}
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
+	}
+
+	var n int
+	if err := d2.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('spawn_inputs') WHERE name = 'isolation_mode'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info isolation_mode on second open: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("spawn_inputs.isolation_mode count after idempotent open: got %d, want 1", n)
+	}
+}

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -51,8 +51,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version: got %d, want 35", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1233,8 +1233,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1308,8 +1308,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1860,8 +1860,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1926,8 +1926,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1996,8 +1996,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -2091,8 +2091,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -2184,8 +2184,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2728,8 +2728,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2817,8 +2817,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4667,8 +4667,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// Check each row.
@@ -5095,8 +5095,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5370,8 +5370,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5591,8 +5591,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// sessions table must exist.
@@ -5745,8 +5745,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 }
 
@@ -6299,8 +6299,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6357,8 +6357,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6659,8 +6659,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6721,8 +6721,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6880,8 +6880,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6934,8 +6934,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	var startedAt int64
@@ -7088,8 +7088,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -7161,8 +7161,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7297,8 +7297,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7351,8 +7351,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	// spawn_outcome must still exist.
@@ -7466,8 +7466,8 @@ func TestMigration_V23ToV24_CrashRecovery(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&finalVer); err != nil {
 		t.Fatalf("read schema_version after recovery: %v", err)
 	}
-	if finalVer != 34 {
-		t.Errorf("schema_version after recovery: got %d, want 34", finalVer)
+	if finalVer != 35 {
+		t.Errorf("schema_version after recovery: got %d, want 35", finalVer)
 	}
 
 	// Sessions data must be preserved (the two rows seeded by seedV23DB).
@@ -8352,8 +8352,8 @@ func TestMigration_V10ToV11_DropsLegacyOpencodeColumns(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// opencode_sid and opencode_port must be gone from agent_status.
@@ -8436,8 +8436,8 @@ func TestMigration_V10ToV11_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	// Columns must remain dropped.
@@ -8606,8 +8606,8 @@ func TestMigration_V11ToV12_CreatesIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// Index must exist after migration.
@@ -8679,8 +8679,8 @@ func TestMigration_V11ToV12_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	var idxName string
@@ -8780,8 +8780,8 @@ func TestMigration_V16ToV17_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// The pre-existing sessions row must be unchanged.
@@ -8816,8 +8816,8 @@ func TestMigration_V16ToV17_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 }
 
@@ -8908,8 +8908,8 @@ func TestMigration_V18ToV19_CreatesPendingMerges(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	var tname string
@@ -9055,8 +9055,8 @@ func TestMigration_V19ToV20_AddsStatusSessionIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	var iname string
@@ -9224,8 +9224,8 @@ func TestMigration_V24ToV25_CreatesSpawnInputs(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	var tname string
@@ -9426,8 +9426,8 @@ func TestMigration_V25ToV26_DropsHostModeAndBackfillsPodman(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// host_mode column must be gone.
@@ -9525,8 +9525,8 @@ func TestMigration_V25ToV26_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 
 	var hmCount int
@@ -9646,8 +9646,8 @@ func TestMigration_V26ToV27_CreatesHarnessFrames(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	var tname string
@@ -9816,8 +9816,8 @@ func TestMigration_V27ToV28_BodyRuns_AddsAbtestPairID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// abtest_pair_id must exist on spawn_inputs.
@@ -9860,8 +9860,8 @@ func TestMigration_V27ToV28_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// The column must still be present — exactly one (not duplicated by a
@@ -9989,8 +9989,8 @@ func TestMigration_V28ToV29_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	var startedAt int64
@@ -10023,8 +10023,8 @@ func TestMigration_V28ToV29_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 }
 
@@ -10121,8 +10121,8 @@ func TestMigration_V29ToV30_BodyRuns_AddsParentSession(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	var n int
@@ -10161,8 +10161,8 @@ func TestMigration_V29ToV30_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	// Exactly one parent_session column — not duplicated by re-ADD.
@@ -10292,8 +10292,8 @@ func TestMigration_V30ToV31_AddsPRNumberAndRound(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after migration: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after migration: got %d, want 35", version)
 	}
 
 	for _, col := range []string{"pr_number", "round"} {

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 34 {
-		t.Errorf("schema_version after fresh open = %d, want 34", ver)
+	if ver != 35 {
+		t.Errorf("schema_version after fresh open = %d, want 35", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 34 {
-		t.Errorf("schema_version after second open = %d, want 34", ver)
+	if ver != 35 {
+		t.Errorf("schema_version after second open = %d, want 35", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1424,8 +1424,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 34 {
-		t.Errorf("schema_version after second open: got %d, want 34", version)
+	if version != 35 {
+		t.Errorf("schema_version after second open: got %d, want 35", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -1170,6 +1170,16 @@ func spawnInputsFromOpts(opts SpawnOpts) db.SpawnInputs {
 		s := opts.IsolationFlag
 		si.IsolationFlag = &s
 	}
+	// IsolationMode is the resolved effective mode the session actually ran
+	// under — always populated when known so that `prism stats compare`'s
+	// Spawn Inputs block surfaces a meaningful value even when the user
+	// relied on the default and omitted --isolation (the common case).
+	// Distinct from IsolationFlag above, which preserves the raw CLI value
+	// (nil when omitted) as a separate audit trail. Issue #2105.
+	if opts.IsolationMode != "" {
+		s := opts.IsolationMode
+		si.IsolationMode = &s
+	}
 	si.HostModeFlag = opts.HostModeFlag
 	if opts.PRNumber != 0 {
 		n := opts.PRNumber


### PR DESCRIPTION
Closes #2105

Third and final PR in the stats compare stream:

- #2099 → #2119 (merged) — output contract: table alignment, `--json`, error envelope
- #2110 → #2123 (merged) — write paths for the `Agent-level outcomes` columns
- **#2105 → this PR — `isolation_mode` capture for `Spawn Inputs` block + db.go comment cleanup**

After this lands, `prism stats compare` shows real values across all three blocks (Process-level outcomes, Spawn Inputs, Agent-level outcomes) for new sessions.

## What changed

### 1. `spawn_inputs.isolation_mode` capture (the meat)

Pre-fix, `spawn_inputs.isolation_mode` was NULL for nearly every session because the writers (`spawnInputsFromOpts` and the `prism pr` variant) recorded only the raw `--isolation` CLI flag value. Users rarely pass `--isolation` explicitly — they rely on the resolved default from `~/.config/prism/config.json` or the nix-configured `DefaultIsolationMode` — so the column was blank.

Audit-vs-effective column split:

- `spawn_inputs.isolation_flag` — raw `--isolation` CLI value (NULL when omitted). Preserved purely as audit trail.
- `spawn_inputs.isolation_mode` — **NEW**. Resolved effective mode the session actually ran under, captured at spawn time. Always populated post-fix.

Writers updated:

- `internal/session/spawn.go::spawnInputsFromOpts` — centralised writer used by `prism spawn` (incl. `--abtest` legs), `prism review`, and `prism investigate` via `SpawnSession`. Sets `IsolationMode` from `opts.IsolationMode` (the resolved value the spawner already computes).
- `cmd/pr.go::buildPRSpawnInputs` (extracted from `writeSpawnInputsForPR` so the flag→column mapping is testable) — the `prism pr` writer.

Renderer (`cmd/stats_compare.go::inputsValue`) prefers `IsolationMode` and falls back to `IsolationFlag` for pre-fix rows — back-compat so historical sessions still display sensibly rather than "—".

Schema: new migration v34→v35 that `ALTER TABLE spawn_inputs ADD COLUMN isolation_mode TEXT`, guarded by `pragma_table_info`. **No backfill** — pre-#2105 rows keep their NULL `isolation_mode` and the renderer's fallback chain handles them.

### 2. `db.go` migration-comment cleanup (the companion sweep)

PR #1659 deleted `docs/reviews/C1-ab-readiness-and-schema-delta.md` but four comments in `internal/db/db.go` still cited it. Updated each to either reference the PRs that actioned the schema (#2087 introduced `spawn_inputs`; #1130 introduced `spawn_outcome`) or describe the schema's current purpose without the obsolete spec-section reference, mirroring #1659's F1 / B.2 update shape. **Comments only — no code-behaviour changes.**

## Tests

| Test | What it pins |
|---|---|
| `TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted` | Writer AC: no `--isolation` flag → `isolation_mode` = resolved, `isolation_flag` = NULL |
| `TestSpawnInputsFromOpts_IsolationModeMatchesFlagWhenPassed` | Writer AC: `--isolation bwrap` → both columns = `"bwrap"` |
| `TestBuildPRSpawnInputs_*` | Same two cases for the `prism pr` writer (pure-function tests against `buildPRSpawnInputs`) |
| `TestInputsValue_IsolationModePreferredOverFlag` | Renderer prefers `IsolationMode` over `IsolationFlag` when both are set |
| `TestInputsValue_IsolationModeFallsBackToFlagForLegacyRow` | **Over-broad-fix guard**: pre-#2105 rows with NULL `isolation_mode` but populated `isolation_flag` still render correctly |
| `TestInputsValue_IsolationModeAbsentRendersDash` | Nil-pointer guard: no `isolation_mode` and no `isolation_flag` → "—" (no crash) |
| `TestMigration_V34ToV35_*` | Body-runs, body-skips, idempotent |

## Negative-mutation check (discipline gate)

Confirmed `TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted` FAILS without the fix:

```
=== RUN   TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted
    spawn_inputs_writer_test.go:448: IsolationMode: got nil, want "sandbox-exec"
--- FAIL: TestSpawnInputsFromOpts_IsolationModeDefaultsWhenFlagOmitted (0.01s)
```

Re-applied the fix → test PASSES.

Same check on the renderer side: reverting the `IsolationMode` preference branch in `inputsValue` makes `TestInputsValue_IsolationModePreferredOverFlag` FAIL with `inputsValue(isolation_mode) = "bwrap", want "sandbox-exec"`. Re-applied → PASSES.

## Quality gates

- `go build ./...` ✓
- `go test ./internal/db/ ./internal/session/ -race` ✓
- `go test ./cmd/ -run "TestSpawnInputs|TestInputsValue|TestBuildPRSpawnInputs|TestMigration_V34" -race` ✓
- `nix build .#prism` — deferred to CI (sandbox restrictions on this host prevent local nix invocation)

## Out of scope

- Renaming existing `spawn_inputs` columns
- Backfilling NULL `isolation_mode` for existing rows
- Any other PR #2104 changes that didn't make it into #2103
