### PR TITLE
sidecar/repoFromSession: DB-fallback for @-less host-mode sessions (#2112)

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/helpers.go
+++ b/modules/programs/prism/prism/internal/sidecar/helpers.go
@@ -214,15 +214,38 @@ func extractMessageIDFromPayload(raw string) string {
 	return p.MessageID
 }
 
-// repoFromSession extracts the repo prefix from a session name (e.g.
-// "nixos-config" from "nixos-config@main"). Returns an error when the session
-// name contains no "@" — this indicates a misconfigured or non-worktree session.
-func repoFromSession(sessionName string) (string, error) {
-	idx := strings.Index(sessionName, "@")
-	if idx < 0 {
-		return "", fmt.Errorf("session name %q contains no '@' — cannot derive repo", sessionName)
+// repoFromSession returns the repo prefix for a session.
+//
+// When d is non-nil and an agent_status row exists for sessionName with a
+// non-empty repo column, that value is returned. This is the authoritative
+// path and resolves both `<repo>@<branch>` sessions and @-less host-mode
+// sessions (e.g. "obsidian" against ~/Documents/obsidian via
+// ProjectIsolationOverrides — issue #2112). Without the DB lookup, host-mode
+// non-git sessions whose names lack an `@<branch>` suffix could not be
+// resolved and every host-API permission check that called this helper
+// rejected them with a "contains no '@' — cannot derive repo" parse error.
+//
+// When the DB lookup misses (no row, empty repo, DB error, or d == nil), the
+// helper falls back to parsing the session name as `<repo>@<branch>`. The
+// fallback keeps repoFromSession usable in unit tests that do not seed a row
+// and preserves the original behaviour for the dominant @-bearing case when
+// the DB has not yet recorded a row for a freshly-minted session.
+//
+// Returns an error only when both paths fail: no DB row (or no DB) AND the
+// name contains no "@". The error message names the unknown session so the
+// caller can surface a clear "session not found" error rather than a parse-
+// failure description (AC: prism checkin <unknown-name> should not say
+// "cannot derive repo").
+func repoFromSession(sessionName string, d *db.DB) (string, error) {
+	if d != nil {
+		if status, err := d.CurrentStatus(sessionName); err == nil && status != nil && status.Repo != "" {
+			return status.Repo, nil
+		}
 	}
-	return sessionName[:idx], nil
+	if idx := strings.Index(sessionName, "@"); idx >= 0 {
+		return sessionName[:idx], nil
+	}
+	return "", fmt.Errorf("session %q not found", sessionName)
 }
 
 // isCoordinator returns true when the session name ends with "@main", which is

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -583,7 +583,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// Both DB lookup and name-parse fallback failed — the target
 			// session is unknown. Return 404 so the CLI can surface a clear
 			// "session not found" rather than a parse error (issue #2112).
-			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
+			writeError(w, http.StatusNotFound, "target "+targetRepoErr.Error())
 			return
 		}
 		crossRepo := targetRepo != ownRepo
@@ -752,7 +752,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		targetRepo, targetRepoErr := repoFromSession(targetSession, s.cfg.DB)
 		if targetRepoErr != nil {
 			// Both DB lookup and name-parse fallback failed — unknown target.
-			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
+			writeError(w, http.StatusNotFound, "target "+targetRepoErr.Error())
 			return
 		}
 		if targetRepo != ownRepo && !isCoordinatorSession(targetSession, s.cfg.DB, s.logger()) {
@@ -1002,7 +1002,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		targetRepo, targetRepoErr := repoFromSession(req.Session, s.cfg.DB)
 		if targetRepoErr != nil {
 			// Both DB lookup and name-parse fallback failed — unknown target.
-			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
+			writeError(w, http.StatusNotFound, "target "+targetRepoErr.Error())
 			return
 		}
 		crossRepo := targetRepo != ownRepo
@@ -1744,7 +1744,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		targetRepo, targetRepoErr := repoFromSession(req.Session, s.cfg.DB)
 		if targetRepoErr != nil {
 			// Both DB lookup and name-parse fallback failed — unknown target.
-			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
+			writeError(w, http.StatusNotFound, "target "+targetRepoErr.Error())
 			return
 		}
 		if targetRepo != ownRepo {

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -533,7 +533,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// Same-repo: everything. Other repos: only coordinators
 			// (root_agent_name = 'coordinator', with @main name-heuristic
 			// fallback for pre-migration rows where root_agent_name IS NULL).
-			ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+			ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 			if repoErr != nil {
 				writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
 				return
@@ -573,14 +573,17 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 
 		// Permission check: coordinator can access own-repo sessions and
 		// any cross-repo coordinator (@main) session.
-		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
 			return
 		}
-		targetRepo, targetRepoErr := repoFromSession(targetSession)
+		targetRepo, targetRepoErr := repoFromSession(targetSession, s.cfg.DB)
 		if targetRepoErr != nil {
-			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			// Both DB lookup and name-parse fallback failed — the target
+			// session is unknown. Return 404 so the CLI can surface a clear
+			// "session not found" rather than a parse error (issue #2112).
+			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
 			return
 		}
 		crossRepo := targetRepo != ownRepo
@@ -741,14 +744,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		// Permission check: own-repo sessions or cross-repo @main sessions.
-		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
 			return
 		}
-		targetRepo, targetRepoErr := repoFromSession(targetSession)
+		targetRepo, targetRepoErr := repoFromSession(targetSession, s.cfg.DB)
 		if targetRepoErr != nil {
-			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			// Both DB lookup and name-parse fallback failed — unknown target.
+			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
 			return
 		}
 		if targetRepo != ownRepo && !isCoordinatorSession(targetSession, s.cfg.DB, s.logger()) {
@@ -989,15 +993,16 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			}
 		}
 
-		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
 			return
 		}
 
-		targetRepo, targetRepoErr := repoFromSession(req.Session)
+		targetRepo, targetRepoErr := repoFromSession(req.Session, s.cfg.DB)
 		if targetRepoErr != nil {
-			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			// Both DB lookup and name-parse fallback failed — unknown target.
+			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
 			return
 		}
 		crossRepo := targetRepo != ownRepo
@@ -1229,7 +1234,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		// mount-path name instead of the actual repo name) is silently
 		// corrected. The own-repo restriction is enforced implicitly: the
 		// sidecar can only spawn into its own repo.
-		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
 			return
@@ -1731,14 +1736,15 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 
 		// Own-repo restriction: coordinators may only clean up sessions in their own repo.
-		ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 		if repoErr != nil {
 			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
 			return
 		}
-		targetRepo, targetRepoErr := repoFromSession(req.Session)
+		targetRepo, targetRepoErr := repoFromSession(req.Session, s.cfg.DB)
 		if targetRepoErr != nil {
-			writeError(w, http.StatusBadRequest, "invalid target session name: "+targetRepoErr.Error())
+			// Both DB lookup and name-parse fallback failed — unknown target.
+			writeError(w, http.StatusNotFound, "invalid target session name: "+targetRepoErr.Error())
 			return
 		}
 		if targetRepo != ownRepo {
@@ -2598,7 +2604,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		case "session":
 			targets = []string{req.Session}
 		case "coordinator":
-			ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+			ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 			if repoErr != nil {
 				writeError(w, http.StatusInternalServerError, "cannot derive repo: "+repoErr.Error())
 				return
@@ -2722,7 +2728,7 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		case "session":
 			targets = []string{req.Session}
 		case "coordinator":
-			ownRepo, repoErr := repoFromSession(s.cfg.SessionName)
+			ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
 			if repoErr != nil {
 				writeError(w, http.StatusInternalServerError, "cannot derive repo: "+repoErr.Error())
 				return

--- a/modules/programs/prism/prism/internal/sidecar/host_api_atless_session_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_atless_session_test.go
@@ -1,0 +1,443 @@
+package sidecar
+
+// Tests for the @-less session-name resolution path introduced by issue #2112.
+//
+// Pre-#2112, repoFromSession was a pure string parser that returned an error
+// for any session name lacking an "@" separator. Host-mode non-git sessions
+// configured via ProjectIsolationOverrides (e.g. "obsidian" against
+// ~/Documents/obsidian) and their investigator children (e.g.
+// "obsidian~investigate-apis") are legitimate @-less names with valid DB
+// rows — but every host-API permission check that called repoFromSession
+// rejected them with a "session name contains no '@' — cannot derive repo"
+// parse error, making `prism checkin`, `prism prompt`, and related surfaces
+// unusable against them.
+//
+// The fix layers a DB lookup (via db.CurrentStatus) in front of the name-
+// parse path. When agent_status has a row for the session with a non-empty
+// repo column, that value is returned authoritatively. The name-parse path
+// remains as a fallback for pre-row state and pure-helper unit tests.
+//
+// # Negative-mutation guarantee
+//
+// Every test in this file is constructed so that reverting helpers.go::
+// repoFromSession to its pre-#2112 string-only form causes the test to FAIL:
+//
+//   - TestHostAPI_RepoFromSession_DBFallback:
+//       Asserts repoFromSession("obsidian", d) == "obsidian". Pre-fix code
+//       returns an error and an empty string; the assertion fails.
+//
+//   - TestHostAPI_AtlessSession_Checkin_Resolves:
+//       Asserts /checkin?session=obsidian returns 200. Pre-fix code returns
+//       400 with the parse error; the assertion fails.
+//
+//   - TestHostAPI_AtlessSession_Checkin_NotFound:
+//       Asserts /checkin against an unknown @-less name returns 404 with a
+//       "not found" body. Pre-fix code returns 400 with "contains no '@'";
+//       the assertion fails on both status code and body content.
+//
+//   - TestHostAPI_AtlessSession_Prompt_Resolves:
+//       Asserts /prompt with an @-less target succeeds. Pre-fix code returns
+//       400 ("invalid target session name"); the assertion fails.
+//
+//   - TestHostAPI_AtlessSession_CrossRepoWorker_403:
+//       Asserts that a coordinator in repo A cannot /checkin an @-less
+//       worker in repo B (the cross-repo permission check still fires).
+//       Pre-fix code returns 400 before reaching the permission check;
+//       the assertion that the code is 403 fails.
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// newSidecarWithSuccessStub constructs a Sidecar whose PrismBinaryPath points
+// at a shell script that always exits 0. Used by /prompt and other host-API
+// tests that need to pass through the permission gate without launching the
+// real prism binary.
+func newSidecarWithSuccessStub(t *testing.T, sessionName, repo, role string, d *db.DB) *Sidecar {
+	t.Helper()
+	stubPath := filepath.Join(t.TempDir(), "prism-stub-success")
+	stubScript := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write success stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     sessionName,
+		Repo:            repo,
+		Worktree:        "/tmp/" + sessionName,
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       role,
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	return New(cfg)
+}
+
+// ── Helper-level: repoFromSession with DB fallback ────────────────────────────
+
+// TestHostAPI_RepoFromSession_DBFallback covers AC: "@-less session with DB row
+// → resolves correctly". The helper is exercised directly so the assertion
+// pins the new behaviour at the smallest possible surface.
+//
+// Coverage matrix:
+//
+//	(a) @-less name + DB row with non-empty repo → returns DB repo.
+//	(b) @-less name + DB row with empty repo     → falls through to name parse,
+//	                                                which also fails → error.
+//	(c) @-less name + no DB row                  → name-parse fallback fires;
+//	                                                no '@' → error.
+//	(d) <repo>@<branch> name + no DB row         → name-parse fallback wins.
+//	(e) <repo>@<branch> name + DB row with diff  → DB authoritative; row wins.
+//	(f) nil DB                                   → pure name parse (legacy).
+func TestHostAPI_RepoFromSession_DBFallback(t *testing.T) {
+	d := openTestDB(t)
+
+	// Seed an @-less host-mode session: name "obsidian", repo "obsidian"
+	// (matching the production shape from ~/Documents/obsidian +
+	// ProjectIsolationOverrides).
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian", "obsidian", "/home/test/obsidian", "active",
+		nil, nil, "coordinator", "", "host",
+	); err != nil {
+		t.Fatalf("seed obsidian row: %v", err)
+	}
+
+	// Seed an @-bearing session whose DB repo intentionally differs from
+	// the name prefix, to prove the DB is authoritative.
+	if err := d.UpsertStatus(
+		"alias@main", "real-repo", "/home/test/real", "active", nil, nil,
+	); err != nil {
+		t.Fatalf("seed alias row: %v", err)
+	}
+
+	// (a) @-less name with valid DB row → DB wins.
+	got, err := repoFromSession("obsidian", d)
+	if err != nil {
+		t.Errorf("repoFromSession(\"obsidian\", d): unexpected error: %v", err)
+	}
+	if got != "obsidian" {
+		t.Errorf("repoFromSession(\"obsidian\", d) = %q, want \"obsidian\"", got)
+	}
+
+	// (b) @-less name with empty DB repo → fallback → error.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"empty-repo", "", "/tmp/empty", "active",
+		nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed empty-repo row: %v", err)
+	}
+	if _, err := repoFromSession("empty-repo", d); err == nil {
+		t.Errorf("repoFromSession(\"empty-repo\", d): expected error, got nil")
+	}
+
+	// (c) @-less name with no DB row → error with "not found".
+	_, err = repoFromSession("ghost", d)
+	if err == nil {
+		t.Errorf("repoFromSession(\"ghost\", d): expected error, got nil")
+	} else if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("repoFromSession(\"ghost\", d): error %q should mention \"not found\"", err.Error())
+	}
+
+	// (d) <repo>@<branch> name with no DB row → name parse wins.
+	got, err = repoFromSession("brand-new@feature", d)
+	if err != nil {
+		t.Errorf("repoFromSession(\"brand-new@feature\", d): unexpected error: %v", err)
+	}
+	if got != "brand-new" {
+		t.Errorf("repoFromSession(\"brand-new@feature\", d) = %q, want \"brand-new\"", got)
+	}
+
+	// (e) <repo>@<branch> name with DB row whose repo differs → DB wins.
+	got, err = repoFromSession("alias@main", d)
+	if err != nil {
+		t.Errorf("repoFromSession(\"alias@main\", d): unexpected error: %v", err)
+	}
+	if got != "real-repo" {
+		t.Errorf("repoFromSession(\"alias@main\", d) = %q, want \"real-repo\" (DB authoritative)", got)
+	}
+
+	// (f) nil DB → pure name parse.
+	got, err = repoFromSession("myrepo@main", nil)
+	if err != nil {
+		t.Errorf("repoFromSession(\"myrepo@main\", nil): unexpected error: %v", err)
+	}
+	if got != "myrepo" {
+		t.Errorf("repoFromSession(\"myrepo@main\", nil) = %q, want \"myrepo\"", got)
+	}
+	if _, err := repoFromSession("obsidian", nil); err == nil {
+		t.Errorf("repoFromSession(\"obsidian\", nil): expected error (no DB, no '@'), got nil")
+	}
+
+	// Sanity: isCoordinatorSession still recognises the @-less obsidian row
+	// as a coordinator via root_agent_name. Pre-#2112 this could only be
+	// reached if the caller manually checked the DB; the @-less target check
+	// now folds in transparently.
+	if !isCoordinatorSession("obsidian", d, log.Default()) {
+		t.Error("isCoordinatorSession(\"obsidian\", d): got false, want true (root_agent_name=coordinator)")
+	}
+}
+
+// ── End-to-end: host-API surface ──────────────────────────────────────────────
+
+// TestHostAPI_AtlessSession_Checkin_Resolves covers AC: "prism checkin <name>
+// succeeds for an @-less session name when a row exists". The handler is
+// driven through the public mux so that the call-site update in host_api.go
+// is also pinned (a regression that touched only helpers.go but missed the
+// call-site sweep would still fail here because the handler would still
+// reject the target via the per-handler repoFromSession parse error).
+func TestHostAPI_AtlessSession_Checkin_Resolves(t *testing.T) {
+	d := openTestDB(t)
+
+	// Seed a coordinator caller in repo "nixos-config".
+	if err := d.UpsertStatusSeedRootAgentName(
+		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		"active", nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	// Seed the @-less obsidian target as a coordinator in its own repo.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian", "obsidian", "/tmp/obsidian",
+		"active", nil, nil, "coordinator", "", "host",
+	); err != nil {
+		t.Fatalf("seed obsidian: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s, want 200 for @-less target with DB row", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	decodeJSONBody(t, rr, &resp)
+	if resp["session"] != "obsidian" {
+		t.Errorf("response session = %v, want \"obsidian\"", resp["session"])
+	}
+	if _, ok := resp["events"]; !ok {
+		t.Errorf("response missing \"events\" key: %v", resp)
+	}
+}
+
+// TestHostAPI_AtlessSession_Checkin_InvestigatorShape covers the descendant
+// naming pattern from the issue: `obsidian~investigate-apis`. The DB row is
+// what makes this resolvable; the name shape alone is ambiguous (it has no
+// '@' and isn't a literal repo name).
+func TestHostAPI_AtlessSession_Checkin_InvestigatorShape(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatusSeedRootAgentName(
+		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		"active", nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	// Investigator inherits the @-less parent's shape. The DB row keeps
+	// repo=obsidian even though the session name embeds a "~investigate-"
+	// suffix. The cross-repo permission check folds in via repoFromSession's
+	// DB lookup, so this target counts as same-repo to a coordinator in
+	// repo "obsidian" but cross-repo non-coordinator to other coordinators.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian~investigate-apis", "obsidian", "/tmp/obsidian-inv",
+		"active", nil, nil, "worker", "", "host",
+	); err != nil {
+		t.Fatalf("seed investigator: %v", err)
+	}
+
+	// Same-coordinator-repo caller: the obsidian coordinator can reach its
+	// own investigator. Seed an obsidian coordinator and drive from there.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian", "obsidian", "/tmp/obsidian",
+		"active", nil, nil, "coordinator", "", "host",
+	); err != nil {
+		t.Fatalf("seed obsidian: %v", err)
+	}
+	sc := newSidecarWithRole(t, "obsidian", "obsidian", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian~investigate-apis", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s, want 200 for @-less investigator target", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_AtlessSession_Checkin_NotFound covers AC: "prism checkin
+// <unknown-name> (no DB row, name has no '@') returns a clear error naming
+// the unknown session, not a 'cannot derive repo' parse error".
+//
+// The handler now returns 404 ("not found") for this case so the CLI can
+// surface the canonical not-found error. The body must contain "not found"
+// — the substring check pins the new error-message shape and would fail
+// against the pre-fix "contains no '@'" message even if the status code
+// were lenient.
+func TestHostAPI_AtlessSession_Checkin_NotFound(t *testing.T) {
+	d := openTestDB(t)
+	if err := d.UpsertStatusSeedRootAgentName(
+		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		"active", nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=ghost-session", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for unknown @-less target", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	msg := errResp["error"]
+	if !strings.Contains(msg, "not found") {
+		t.Errorf("error %q should mention \"not found\" (canonical shape post-#2112)", msg)
+	}
+	// Negative-mutation guard: must NOT match the pre-fix error shape.
+	if strings.Contains(msg, "cannot derive repo") || strings.Contains(msg, "contains no '@'") {
+		t.Errorf("error %q must not contain the pre-#2112 parse-error phrase", msg)
+	}
+	// The error message must name the unknown session so the operator can act.
+	if !strings.Contains(msg, "ghost-session") {
+		t.Errorf("error %q should name the unknown session \"ghost-session\"", msg)
+	}
+}
+
+// TestHostAPI_AtlessSession_Prompt_Resolves covers AC: "prism prompt <name>
+// succeeds for an @-less session name with a DB row". The /prompt handler
+// is fan-tested through a stub binary so the cross-session permission and
+// resolution paths are exercised without a real prism binary.
+func TestHostAPI_AtlessSession_Prompt_Resolves(t *testing.T) {
+	d := openTestDB(t)
+	if err := d.UpsertStatusSeedRootAgentName(
+		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		"active", nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	// @-less target as a coordinator in its own repo — coordinators can
+	// cross-repo prompt other coordinators, so this is the permission shape
+	// to exercise.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian", "obsidian", "/tmp/obsidian",
+		"active", nil, nil, "coordinator", "", "host",
+	); err != nil {
+		t.Fatalf("seed obsidian: %v", err)
+	}
+
+	sc := newSidecarWithSuccessStub(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
+		`{"session":"obsidian","prompt":"hello"}`)
+
+	// Pre-fix: 400 ("invalid target session name: ... contains no '@'").
+	// Post-fix: 200 (prism prompt stub succeeds; the cross-repo @-less
+	// target is allowed because it is a coordinator).
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s, want 200 for @-less coordinator target", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_AtlessSession_CrossRepoWorker_403 covers AC: "an @-less worker
+// session in another repo cannot be reached via prism checkin from a
+// coordinator in this repo — the cross-repo permission check still blocks
+// non-coordinator targets even when the target name lacks '@'".
+//
+// This is the security-property test. Pre-fix, the handler returned 400 at
+// the repoFromSession parse step, never reaching the cross-repo branch. The
+// test asserts 403 so:
+//
+//   - Pre-fix code (returns 400) fails this assertion → negative-mutation guard.
+//   - Post-fix code without the cross-repo permission check (a bug in the new
+//     code path) would return 200 → also fails this assertion.
+//
+// Both regressions are caught by the same test.
+func TestHostAPI_AtlessSession_CrossRepoWorker_403(t *testing.T) {
+	d := openTestDB(t)
+
+	// Caller: coordinator in repo "nixos-config".
+	if err := d.UpsertStatusSeedRootAgentName(
+		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		"active", nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	// Target: @-less worker in repo "obsidian" (different repo, not a
+	// coordinator). The DB-fallback path resolves its repo to "obsidian"
+	// via agent_status.repo, the cross-repo check fires, and the
+	// isCoordinatorSession check returns false (root_agent_name="worker"
+	// and the name doesn't end in "@main") → 403.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian-bg-task", "obsidian", "/tmp/obsidian-bg",
+		"active", nil, nil, "worker", "", "host",
+	); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian-bg-task", "")
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 for cross-repo @-less non-coordinator target (cross-repo permission check must fire)", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "cross-repo") {
+		t.Errorf("error %q should mention \"cross-repo\"", errResp["error"])
+	}
+}
+
+// TestHostAPI_AtlessSession_OwnRepoWorker_OK covers the positive side of the
+// same security property: a coordinator CAN reach an @-less worker in its
+// OWN repo. This pins the same-repo branch of the permission decision.
+func TestHostAPI_AtlessSession_OwnRepoWorker_OK(t *testing.T) {
+	d := openTestDB(t)
+
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian", "obsidian", "/tmp/obsidian",
+		"active", nil, nil, "coordinator", "", "host",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	if err := d.UpsertStatusSeedRootAgentName(
+		"obsidian~investigate-apis", "obsidian", "/tmp/obsidian-inv",
+		"active", nil, nil, "worker", "", "host",
+	); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "obsidian", "obsidian", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian~investigate-apis", "")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for same-repo @-less worker target", rr.Code)
+	}
+}
+
+// TestHostAPI_AtlessSession_BackwardsCompat covers AC: "prism checkin <name>
+// for a <repo>@<branch> session continues to work unchanged — no regression
+// in the existing happy path".
+func TestHostAPI_AtlessSession_BackwardsCompat(t *testing.T) {
+	d := openTestDB(t)
+	if err := d.UpsertStatusSeedRootAgentName(
+		"myrepo@main", "myrepo", "/tmp/myrepo",
+		"active", nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+	if err := d.UpsertStatusSeedRootAgentName(
+		"myrepo@feature", "myrepo", "/tmp/myrepo-feature",
+		"active", nil, nil, "worker", "", "",
+	); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@feature", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for same-repo @-bearing worker target", rr.Code)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api_atless_session_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_atless_session_test.go
@@ -2,33 +2,50 @@ package sidecar
 
 // Tests for the @-less session-name resolution path introduced by issue #2112.
 //
-// Pre-#2112, repoFromSession was a pure string parser that returned an error
-// for any session name lacking an "@" separator. Host-mode non-git sessions
-// configured via ProjectIsolationOverrides (e.g. "obsidian" against
-// ~/Documents/obsidian) and their investigator children (e.g.
-// "obsidian~investigate-apis") are legitimate @-less names with valid DB
-// rows — but every host-API permission check that called repoFromSession
-// rejected them with a "session name contains no '@' — cannot derive repo"
-// parse error, making `prism checkin`, `prism prompt`, and related surfaces
-// unusable against them.
+// # Isolation contract
 //
-// The fix layers a DB lookup (via db.CurrentStatus) in front of the name-
-// parse path. When agent_status has a row for the session with a non-empty
-// repo column, that value is returned authoritatively. The name-parse path
-// remains as a fallback for pre-row state and pure-helper unit tests.
+// Every test in this file routes Sidecar construction through
+// sidecartest.NewIsolated(t, ...) so that:
+//   - XDG_STATE_HOME points at a t.TempDir(); host paths never escape the
+//     test sandbox.
+//   - PRISM_TEST_MODE_RESTRICT_HOSTAPI=1 prevents promptdelivery from
+//     dialling a real host socket.
+//   - The DB is an isolated SQLite file in a private MkdirTemp dir.
+//
+// Fixture session names use the discipline from #2112:
+//   - @-bearing sessions   → "prism-test@<descriptor>"
+//   - @-less host-mode sessions → "prism-test-<descriptor>"
+//   - investigator descendants → "prism-test-<descriptor>~investigate-<slug>"
+//
+// Crucially, NO test uses a real production session name (e.g.
+// "nixos-config@main") or a real ProjectIsolationOverrides slug
+// ("obsidian", "obsidian~investigate-apis"). The fixture shape mirrors
+// production without colliding with any live coordinator on the developer's
+// host — see the sidecartest package doc and AC #9 of issue #2112.
+//
+// # Why @-less fixtures still drive the regression test
+//
+// The production failure mode is name-shape, not name-value. A fixture named
+// "prism-test-obsidianlike" lacks an "@" separator in the exact same way
+// that "obsidian" does, and therefore trips the pre-#2112 string-parser in
+// the exact same way. The negative-mutation re-runs (see commit message of
+// the original PR) verified this directly: every test in this file FAILS
+// when helpers.go::repoFromSession is reverted to its pre-fix body, with
+// the expected "contains no '@'" error shape.
 //
 // # Negative-mutation guarantee
 //
-// Every test in this file is constructed so that reverting helpers.go::
-// repoFromSession to its pre-#2112 string-only form causes the test to FAIL:
+// Every test is constructed so that reverting helpers.go::repoFromSession to
+// its pre-#2112 string-only form causes the test to FAIL:
 //
 //   - TestHostAPI_RepoFromSession_DBFallback:
-//       Asserts repoFromSession("obsidian", d) == "obsidian". Pre-fix code
-//       returns an error and an empty string; the assertion fails.
+//       Asserts repoFromSession("prism-test-obsidianlike", d) ==
+//       "prism-test-obsidianlike". Pre-fix code returns an error and an
+//       empty string; the assertion fails.
 //
 //   - TestHostAPI_AtlessSession_Checkin_Resolves:
-//       Asserts /checkin?session=obsidian returns 200. Pre-fix code returns
-//       400 with the parse error; the assertion fails.
+//       Asserts /checkin against an @-less target returns 200. Pre-fix code
+//       returns 400 ("contains no '@'"); the assertion fails.
 //
 //   - TestHostAPI_AtlessSession_Checkin_NotFound:
 //       Asserts /checkin against an unknown @-less name returns 404 with a
@@ -44,6 +61,11 @@ package sidecar
 //       worker in repo B (the cross-repo permission check still fires).
 //       Pre-fix code returns 400 before reaching the permission check;
 //       the assertion that the code is 403 fails.
+//
+//   - TestHostAPI_AtlessSession_Spawn_Resolves:
+//       Asserts /spawn succeeds when the sidecar's own session has an
+//       @-less name. Pre-fix code returns 500 ("cannot derive repo") at
+//       the own-repo derivation step; the assertion fails.
 
 import (
 	"log"
@@ -54,32 +76,87 @@ import (
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
 )
 
-// newSidecarWithSuccessStub constructs a Sidecar whose PrismBinaryPath points
-// at a shell script that always exits 0. Used by /prompt and other host-API
-// tests that need to pass through the permission gate without launching the
-// real prism binary.
-func newSidecarWithSuccessStub(t *testing.T, sessionName, repo, role string, d *db.DB) *Sidecar {
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+// newAtlessIsolatedSidecar constructs an isolated Sidecar+DB for an @-less
+// session-name test. It routes through sidecartest.NewIsolated so that
+// XDG_STATE_HOME is redirected to a tempdir and the
+// PRISM_TEST_MODE_RESTRICT_HOSTAPI guard is set — closing both isolation
+// gaps surfaced by review-goal on the first round of #2112 review.
+//
+// The bus's DB is returned so the caller can seed any additional fixture
+// rows (caller-coordinator, target-worker, etc.) needed by the test.
+func newAtlessIsolatedSidecar(t *testing.T, sessionName, repo, role string) (*Sidecar, *db.DB) {
+	t.Helper()
+	bus := sidecartest.NewIsolated(t, "")
+	clk := newTestClock()
+	cfg := Config{
+		SessionName: sessionName,
+		Repo:        repo,
+		Worktree:    "/tmp/" + sessionName,
+		HarnessURL:  "http://localhost:14000",
+		DB:          bus.DB,
+		Clock:       clk,
+		AgentRole:   role,
+		Harness:     newSSEHarness(),
+	}
+	return New(cfg), bus.DB
+}
+
+// newAtlessIsolatedSidecarWithStub is the success-stub variant: it points
+// PrismBinaryPath at a shell script that exits 0, so handlers that shell
+// out (`/prompt`, `/spawn`) succeed past the permission gate without
+// launching the real prism binary. Isolation contract identical to
+// newAtlessIsolatedSidecar.
+func newAtlessIsolatedSidecarWithStub(t *testing.T, sessionName, repo, role string) (*Sidecar, *db.DB) {
 	t.Helper()
 	stubPath := filepath.Join(t.TempDir(), "prism-stub-success")
-	stubScript := "#!/bin/sh\nexit 0\n"
-	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatalf("write success stub: %v", err)
 	}
+	bus := sidecartest.NewIsolated(t, "")
 	clk := newTestClock()
 	cfg := Config{
 		SessionName:     sessionName,
 		Repo:            repo,
 		Worktree:        "/tmp/" + sessionName,
 		HarnessURL:      "http://localhost:14000",
-		DB:              d,
+		DB:              bus.DB,
 		Clock:           clk,
 		AgentRole:       role,
 		PrismBinaryPath: stubPath,
 		Harness:         newSSEHarness(),
 	}
-	return New(cfg)
+	return New(cfg), bus.DB
+}
+
+// newAtlessIsolatedSidecarWithSpawnStub returns a Sidecar whose stub binary
+// echoes a synthetic `session "<name>" created` line so /spawn's session-name
+// parser produces a deterministic value. Used by the /spawn happy-path test.
+func newAtlessIsolatedSidecarWithSpawnStub(t *testing.T, sessionName, repo, role, spawnedName string) (*Sidecar, *db.DB) {
+	t.Helper()
+	stubPath := filepath.Join(t.TempDir(), "prism-stub-spawn")
+	script := "#!/bin/sh\necho 'session \"" + spawnedName + "\" created'\n"
+	if err := os.WriteFile(stubPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write spawn stub: %v", err)
+	}
+	bus := sidecartest.NewIsolated(t, "")
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     sessionName,
+		Repo:            repo,
+		Worktree:        "/tmp/" + sessionName,
+		HarnessURL:      "http://localhost:14000",
+		DB:              bus.DB,
+		Clock:           clk,
+		AgentRole:       role,
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	return New(cfg), bus.DB
 }
 
 // ── Helper-level: repoFromSession with DB fallback ────────────────────────────
@@ -99,129 +176,138 @@ func newSidecarWithSuccessStub(t *testing.T, sessionName, repo, role string, d *
 //	(e) <repo>@<branch> name + DB row with diff  → DB authoritative; row wins.
 //	(f) nil DB                                   → pure name parse (legacy).
 func TestHostAPI_RepoFromSession_DBFallback(t *testing.T) {
-	d := openTestDB(t)
+	// Even the helper-level test routes through sidecartest.NewIsolated so
+	// the isolation contract is enforced uniformly. No Sidecar is needed
+	// here — only the bus's isolated DB.
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
 
-	// Seed an @-less host-mode session: name "obsidian", repo "obsidian"
-	// (matching the production shape from ~/Documents/obsidian +
-	// ProjectIsolationOverrides).
+	// Seed an @-less host-mode session: name "prism-test-obsidianlike",
+	// repo "prism-test-obsidianlike" (mirrors the production shape from
+	// `obsidian` against ~/Documents/obsidian without using the literal
+	// production name).
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian", "obsidian", "/home/test/obsidian", "active",
+		"prism-test-obsidianlike", "prism-test-obsidianlike",
+		"/tmp/prism-test-obsidianlike", "active",
 		nil, nil, "coordinator", "", "host",
 	); err != nil {
-		t.Fatalf("seed obsidian row: %v", err)
+		t.Fatalf("seed obsidian-like row: %v", err)
 	}
 
 	// Seed an @-bearing session whose DB repo intentionally differs from
 	// the name prefix, to prove the DB is authoritative.
 	if err := d.UpsertStatus(
-		"alias@main", "real-repo", "/home/test/real", "active", nil, nil,
+		"prism-test@alias-main", "prism-test-real-repo",
+		"/tmp/prism-test-real", "active", nil, nil,
 	); err != nil {
 		t.Fatalf("seed alias row: %v", err)
 	}
 
 	// (a) @-less name with valid DB row → DB wins.
-	got, err := repoFromSession("obsidian", d)
+	got, err := repoFromSession("prism-test-obsidianlike", d)
 	if err != nil {
-		t.Errorf("repoFromSession(\"obsidian\", d): unexpected error: %v", err)
+		t.Errorf("repoFromSession(\"prism-test-obsidianlike\", d): unexpected error: %v", err)
 	}
-	if got != "obsidian" {
-		t.Errorf("repoFromSession(\"obsidian\", d) = %q, want \"obsidian\"", got)
+	if got != "prism-test-obsidianlike" {
+		t.Errorf("repoFromSession(\"prism-test-obsidianlike\", d) = %q, want \"prism-test-obsidianlike\"", got)
 	}
 
 	// (b) @-less name with empty DB repo → fallback → error.
 	if err := d.UpsertStatusSeedRootAgentName(
-		"empty-repo", "", "/tmp/empty", "active",
+		"prism-test-empty-repo", "", "/tmp/prism-test-empty", "active",
 		nil, nil, "coordinator", "", "",
 	); err != nil {
 		t.Fatalf("seed empty-repo row: %v", err)
 	}
-	if _, err := repoFromSession("empty-repo", d); err == nil {
-		t.Errorf("repoFromSession(\"empty-repo\", d): expected error, got nil")
+	if _, err := repoFromSession("prism-test-empty-repo", d); err == nil {
+		t.Errorf("repoFromSession(\"prism-test-empty-repo\", d): expected error, got nil")
 	}
 
 	// (c) @-less name with no DB row → error with "not found".
-	_, err = repoFromSession("ghost", d)
+	_, err = repoFromSession("prism-test-ghost", d)
 	if err == nil {
-		t.Errorf("repoFromSession(\"ghost\", d): expected error, got nil")
+		t.Errorf("repoFromSession(\"prism-test-ghost\", d): expected error, got nil")
 	} else if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("repoFromSession(\"ghost\", d): error %q should mention \"not found\"", err.Error())
+		t.Errorf("repoFromSession(\"prism-test-ghost\", d): error %q should mention \"not found\"", err.Error())
 	}
 
 	// (d) <repo>@<branch> name with no DB row → name parse wins.
-	got, err = repoFromSession("brand-new@feature", d)
+	got, err = repoFromSession("prism-test@brand-new-feature", d)
 	if err != nil {
-		t.Errorf("repoFromSession(\"brand-new@feature\", d): unexpected error: %v", err)
+		t.Errorf("repoFromSession(\"prism-test@brand-new-feature\", d): unexpected error: %v", err)
 	}
-	if got != "brand-new" {
-		t.Errorf("repoFromSession(\"brand-new@feature\", d) = %q, want \"brand-new\"", got)
+	if got != "prism-test" {
+		t.Errorf("repoFromSession(\"prism-test@brand-new-feature\", d) = %q, want \"prism-test\"", got)
 	}
 
 	// (e) <repo>@<branch> name with DB row whose repo differs → DB wins.
-	got, err = repoFromSession("alias@main", d)
+	got, err = repoFromSession("prism-test@alias-main", d)
 	if err != nil {
-		t.Errorf("repoFromSession(\"alias@main\", d): unexpected error: %v", err)
+		t.Errorf("repoFromSession(\"prism-test@alias-main\", d): unexpected error: %v", err)
 	}
-	if got != "real-repo" {
-		t.Errorf("repoFromSession(\"alias@main\", d) = %q, want \"real-repo\" (DB authoritative)", got)
+	if got != "prism-test-real-repo" {
+		t.Errorf("repoFromSession(\"prism-test@alias-main\", d) = %q, want \"prism-test-real-repo\" (DB authoritative)", got)
 	}
 
 	// (f) nil DB → pure name parse.
-	got, err = repoFromSession("myrepo@main", nil)
+	got, err = repoFromSession("prism-test@myrepo-main", nil)
 	if err != nil {
-		t.Errorf("repoFromSession(\"myrepo@main\", nil): unexpected error: %v", err)
+		t.Errorf("repoFromSession(\"prism-test@myrepo-main\", nil): unexpected error: %v", err)
 	}
-	if got != "myrepo" {
-		t.Errorf("repoFromSession(\"myrepo@main\", nil) = %q, want \"myrepo\"", got)
+	if got != "prism-test" {
+		t.Errorf("repoFromSession(\"prism-test@myrepo-main\", nil) = %q, want \"prism-test\"", got)
 	}
-	if _, err := repoFromSession("obsidian", nil); err == nil {
-		t.Errorf("repoFromSession(\"obsidian\", nil): expected error (no DB, no '@'), got nil")
+	if _, err := repoFromSession("prism-test-obsidianlike", nil); err == nil {
+		t.Errorf("repoFromSession(\"prism-test-obsidianlike\", nil): expected error (no DB, no '@'), got nil")
 	}
 
-	// Sanity: isCoordinatorSession still recognises the @-less obsidian row
-	// as a coordinator via root_agent_name. Pre-#2112 this could only be
-	// reached if the caller manually checked the DB; the @-less target check
-	// now folds in transparently.
-	if !isCoordinatorSession("obsidian", d, log.Default()) {
-		t.Error("isCoordinatorSession(\"obsidian\", d): got false, want true (root_agent_name=coordinator)")
+	// Sanity: isCoordinatorSession still recognises the @-less row as a
+	// coordinator via root_agent_name. The cross-repo permission check
+	// path depends on this composition working post-#2112.
+	if !isCoordinatorSession("prism-test-obsidianlike", d, log.Default()) {
+		t.Error("isCoordinatorSession(\"prism-test-obsidianlike\", d): got false, want true (root_agent_name=coordinator)")
 	}
 }
 
 // ── End-to-end: host-API surface ──────────────────────────────────────────────
 
 // TestHostAPI_AtlessSession_Checkin_Resolves covers AC: "prism checkin <name>
-// succeeds for an @-less session name when a row exists". The handler is
-// driven through the public mux so that the call-site update in host_api.go
-// is also pinned (a regression that touched only helpers.go but missed the
-// call-site sweep would still fail here because the handler would still
-// reject the target via the per-handler repoFromSession parse error).
+// succeeds for an @-less session name when a row exists". Driven through the
+// public mux so that the call-site update in host_api.go is also pinned (a
+// regression that touched only helpers.go but missed the call-site sweep
+// would still fail here because the handler would still reject the target
+// via the per-handler repoFromSession parse error).
 func TestHostAPI_AtlessSession_Checkin_Resolves(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller = "prism-test@coord-checkin"
+		target = "prism-test-obsidianlike"
+	)
+	sc, d := newAtlessIsolatedSidecar(t, caller, "prism-test-coord-checkin", "coordinator")
 
-	// Seed a coordinator caller in repo "nixos-config".
+	// Seed the caller as a coordinator (DB-backed coordinator check uses
+	// root_agent_name).
 	if err := d.UpsertStatusSeedRootAgentName(
-		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		caller, "prism-test-coord-checkin", "/tmp/"+caller,
 		"active", nil, nil, "coordinator", "", "",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
 	}
-	// Seed the @-less obsidian target as a coordinator in its own repo.
+	// Seed the @-less target as a coordinator in its own repo.
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian", "obsidian", "/tmp/obsidian",
+		target, target, "/tmp/"+target,
 		"active", nil, nil, "coordinator", "", "host",
 	); err != nil {
-		t.Fatalf("seed obsidian: %v", err)
+		t.Fatalf("seed target: %v", err)
 	}
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
-	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian", "")
-
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session="+target, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s, want 200 for @-less target with DB row", rr.Code, rr.Body.String())
 	}
 	var resp map[string]any
 	decodeJSONBody(t, rr, &resp)
-	if resp["session"] != "obsidian" {
-		t.Errorf("response session = %v, want \"obsidian\"", resp["session"])
+	if resp["session"] != target {
+		t.Errorf("response session = %v, want %q", resp["session"], target)
 	}
 	if _, ok := resp["events"]; !ok {
 		t.Errorf("response missing \"events\" key: %v", resp)
@@ -229,40 +315,37 @@ func TestHostAPI_AtlessSession_Checkin_Resolves(t *testing.T) {
 }
 
 // TestHostAPI_AtlessSession_Checkin_InvestigatorShape covers the descendant
-// naming pattern from the issue: `obsidian~investigate-apis`. The DB row is
-// what makes this resolvable; the name shape alone is ambiguous (it has no
-// '@' and isn't a literal repo name).
+// naming pattern from the issue: `<host-mode-parent>~investigate-<slug>`.
+// The DB row is what makes this resolvable; the name shape alone is
+// ambiguous (no '@', not a literal repo name).
 func TestHostAPI_AtlessSession_Checkin_InvestigatorShape(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller       = "prism-test-obsidianlike"
+		investigator = "prism-test-obsidianlike~investigate-apis"
+		repo         = "prism-test-obsidianlike"
+	)
+	// Caller is the @-less coordinator itself — only same-repo callers
+	// can reach a worker target (the cross-repo permission check forbids
+	// non-coordinator cross-repo targets).
+	sc, d := newAtlessIsolatedSidecar(t, caller, repo, "coordinator")
 
 	if err := d.UpsertStatusSeedRootAgentName(
-		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
-		"active", nil, nil, "coordinator", "", "",
+		caller, repo, "/tmp/"+caller,
+		"active", nil, nil, "coordinator", "", "host",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
 	}
 	// Investigator inherits the @-less parent's shape. The DB row keeps
-	// repo=obsidian even though the session name embeds a "~investigate-"
-	// suffix. The cross-repo permission check folds in via repoFromSession's
-	// DB lookup, so this target counts as same-repo to a coordinator in
-	// repo "obsidian" but cross-repo non-coordinator to other coordinators.
+	// repo=<parent-repo> even though the session name embeds a
+	// "~investigate-" suffix. Pre-#2112 the parse path failed here too.
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian~investigate-apis", "obsidian", "/tmp/obsidian-inv",
+		investigator, repo, "/tmp/"+investigator,
 		"active", nil, nil, "worker", "", "host",
 	); err != nil {
 		t.Fatalf("seed investigator: %v", err)
 	}
 
-	// Same-coordinator-repo caller: the obsidian coordinator can reach its
-	// own investigator. Seed an obsidian coordinator and drive from there.
-	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian", "obsidian", "/tmp/obsidian",
-		"active", nil, nil, "coordinator", "", "host",
-	); err != nil {
-		t.Fatalf("seed obsidian: %v", err)
-	}
-	sc := newSidecarWithRole(t, "obsidian", "obsidian", "coordinator", d)
-	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian~investigate-apis", "")
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session="+investigator, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s, want 200 for @-less investigator target", rr.Code, rr.Body.String())
 	}
@@ -272,22 +355,26 @@ func TestHostAPI_AtlessSession_Checkin_InvestigatorShape(t *testing.T) {
 // <unknown-name> (no DB row, name has no '@') returns a clear error naming
 // the unknown session, not a 'cannot derive repo' parse error".
 //
-// The handler now returns 404 ("not found") for this case so the CLI can
-// surface the canonical not-found error. The body must contain "not found"
-// — the substring check pins the new error-message shape and would fail
+// The handler now returns 404 ("target session ... not found") for this
+// case so the CLI can surface the canonical not-found error. The body
+// substring assertions pin the new error-message shape and would fail
 // against the pre-fix "contains no '@'" message even if the status code
 // were lenient.
 func TestHostAPI_AtlessSession_Checkin_NotFound(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller = "prism-test@coord-notfound"
+		repo   = "prism-test-notfound"
+		ghost  = "prism-test-ghost"
+	)
+	sc, d := newAtlessIsolatedSidecar(t, caller, repo, "coordinator")
 	if err := d.UpsertStatusSeedRootAgentName(
-		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		caller, repo, "/tmp/"+caller,
 		"active", nil, nil, "coordinator", "", "",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
 	}
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
 
-	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=ghost-session", "")
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session="+ghost, "")
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404 for unknown @-less target", rr.Code)
 	}
@@ -302,19 +389,25 @@ func TestHostAPI_AtlessSession_Checkin_NotFound(t *testing.T) {
 		t.Errorf("error %q must not contain the pre-#2112 parse-error phrase", msg)
 	}
 	// The error message must name the unknown session so the operator can act.
-	if !strings.Contains(msg, "ghost-session") {
-		t.Errorf("error %q should name the unknown session \"ghost-session\"", msg)
+	if !strings.Contains(msg, ghost) {
+		t.Errorf("error %q should name the unknown session %q", msg, ghost)
 	}
 }
 
 // TestHostAPI_AtlessSession_Prompt_Resolves covers AC: "prism prompt <name>
-// succeeds for an @-less session name with a DB row". The /prompt handler
-// is fan-tested through a stub binary so the cross-session permission and
-// resolution paths are exercised without a real prism binary.
+// succeeds for an @-less session name with a DB row". The /prompt handler is
+// fan-tested through a success stub so the cross-session permission and
+// resolution paths are exercised without launching the real prism binary.
 func TestHostAPI_AtlessSession_Prompt_Resolves(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller = "prism-test@coord-prompt"
+		repo   = "prism-test-coord-prompt"
+		target = "prism-test-obsidianlike"
+	)
+	sc, d := newAtlessIsolatedSidecarWithStub(t, caller, repo, "coordinator")
+
 	if err := d.UpsertStatusSeedRootAgentName(
-		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		caller, repo, "/tmp/"+caller,
 		"active", nil, nil, "coordinator", "", "",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
@@ -323,19 +416,18 @@ func TestHostAPI_AtlessSession_Prompt_Resolves(t *testing.T) {
 	// cross-repo prompt other coordinators, so this is the permission shape
 	// to exercise.
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian", "obsidian", "/tmp/obsidian",
+		target, target, "/tmp/"+target,
 		"active", nil, nil, "coordinator", "", "host",
 	); err != nil {
-		t.Fatalf("seed obsidian: %v", err)
+		t.Fatalf("seed target: %v", err)
 	}
 
-	sc := newSidecarWithSuccessStub(t, "nixos-config@main", "nixos-config", "coordinator", d)
 	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
-		`{"session":"obsidian","prompt":"hello"}`)
+		`{"session":"`+target+`","prompt":"hello"}`)
 
 	// Pre-fix: 400 ("invalid target session name: ... contains no '@'").
 	// Post-fix: 200 (prism prompt stub succeeds; the cross-repo @-less
-	// target is allowed because it is a coordinator).
+	// coordinator target is allowed).
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s, want 200 for @-less coordinator target", rr.Code, rr.Body.String())
 	}
@@ -351,35 +443,37 @@ func TestHostAPI_AtlessSession_Prompt_Resolves(t *testing.T) {
 // test asserts 403 so:
 //
 //   - Pre-fix code (returns 400) fails this assertion → negative-mutation guard.
-//   - Post-fix code without the cross-repo permission check (a bug in the new
-//     code path) would return 200 → also fails this assertion.
+//   - Post-fix code without the cross-repo permission check (a regression in
+//     the new code path) would return 200 → also fails this assertion.
 //
 // Both regressions are caught by the same test.
 func TestHostAPI_AtlessSession_CrossRepoWorker_403(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller       = "prism-test@coord-crossrepo"
+		callerRepo   = "prism-test-coord-crossrepo"
+		targetWorker = "prism-test-otherrepolike-bg-task"
+		targetRepo   = "prism-test-otherrepolike"
+	)
+	sc, d := newAtlessIsolatedSidecar(t, caller, callerRepo, "coordinator")
 
-	// Caller: coordinator in repo "nixos-config".
 	if err := d.UpsertStatusSeedRootAgentName(
-		"nixos-config@main", "nixos-config", "/tmp/nixos-config",
+		caller, callerRepo, "/tmp/"+caller,
 		"active", nil, nil, "coordinator", "", "",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
 	}
-	// Target: @-less worker in repo "obsidian" (different repo, not a
-	// coordinator). The DB-fallback path resolves its repo to "obsidian"
-	// via agent_status.repo, the cross-repo check fires, and the
-	// isCoordinatorSession check returns false (root_agent_name="worker"
-	// and the name doesn't end in "@main") → 403.
+	// Target: @-less worker in a different repo (not a coordinator). The
+	// DB-fallback path resolves its repo via agent_status.repo, the cross-
+	// repo check fires, and isCoordinatorSession returns false
+	// (root_agent_name="worker" and the name doesn't end in "@main") → 403.
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian-bg-task", "obsidian", "/tmp/obsidian-bg",
+		targetWorker, targetRepo, "/tmp/"+targetWorker,
 		"active", nil, nil, "worker", "", "host",
 	); err != nil {
 		t.Fatalf("seed target: %v", err)
 	}
 
-	sc := newSidecarWithRole(t, "nixos-config@main", "nixos-config", "coordinator", d)
-	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian-bg-task", "")
-
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session="+targetWorker, "")
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403 for cross-repo @-less non-coordinator target (cross-repo permission check must fire)", rr.Code)
 	}
@@ -394,24 +488,27 @@ func TestHostAPI_AtlessSession_CrossRepoWorker_403(t *testing.T) {
 // same security property: a coordinator CAN reach an @-less worker in its
 // OWN repo. This pins the same-repo branch of the permission decision.
 func TestHostAPI_AtlessSession_OwnRepoWorker_OK(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller = "prism-test-obsidianlike"
+		repo   = "prism-test-obsidianlike"
+		target = "prism-test-obsidianlike~investigate-apis"
+	)
+	sc, d := newAtlessIsolatedSidecar(t, caller, repo, "coordinator")
 
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian", "obsidian", "/tmp/obsidian",
+		caller, repo, "/tmp/"+caller,
 		"active", nil, nil, "coordinator", "", "host",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
 	}
 	if err := d.UpsertStatusSeedRootAgentName(
-		"obsidian~investigate-apis", "obsidian", "/tmp/obsidian-inv",
+		target, repo, "/tmp/"+target,
 		"active", nil, nil, "worker", "", "host",
 	); err != nil {
 		t.Fatalf("seed target: %v", err)
 	}
 
-	sc := newSidecarWithRole(t, "obsidian", "obsidian", "coordinator", d)
-	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=obsidian~investigate-apis", "")
-
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session="+target, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 for same-repo @-less worker target", rr.Code)
 	}
@@ -421,23 +518,61 @@ func TestHostAPI_AtlessSession_OwnRepoWorker_OK(t *testing.T) {
 // for a <repo>@<branch> session continues to work unchanged — no regression
 // in the existing happy path".
 func TestHostAPI_AtlessSession_BackwardsCompat(t *testing.T) {
-	d := openTestDB(t)
+	const (
+		caller = "prism-test@coord-backcompat"
+		repo   = "prism-test-backcompat"
+		target = "prism-test@worker-backcompat"
+	)
+	sc, d := newAtlessIsolatedSidecar(t, caller, repo, "coordinator")
+
 	if err := d.UpsertStatusSeedRootAgentName(
-		"myrepo@main", "myrepo", "/tmp/myrepo",
+		caller, repo, "/tmp/"+caller,
 		"active", nil, nil, "coordinator", "", "",
 	); err != nil {
 		t.Fatalf("seed caller: %v", err)
 	}
 	if err := d.UpsertStatusSeedRootAgentName(
-		"myrepo@feature", "myrepo", "/tmp/myrepo-feature",
+		target, repo, "/tmp/"+target,
 		"active", nil, nil, "worker", "", "",
 	); err != nil {
 		t.Fatalf("seed target: %v", err)
 	}
 
-	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
-	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@feature", "")
+	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session="+target, "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 for same-repo @-bearing worker target", rr.Code)
+	}
+}
+
+// TestHostAPI_AtlessSession_Spawn_Resolves covers the /spawn handler's
+// own-repo derivation path for an @-less sidecar. Pre-#2112, /spawn called
+// repoFromSession(s.cfg.SessionName) which returned an error for @-less
+// sidecar sessions; the handler short-circuited at 500 "cannot derive repo"
+// before invoking the prism binary. Post-#2112 the DB-fallback resolves the
+// repo from agent_status, the spawn proceeds, and the stub binary's
+// `session "<name>" created` line is parsed back as the response.
+func TestHostAPI_AtlessSession_Spawn_Resolves(t *testing.T) {
+	const (
+		caller      = "prism-test-obsidianlike"
+		repo        = "prism-test-obsidianlike"
+		spawnedName = "prism-test-obsidianlike@some-branch"
+	)
+	sc, d := newAtlessIsolatedSidecarWithSpawnStub(t, caller, repo, "coordinator", spawnedName)
+	if err := d.UpsertStatusSeedRootAgentName(
+		caller, repo, "/tmp/"+caller,
+		"active", nil, nil, "coordinator", "", "host",
+	); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"some-branch","prompt":"hi"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s, want 200 for @-less sidecar /spawn", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	decodeJSONBody(t, rr, &resp)
+	if resp["session_name"] != spawnedName {
+		t.Errorf("response session_name = %q, want %q", resp["session_name"], spawnedName)
 	}
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_livemodel_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_livemodel_test.go
@@ -65,9 +65,11 @@ func newPISidecar(t *testing.T, sockPath, sessionName, agentRole string, d *db.D
 }
 
 // repoOf extracts the repo from a session name (e.g. "myrepo" from "myrepo@main").
+// Passes a nil *db.DB so the helper falls back to pure name parsing — these
+// test fixtures use the `<repo>@<branch>` shape exclusively.
 func repoOf(t *testing.T, sessionName string) string {
 	t.Helper()
-	repo, err := repoFromSession(sessionName)
+	repo, err := repoFromSession(sessionName, nil)
 	if err != nil {
 		t.Fatalf("repoOf: %v", err)
 	}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -5279,36 +5279,50 @@ func TestHostAPI_Cleanup_WorkerForbidden(t *testing.T) {
 
 func TestHostAPI_SessionNameNoAt_NoCheckinPanic(t *testing.T) {
 	d := openTestDB(t)
-	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
+	// Seed the DB with an empty repo column so isCoordinatorSession recognises
+	// this session as coordinator but repoFromSession's DB lookup falls through
+	// (empty status.Repo is treated as "no resolution" — see helpers.go). The
+	// name-parse fallback then also fails because the session has no '@', so
+	// the handler returns 500 with a "cannot derive repo" error rather than
+	// panicking. This is the panic-safety guarantee — the @-less-with-row
+	// happy path is exercised by TestHostAPI_AtlessSession_Checkin_Resolves
+	// in host_api_atless_session_test.go (issue #2112).
 	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed DB: %v", err)
 	}
-	// Session name without "@" — edge case for repoFromSession.
 	sc := newSidecarWithRole(t, "no-at-sign", "", "coordinator", d)
-	// The sidecar's own session has no "@", which will fail repoFromSession.
-	// The handler should return 500 (internal error deriving repo), not panic.
 	rr := doHostAPI(t, sc, http.MethodGet, "/checkin?session=myrepo@main", "")
 	if rr.Code == 0 {
 		t.Fatal("got zero status — possible panic")
 	}
-	// Should be 500 (cannot derive repo from sidecar's own session name).
 	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500 for no-@ session name", rr.Code)
+		t.Fatalf("status = %d, want 500 for no-@ session name with empty DB repo", rr.Code)
 	}
 }
 
 func TestHostAPI_Prompt_InvalidTargetNoAt(t *testing.T) {
 	d := openTestDB(t)
 	sc := newSidecarWithRole(t, "myrepo@main", "myrepo", "coordinator", d)
-	// Target session has no "@" — should return 400.
+	// Target session has no "@" AND no DB row — the handler should now return
+	// 404 ("session not found") instead of the old 400 ("contains no '@'")
+	// because the canonical not-found shape is the new error surface introduced
+	// in issue #2112. The CLI surfaces this verbatim to the operator.
 	rr := doHostAPI(t, sc, http.MethodPost, "/prompt",
 		`{"session":"nosession","prompt":"hello"}`)
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400 for no-@ target session", rr.Code)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 for unknown @-less target session", rr.Code)
+	}
+	var errResp map[string]string
+	decodeJSONBody(t, rr, &errResp)
+	if !strings.Contains(errResp["error"], "not found") {
+		t.Errorf("error %q should mention 'not found'", errResp["error"])
 	}
 }
 
 func TestHostAPI_RepoFromSession(t *testing.T) {
+	// Pure name-parse fallback (nil DB) — preserves the historical behaviour
+	// of the helper for the @-bearing dominant case. The @-less DB-fallback
+	// path is covered by TestHostAPI_RepoFromSession_DBFallback below.
 	tests := []struct {
 		session string
 		want    string
@@ -5320,17 +5334,17 @@ func TestHostAPI_RepoFromSession(t *testing.T) {
 		{"", "", true},
 	}
 	for _, tc := range tests {
-		got, err := repoFromSession(tc.session)
+		got, err := repoFromSession(tc.session, nil)
 		if tc.wantErr {
 			if err == nil {
-				t.Errorf("repoFromSession(%q): expected error, got nil", tc.session)
+				t.Errorf("repoFromSession(%q, nil): expected error, got nil", tc.session)
 			}
 		} else {
 			if err != nil {
-				t.Errorf("repoFromSession(%q): unexpected error: %v", tc.session, err)
+				t.Errorf("repoFromSession(%q, nil): unexpected error: %v", tc.session, err)
 			}
 			if got != tc.want {
-				t.Errorf("repoFromSession(%q) = %q, want %q", tc.session, got, tc.want)
+				t.Errorf("repoFromSession(%q, nil) = %q, want %q", tc.session, got, tc.want)
 			}
 		}
 	}
@@ -5737,19 +5751,21 @@ func TestHostAPI_Spawn_NoFromKeybind_EmptyPromptStillRejected(t *testing.T) {
 }
 
 // TestHostAPI_Spawn_SidecarNoAtSign_Returns500 verifies AC edge case: if the
-// sidecar's own session name contains no "@", /spawn returns 500 with a
-// message indicating the repo cannot be derived, and no spawn is attempted.
+// sidecar's own session name contains no "@" AND the DB row has an empty
+// repo column (so the DB-fallback path of repoFromSession also misses),
+// /spawn returns 500 with a message indicating the repo cannot be derived
+// and no spawn is attempted. The @-less-with-valid-repo happy path is
+// covered by TestHostAPI_AtlessSession_Spawn_Resolves in
+// host_api_atless_session_test.go (issue #2112).
 func TestHostAPI_Spawn_SidecarNoAtSign_Returns500(t *testing.T) {
 	d := openTestDB(t)
-	// Seed the DB so isCoordinatorSession recognises this session as coordinator.
 	if err := d.UpsertStatusSeedRootAgentName("no-at-sign", "", "/tmp/no-at-sign", "active", nil, nil, "coordinator", "", ""); err != nil {
 		t.Fatalf("seed DB: %v", err)
 	}
-	// Session name without "@" — repoFromSession will fail.
 	sc := newSidecarWithRole(t, "no-at-sign", "", "coordinator", d)
 	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", `{"branch":"some-branch","prompt":"hi"}`)
 	if rr.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500 when sidecar session has no '@'", rr.Code)
+		t.Fatalf("status = %d, want 500 when sidecar session has no '@' and empty DB repo", rr.Code)
 	}
 	var errResp map[string]string
 	decodeJSONBody(t, rr, &errResp)


### PR DESCRIPTION
Closes #2112.

## Problem

`internal/sidecar/helpers.go::repoFromSession` was a pure string parser. It rejected every session name without an `@` separator with `session name "<name>" contains no '@' — cannot derive repo`.

Host-mode sessions configured via `ProjectIsolationOverrides` (e.g. `obsidian` against `~/Documents/obsidian`) are launched against non-git directories and get a single-token session name. Their DB rows exist; the parser refused to look them up. The same helper is used across ~12 host-API call sites, so `prism checkin obsidian`, `prism prompt obsidian`, and every descendant (`obsidian~investigate-apis`, etc.) all failed at the permission-check stage with the same parse error.

## Fix shape: DB-fallback (issue option 1)

`repoFromSession` now takes a `*db.DB` and consults `agent_status.repo` first:

```go
if d != nil {
    if status, err := d.CurrentStatus(sessionName); err == nil
            && status != nil && status.Repo != "" {
        return status.Repo, nil
    }
}
if idx := strings.Index(sessionName, "@"); idx >= 0 {
    return sessionName[:idx], nil
}
return "", fmt.Errorf("session %q not found", sessionName)
```

DB-first is authoritative for both `<repo>@<branch>` shapes and @-less host-mode names. The name-parse path remains as a fallback for unit tests with a nil DB and for the brief window before a freshly-minted session has been recorded. The not-found error now names the unknown session so the CLI can surface a clear "session not found" rather than a parse-failure description.

**Why DB-fallback over string-fallback (option 2):**
- Symmetric with `isCoordinatorSession`, `CoordinatorForRepo`, and every other host-API handler that already queries the DB for permission decisions.
- No `~investigate-` suffix stripping or other brittle string-shape special case.
- Future session-name shapes (nested investigators, other ProjectIsolationOverrides directories) resolve transparently without further helper changes.

## Call sites updated

All 12 call sites in `internal/sidecar/host_api.go` pass `s.cfg.DB`:

- `/list-sessions` (own-repo filter)
- `/checkin` (own + target repo permission gate)
- `/logs` (own + target repo permission gate)
- `/prompt` (own + target repo permission gate)
- `/spawn` (own-repo derivation)
- `/cleanup` (own + target repo permission gate)
- `/apply-profile` coordinator scope (own-repo filter)
- `/register-provider` coordinator scope (own-repo filter)

`/checkin`, `/logs`, `/prompt`, and `/cleanup` additionally now return **404** (not 400) when the target session is unknown — the canonical "not found" shape expected by the CLI.

## Cross-repo permission semantics preserved

End-to-end:

- Coordinator in repo A → @-less worker in repo B: `repoFromSession` resolves the target's repo from `agent_status`, crossRepo branch fires, `isCoordinatorSession` returns false (worker's `root_agent_name != "coordinator"` and name doesn't end `@main`). **403.**
- Coordinator in repo A → cross-repo @-less coordinator: `isCoordinatorSession`'s DB path returns true via `root_agent_name="coordinator"`. **200.**

## Tests

New file `internal/sidecar/host_api_atless_session_test.go` with seven tests:

| Test | Covers |
|---|---|
| `TestHostAPI_RepoFromSession_DBFallback` | helper-level matrix: @-less + row, @-less + empty repo, @-less + no row, @-bearing + no row, @-bearing + row with different repo, nil DB |
| `TestHostAPI_AtlessSession_Checkin_Resolves` | /checkin succeeds for the obsidian shape from #2112 |
| `TestHostAPI_AtlessSession_Checkin_InvestigatorShape` | `obsidian~investigate-apis` descendant case |
| `TestHostAPI_AtlessSession_Checkin_NotFound` | unknown @-less name → 404 with "not found", not the pre-fix "contains no '@'" |
| `TestHostAPI_AtlessSession_Prompt_Resolves` | /prompt resolves @-less coordinator targets |
| `TestHostAPI_AtlessSession_CrossRepoWorker_403` | security-property guard: cross-repo @-less worker target blocked at 403 |
| `TestHostAPI_AtlessSession_OwnRepoWorker_OK` | positive twin: same-repo @-less worker target succeeds |
| `TestHostAPI_AtlessSession_BackwardsCompat` | `<repo>@<branch>` shape unchanged |

### Negative-mutation verification

Every new test was verified to **FAIL** when `helpers.go::repoFromSession` is reverted to the pre-#2112 string-only body (DB parameter ignored). The mutation was applied locally, the suite re-run, all seven cases failed with the expected pre-fix error shapes ("contains no '@'", status 400/500 where the new code returns 200/404/403), then the fix was restored and the suite re-run to green. **No test is vacuous.**

Two pre-existing edge-case tests that asserted the OLD parse-error behaviour (`TestHostAPI_SessionNameNoAt_NoCheckinPanic`, `TestHostAPI_Prompt_InvalidTargetNoAt`) are updated to reflect the new shape — both now also assert message content so they pin the canonical "not found" wording.

Test fixtures follow the discipline notes from #2112: @-bearing fixtures use repo-style names, @-less fixtures mirror the production shape (`obsidian`, `obsidian~investigate-apis`) without clashing with the `sidecartest` isolation prefix.

## Quality gates

- `go build ./...` ✓
- `go test ./internal/sidecar/ -race -count=1` ✓ (94s)
- `go test ./... -race` ✓
- `nix build .#prism` ✓