### PR TITLE
prism (container): remove dead writeClaudeCredentials closure

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -389,12 +389,6 @@ type Manager struct {
 	// allowed_signers temp file. buildRunArgs uses this to gate the bind-mount
 	// so that bwrap is never given a source path that doesn't exist on disk.
 	allowedSignersReady bool
-	// claudeCredentialsReady is true when writeClaudeCredentials successfully
-	// extracted Claude credentials from the macOS Keychain and wrote them to
-	// a temp file. buildRunArgs uses this to gate the bind-mount so that
-	// bwrap is never given a source path that doesn't exist on disk.
-	// This field is only ever true on Darwin.
-	claudeCredentialsReady bool
 
 	// piBwrapErr holds any error produced by appendPIBwrapMounts during
 	// BuildArgs. BuildArgs cannot return an error, so the error is stored
@@ -513,16 +507,6 @@ func WriteHarnessConfig(sessionName, content string) error {
 		return fmt.Errorf("container: write harness config for session %q: %w", sessionName, err)
 	}
 	return nil
-}
-
-// claudeCredentialsFilePath returns the host path for the temporary Claude
-// credentials file written before container start (Darwin only). On Darwin,
-// Claude Code stores OAuth credentials in the macOS Keychain rather than
-// ~/.claude/.credentials.json. We extract the token and write it to a temp
-// file so it can be bind-mounted at /root/.claude/.credentials.json inside
-// the container where opencode-claude-auth can read it.
-func (m *Manager) claudeCredentialsFilePath() string {
-	return m.tempPath("claude-creds", "")
 }
 
 // writeSshConfig generates a minimal ~/.ssh/config for the sandbox and writes

--- a/modules/programs/prism/prism/internal/container/credentials.go
+++ b/modules/programs/prism/prism/internal/container/credentials.go
@@ -6,48 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
 )
-
-// writeClaudeCredentials extracts Claude Code credentials from the macOS
-// Keychain and writes them to a temp file. On Linux, Claude Code stores
-// credentials in ~/.claude/.credentials.json which is already inside the
-// claudeMount bind-mounted directory and requires no special handling. On
-// Darwin, credentials are stored in the Keychain under the service name
-// "Claude Code-credentials" and never reach disk, so the container never
-// sees them via the directory mount alone.
-//
-// Sets m.claudeCredentialsReady to true on success so that buildRunArgs can
-// add the bind-mount. Logs and returns without error on failure — a missing
-// Keychain entry (e.g. not logged in) should surface as an auth error from
-// the agent harness rather than a hard container launch failure.
-func (m *Manager) writeClaudeCredentials() {
-	m.claudeCredentialsReady = false
-	if runtime.GOOS != "darwin" {
-		return
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "security", "find-generic-password",
-		"-l", "Claude Code-credentials", "-w").Output()
-	if err != nil {
-		log.Printf("container: could not extract Claude credentials from macOS Keychain: %v — pi-anthropic-oauth may fail to authenticate", err)
-		return
-	}
-	creds := strings.TrimSpace(string(out))
-	if creds == "" {
-		log.Printf("container: macOS Keychain returned empty Claude credentials — run `claude login` to authenticate")
-		return
-	}
-	if err := os.WriteFile(m.claudeCredentialsFilePath(), []byte(creds), 0o600); err != nil {
-		log.Printf("container: failed to write Claude credentials temp file: %v", err)
-		return
-	}
-	m.claudeCredentialsReady = true
-}
 
 // gitBareRootTimeout is the per-call timeout for git subprocess invocations
 // inside githubAccountFromBareRoot. Matches the convention introduced for

--- a/modules/programs/prism/prism/internal/container/lifecycle.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle.go
@@ -37,7 +37,6 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	_ = os.Remove(m.gitconfigFilePath())
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.harnessConfigFilePath())
-	_ = os.Remove(m.claudeCredentialsFilePath())
 	_ = os.Remove(m.sandboxExecProfilePath())
 	if stagingHome, err := m.sandboxExecHomePath(); err == nil {
 		_ = os.RemoveAll(stagingHome)
@@ -149,7 +148,6 @@ func (m *Manager) Shutdown() {
 	_ = os.Remove(m.gitconfigFilePath())
 	_ = os.Remove(m.allowedSignersFilePath())
 	_ = os.Remove(m.harnessConfigFilePath())
-	_ = os.Remove(m.claudeCredentialsFilePath())
 	_ = os.Remove(m.sandboxExecProfilePath())
 	// Remove the per-session sandbox-exec staging HOME directory tree.
 	if stagingHome, err := m.sandboxExecHomePath(); err == nil {


### PR DESCRIPTION
## Summary

Removes the dead `writeClaudeCredentials` function and its transitively-dead state/helpers from the container credential layer.

`writeClaudeCredentials` extracted Claude Code OAuth credentials from the macOS Keychain and wrote them to a temp file so the legacy podman-attach path could bind-mount them at `/root/.claude/.credentials.json` inside the container. The podman-attach path was removed in #1327 (merged 2026-05-03); the function has had zero callers ever since.

Closes #2128.

## Verification (pre-cut)

Per the issue's mandatory verification step:

1. `rg "writeClaudeCredentials" modules/programs/prism/prism/` returned 3 hits — the function definition, its own body, and one backreference doc comment on the `claudeCredentialsReady` field in `container.go`. **No live (non-test) caller anywhere.** No test functions whose subject is `writeClaudeCredentials` exist in the package.
2. `gh pr view 1327` confirms that PR removed `podmanIsolator` and the podman-attach dispatch branches that originally consumed the function.

## Scope: extended dead-code closure

The issue body lists `writeClaudeCredentials` and "any private helpers used only by it" as the deletion target. The dead-code closure traced from the function turned out to span three files in the same package:

- `internal/container/credentials.go` — the function itself and its now-unused `"runtime"` import.
- `internal/container/container.go` — the `claudeCredentialsReady bool` field (only ever written by `writeClaudeCredentials`, never read) and the `claudeCredentialsFilePath()` method (called only by `writeClaudeCredentials` itself and the two defensive `os.Remove` cleanup calls below).
- `internal/container/lifecycle.go` — the two `_ = os.Remove(m.claudeCredentialsFilePath())` calls in `EnsureRemoved` and `Shutdown`, which were sweeping up a file that no version of prism in active use writes anymore (PR #1327 has been in `main` for five weeks).

Shipping just the function body would have left a dead struct field, an orphan method, and two no-op `os.Remove` calls on disk — i.e. *more* dead code in place than what the cut removed. The extended closure is the natural atomic unit. The issue's "Out of scope — refactoring the credential layer" line still holds: `writeAtlassianOAuth`, `stagePIOAuthToken`, the GitHub 4-PAT plumbing, and every other live function in `credentials.go` / `container.go` / `lifecycle.go` is untouched.

## Verification (post-cut)

- `rg "writeClaudeCredentials" modules/programs/prism/prism/` → **0 hits** (satisfies AC3 from #2128).
- `rg "claudeCredentials" modules/programs/prism/prism/` → **0 hits** (strengthened grep — confirms no residual references to the field or helper either).
- No callers anywhere in the prism Go source of any removed symbol (`writeClaudeCredentials`, `claudeCredentialsReady`, `claudeCredentialsFilePath`).
- `go build ./...` from `modules/programs/prism/prism/` — pass.
- `go test ./... -race` from `modules/programs/prism/prism/` — pass (all 30 packages).
- `nix build .#prism` from repo root — pass.

## Diff

3 files changed, 56 deletions(-), 0 insertions(+).
