### PR TITLE
prism (bwrap): stage ~/.npm/ RW for npx cache parity with sandbox-exec

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -1407,7 +1407,7 @@ func TestBwrapBuildArgs_MissingMcpAuthOmitted(t *testing.T) {
 // tools) caches downloaded packages under ~/.npm/_npx/; without this mount
 // the sandbox cache-misses and re-downloads, which then fails under the
 // sandbox's network policy. Parity with sandbox-exec's staging-HOME entry at
-// sandbox_exec_home.go:334-340. See issue #2127.
+// sandbox_exec_home.go:309-316. See issue #2127.
 func TestBwrapBuildArgs_NpmCacheBound(t *testing.T) {
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -100,6 +100,7 @@ func bwrapFixture(t *testing.T, cfg Config) (m *Manager, fakeHome string, cleanu
 	dirs := []string{
 		filepath.Join(fakeHome, ".claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
+		filepath.Join(fakeHome, ".npm"),
 		filepath.Join(fakeHome, ".cache", "nix"),
 	}
 	for _, d := range dirs {
@@ -1398,6 +1399,61 @@ func TestBwrapBuildArgs_MissingMcpAuthOmitted(t *testing.T) {
 
 	if hasBind(args, mcpAuthDir) {
 		t.Errorf("missing ~/.mcp-auth should be omitted but found as --bind in args: %v", args)
+	}
+}
+
+// TestBwrapBuildArgs_NpmCacheBound pins the ~/.npm RW bind-mount when the
+// host directory exists. npx (used by mcp-remote and similar npx-fetched
+// tools) caches downloaded packages under ~/.npm/_npx/; without this mount
+// the sandbox cache-misses and re-downloads, which then fails under the
+// sandbox's network policy. Parity with sandbox-exec's staging-HOME entry at
+// sandbox_exec_home.go:334-340. See issue #2127.
+func TestBwrapBuildArgs_NpmCacheBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	npmDir := filepath.Join(fakeHome, ".npm")
+	if !hasBind(args, npmDir) {
+		t.Errorf("~/.npm %q not found as --bind SRC SRC in args: %v", npmDir, args)
+	}
+	// And it must NOT be read-only — npx writes to its cache on first use.
+	if hasROBind(args, npmDir) {
+		t.Errorf("~/.npm %q must be RW (--bind), not RO (--ro-bind): %v", npmDir, args)
+	}
+}
+
+// TestBwrapBuildArgs_MissingNpmCacheOmitted pins the conditional-on-existence
+// semantics: when ~/.npm does not exist on the host, the mount is omitted
+// silently and the sandbox starts cleanly. Mirrors
+// TestBwrapBuildArgs_MissingMcpAuthOmitted. See issue #2127.
+func TestBwrapBuildArgs_MissingNpmCacheOmitted(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	npmDir := filepath.Join(fakeHome, ".npm")
+	if err := os.RemoveAll(npmDir); err != nil {
+		t.Fatalf("RemoveAll npm: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasBind(args, npmDir) {
+		t.Errorf("missing ~/.npm should be omitted but found as --bind in args: %v", args)
+	}
+	if hasROBind(args, npmDir) {
+		t.Errorf("missing ~/.npm should be omitted but found as --ro-bind in args: %v", args)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -173,6 +173,26 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 			OptionalIfMissing: true,
 		},
 
+		// ── ~/.npm (RW, conditional) ─────────────────────────────────────
+		// npx caches downloaded packages (e.g. mcp-remote) under
+		// ~/.npm/_npx/. Without this mount, an npx-fetched tool inside
+		// the sandbox cannot find its cache and attempts to re-download —
+		// which then fails under the sandbox's network restrictions.
+		//
+		// Read-write so npx can populate the cache on first use. Mounted
+		// only when the directory exists on the host — hosts that have
+		// never run npm/npx are unaffected. Dst==Src under bwrap (where
+		// sandboxHomeDir == hostHome) so the canonical $HOME/.npm path
+		// inside the sandbox matches the host path.
+		//
+		// Parity with sandbox-exec's staging-HOME entry at
+		// sandbox_exec_home.go:334-340. See issue #2127.
+		{
+			HostPath:          filepath.Join(hostHome, ".npm"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".npm"),
+			OptionalIfMissing: true,
+		},
+
 		// ── ~/.cache/nix (RW) ────────────────────────────────────────────
 		// Pre-populated nix flake input cache. Read-write because nix
 		// writes to its SQLite databases during evaluation.

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -186,7 +186,7 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 		// inside the sandbox matches the host path.
 		//
 		// Parity with sandbox-exec's staging-HOME entry at
-		// sandbox_exec_home.go:334-340. See issue #2127.
+		// sandbox_exec_home.go:309-316. See issue #2127.
 		{
 			HostPath:          filepath.Join(hostHome, ".npm"),
 			SandboxPath:       filepath.Join(sandboxHomeDir, ".npm"),


### PR DESCRIPTION
Closes #2127.

## What

Adds a conditional RW bind-mount for the host `~/.npm/` directory to bwrap's mount set, bringing it to parity with sandbox-exec's existing `~/.npm/` staging at `internal/container/sandbox_exec_home.go:334-340`.

## Why

`npx` (used by `mcp-remote` and similar MCP-bridge invocations) caches downloaded packages under `~/.npm/_npx/`. Sandbox-exec already symlinks this directory into its staging HOME because, without it, the cache miss → re-download path then fails under the sandbox's network policy.

bwrap had no equivalent mount. `rg "\.npm" internal/container/` on `main` returns only the sandbox-exec call site, confirming the gap.

## Mount call site chosen

`StandardSandboxMounts` in `internal/container/mounts.go`, alongside the existing `~/.mcp-auth` entry. The pattern matches exactly:

- RW (`--bind`, not `--ro-bind`) — npx writes to its cache on first use.
- `OptionalIfMissing: true` — silently skipped on hosts that have never run npm/npx, mirroring the conditional-mount behaviour of `~/.mcp-auth` and `~/.cache/bun`.
- `Dst == Src` under bwrap (because `sandboxHomeDir == hostHome` at the bwrap call site), so the canonical `$HOME/.npm/` path inside the sandbox matches the host path.

The `mounts.go` location was preferred over an inline block in `bwrap.go` (alongside `~/.cache/bun`) because the file header explicitly designates `StandardSandboxMounts` as the canonical home for "the common decision tree" of host-to-sandbox mounts, and the `~/.mcp-auth` neighbour is the closest shape match. Only the bwrap appender walks the spec (`podman` support was removed in #1327), so this addition is isolated to the bwrap path. Sandbox-exec's existing staging at `sandbox_exec_home.go:334-340` is untouched, per the issue's out-of-scope clause.

## Verification outcome

**No live failure mode reproduced.** Per the issue's verification step, I grepped `modules/programs/prism/pi/extensions/` and the agent runtime for live `mcp-remote` / `npx` invocations inside a bwrap sandbox. The Atlassian extension (`pi/extensions/atlassian/`) implements its own in-process `mcp-client.ts` rather than spawning `mcp-remote`; references to `mcp-remote` in `auth.ts` are historical comments explaining the OAuth PKCE heritage. The `playwright-cli` skill references `npx` but is invoked from outside the sandbox.

Therefore this PR is **defensive parity** — there is no in-tree path that fails today on `main`. The cost is minimal (one spec entry, mirrors an existing pattern) and the defence-in-depth matches the sandbox-exec contract, so the surface is closed before a future extension trips it.

## Tests added

`internal/container/bwrap_test.go`:

- `TestBwrapBuildArgs_NpmCacheBound` — pins the `--bind SRC SRC` triple appearing when host `~/.npm/` exists, and asserts it is NOT emitted as `--ro-bind` (npx requires writability).
- `TestBwrapBuildArgs_MissingNpmCacheOmitted` — pins the mount being absent when host `~/.npm/` does not exist, mirroring `TestBwrapBuildArgs_MissingMcpAuthOmitted`.

Verified the tests are not no-ops: temporarily stashed the `mounts.go` change and confirmed `TestBwrapBuildArgs_NpmCacheBound` FAILS without the fix and PASSES with it; `TestBwrapBuildArgs_MissingNpmCacheOmitted` PASSES in both directions (correct, since the assertion is about absence).

The fixture (`bwrapFixture`) now pre-creates `~/.npm/` alongside `~/.claude/`, `~/.mcp-auth/`, and `~/.cache/nix/` so the "present" assertion can be exercised.

## Gates

- `go build ./...` — clean.
- `go test ./internal/container/ -race` — pass.
- `go test ./... -race` — pass (full suite).
- `nix build .#prism` — pass.

## Out of scope (per issue)

- Sandbox-exec's existing `~/.npm/` staging at `sandbox_exec_home.go:334-340` — untouched.
- Replacing `mcp-remote` or `npx`.
- The broader staging-HOME removal.

## Notes for review

Pre-existing `gofmt -l` cosmetics in `bwrap_test.go`, `sandbox_exec_integration_test.go`, and `sandbox_exec_test.go` (missing blank line before section comments) are on `main` and not introduced by this PR. Not fixed here to avoid scope creep.