### PR TITLE
tmux: silence prism mute success-path stdout in prefix-m binding

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -226,7 +226,7 @@ in
               # not correspond to a prism session) so a stray Prefix+m there
               # does not crash tmux or surface a stack trace.
               bind-key m if-shell '[ -n "#{session_name}" ]' \
-                'run-shell -b "${prism} mute #{session_name} || ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\""' \
+                'run-shell -b "${prism} mute #{session_name} >/dev/null || ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\""' \
                 'display-message "prism mute: no current session"'
               # easy config reload
               bind-key r source-file ~/.config/tmux/tmux.conf \; display-message "tmux.conf reloaded"


### PR DESCRIPTION
## Symptom

Pressing `prefix-m` (the `prism mute` toggle keybind) was dropping the tmux pane into copy mode showing `prism mute`'s success-path stdout (`muted: <session-name>` or `unmuted: <session-name>`). Operator had to press Enter/q to exit copy mode and get back to the session. Same on both mute and unmute paths. The `MUTED` status-bar indicator still updated correctly — the mute itself worked. The bug was purely the binding letting stdout reach tmux's `run-shell` output buffer.

## Fix

One-character (well, one-token) addition: redirect the success-path stdout to `/dev/null` inside the `run-shell -b` invocation.

```diff
 bind-key m if-shell '[ -n "#{session_name}" ]' \
-  'run-shell -b "${prism} mute #{session_name} || ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\""' \
+  'run-shell -b "${prism} mute #{session_name} >/dev/null || ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\""' \
   'display-message "prism mute: no current session"'
```

`run-shell -b` is *supposed* to discard output, but in practice (depending on tmux version) can still surface stdout into copy mode after the command exits. Redirecting stdout fixes the copy-mode entry. Stderr is intentionally left unredirected so genuine errors still reach tmux's `run-shell` handler, and the `||` chain still triggers on non-zero exit code to surface the "not a prism session" `display-message`.

## Scope

- Single-line change in `modules/programs/prism/tmux.nix`.
- `prism mute` itself is untouched — its CLI stdout output is correct for scripting / direct-shell use; the issue was purely how the tmux binding consumed it.
- No issue filed — fix is single-line.