### PR TITLE
tmux: refresh status bar after prism mute toggle (prefix-m)

### DIFF
--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -226,7 +226,7 @@ in
               # not correspond to a prism session) so a stray Prefix+m there
               # does not crash tmux or surface a stack trace.
               bind-key m if-shell '[ -n "#{session_name}" ]' \
-                'run-shell -b "${prism} mute #{session_name} >/dev/null || ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\""' \
+                'run-shell -b "if ${prism} mute #{session_name} >/dev/null; then ${pkgs.tmux}/bin/tmux refresh-client -S; else ${pkgs.tmux}/bin/tmux display-message \"prism mute: not a prism session\"; fi"' \
                 'display-message "prism mute: no current session"'
               # easy config reload
               bind-key r source-file ~/.config/tmux/tmux.conf \; display-message "tmux.conf reloaded"


### PR DESCRIPTION
## Summary

After `prefix-m` toggles `prism mute`, the `MUTED` indicator in the tmux status-right lagged up to `status-interval` seconds because the binding didn't ask tmux to redraw. The mute itself was instant; only the visual indicator stale-rendered until the next scheduled refresh.

Chain `tmux refresh-client -S` after the mute succeeds so the status line redraws on the next frame. `-S` scopes the refresh to the status line — no pane disturbance, no copy-mode entry.

The binding now uses an `if/then/else` shape rather than `&&||`, which avoids the pitfall where a `refresh-client` failure would incorrectly trigger the "not a prism session" error path.

## Diff shape

```
- 'run-shell -b "${prism} mute #{session_name} >/dev/null || tmux display-message ..."'
+ 'run-shell -b "if ${prism} mute #{session_name} >/dev/null; then tmux refresh-client -S; else tmux display-message ...; fi"'
```

## Verification

- `nix flake check` — passes.
- `nixfmt .` — clean.
- Functional / runtime verification (next-frame indicator refresh) is on Ben to confirm after the next `nh switch` per the AC notes.

## Related

- PR #2133 — the previous prefix-m UX fix (silenced success-path stdout); this PR builds on it.

Closes #2135