### PR TITLE
flake: make impermanence follow root nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780048612,
-        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
+        "lastModified": 1780290312,
+        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
+        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780679734,
+        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
         "type": "github"
       },
       "original": {
@@ -85,7 +85,9 @@
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager_2",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1769548169,
@@ -103,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768564909,
-        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -119,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780206208,
-        "narHash": "sha256-ozIQlvCKb1Mw7TjIydOxuTSlLgLZZxo7NgaDt+rpOhk=",
+        "lastModified": 1780700792,
+        "narHash": "sha256-sGCauddYNF1Nymtdjnl3xx2fkJl8yZ4HgW/ucuEnSb8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a9b364c4497a3debd88664323219ef1e2a5e2a6",
+        "rev": "0381b3037a2256efc2b54b9c5f16b71d48e7d9a0",
         "type": "github"
       },
       "original": {
@@ -135,32 +137,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1780511130,
+        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -171,7 +157,7 @@
         "disko": "disko",
         "home-manager": "home-manager",
         "impermanence": "impermanence",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-stable": "nixpkgs-stable",
         "sops-nix": "sops-nix"
@@ -184,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,10 @@
       url = "github:nix-community/disko";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    impermanence.url = "github:nix-community/impermanence";
+    impermanence = {
+      url = "github:nix-community/impermanence";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     sops-nix = {
       url = "github:mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Adds `inputs.nixpkgs.follows = "nixpkgs";` to the `impermanence` input in
`flake.nix`, mirroring the other follows-using inputs (`disko`, `sops-nix`,
`home-manager`, `darwin`). `nix flake update` then collapses the duplicate
`nixos-unstable` lock nodes — the orphan `nixpkgs` (Jan 16) that only
`impermanence` referenced is gone; only the root node remains.

### Verification

```
$ jq '.nodes | to_entries[] | select(.value.original.ref == "nixos-unstable") | .key' flake.lock
"nixpkgs"
```

Exactly one line, as the AC requires.

All five followers (including `impermanence` now) resolve their `nixpkgs`
input to the single root node:

```
$ for input in disko sops-nix home-manager darwin impermanence; do
    echo "=== $input ==="
    jq ".nodes.\"$input\".inputs.nixpkgs" flake.lock
  done
=== disko ===
[ "nixpkgs" ]
=== sops-nix ===
[ "nixpkgs" ]
=== home-manager ===
[ "nixpkgs" ]
=== darwin ===
[ "nixpkgs" ]
=== impermanence ===
[ "nixpkgs" ]
```

`nix flake check --no-build` passes — both `nixosConfigurations.navi` and
`nixosConfigurations.tui` evaluate cleanly against the updated lock. Per
the spawn notes I did not run `nh switch` from this worktree; the
coordinator handles host-wide application post-merge.

### Out of scope

The Home Manager 26.11 / Nixpkgs 26.05 evaluation warning is unrelated —
resolves separately once the next nixpkgs bump lands.

Closes #2136