### PR TITLE
mux-spike: fix interactive run paint loop

### DIFF
--- a/modules/programs/prism/mux-spike/cmd/run.go
+++ b/modules/programs/prism/mux-spike/cmd/run.go
@@ -64,8 +64,11 @@ func Run(args []string) error {
 	}
 
 	// Switch host terminal into alt-screen so we don't pollute the scrollback
-	// with the hosted TUI's frames. Plain ANSI; no dep needed.
-	os.Stdout.WriteString("\x1b[?1049h\x1b[?25l")
+	// with the hosted TUI's frames, hide the cursor for the duration (paint
+	// re-shows it per-frame at the engine's tracked position), and scrub
+	// once with ED2 so any shell-prompt residue under the alt-screen layer
+	// is gone before the first paint. Plain ANSI; no dep needed.
+	os.Stdout.WriteString("\x1b[?1049h\x1b[?25l\x1b[2J\x1b[H")
 	defer os.Stdout.WriteString("\x1b[?25h\x1b[?1049l")
 
 	sess, err := pty.Start(argv, uint16(*cols), uint16(*rows))
@@ -167,14 +170,61 @@ func Run(args []string) error {
 	}
 }
 
-// paint clears the host terminal and writes the emulator's rendering to
-// stdout. The CSI sequences here are deliberately bare-bones — anything
-// fancier (sync output, double-buffering) would muddy the fidelity signal.
+// paint writes one frame of the hosted TUI to stdout. Factored as
+// build-then-write so the frame-building logic is testable without an
+// attached TTY — see cmd/run_test.go.
 func paint(host *vt.Host) {
-	// Move cursor home, then write the rendered cells. No clear — the
-	// engine's Render() emits a full repaint per row, which is sufficient.
+	_, _ = os.Stdout.WriteString(buildFrame(host))
+}
+
+// buildFrame produces one frame of host-terminal output for the current
+// emulator state.
+//
+// Why per-row absolute positioning rather than `\x1b[H` + host.Render():
+//
+//  1. x/vt's Render() emits rows separated by bare LF (no CR). In raw
+//     mode — which run.go has set on stdin via xterm.MakeRaw — LF is
+//     line-feed only: the cursor moves down one row at the current
+//     column. Every row past the first drifts rightward by the previous
+//     row's width. The first broken-render screenshot shows nvim's
+//     tildes cascading to the right edge for exactly this reason.
+//
+//  2. Render() does NOT pad short rows to the emulator width. Cells
+//     left unfilled by the engine carry over from whatever was last
+//     painted into those cells on the host terminal. The third
+//     screenshot shows two complete nvim status bars at different y
+//     positions — the previous frame's bottom row was still painted
+//     when the new frame's shorter rows landed.
+//
+// Per-row absolute positioning sidesteps both: every row gets
+// `\x1b[<y+1>;1H` so column drift is impossible, and a trailing
+// `\x1b[0m\x1b[K` erases anything left of the previous frame on that
+// row's tail. Cursor is hidden across the frame and reshown at the
+// engine's tracked position (mirroring DECTCEM) at the very end.
+func buildFrame(host *vt.Host) string {
+	snap := host.Snapshot()
+	rows := host.RenderRows()
+
 	var b strings.Builder
-	b.WriteString("\x1b[H")
-	b.WriteString(host.Render())
-	_, _ = os.Stdout.WriteString(b.String())
+	// Hide cursor while we walk it row-to-row so users don't see it dart
+	// around mid-paint at 30 Hz.
+	b.WriteString("\x1b[?25l")
+	for y, row := range rows {
+		// CSI row;col H — absolute position, 1-indexed.
+		fmt.Fprintf(&b, "\x1b[%d;1H", y+1)
+		b.WriteString(row)
+		// Reset SGR before EL so the erase uses the default background,
+		// not whatever colour the last cell in this row left active.
+		b.WriteString("\x1b[0m\x1b[K")
+	}
+	// Position the host cursor where the engine thinks it is. Snapshot's
+	// CursorX/Y are 0-indexed; CSI H wants 1-indexed.
+	fmt.Fprintf(&b, "\x1b[%d;%dH", snap.CursorY+1, snap.CursorX+1)
+	// Mirror the engine's DECTCEM state. If the hosted TUI hid its
+	// cursor (nvim in some modes, htop) we leave it hidden; otherwise we
+	// re-show so users get the standard blinking cursor at the right cell.
+	if host.CursorVisible() {
+		b.WriteString("\x1b[?25h")
+	}
+	return b.String()
 }

--- a/modules/programs/prism/mux-spike/cmd/run_test.go
+++ b/modules/programs/prism/mux-spike/cmd/run_test.go
@@ -1,0 +1,207 @@
+// Structural tests for the interactive paint loop. These are NOT a substitute
+// for an interactive smoke test against a real TTY — they cannot prove the
+// frame *looks* right, only that the byte stream has the structural
+// properties that protect against the two bugs the initial spike shipped
+// with:
+//
+//   1. LF-without-CR right-drift. xvt's Render() separates rows with bare
+//      LF; in raw mode that walks the cursor down without resetting the
+//      column. The fix is to never emit raw inter-row LF — each row gets
+//      its own CSI <y>;1 H absolute position. The assertions here pin
+//      that.
+//
+//   2. Previous-frame residue. Render() does not pad short rows, so
+//      anything left from the previous paint at columns past the row's
+//      end-of-content stays on screen. The fix is a trailing CSI K
+//      (erase-in-line) on every row. The assertions here pin that too.
+//
+// Interactive verification is Ben's responsibility once the patch lands —
+// only he has the host TTY the run subcommand drives.
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/nixos-config/modules/programs/prism/mux-spike/internal/vt"
+)
+
+// feed runs raw bytes into a fresh Host of the given dimensions and returns
+// the host. The bytes are interpreted by x/vt as if they came from a PTY.
+func feed(t *testing.T, cols, rows int, payload string) *vt.Host {
+	t.Helper()
+	h := vt.New(cols, rows)
+	if _, err := h.Feed([]byte(payload)); err != nil {
+		t.Fatalf("Feed: %v", err)
+	}
+	return h
+}
+
+// TestBuildFrame_PerRowAbsolutePositioning is the load-bearing structural
+// assertion. Every visible row must be preceded by a CSI <y>;1 H sequence
+// — that is what prevents the LF-without-CR right-drift in raw mode.
+//
+// Equivalently: between consecutive row contents, the bytes that *would*
+// have been a bare \n in xvt's Render() must not appear in the frame.
+func TestBuildFrame_PerRowAbsolutePositioning(t *testing.T) {
+	const cols, rows = 20, 5
+	// Three short rows; rows 3 and 4 are blank. This is the shape that
+	// breaks Render(): unfilled rows leave residue from a previous frame.
+	h := feed(t, cols, rows, "ROW0\r\nROW1\r\nROW2")
+
+	frame := buildFrame(h)
+
+	for y := 1; y <= rows; y++ {
+		want := fmt.Sprintf("\x1b[%d;1H", y)
+		if !strings.Contains(frame, want) {
+			t.Errorf("frame missing absolute-position prefix %q for row %d.\nframe=%q",
+				want, y, frame)
+		}
+	}
+
+	// Verify ordering: row k's position must come before row k+1's. If
+	// they ever swapped we'd be painting rows out of order, which would
+	// still pass the contains check above but break in practice.
+	var lastIdx int
+	for y := 1; y <= rows; y++ {
+		want := fmt.Sprintf("\x1b[%d;1H", y)
+		idx := strings.Index(frame, want)
+		if idx < lastIdx {
+			t.Errorf("row %d position %q appears at byte %d, before previous row's %d",
+				y, want, idx, lastIdx)
+		}
+		lastIdx = idx
+	}
+}
+
+// TestBuildFrame_NoBareLineFeedBetweenRows is the direct anti-regression
+// against the original bug — a bare LF anywhere between row contents would
+// have allowed the right-drift to come back.
+//
+// We allow a single trailing LF only if it sits at the very end of the
+// frame (xvt sometimes emits one and there's no harm in passing it on);
+// any LF that is NOT immediately followed by CSI <n>;1 H or end-of-string
+// is suspect.
+func TestBuildFrame_NoBareLineFeedBetweenRows(t *testing.T) {
+	h := feed(t, 20, 5, "ROW0\r\nROW1\r\nROW2")
+	frame := buildFrame(h)
+
+	for i := 0; i < len(frame); i++ {
+		if frame[i] != '\n' {
+			continue
+		}
+		t.Errorf("frame contains bare LF at byte %d — that re-introduces the right-drift bug.\nframe=%q",
+			i, frame)
+	}
+}
+
+// TestBuildFrame_EraseToEndOfLinePerRow pins the residue fix. Each row's
+// emitted content must end with CSI K (erase-in-line) so any leftover
+// glyphs from a previous frame at columns past this row's end-of-content
+// get blanked. We also expect a CSI 0 m reset immediately before CSI K so
+// the erase paints the default background, not the last cell's bg colour.
+func TestBuildFrame_EraseToEndOfLinePerRow(t *testing.T) {
+	h := feed(t, 20, 3, "AAA\r\nBBB\r\nCCC")
+	frame := buildFrame(h)
+
+	// Count occurrences of the reset+EL pair. Should be exactly one per
+	// row (3 in this case). If the count is lower the residue bug is
+	// back; if higher, something is double-painting.
+	got := strings.Count(frame, "\x1b[0m\x1b[K")
+	if got != 3 {
+		t.Errorf("expected 3 reset+erase-in-line sequences (one per row), got %d.\nframe=%q",
+			got, frame)
+	}
+}
+
+// TestBuildFrame_CursorPositionedAtEngineCursor verifies the frame ends
+// with the host cursor parked where the engine thinks the cursor is —
+// otherwise nvim's blinking cursor would sit at the home position or at
+// wherever the last row's absolute-position sequence left it.
+func TestBuildFrame_CursorPositionedAtEngineCursor(t *testing.T) {
+	// Move cursor to row 2 col 5 (1-indexed in CSI, 0-indexed in the
+	// Snapshot — we assert against the Snapshot's view).
+	h := feed(t, 20, 5, "\x1b[2;5H")
+	snap := h.Snapshot()
+	if snap.CursorX != 4 || snap.CursorY != 1 {
+		t.Fatalf("engine cursor not where we set it: got (%d,%d), want (4,1)",
+			snap.CursorX, snap.CursorY)
+	}
+
+	frame := buildFrame(h)
+	want := fmt.Sprintf("\x1b[%d;%dH", snap.CursorY+1, snap.CursorX+1)
+
+	// The cursor-position sequence must appear AFTER every per-row
+	// absolute-position sequence — otherwise the per-row paints would
+	// stomp on it.
+	cursorIdx := strings.LastIndex(frame, want)
+	if cursorIdx < 0 {
+		t.Fatalf("frame missing cursor-position sequence %q.\nframe=%q", want, frame)
+	}
+	rowPosRe := regexp.MustCompile(`\x1b\[(\d+);1H`)
+	for _, m := range rowPosRe.FindAllStringIndex(frame, -1) {
+		if m[0] > cursorIdx {
+			t.Errorf("row-positioning sequence at byte %d appears after the cursor-position at byte %d — the cursor will be wrong.",
+				m[0], cursorIdx)
+		}
+	}
+}
+
+// TestBuildFrame_CursorVisibilityMirrorsEngine checks that the frame's
+// final DECTCEM state matches the engine's. Default state is visible, and
+// the frame should re-show the cursor (paint hides it mid-frame so the
+// dart between row positions doesn't blink across the screen).
+func TestBuildFrame_CursorVisibilityMirrorsEngine(t *testing.T) {
+	t.Run("visible by default", func(t *testing.T) {
+		h := feed(t, 10, 3, "hi")
+		if !h.CursorVisible() {
+			t.Fatalf("engine should default to cursor-visible")
+		}
+		frame := buildFrame(h)
+		// Hide must appear once at the start (mid-paint suppression),
+		// show must appear at the end.
+		if !strings.HasPrefix(frame, "\x1b[?25l") {
+			t.Errorf("frame should start with cursor-hide (\\x1b[?25l) to suppress mid-paint blinking.\nframe=%q",
+				frame)
+		}
+		if !strings.HasSuffix(frame, "\x1b[?25h") {
+			t.Errorf("frame should end with cursor-show (\\x1b[?25h) when engine has cursor visible.\nframe=%q",
+				frame)
+		}
+	})
+
+	t.Run("hidden when engine hides it", func(t *testing.T) {
+		// DECTCEM off — engine should track this via the CursorVisibility
+		// callback we register in vt.New.
+		h := feed(t, 10, 3, "\x1b[?25l")
+		if h.CursorVisible() {
+			t.Fatalf("engine should track DECTCEM-off as cursor-hidden")
+		}
+		frame := buildFrame(h)
+		if strings.HasSuffix(frame, "\x1b[?25h") {
+			t.Errorf("frame should NOT re-show the cursor when engine hid it.\nframe=%q",
+				frame)
+		}
+	})
+}
+
+// TestBuildFrame_EmitsOneRowPerEmulatorRow guarantees that even when the
+// engine has rendered fewer rows than the emulator height (e.g. a fresh
+// emulator with a single line of text), we still emit positioning for
+// every row up to the configured height. Otherwise the bottom of a
+// previous frame could remain on screen — the same residue class of bug
+// from a different angle.
+func TestBuildFrame_EmitsOneRowPerEmulatorRow(t *testing.T) {
+	const cols, rows = 10, 7
+	h := feed(t, cols, rows, "only one") // single-row content
+	frame := buildFrame(h)
+	for y := 1; y <= rows; y++ {
+		want := fmt.Sprintf("\x1b[%d;1H", y)
+		if !strings.Contains(frame, want) {
+			t.Errorf("frame missing per-row position for row %d (height=%d). All %d rows must be repainted every frame to avoid residue.\nframe=%q",
+				y, rows, rows, frame)
+		}
+	}
+}

--- a/modules/programs/prism/mux-spike/internal/vt/vt.go
+++ b/modules/programs/prism/mux-spike/internal/vt/vt.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"io"
 	"sync"
+	"sync/atomic"
 
 	xvt "github.com/charmbracelet/x/vt"
 
@@ -23,15 +24,35 @@ type Host struct {
 	mu   sync.Mutex
 	emul *xvt.Emulator
 	w, h int
+
+	// cursorVisible tracks DECTCEM (the cursor show/hide mode) so the
+	// renderer in cmd/run.go can mirror it to the host terminal each
+	// frame. x/vt does not expose a getter for the visibility flag, but
+	// it fires a Callbacks.CursorVisibility callback whenever the hosted
+	// TUI toggles it. Terminals power on with the cursor visible, so the
+	// zero value (false) is wrong — we seed true in New.
+	cursorVisible atomic.Bool
 }
 
 // New constructs a Host backed by an Emulator of the given dimensions.
 func New(cols, rows int) *Host {
-	return &Host{
+	h := &Host{
 		emul: xvt.NewEmulator(cols, rows),
 		w:    cols,
 		h:    rows,
 	}
+	h.cursorVisible.Store(true)
+	h.emul.SetCallbacks(xvt.Callbacks{
+		CursorVisibility: func(v bool) { h.cursorVisible.Store(v) },
+	})
+	return h
+}
+
+// CursorVisible reports the emulator's current DECTCEM state. Safe to call
+// concurrently with Feed — the value is tracked via an atomic updated from
+// the x/vt callback that fires inside Write.
+func (h *Host) CursorVisible() bool {
+	return h.cursorVisible.Load()
 }
 
 // Feed writes raw PTY bytes into the VT engine. Safe to call concurrently
@@ -158,10 +179,53 @@ func (h *Host) Snapshot() Snapshot {
 // Render returns the emulator's own ANSI rendering of the visible screen.
 // This is the engine's view of what the cells should look like when emitted
 // back out, useful for visual diff against the tmux capture-pane output.
+//
+// Caveat for live replay: x/vt's Render() emits rows separated by bare LF
+// (no CR) and does NOT pad short rows to the emulator width. Driving a host
+// terminal directly with this output in raw mode produces right-drift
+// (cursor walks across the screen at every LF) and previous-frame residue
+// (unfilled cells leave whatever was there before). The corpus path is
+// fine — it captures Render() as a textual artefact — but live-replay
+// callers (see cmd/run.go) should consume the per-row data and emit their
+// own absolute-positioned frame.
 func (h *Host) Render() string {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	return h.emul.Render()
+}
+
+// RenderRows splits the emulator's Render() output into one string per
+// visible row, padded out to the configured row count. Rows beyond what
+// Render() emits come back as empty strings. This is the live-replay
+// primitive used by cmd/run.go::paint — the caller wraps each row in an
+// absolute-position sequence and an erase-to-end-of-line, sidestepping the
+// LF-without-CR and no-padding hazards described on Render().
+func (h *Host) RenderRows() []string {
+	rendered := h.Render()
+	h.mu.Lock()
+	rows := h.h
+	h.mu.Unlock()
+
+	out := make([]string, rows)
+	if rendered == "" {
+		return out
+	}
+	// Split on bare LF — that is what x/vt emits between rows. A trailing
+	// LF would produce an extra empty element; clip the result to row
+	// count so callers always see exactly rows entries.
+	line := 0
+	start := 0
+	for i := 0; i < len(rendered) && line < rows; i++ {
+		if rendered[i] == '\n' {
+			out[line] = rendered[start:i]
+			line++
+			start = i + 1
+		}
+	}
+	if line < rows && start < len(rendered) {
+		out[line] = rendered[start:]
+	}
+	return out
 }
 
 func convertCell(c *uv.Cell) Cell {

--- a/modules/programs/prism/prism/docs/multiplexer-proposal.md
+++ b/modules/programs/prism/prism/docs/multiplexer-proposal.md
@@ -493,6 +493,25 @@ between two options, captured in a fresh issue at the time:
 The spike PR does not pre-commit to either follow-up. The follow-up
 is a coordinator decision once the verdict is in hand.
 
+### Spike findings post-merge
+
+After the spike's proceed-verdict landed in #2143, a hands-on smoke
+test of the `run` subcommand surfaced two interactive-paint bugs that
+the corpus grading process did not catch: `host.Render()`'s output
+uses bare LF between rows (right-drift in raw mode) and does not pad
+short rows (previous-frame residue). These were spike-level bugs in
+the live-replay loop, not engine-level bugs in `x/vt` — the corpus
+path drives `host.Snapshot()` rather than `host.Render()`, so the
+fidelity grading was unaffected and the verdict stands. The lesson
+transfers to the multiplexer programme: a corpus snapshot path
+(`host.Snapshot()` + structural cell extraction) is necessary but not
+sufficient for fidelity grading. Any future characterisation spike
+should also drive a live render path (`host.Render()` or equivalent)
+so that interactive-use bugs surface during grading rather than at
+first-hands-on. The mux-spike's verdict remains valid because
+cell-grid fidelity is the load-bearing question; the live-render bugs
+were spike-level, not engine-level.
+
 ## 9. Out of scope
 
 The proposal is deliberately narrow. The following are **not** part


### PR DESCRIPTION
## Summary

The mux-spike's `run` subcommand shipped with a paint loop that emitted `\x1b[H` + `host.Render()` once per frame. Ben smoke-tested it with `nix run .#mux-spike -- run nvim /tmp/test.txt` and got severely degraded rendering: nvim's tildes cascaded to the right edge instead of stacking in column 0, and after a single keystroke two complete status bars appeared at different rows. Screenshots (from the original prompt's cache paths):

- Broken initial render — tildes drift right: `~/.cache/prism/clipboard/38ae8534-f2e4-4a0d-a8ab-ce73822e920f.png`
- Expected render (tmux baseline): `~/.cache/prism/clipboard/9f8073d6-0d22-405b-a8ad-e4c722d57d1d.png`
- Broken render after typing "test" — stacked status bars: `~/.cache/prism/clipboard/1a0cc6b2-11d9-4b35-9ce7-4fc2c8b9ae14.png`

This PR fixes the live-replay path. The corpus path and the proceed-verdict from #2143 are **not** affected — the corpus drives `host.Snapshot()` (structural cell extraction), not `host.Render()` (ANSI re-emission), so the fidelity grading was unaffected.

## Root cause (verified)

Two compounding bugs, both in `cmd/run.go::paint()`. I verified the diagnosis with a tiny Go probe against `xvt.Emulator.Render()` before patching:

```
Render output for a 10x4 emulator fed "AAA\r\nBBB":  "AAA\nBBB\n\n"
Render output for sparse rows 0,2 of 4:              "FIRST\n\nTHIRD\n"
Render output with colour transitions:               "\x1b[31mRED\x1b[m\n\x1b[32mGREEN\x1b[m"
```

1. **Bare LF between rows.** `xvt.Emulator.Render()` separates rows with `\n`, not `\r\n`. Stdin is in raw mode (line 60 of `run.go` via `xterm.MakeRaw`), so `\n` is line-feed only — the cursor moves down one row at the *current column*. Every row past the first drifts rightward by the previous row's width. That's exactly what the first screenshot shows: tildes cascading off to the right edge instead of stacking in column 0.

2. **No padding of short rows.** `Render()` emits only what's been written, not the full width. Cells the engine left unfilled stayed showing whatever the previous frame painted into them. With no per-frame clear, the previous frame's bottom-of-screen content (e.g. the status bar) remained visible when the new frame's shorter rows landed elsewhere. That's the stacked-status-bars artefact in the third screenshot.

Both hypotheses from the spawn prompt confirmed by direct observation of `Render()`'s bytes.

## Fix shape

**Option 1 — per-row absolute positioning.** Each visible row gets its own `\x1b[<y+1>;1H` prefix and an `\x1b[0m\x1b[K` suffix:

- The per-row position prefix eliminates the LF-without-CR drift by construction — we never emit bare LF between rows, so raw mode can't bite us.
- The reset-SGR + erase-in-line suffix eliminates previous-frame residue by clearing whatever sat past this row's end-of-content. Reset goes first so the erase uses the default background, not the last cell's bg colour.

Picked over option 2 (`\x1b[2J\x1b[H` + `Render()`) because option 2 alone doesn't fix the LF issue — `Render()` still emits bare LFs — and would flicker at 30 Hz on top of that.

Supporting changes:

- `internal/vt/vt.go` gains a `RenderRows() []string` helper that splits `Render()`'s output into per-row strings, padded to the configured row count so the paint loop always repaints every row (preventing residue at the bottom when the engine has fewer rows of content).
- `internal/vt/vt.go` gains a `CursorVisible() bool` method backed by an `atomic.Bool` updated from x/vt's `Callbacks.CursorVisibility` callback. x/vt exposes the callback but not a getter, so we track the state on the `Host`. Cursor is hidden across the frame (so users don't see it dart between row positions) and reshown at the end at `Snapshot().CursorX/Y` if the engine has it visible.
- `cmd/run.go` adds a one-shot `\x1b[2J\x1b[H` to the alt-screen entry sequence so any shell-prompt residue under the alt-screen layer is scrubbed before the first paint.
- `paint()` is split into `paint()` (writes to stdout) and `buildFrame()` (pure string builder), so the structural logic is testable without an attached TTY.

## Verification

`go build ./...`, `go test ./... -race`, and `nix build .#mux-spike` all pass locally.

New `cmd/run_test.go` pins six structural properties of `buildFrame`:

1. Every visible row gets a `\x1b[<y>;1H` absolute-position prefix, in order.
2. No bare LF appears anywhere in the frame (the direct anti-regression against the right-drift bug).
3. Every row ends with `\x1b[0m\x1b[K` (residue fix).
4. Frame ends with the host cursor parked at the engine's tracked position, and no later row-positioning sequence stomps on it.
5. DECTCEM is mirrored: default visible, suppressed across the frame, restored at the end; hidden if the engine has hidden it.
6. Every row up to the emulator height is repainted, even when the engine has rendered fewer rows.

Each assertion was verified against a buggy stub of `buildFrame` that reproduces the original `\x1b[H + Render()` logic — every test fails against the stub and passes against the fix. So these aren't no-ops.

**Interactive verification is pending Ben's hands-on smoke test.** Structural tests cover the failure modes the screenshots showed, but only a human at a terminal can confirm the frame *looks* right end-to-end. If still broken, I'll iterate.

## Design doc

Section 8 of `modules/programs/prism/prism/docs/multiplexer-proposal.md` gains a `Spike findings post-merge` subsection recording the lesson: a corpus snapshot path (`host.Snapshot()`) is necessary but not sufficient for fidelity grading. Future characterisation spikes should drive a live render path (`host.Render()` or equivalent) too, so interactive-use bugs surface during grading rather than at first-hands-on. The mux-spike's proceed-verdict from #2143 remains valid — cell-grid fidelity was the load-bearing question and these bugs were spike-level, not engine-level.

## CI notes

`pr-gate`'s `paths-filter` still matches only `modules/programs/prism/prism/**` (verified via `rg`), so the spike-only Go changes wouldn't trigger `go-tests` / `nix-build-prism-checked` on their own. The doc change at `modules/programs/prism/prism/docs/multiplexer-proposal.md` does match that filter and will trigger both heavy jobs — they'll pass trivially because no Go code under `modules/programs/prism/prism/` changed.

Refs #2143, #2141.
