### PR TITLE
mux-spike: mirror DECSCUSR cursor shape to host terminal

### DIFF
--- a/modules/programs/prism/mux-spike/cmd/run.go
+++ b/modules/programs/prism/mux-spike/cmd/run.go
@@ -69,7 +69,11 @@ func Run(args []string) error {
 	// once with ED2 so any shell-prompt residue under the alt-screen layer
 	// is gone before the first paint. Plain ANSI; no dep needed.
 	os.Stdout.WriteString("\x1b[?1049h\x1b[?25l\x1b[2J\x1b[H")
-	defer os.Stdout.WriteString("\x1b[?25h\x1b[?1049l")
+	// On exit, reshow the cursor, reset the cursor shape to the
+	// terminal-configured default (DECSCUSR 0) so a hosted TUI that left
+	// the cursor as a beam doesn't bleed shape state into the user's
+	// shell, then leave the alt screen.
+	defer os.Stdout.WriteString("\x1b[?25h\x1b[0 q\x1b[?1049l")
 
 	sess, err := pty.Start(argv, uint16(*cols), uint16(*rows))
 	if err != nil {
@@ -225,6 +229,15 @@ func buildFrame(host *vt.Host) string {
 	// re-show so users get the standard blinking cursor at the right cell.
 	if host.CursorVisible() {
 		b.WriteString("\x1b[?25h")
+	}
+	// Mirror the engine's DECSCUSR (cursor-shape) state. nvim sends
+	// \x1b[5 q on INSERT-mode entry (blinking bar); without this relay
+	// the host terminal's cursor stays a block. Skip emission when the
+	// engine has not yet signalled a shape (shape == 0) so we don't
+	// override the user's terminal default before the hosted TUI has an
+	// opinion.
+	if shape := host.CursorShape(); shape != 0 {
+		fmt.Fprintf(&b, "\x1b[%d q", shape)
 	}
 	return b.String()
 }

--- a/modules/programs/prism/mux-spike/cmd/run_test.go
+++ b/modules/programs/prism/mux-spike/cmd/run_test.go
@@ -187,6 +187,85 @@ func TestBuildFrame_CursorVisibilityMirrorsEngine(t *testing.T) {
 	})
 }
 
+// TestBuildFrame_CursorShapeMirrorsEngine pins the DECSCUSR (cursor-shape)
+// relay added on top of PR #2144's visibility + position mirroring. nvim
+// sends "\x1b[5 q" (blinking bar) on INSERT-mode entry; if the paint loop
+// does not forward that sequence to the host terminal, the user's cursor
+// stays a block and INSERT mode is invisible.
+//
+// Anti-regression: this test was verified to FAIL against a stub of
+// buildFrame that omits the `host.CursorShape()` emission — same discipline
+// PR #2144 applied to its five structural tests. The "no shape emitted by
+// default" sub-test also pins that we don't override the host's terminal
+// default before the hosted TUI signals a shape.
+func TestBuildFrame_CursorShapeMirrorsEngine(t *testing.T) {
+	// DECSCUSR sequences look like "\x1b[<n> q" — CSI, decimal digits,
+	// literal space, literal q. Match zero-or-more digits so the regex
+	// also catches "\x1b[ q" (reset to default) variants if we ever emit
+	// them by accident inside a frame.
+	decscusrRe := regexp.MustCompile(`\x1b\[\d* q`)
+
+	t.Run("no shape emitted by default", func(t *testing.T) {
+		// Fresh emulator, no DECSCUSR fed. CursorShape() returns 0; the
+		// frame must NOT contain any DECSCUSR or we'd be stomping on the
+		// host terminal's configured default cursor.
+		h := feed(t, 10, 3, "hi")
+		if got := h.CursorShape(); got != 0 {
+			t.Fatalf("engine cursor shape should be 0 before any DECSCUSR; got %d", got)
+		}
+		frame := buildFrame(h)
+		if loc := decscusrRe.FindStringIndex(frame); loc != nil {
+			t.Errorf("frame should not emit DECSCUSR before engine has seen one; found %q at byte %d.\nframe=%q",
+				frame[loc[0]:loc[1]], loc[0], frame)
+		}
+	})
+
+	t.Run("mirrors blinking bar (DECSCUSR 5)", func(t *testing.T) {
+		// \x1b[5 q is the sequence nvim emits when entering INSERT mode.
+		h := feed(t, 10, 3, "\x1b[5 q")
+		if got := h.CursorShape(); got != 5 {
+			t.Fatalf("engine should track DECSCUSR 5 (blinking bar); got %d", got)
+		}
+
+		frame := buildFrame(h)
+		const want = "\x1b[5 q"
+		idx := strings.Index(frame, want)
+		if idx < 0 {
+			t.Fatalf("frame missing DECSCUSR %q.\nframe=%q", want, frame)
+		}
+
+		// The shape sequence must land AFTER the final cursor-position
+		// sequence — otherwise a row-paint or the end-of-frame position
+		// move could reset the cursor shape on terminals that tie shape
+		// state to the cursor. The spec is explicit: "emit ... at
+		// end-of-frame alongside the cursor-position + visibility-restore".
+		posRe := regexp.MustCompile(`\x1b\[\d+;\d+H`)
+		positions := posRe.FindAllStringIndex(frame, -1)
+		if len(positions) == 0 {
+			t.Fatalf("frame missing any cursor-position sequence.\nframe=%q", frame)
+		}
+		lastPos := positions[len(positions)-1]
+		if idx < lastPos[1] {
+			t.Errorf("DECSCUSR at byte %d appears before the final cursor-position sequence ending at byte %d — the shape relay must come after the position move.\nframe=%q",
+				idx, lastPos[1], frame)
+		}
+	})
+
+	t.Run("mirrors steady block (DECSCUSR 2)", func(t *testing.T) {
+		// Sanity-check the n-value reconstruction across a different
+		// (style, steady) pair so the test doesn't pass by accident on a
+		// hard-coded "5" path.
+		h := feed(t, 10, 3, "\x1b[2 q")
+		if got := h.CursorShape(); got != 2 {
+			t.Fatalf("engine should track DECSCUSR 2 (steady block); got %d", got)
+		}
+		frame := buildFrame(h)
+		if !strings.Contains(frame, "\x1b[2 q") {
+			t.Errorf("frame missing DECSCUSR 2.\nframe=%q", frame)
+		}
+	})
+}
+
 // TestBuildFrame_EmitsOneRowPerEmulatorRow guarantees that even when the
 // engine has rendered fewer rows than the emulator height (e.g. a fresh
 // emulator with a single line of text), we still emit positioning for

--- a/modules/programs/prism/mux-spike/internal/vt/vt.go
+++ b/modules/programs/prism/mux-spike/internal/vt/vt.go
@@ -32,6 +32,24 @@ type Host struct {
 	// TUI toggles it. Terminals power on with the cursor visible, so the
 	// zero value (false) is wrong — we seed true in New.
 	cursorVisible atomic.Bool
+
+	// cursorShape tracks the DECSCUSR cursor-shape parameter (1-6 per
+	// the xterm convention: 1=blinking block, 2=steady block,
+	// 3=blinking underline, 4=steady underline, 5=blinking bar,
+	// 6=steady bar) so the renderer in cmd/run.go can mirror it to the
+	// host terminal each frame.
+	//
+	// x/vt fires a Callbacks.CursorStyle callback with (style, steady)
+	// — note the callback's documented second arg is named `blink` but
+	// the value actually passed is `Steady` (= !blink); see
+	// vendor charmbracelet/x/vt/screen.go::setCursorStyle. We convert
+	// back to the DECSCUSR n-value here so the renderer can emit it
+	// verbatim.
+	//
+	// Zero means "engine has not signalled a shape" — in that case the
+	// renderer leaves the host cursor's shape untouched rather than
+	// overriding the terminal's configured default.
+	cursorShape atomic.Uint32
 }
 
 // New constructs a Host backed by an Emulator of the given dimensions.
@@ -44,6 +62,20 @@ func New(cols, rows int) *Host {
 	h.cursorVisible.Store(true)
 	h.emul.SetCallbacks(xvt.Callbacks{
 		CursorVisibility: func(v bool) { h.cursorVisible.Store(v) },
+		// x/vt's Callbacks.CursorStyle documents `blink bool` as the
+		// second arg, but screen.go::setCursorStyle actually passes
+		// `Steady` (= !blink). We name the parameter accordingly so the
+		// n-value reconstruction reads right.
+		CursorStyle: func(style xvt.CursorStyle, steady bool) {
+			// DECSCUSR n encoding: n = 2*style + (steady ? 2 : 1).
+			// Verified against the table in xterm's DECSCUSR spec and
+			// x/vt's handlers.go decoder.
+			n := uint32(2*int(style) + 1)
+			if steady {
+				n = uint32(2*int(style) + 2)
+			}
+			h.cursorShape.Store(n)
+		},
 	})
 	return h
 }
@@ -53,6 +85,15 @@ func New(cols, rows int) *Host {
 // the x/vt callback that fires inside Write.
 func (h *Host) CursorVisible() bool {
 	return h.cursorVisible.Load()
+}
+
+// CursorShape reports the emulator's current DECSCUSR n-parameter (1-6).
+// Returns 0 if no DECSCUSR has been seen yet — callers should treat 0 as
+// "do not override the host terminal's default cursor shape". Safe to call
+// concurrently with Feed — the value is tracked via an atomic updated from
+// the x/vt callback that fires inside Write.
+func (h *Host) CursorShape() uint32 {
+	return h.cursorShape.Load()
 }
 
 // Feed writes raw PTY bytes into the VT engine. Safe to call concurrently

--- a/modules/programs/prism/prism/docs/multiplexer-proposal.md
+++ b/modules/programs/prism/prism/docs/multiplexer-proposal.md
@@ -512,6 +512,20 @@ first-hands-on. The mux-spike's verdict remains valid because
 cell-grid fidelity is the load-bearing question; the live-render bugs
 were spike-level, not engine-level.
 
+A follow-up smoke test surfaced a third, related lesson once the
+paint loop itself was correct: the cursor surface needs full
+attribute mirroring across the live-render boundary, not just the
+show/hide bit. nvim sends `\x1b[<n> q` (DECSCUSR) to switch to a beam
+on INSERT-mode entry; x/vt's emulator tracks the shape internally,
+but the spike's paint loop initially only relayed cursor *visibility*
+(PR #2144) and *position* (PR #2144), so the host terminal's cursor
+stayed a block. A follow-up PR adds the shape relay. The same gap likely
+exists for cursor colour (`OSC 12`) and blink state, which a real TUI
+may also drive. The structural lesson for the real `internal/mux/`
+package is that a general "cursor-attribute relay" abstraction — one
+that picks up new x/vt callbacks as they're added — would be cleaner
+than the ad-hoc per-attribute mirroring the spike has accreted.
+
 ## 9. Rollout and reversibility
 
 Captures the agreed strategy for how the programme would execute **if**


### PR DESCRIPTION
## Summary

When nvim enters INSERT mode it emits `\x1b[5 q` (DECSCUSR 5, blinking bar) to switch the host cursor from a block to a beam. x/vt's emulator receives and tracks the shape change, but the spike's paint loop in `cmd/run.go` was only mirroring cursor *visibility* (#2144) and *position* (#2144) — not shape. The host terminal's cursor stayed a block and INSERT mode was visually indistinguishable from NORMAL. This PR extends the existing mirror with a parallel cursor-shape track.

## Root cause (verified)

x/vt exposes cursor shape via `Callbacks.CursorStyle func(style CursorStyle, blink bool)` — but `vendor charmbracelet/x/vt/screen.go::setCursorStyle` actually passes `!blink` (`Steady`) as that second argument, despite the parameter name. So the callback fires with `(style, steady)` semantics. The decoder in `handlers.go` for `CSI <n> SP q` (DECSCUSR) gives us:

| n | style | steady |
|---|---|---|
| 1 | block (0) | false |
| 2 | block (0) | true  |
| 3 | underline (1) | false |
| 4 | underline (1) | true  |
| 5 | bar (2) | false |
| 6 | bar (2) | true  |

So `n = 2*style + (steady ? 2 : 1)`.

## Fix shape

Same pattern as PR #2144's `CursorVisibility` mirror:

- **`internal/vt/vt.go`** — new `cursorShape atomic.Uint32` on `Host`, fed from a new `Callbacks.CursorStyle` registration in `New`. Public getter `CursorShape() uint32` returns the reconstructed DECSCUSR n-value, or `0` if the engine hasn't seen a `DECSCUSR` yet.
- **`cmd/run.go::buildFrame`** — emits `\x1b[<n> q` at end-of-frame, after the cursor-position move and the visibility-restore. Skips emission when `CursorShape() == 0` so we don't override the host terminal's configured default before the hosted TUI takes a position.
- **`cmd/run.go::Run`** — alt-screen-leave deferred string gains `\x1b[0 q` (reset to terminal-configured default) so a hosted TUI that left the cursor as a beam doesn't bleed shape state into the user's shell after `Ctrl-q`.

## Verification

- `go build ./...`, `go test ./... -race`, and `nix build .#mux-spike` all pass locally.
- New structural test `TestBuildFrame_CursorShapeMirrorsEngine` in `cmd/run_test.go` follows the pattern PR #2144 set:
  1. "no shape emitted by default" — `CursorShape()` returns `0` on a fresh emulator, and the frame contains no DECSCUSR.
  2. "mirrors blinking bar (DECSCUSR 5)" — feeding `\x1b[5 q` (what nvim sends on INSERT entry) produces `\x1b[5 q` in the frame *after* the final cursor-position sequence.
  3. "mirrors steady block (DECSCUSR 2)" — sanity-check against a hard-coded `5` path that would pass (2) by accident.
- **Anti-regression check (same discipline as PR #2144):** sub-tests (2) and (3) were verified to FAIL against a stubbed `buildFrame` that omits the shape emission. Sub-test (1) correctly still passes against the stub since stubbing emits nothing at all. So the positive sub-tests are non-vacuous.
- **Interactive verification is pending Ben's hands-on smoke test post-merge.** The structural tests cover the byte-level relay; only a human at a real TTY can confirm the cursor actually becomes a beam in INSERT mode.

## Out of scope

Per the spawn prompt: no mouse-mode passthrough, bracketed paste, focus events, window title (OSC 2), or further paint-loop rewrites — Ben hasn't reported these as broken; this is throwaway spike code. The corpus subcommand is unaffected.

## Design doc

`modules/programs/prism/prism/docs/multiplexer-proposal.md` §8.x "Spike findings post-merge" gains one paragraph capturing the structural lesson for the real `internal/mux/` package: a general "cursor-attribute relay" abstraction would be cleaner than the ad-hoc per-attribute mirroring the spike has accreted (visibility → position → shape, plus probable future colour (`OSC 12`) and blink).

## CI

Spike Go code changes don't trigger `pr-gate` (path filter). Design doc change does trigger but passes trivially.

Refs #2144 (the previous paint-loop fix), #2143 (the original spike).
