### PR TITLE
mux/model: internal/mux/pane/ — session and pane data model

### DIFF
--- a/modules/programs/prism/prism/internal/mux/pane/pane.go
+++ b/modules/programs/prism/prism/internal/mux/pane/pane.go
@@ -1,0 +1,853 @@
+// Package pane is the typed data model shared by every other layer of the
+// prism-native multiplexer (server, render, state, persist). It carries the
+// repo cluster → session → review subsession hierarchy codified in §3.1 of
+// docs/multiplexer-proposal.md and the per-session flat pane model
+// (N named panes, one visible at a time).
+//
+// Design notes:
+//
+//   - Pure data model. No I/O, no PTY interaction, no rendering. The package
+//     does not import any other internal/* package — the four parallel
+//     consumer packages (#2152 render, #2153 server, #2155 state, #2156
+//     persist) all sit on top of this without cycles.
+//
+//   - Mutex-guarded reads and writes. The pattern mirrors
+//     internal/mux/vt.Host — a single mutex serialises every state
+//     transition and every read so the tree never observes a partially
+//     applied write. Readers get deep-copied snapshots; the package never
+//     hands out a pointer into its own state.
+//
+//   - JSON round-trip is a first-class operation. The snapshot/restore layer
+//     in PR #2156 uses encoding/json directly on *SessionTree —
+//     MarshalJSON serialises the inner state, UnmarshalJSON revalidates
+//     every invariant so a tampered or malformed blob fails closed instead
+//     of leaving the tree partially populated.
+//
+//   - No panic / log.Fatal. Every failure path returns a wrapped sentinel
+//     error so the server layer (#2153) can surface it to the CLI client
+//     without unwinding the goroutine.
+package pane
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Sentinel errors. Callers compare with errors.Is so the server can map
+// specific failure modes to specific socket-protocol responses without
+// string-matching.
+var (
+	// ErrSessionExists is returned by AddSession when the provided ID is
+	// already registered in the tree.
+	ErrSessionExists = errors.New("pane: session already exists")
+
+	// ErrSessionNotFound is returned by any operation that takes a session
+	// ID for a session that is not in the tree.
+	ErrSessionNotFound = errors.New("pane: session not found")
+
+	// ErrParentNotFound is returned by AddSession when ParentID is set but
+	// the parent is not in the tree.
+	ErrParentNotFound = errors.New("pane: parent session not found")
+
+	// ErrParentIsReview is returned by AddSession when ParentID points at
+	// a session that is itself a review subsession — review subs are
+	// exactly two levels deep per the §3.1 invariant.
+	ErrParentIsReview = errors.New("pane: review subsession cannot have children")
+
+	// ErrInvalidSession is returned by AddSession when the Session struct
+	// fails the basic schema check (empty ID, empty Repo on a top-level
+	// session, etc.).
+	ErrInvalidSession = errors.New("pane: invalid session")
+
+	// ErrPaneExists is returned by AddPane when a pane with the given
+	// name already exists on the target session.
+	ErrPaneExists = errors.New("pane: pane already exists in session")
+
+	// ErrPaneNotFound is returned by any operation that takes a pane name
+	// for a pane that is not in the session.
+	ErrPaneNotFound = errors.New("pane: pane not found in session")
+
+	// ErrNoPanes is returned by NextPane / PrevPane when the session has
+	// no panes to cycle through.
+	ErrNoPanes = errors.New("pane: session has no panes")
+
+	// ErrInconsistent is returned by UnmarshalJSON when the on-disk state
+	// fails one of the tree invariants. The wrapped error names which
+	// invariant tripped.
+	ErrInconsistent = errors.New("pane: inconsistent tree state")
+)
+
+// Pane is one named pane within a session. Name is the only first-class
+// attribute — keeping it a string (rather than an enum) lets the §3.1
+// initial set of "agent" / "term" / "edit" grow without a model change.
+//
+// The package does NOT attribute any meaning to particular names; the
+// renderer (#2152) and server (#2153) decide what "agent" or "term" do.
+type Pane struct {
+	// Name is the pane's identifier within its session. Must be non-empty
+	// and unique within the owning session — AddPane enforces both.
+	Name string `json:"name"`
+}
+
+// Session represents one prism session — either a top-level worker /
+// coordinator session (ParentID == "") or a review subsession
+// (ParentID set to its parent's ID).
+//
+// All fields except ID and Repo are advisory carry-through for the
+// consumers; the model does not act on them. JSON tags use omitempty so
+// snapshots are compact and review subsessions (which inherit most fields
+// from their parent and typically leave them empty) round-trip without
+// noise.
+type Session struct {
+	// ID is the session's globally unique identifier. Prism's existing
+	// naming convention is "<repo>@<branch>" for top-level sessions and
+	// "<parent>~review-<N>-<agent>" for review subsessions, but the model
+	// only requires the string be non-empty and unique within the tree —
+	// it does not parse or interpret the structure.
+	ID string `json:"id"`
+
+	// Repo is the cluster name (e.g. "nixos-config"). Top-level sessions
+	// MUST set this; review subsessions inherit their parent's Repo and
+	// MAY leave it empty on input (AddSession backfills from the parent).
+	Repo string `json:"repo,omitempty"`
+
+	// Branch is the git branch the session's worktree is checked out at.
+	// Carry-through for consumers; never inspected by the model.
+	Branch string `json:"branch,omitempty"`
+
+	// Worktree is the absolute path to the git worktree. Review
+	// subsessions share their parent's worktree and typically leave this
+	// empty.
+	Worktree string `json:"worktree,omitempty"`
+
+	// AgentRole is the prism agent role string (e.g. "worker",
+	// "coordinator", "review-code"). Carry-through.
+	AgentRole string `json:"agent_role,omitempty"`
+
+	// SidecarAddr is the address of the sidecar host-API socket that
+	// serves this session. Carry-through.
+	SidecarAddr string `json:"sidecar_addr,omitempty"`
+
+	// ParentID is empty for top-level sessions and set to the parent's ID
+	// for review subsessions. The §3.1 invariant is that review
+	// subsessions are exactly two levels deep and never have children of
+	// their own — AddSession enforces this.
+	ParentID string `json:"parent_id,omitempty"`
+
+	// Panes is the ordered list of panes in this session. The order is
+	// the AddPane insertion order, which is the order NextPane / PrevPane
+	// cycle through.
+	Panes []Pane `json:"panes,omitempty"`
+
+	// ActivePane is the name of the currently visible pane, or "" if the
+	// session has no panes. Always refers to a pane in Panes or is empty.
+	ActivePane string `json:"active_pane,omitempty"`
+}
+
+// IsReview reports whether this session is a review subsession.
+func (s Session) IsReview() bool { return s.ParentID != "" }
+
+// clone returns a deep copy of the session — used by Snapshot and the
+// per-session accessors so callers can mutate the returned value without
+// racing against the tree.
+func (s Session) clone() Session {
+	out := s
+	if len(s.Panes) > 0 {
+		out.Panes = make([]Pane, len(s.Panes))
+		copy(out.Panes, s.Panes)
+	}
+	return out
+}
+
+// SessionTree is the concurrent-safe data model. Every method acquires the
+// internal mutex; callers never need to lock externally.
+//
+// The zero value is NOT ready for use — construct with New. The zero value
+// of treeState contains nil maps, and operations would panic on map writes;
+// the constructor exists to keep that failure mode out of the API surface.
+type SessionTree struct {
+	mu    sync.RWMutex
+	state treeState
+}
+
+// treeState is the inner, JSON-serialisable shape. It is deliberately not
+// exported so callers cannot bypass the SessionTree mutex to mutate it
+// directly. JSON ser/de routes through *SessionTree.MarshalJSON /
+// UnmarshalJSON, which acquire the lock and (on unmarshal) revalidate.
+type treeState struct {
+	// Sessions is the canonical store: every session in the tree, keyed
+	// by its ID.
+	Sessions map[string]*Session `json:"sessions"`
+
+	// RepoOrder is the display order of repo clusters — the order they
+	// appear in the sidebar's §3.1 layout. Repos are added the first
+	// time a top-level session in that repo is added and removed when
+	// the last top-level session in that repo is removed.
+	RepoOrder []string `json:"repo_order"`
+
+	// SessionOrder maps a repo cluster name to the ordered list of
+	// top-level session IDs in that cluster. The order matches the
+	// AddSession insertion order.
+	SessionOrder map[string][]string `json:"session_order"`
+
+	// ChildOrder maps a top-level session ID to the ordered list of its
+	// review subsession IDs. The order matches the AddSession insertion
+	// order.
+	ChildOrder map[string][]string `json:"child_order"`
+
+	// ActiveSession is the tree-level focus pointer — the session
+	// currently selected in the sidebar. Either references a session in
+	// Sessions or is empty.
+	ActiveSession string `json:"active_session,omitempty"`
+}
+
+// New returns a freshly initialised, empty SessionTree.
+func New() *SessionTree {
+	return &SessionTree{state: newTreeState()}
+}
+
+func newTreeState() treeState {
+	return treeState{
+		Sessions:     make(map[string]*Session),
+		RepoOrder:    []string{},
+		SessionOrder: make(map[string][]string),
+		ChildOrder:   make(map[string][]string),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mutating operations
+// ---------------------------------------------------------------------------
+
+// AddSession inserts a session into the tree.
+//
+// For a top-level session: s.ID and s.Repo MUST be non-empty; s.ParentID
+// MUST be empty. The repo is added to RepoOrder if this is the first
+// session in it; otherwise the session is appended to the repo's existing
+// SessionOrder slice.
+//
+// For a review subsession: s.ID and s.ParentID MUST be non-empty. The
+// parent MUST exist and MUST NOT itself be a review subsession (the §3.1
+// "exactly two levels" invariant). s.Repo is backfilled from the parent if
+// left empty on input; if set, it MUST match the parent's Repo or
+// ErrInvalidSession is returned.
+//
+// s.Panes is preserved as-is; if s.ActivePane is non-empty it MUST name a
+// pane in s.Panes, or ErrInvalidSession is returned. If s.ActivePane is
+// empty and s.Panes is non-empty, the first pane is auto-selected as
+// active so callers do not have to write the same two lines after every
+// AddSession.
+//
+// Returns ErrSessionExists if s.ID is already in the tree.
+func (t *SessionTree) AddSession(s Session) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if s.ID == "" {
+		return fmt.Errorf("%w: empty ID", ErrInvalidSession)
+	}
+	if _, exists := t.state.Sessions[s.ID]; exists {
+		return fmt.Errorf("%w: %q", ErrSessionExists, s.ID)
+	}
+	if s.ParentID == "" {
+		// Top-level session.
+		if s.Repo == "" {
+			return fmt.Errorf("%w: top-level session %q has empty Repo", ErrInvalidSession, s.ID)
+		}
+	} else {
+		// Review subsession.
+		parent, ok := t.state.Sessions[s.ParentID]
+		if !ok {
+			return fmt.Errorf("%w: %q", ErrParentNotFound, s.ParentID)
+		}
+		if parent.IsReview() {
+			return fmt.Errorf("%w: parent %q is itself a review subsession", ErrParentIsReview, s.ParentID)
+		}
+		switch {
+		case s.Repo == "":
+			s.Repo = parent.Repo
+		case s.Repo != parent.Repo:
+			return fmt.Errorf("%w: review subsession %q has Repo %q but parent has Repo %q",
+				ErrInvalidSession, s.ID, s.Repo, parent.Repo)
+		}
+	}
+
+	// Validate the pane set: unique names, and ActivePane (if set) must
+	// resolve to a pane in the slice.
+	seen := make(map[string]struct{}, len(s.Panes))
+	for i, p := range s.Panes {
+		if p.Name == "" {
+			return fmt.Errorf("%w: pane %d has empty name", ErrInvalidSession, i)
+		}
+		if _, dup := seen[p.Name]; dup {
+			return fmt.Errorf("%w: duplicate pane name %q", ErrInvalidSession, p.Name)
+		}
+		seen[p.Name] = struct{}{}
+	}
+	if s.ActivePane != "" {
+		if _, ok := seen[s.ActivePane]; !ok {
+			return fmt.Errorf("%w: ActivePane %q is not in Panes", ErrInvalidSession, s.ActivePane)
+		}
+	} else if len(s.Panes) > 0 {
+		s.ActivePane = s.Panes[0].Name
+	}
+
+	// Defensive copy so callers cannot mutate the slice we now own.
+	copied := s.clone()
+	t.state.Sessions[s.ID] = &copied
+
+	if s.ParentID == "" {
+		if _, ok := t.state.SessionOrder[s.Repo]; !ok {
+			t.state.RepoOrder = append(t.state.RepoOrder, s.Repo)
+		}
+		t.state.SessionOrder[s.Repo] = append(t.state.SessionOrder[s.Repo], s.ID)
+	} else {
+		t.state.ChildOrder[s.ParentID] = append(t.state.ChildOrder[s.ParentID], s.ID)
+	}
+	return nil
+}
+
+// RemoveSession deletes a session from the tree.
+//
+// If the session is top-level, all of its review subsessions are removed
+// as well (the §3.1 invariant: review subs cannot exist without a parent).
+// If removing the last top-level session in a repo cluster, the cluster is
+// also dropped from RepoOrder.
+//
+// If the removed session (or one of its cascaded review subs) was the
+// tree's ActiveSession, ActiveSession is cleared.
+//
+// Returns ErrSessionNotFound if id is not in the tree.
+func (t *SessionTree) RemoveSession(id string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.removeSessionLocked(id)
+}
+
+func (t *SessionTree) removeSessionLocked(id string) error {
+	s, ok := t.state.Sessions[id]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSessionNotFound, id)
+	}
+
+	if !s.IsReview() {
+		// Cascade-remove every review subsession first.
+		for _, childID := range t.state.ChildOrder[id] {
+			delete(t.state.Sessions, childID)
+			if t.state.ActiveSession == childID {
+				t.state.ActiveSession = ""
+			}
+		}
+		delete(t.state.ChildOrder, id)
+
+		// Remove from the repo's SessionOrder.
+		repo := s.Repo
+		order := t.state.SessionOrder[repo]
+		t.state.SessionOrder[repo] = removeString(order, id)
+		if len(t.state.SessionOrder[repo]) == 0 {
+			delete(t.state.SessionOrder, repo)
+			t.state.RepoOrder = removeString(t.state.RepoOrder, repo)
+		}
+	} else {
+		// Review subsession — just unhook from the parent's child order.
+		parentID := s.ParentID
+		t.state.ChildOrder[parentID] = removeString(t.state.ChildOrder[parentID], id)
+		if len(t.state.ChildOrder[parentID]) == 0 {
+			delete(t.state.ChildOrder, parentID)
+		}
+	}
+
+	delete(t.state.Sessions, id)
+	if t.state.ActiveSession == id {
+		t.state.ActiveSession = ""
+	}
+	return nil
+}
+
+// AddPane appends a pane to a session. Pane names must be unique within
+// the session. If the session previously had no panes, the new pane is
+// auto-activated.
+//
+// Returns ErrSessionNotFound if sessionID is unknown, ErrPaneExists if a
+// pane with the same name already exists in the session, or
+// ErrInvalidSession if p.Name is empty.
+func (t *SessionTree) AddPane(sessionID string, p Pane) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if p.Name == "" {
+		return fmt.Errorf("%w: empty pane name", ErrInvalidSession)
+	}
+	s, ok := t.state.Sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSessionNotFound, sessionID)
+	}
+	for _, existing := range s.Panes {
+		if existing.Name == p.Name {
+			return fmt.Errorf("%w: session %q already has pane %q",
+				ErrPaneExists, sessionID, p.Name)
+		}
+	}
+	s.Panes = append(s.Panes, p)
+	if s.ActivePane == "" {
+		s.ActivePane = p.Name
+	}
+	return nil
+}
+
+// RemovePane deletes a pane from a session. If the removed pane was the
+// session's ActivePane, ActivePane is set to whichever pane now occupies
+// the same position in the slice (or the new last pane, if the removed
+// one was last), or "" if the session is now empty.
+//
+// Returns ErrSessionNotFound or ErrPaneNotFound on lookup failures.
+func (t *SessionTree) RemovePane(sessionID, paneName string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	s, ok := t.state.Sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSessionNotFound, sessionID)
+	}
+	idx := -1
+	for i, existing := range s.Panes {
+		if existing.Name == paneName {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("%w: session %q has no pane %q",
+			ErrPaneNotFound, sessionID, paneName)
+	}
+	s.Panes = append(s.Panes[:idx], s.Panes[idx+1:]...)
+	if s.ActivePane == paneName {
+		switch {
+		case len(s.Panes) == 0:
+			s.ActivePane = ""
+		case idx < len(s.Panes):
+			// Pane that took the removed pane's index becomes active.
+			s.ActivePane = s.Panes[idx].Name
+		default:
+			// Removed the trailing pane — fall back to the new last.
+			s.ActivePane = s.Panes[len(s.Panes)-1].Name
+		}
+	}
+	return nil
+}
+
+// ActivatePane sets the session's ActivePane. The pane MUST exist in the
+// session, or ErrPaneNotFound is returned.
+func (t *SessionTree) ActivatePane(sessionID, paneName string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	s, ok := t.state.Sessions[sessionID]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrSessionNotFound, sessionID)
+	}
+	for _, existing := range s.Panes {
+		if existing.Name == paneName {
+			s.ActivePane = paneName
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: session %q has no pane %q",
+		ErrPaneNotFound, sessionID, paneName)
+}
+
+// ActivateSession sets the tree-level ActiveSession pointer. The session
+// MUST exist, or ErrSessionNotFound is returned. Passing "" clears the
+// pointer — useful for "nothing focused" states.
+func (t *SessionTree) ActivateSession(id string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if id == "" {
+		t.state.ActiveSession = ""
+		return nil
+	}
+	if _, ok := t.state.Sessions[id]; !ok {
+		return fmt.Errorf("%w: %q", ErrSessionNotFound, id)
+	}
+	t.state.ActiveSession = id
+	return nil
+}
+
+// NextPane cycles the session's ActivePane forward by one position
+// (wrapping at the end of Panes) and returns the new ActivePane name.
+// Returns ErrSessionNotFound if sessionID is unknown, or ErrNoPanes if
+// the session has no panes to cycle.
+//
+// If the session has panes but no ActivePane (e.g. an externally
+// constructed Session with ActivePane left empty), the first pane is
+// selected.
+func (t *SessionTree) NextPane(sessionID string) (string, error) {
+	return t.cyclePane(sessionID, +1)
+}
+
+// PrevPane cycles the session's ActivePane backward by one position
+// (wrapping at the start of Panes) and returns the new ActivePane name.
+// Returns ErrSessionNotFound if sessionID is unknown, or ErrNoPanes if
+// the session has no panes to cycle.
+func (t *SessionTree) PrevPane(sessionID string) (string, error) {
+	return t.cyclePane(sessionID, -1)
+}
+
+func (t *SessionTree) cyclePane(sessionID string, delta int) (string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	s, ok := t.state.Sessions[sessionID]
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrSessionNotFound, sessionID)
+	}
+	if len(s.Panes) == 0 {
+		return "", fmt.Errorf("%w: session %q", ErrNoPanes, sessionID)
+	}
+
+	idx := 0
+	if s.ActivePane != "" {
+		for i, p := range s.Panes {
+			if p.Name == s.ActivePane {
+				idx = i
+				break
+			}
+		}
+		n := len(s.Panes)
+		// (idx + delta + n) % n keeps the result non-negative for delta = -1.
+		idx = ((idx+delta)%n + n) % n
+	}
+	s.ActivePane = s.Panes[idx].Name
+	return s.ActivePane, nil
+}
+
+// ---------------------------------------------------------------------------
+// Read accessors — all return deep copies so callers cannot race the tree.
+// ---------------------------------------------------------------------------
+
+// Session returns a deep copy of the named session and true if it exists,
+// or the zero Session and false otherwise.
+func (t *SessionTree) Session(id string) (Session, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	s, ok := t.state.Sessions[id]
+	if !ok {
+		return Session{}, false
+	}
+	return s.clone(), true
+}
+
+// HasSession reports whether a session with the given ID is in the tree.
+// Cheaper than Session when callers only need an existence check.
+func (t *SessionTree) HasSession(id string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.state.Sessions[id]
+	return ok
+}
+
+// Sessions returns deep copies of every session in the tree. Order is
+// repo-cluster-major (matching RepoOrder), then top-level session within
+// each cluster (matching SessionOrder), then review subsession within
+// each top-level (matching ChildOrder). This is the natural iteration
+// order for the sidebar renderer in #2152.
+func (t *SessionTree) Sessions() []Session {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	out := make([]Session, 0, len(t.state.Sessions))
+	for _, repo := range t.state.RepoOrder {
+		for _, id := range t.state.SessionOrder[repo] {
+			s, ok := t.state.Sessions[id]
+			if !ok {
+				continue
+			}
+			out = append(out, s.clone())
+			for _, childID := range t.state.ChildOrder[id] {
+				if child, ok := t.state.Sessions[childID]; ok {
+					out = append(out, child.clone())
+				}
+			}
+		}
+	}
+	return out
+}
+
+// Repos returns the repo cluster names in display order.
+func (t *SessionTree) Repos() []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]string, len(t.state.RepoOrder))
+	copy(out, t.state.RepoOrder)
+	return out
+}
+
+// RepoSessions returns the top-level session IDs in the named repo
+// cluster, in display order. Returns nil if the repo is not known.
+func (t *SessionTree) RepoSessions(repo string) []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	ids := t.state.SessionOrder[repo]
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, len(ids))
+	copy(out, ids)
+	return out
+}
+
+// Children returns the review subsession IDs of the given top-level
+// session in display order. Returns nil if the parent is not known or has
+// no review subsessions.
+func (t *SessionTree) Children(parentID string) []string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	ids := t.state.ChildOrder[parentID]
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, len(ids))
+	copy(out, ids)
+	return out
+}
+
+// ActiveSessionID returns the tree-level ActiveSession pointer, or "" if
+// nothing is focused.
+func (t *SessionTree) ActiveSessionID() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.state.ActiveSession
+}
+
+// ActivePaneName returns the named session's ActivePane and true if the
+// session exists, or "" and false otherwise. The empty string is
+// ambiguous on its own ("no active" vs "no session") — pair the bool with
+// the string to distinguish.
+func (t *SessionTree) ActivePaneName(sessionID string) (string, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	s, ok := t.state.Sessions[sessionID]
+	if !ok {
+		return "", false
+	}
+	return s.ActivePane, true
+}
+
+// Len returns the total number of sessions in the tree (top-level +
+// review subsessions). Cheap snapshot for the §3.1 sidebar header's
+// `prism · N sessions` count — note though that the §3.1 header counts
+// only top-level sessions; consumers wanting that figure should walk
+// Repos() and sum RepoSessions().
+func (t *SessionTree) Len() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.state.Sessions)
+}
+
+// ---------------------------------------------------------------------------
+// JSON serialisation — first-class for the snapshot/restore layer in #2156.
+// ---------------------------------------------------------------------------
+
+// MarshalJSON implements json.Marshaler. The encoded form is the inner
+// treeState, fully sufficient to reconstruct the tree via UnmarshalJSON.
+func (t *SessionTree) MarshalJSON() ([]byte, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return json.Marshal(t.state)
+}
+
+// UnmarshalJSON implements json.Unmarshaler. The decoded state is
+// revalidated against every tree invariant — a malformed or tampered blob
+// fails closed with ErrInconsistent rather than silently producing a
+// half-built tree.
+//
+// Empty / missing maps in the source JSON are accepted; nil maps are
+// re-initialised to empty so subsequent writes do not panic.
+func (t *SessionTree) UnmarshalJSON(data []byte) error {
+	var s treeState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s.Sessions == nil {
+		s.Sessions = make(map[string]*Session)
+	}
+	if s.RepoOrder == nil {
+		s.RepoOrder = []string{}
+	}
+	if s.SessionOrder == nil {
+		s.SessionOrder = make(map[string][]string)
+	}
+	if s.ChildOrder == nil {
+		s.ChildOrder = make(map[string][]string)
+	}
+	if err := validate(&s); err != nil {
+		return err
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.state = s
+	return nil
+}
+
+// validate runs every invariant check on a treeState. Used by
+// UnmarshalJSON; also exported via the public Validate method below so
+// tests and consumers can spot-check trees they have built up through
+// the API.
+func validate(s *treeState) error {
+	// 1. Every entry in SessionOrder / ChildOrder references a session
+	//    that exists in Sessions.
+	for repo, ids := range s.SessionOrder {
+		for _, id := range ids {
+			sess, ok := s.Sessions[id]
+			if !ok {
+				return fmt.Errorf("%w: SessionOrder[%q] references unknown session %q",
+					ErrInconsistent, repo, id)
+			}
+			if sess.IsReview() {
+				return fmt.Errorf("%w: SessionOrder[%q] contains review subsession %q (must be top-level)",
+					ErrInconsistent, repo, id)
+			}
+			if sess.Repo != repo {
+				return fmt.Errorf("%w: session %q has Repo %q but is listed under SessionOrder[%q]",
+					ErrInconsistent, id, sess.Repo, repo)
+			}
+		}
+	}
+	for parentID, ids := range s.ChildOrder {
+		parent, ok := s.Sessions[parentID]
+		if !ok {
+			return fmt.Errorf("%w: ChildOrder references unknown parent %q",
+				ErrInconsistent, parentID)
+		}
+		if parent.IsReview() {
+			return fmt.Errorf("%w: ChildOrder[%q] — parent is itself a review subsession",
+				ErrInconsistent, parentID)
+		}
+		for _, id := range ids {
+			child, ok := s.Sessions[id]
+			if !ok {
+				return fmt.Errorf("%w: ChildOrder[%q] references unknown child %q",
+					ErrInconsistent, parentID, id)
+			}
+			if child.ParentID != parentID {
+				return fmt.Errorf("%w: child %q has ParentID %q but is listed under ChildOrder[%q]",
+					ErrInconsistent, id, child.ParentID, parentID)
+			}
+		}
+	}
+
+	// 2. Every session in Sessions is reachable via either SessionOrder
+	//    (top-level) or ChildOrder (review subs) — no orphans.
+	reachable := make(map[string]struct{}, len(s.Sessions))
+	for _, ids := range s.SessionOrder {
+		for _, id := range ids {
+			reachable[id] = struct{}{}
+		}
+	}
+	for _, ids := range s.ChildOrder {
+		for _, id := range ids {
+			reachable[id] = struct{}{}
+		}
+	}
+	for id, sess := range s.Sessions {
+		if _, ok := reachable[id]; !ok {
+			return fmt.Errorf("%w: session %q is orphaned (not in SessionOrder or ChildOrder)",
+				ErrInconsistent, id)
+		}
+		if sess.IsReview() {
+			// Review subs must point at an existing top-level parent.
+			parent, ok := s.Sessions[sess.ParentID]
+			if !ok {
+				return fmt.Errorf("%w: review subsession %q references missing parent %q",
+					ErrInconsistent, id, sess.ParentID)
+			}
+			if parent.IsReview() {
+				return fmt.Errorf("%w: review subsession %q has review-subsession parent %q",
+					ErrInconsistent, id, sess.ParentID)
+			}
+		} else {
+			if sess.Repo == "" {
+				return fmt.Errorf("%w: top-level session %q has empty Repo",
+					ErrInconsistent, id)
+			}
+		}
+		// 3. Pane invariants: unique names, ActivePane present in Panes
+		//    if non-empty.
+		seen := make(map[string]struct{}, len(sess.Panes))
+		for _, p := range sess.Panes {
+			if p.Name == "" {
+				return fmt.Errorf("%w: session %q has a pane with empty name",
+					ErrInconsistent, id)
+			}
+			if _, dup := seen[p.Name]; dup {
+				return fmt.Errorf("%w: session %q has duplicate pane %q",
+					ErrInconsistent, id, p.Name)
+			}
+			seen[p.Name] = struct{}{}
+		}
+		if sess.ActivePane != "" {
+			if _, ok := seen[sess.ActivePane]; !ok {
+				return fmt.Errorf("%w: session %q has ActivePane %q not in Panes",
+					ErrInconsistent, id, sess.ActivePane)
+			}
+		}
+	}
+
+	// 4. RepoOrder is exactly the key set of SessionOrder.
+	if len(s.RepoOrder) != len(s.SessionOrder) {
+		return fmt.Errorf("%w: RepoOrder length %d != SessionOrder size %d",
+			ErrInconsistent, len(s.RepoOrder), len(s.SessionOrder))
+	}
+	seenRepo := make(map[string]struct{}, len(s.RepoOrder))
+	for _, repo := range s.RepoOrder {
+		if _, dup := seenRepo[repo]; dup {
+			return fmt.Errorf("%w: RepoOrder contains duplicate %q",
+				ErrInconsistent, repo)
+		}
+		seenRepo[repo] = struct{}{}
+		if _, ok := s.SessionOrder[repo]; !ok {
+			return fmt.Errorf("%w: RepoOrder contains %q with no SessionOrder entry",
+				ErrInconsistent, repo)
+		}
+	}
+
+	// 5. ActiveSession (if set) references an existing session.
+	if s.ActiveSession != "" {
+		if _, ok := s.Sessions[s.ActiveSession]; !ok {
+			return fmt.Errorf("%w: ActiveSession %q does not exist",
+				ErrInconsistent, s.ActiveSession)
+		}
+	}
+	return nil
+}
+
+// Validate runs the full invariant check on the tree's current state.
+// Returns nil if every invariant holds, or a wrapped ErrInconsistent
+// describing the first violation. Cheap defence-in-depth for tests and
+// consumers that want to assert the tree is well-formed after a sequence
+// of operations.
+func (t *SessionTree) Validate() error {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return validate(&t.state)
+}
+
+// ---------------------------------------------------------------------------
+// internal helpers
+// ---------------------------------------------------------------------------
+
+// removeString returns a new slice with the first occurrence of v removed.
+// Returns the input unchanged (but in a freshly allocated slice) if v is
+// not present; the freshly allocated slice keeps the caller from holding
+// on to a backing array that may have been reused.
+func removeString(in []string, v string) []string {
+	for i, s := range in {
+		if s == v {
+			return append(in[:i:i], in[i+1:]...)
+		}
+	}
+	return in
+}

--- a/modules/programs/prism/prism/internal/mux/pane/pane_test.go
+++ b/modules/programs/prism/prism/internal/mux/pane/pane_test.go
@@ -670,7 +670,7 @@ func TestJSONRoundTrip(t *testing.T) {
 		Branch: "2141-mux-spike", AgentRole: "worker",
 	})
 	mustAddSession(t, tree, Session{
-		ID: "nixos-config@2141-mux-spike~review-1-review-code",
+		ID:       "nixos-config@2141-mux-spike~review-1-review-code",
 		ParentID: "nixos-config@2141-mux-spike", AgentRole: "review-code",
 	})
 	mustAddSession(t, tree, Session{

--- a/modules/programs/prism/prism/internal/mux/pane/pane_test.go
+++ b/modules/programs/prism/prism/internal/mux/pane/pane_test.go
@@ -1,0 +1,962 @@
+// Tests for the pane package — the typed data model the four parallel
+// consumer packages (#2152 render, #2153 server, #2155 state, #2156
+// persist) all sit on top of. The tests pin the invariants the AC on
+// #2151 calls out:
+//
+//  1. Tree consistency under every operation — no orphaned panes, no
+//     sessions outside a repo cluster, no review subsessions outside a
+//     parent session.
+//  2. Concurrent access produces no race under `go test -race` (see
+//     race_test.go for the goroutine fan-out).
+//  3. JSON round-trip preserves state and rejects malformed input.
+//
+// Tests construct a fresh tree per case and never touch global state —
+// $HOME, $XDG_STATE_HOME, the on-disk DB. The suite is therefore
+// homeless-shelter-clean on every run.
+package pane
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mustAddSession is a tiny test helper — fail the test on AddSession
+// error so the happy-path setup in each case stays linear.
+func mustAddSession(t *testing.T, tree *SessionTree, s Session) {
+	t.Helper()
+	if err := tree.AddSession(s); err != nil {
+		t.Fatalf("AddSession(%q): %v", s.ID, err)
+	}
+}
+
+func mustAddPane(t *testing.T, tree *SessionTree, sessionID, paneName string) {
+	t.Helper()
+	if err := tree.AddPane(sessionID, Pane{Name: paneName}); err != nil {
+		t.Fatalf("AddPane(%q, %q): %v", sessionID, paneName, err)
+	}
+}
+
+// --- Construction & basic accessors ----------------------------------------
+
+// TestNewTreeIsEmpty pins the constructor contract — a fresh tree has
+// zero sessions, zero repos, and an empty ActiveSession. The render
+// layer (#2152) relies on these zero-valued accessors not panicking
+// before the first AddSession lands.
+func TestNewTreeIsEmpty(t *testing.T) {
+	tree := New()
+	if got := tree.Len(); got != 0 {
+		t.Errorf("Len() = %d, want 0", got)
+	}
+	if got := tree.Repos(); len(got) != 0 {
+		t.Errorf("Repos() = %v, want empty", got)
+	}
+	if got := tree.Sessions(); len(got) != 0 {
+		t.Errorf("Sessions() = %v, want empty", got)
+	}
+	if got := tree.ActiveSessionID(); got != "" {
+		t.Errorf("ActiveSessionID() = %q, want \"\"", got)
+	}
+	if err := tree.Validate(); err != nil {
+		t.Errorf("Validate() on fresh tree: %v", err)
+	}
+}
+
+// TestAddSessionTopLevel walks the happy path for adding a top-level
+// session and verifies the repo cluster is recorded.
+func TestAddSessionTopLevel(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{
+		ID:          "nixos-config@main",
+		Repo:        "nixos-config",
+		Branch:      "main",
+		Worktree:    "/home/ben/code/nixos-config",
+		AgentRole:   "coordinator",
+		SidecarAddr: "/run/prism/host.sock",
+	})
+
+	if got := tree.Repos(); !reflect.DeepEqual(got, []string{"nixos-config"}) {
+		t.Errorf("Repos() = %v, want [nixos-config]", got)
+	}
+	if got := tree.RepoSessions("nixos-config"); !reflect.DeepEqual(got, []string{"nixos-config@main"}) {
+		t.Errorf("RepoSessions = %v, want [nixos-config@main]", got)
+	}
+	s, ok := tree.Session("nixos-config@main")
+	if !ok {
+		t.Fatal("Session lookup failed for nixos-config@main")
+	}
+	if s.Branch != "main" || s.AgentRole != "coordinator" {
+		t.Errorf("Session round-trip mismatched: %+v", s)
+	}
+}
+
+// TestAddSessionRejectsEmptyID and TestAddSessionRejectsDuplicate pin
+// the schema validations on AddSession.
+func TestAddSessionRejectsEmptyID(t *testing.T) {
+	tree := New()
+	err := tree.AddSession(Session{Repo: "x"})
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("AddSession(empty ID) = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestAddSessionRejectsTopLevelWithoutRepo(t *testing.T) {
+	tree := New()
+	err := tree.AddSession(Session{ID: "lonely"})
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("AddSession(top-level, empty Repo) = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestAddSessionRejectsDuplicate(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "a", Repo: "r"})
+	err := tree.AddSession(Session{ID: "a", Repo: "r"})
+	if !errors.Is(err, ErrSessionExists) {
+		t.Errorf("AddSession(duplicate) = %v, want ErrSessionExists", err)
+	}
+}
+
+// TestAddSessionReviewSubsession exercises the parent-child case the
+// §3.1 hierarchy is built around.
+func TestAddSessionReviewSubsession(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "repo@feature", Repo: "repo"})
+	mustAddSession(t, tree, Session{
+		ID:        "repo@feature~review-1-review-code",
+		ParentID:  "repo@feature",
+		AgentRole: "review-code",
+	})
+
+	// Repo on the child should have been backfilled from the parent.
+	child, ok := tree.Session("repo@feature~review-1-review-code")
+	if !ok {
+		t.Fatal("child session not found")
+	}
+	if child.Repo != "repo" {
+		t.Errorf("child.Repo = %q, want %q (backfilled from parent)", child.Repo, "repo")
+	}
+	if !child.IsReview() {
+		t.Error("IsReview() = false on child with ParentID set")
+	}
+
+	// Tree-order iteration places the child directly after its parent.
+	ids := sessionIDs(tree.Sessions())
+	want := []string{"repo@feature", "repo@feature~review-1-review-code"}
+	if !reflect.DeepEqual(ids, want) {
+		t.Errorf("Sessions() iteration order = %v, want %v", ids, want)
+	}
+
+	// Children accessor returns the child.
+	if got := tree.Children("repo@feature"); !reflect.DeepEqual(got, []string{"repo@feature~review-1-review-code"}) {
+		t.Errorf("Children = %v, want one entry", got)
+	}
+}
+
+// TestAddSessionRejectsMissingParent and TestAddSessionRejectsNestedReview
+// pin the §3.1 invariants: reviews must have a parent, and reviews cannot
+// themselves have children.
+func TestAddSessionRejectsMissingParent(t *testing.T) {
+	tree := New()
+	err := tree.AddSession(Session{
+		ID:       "orphan~review-1-review-code",
+		ParentID: "does-not-exist",
+	})
+	if !errors.Is(err, ErrParentNotFound) {
+		t.Errorf("AddSession(orphan review) = %v, want ErrParentNotFound", err)
+	}
+}
+
+func TestAddSessionRejectsNestedReview(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "repo@feature", Repo: "repo"})
+	mustAddSession(t, tree, Session{ID: "repo@feature~review-1-review-code", ParentID: "repo@feature"})
+	err := tree.AddSession(Session{
+		ID:       "repo@feature~review-1-review-code~oops",
+		ParentID: "repo@feature~review-1-review-code",
+	})
+	if !errors.Is(err, ErrParentIsReview) {
+		t.Errorf("AddSession(nested review) = %v, want ErrParentIsReview", err)
+	}
+}
+
+// TestAddSessionReviewRepoMustMatchParent — if the caller sets Repo on a
+// review subsession, it must match the parent's Repo. Avoids silent
+// inconsistency in callers that build the struct from two unrelated
+// sources.
+func TestAddSessionReviewRepoMustMatchParent(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "a@x", Repo: "a"})
+	err := tree.AddSession(Session{
+		ID:       "a@x~review-1-r",
+		Repo:     "b", // wrong
+		ParentID: "a@x",
+	})
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("AddSession(mismatched repo) = %v, want ErrInvalidSession", err)
+	}
+}
+
+// --- RemoveSession ----------------------------------------------------------
+
+// TestRemoveSessionCascadesReviews pins the §3.1 invariant in reverse:
+// removing a top-level session drops every one of its review subs.
+// Without this, the next snapshot would carry orphan children.
+func TestRemoveSessionCascadesReviews(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "repo@feature", Repo: "repo"})
+	mustAddSession(t, tree, Session{ID: "repo@feature~review-1-code", ParentID: "repo@feature"})
+	mustAddSession(t, tree, Session{ID: "repo@feature~review-1-goal", ParentID: "repo@feature"})
+
+	if err := tree.RemoveSession("repo@feature"); err != nil {
+		t.Fatalf("RemoveSession: %v", err)
+	}
+
+	if tree.HasSession("repo@feature") {
+		t.Error("top-level session still present after remove")
+	}
+	if tree.HasSession("repo@feature~review-1-code") {
+		t.Error("review subsession should have been cascade-removed")
+	}
+	if tree.HasSession("repo@feature~review-1-goal") {
+		t.Error("review subsession should have been cascade-removed")
+	}
+	if err := tree.Validate(); err != nil {
+		t.Errorf("Validate after cascade: %v", err)
+	}
+}
+
+// TestRemoveSessionLastInRepoDropsRepo verifies the §3.1 "header counts
+// non-review sessions across all repos" invariant by way of the
+// underlying RepoOrder bookkeeping — an empty repo is removed from the
+// display order entirely.
+func TestRemoveSessionLastInRepoDropsRepo(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "lonely@main", Repo: "lonely"})
+	mustAddSession(t, tree, Session{ID: "keeper@main", Repo: "keeper"})
+
+	if err := tree.RemoveSession("lonely@main"); err != nil {
+		t.Fatalf("RemoveSession: %v", err)
+	}
+	if got := tree.Repos(); !reflect.DeepEqual(got, []string{"keeper"}) {
+		t.Errorf("Repos() = %v, want [keeper]", got)
+	}
+	if got := tree.RepoSessions("lonely"); got != nil {
+		t.Errorf("RepoSessions(lonely) = %v, want nil after last session removed", got)
+	}
+}
+
+// TestRemoveSessionPreservesRepoOrderOfSiblings — removing one session
+// from a multi-session repo keeps the remaining ones in their original
+// insertion order (no reshuffle, no swap-and-pop).
+func TestRemoveSessionPreservesRepoOrderOfSiblings(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "r@a", Repo: "r"})
+	mustAddSession(t, tree, Session{ID: "r@b", Repo: "r"})
+	mustAddSession(t, tree, Session{ID: "r@c", Repo: "r"})
+	if err := tree.RemoveSession("r@b"); err != nil {
+		t.Fatal(err)
+	}
+	if got := tree.RepoSessions("r"); !reflect.DeepEqual(got, []string{"r@a", "r@c"}) {
+		t.Errorf("after remove middle: RepoSessions(r) = %v, want [r@a r@c]", got)
+	}
+}
+
+func TestRemoveSessionUnknownID(t *testing.T) {
+	tree := New()
+	err := tree.RemoveSession("nope")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("RemoveSession(unknown) = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestRemoveSessionClearsActiveSession ensures the tree-level focus
+// pointer never references a session that has been removed (UI would
+// dereference a stale ID).
+func TestRemoveSessionClearsActiveSession(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "r@x", Repo: "r"})
+	if err := tree.ActivateSession("r@x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemoveSession("r@x"); err != nil {
+		t.Fatal(err)
+	}
+	if got := tree.ActiveSessionID(); got != "" {
+		t.Errorf("ActiveSessionID after remove = %q, want empty", got)
+	}
+}
+
+// TestRemoveSessionCascadeClearsActiveReview — if the focused session
+// happens to be a review subsession whose parent is being cascade-removed,
+// ActiveSession must clear, not point at the now-deleted review.
+func TestRemoveSessionCascadeClearsActiveReview(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "r@x", Repo: "r"})
+	mustAddSession(t, tree, Session{ID: "r@x~review-1-c", ParentID: "r@x"})
+	if err := tree.ActivateSession("r@x~review-1-c"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemoveSession("r@x"); err != nil {
+		t.Fatal(err)
+	}
+	if got := tree.ActiveSessionID(); got != "" {
+		t.Errorf("ActiveSessionID after cascade = %q, want empty", got)
+	}
+}
+
+// --- Pane operations --------------------------------------------------------
+
+// TestAddPaneAutoActivates pins the convenience behaviour: the first
+// pane added to a session becomes ActivePane automatically, so the
+// renderer does not have to special-case "session has panes but
+// nothing is active".
+func TestAddPaneAutoActivates(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	got, ok := tree.ActivePaneName("s")
+	if !ok || got != "agent" {
+		t.Errorf("ActivePaneName = (%q, %v), want (agent, true)", got, ok)
+	}
+	mustAddPane(t, tree, "s", "term")
+	// Adding a second pane does NOT change the active pane.
+	got, ok = tree.ActivePaneName("s")
+	if !ok || got != "agent" {
+		t.Errorf("ActivePaneName after second AddPane = (%q, %v), want unchanged", got, ok)
+	}
+}
+
+func TestAddPaneRejectsDuplicate(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	err := tree.AddPane("s", Pane{Name: "agent"})
+	if !errors.Is(err, ErrPaneExists) {
+		t.Errorf("AddPane(duplicate) = %v, want ErrPaneExists", err)
+	}
+}
+
+func TestAddPaneRejectsEmptyName(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	err := tree.AddPane("s", Pane{})
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("AddPane(empty name) = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestAddPaneRejectsUnknownSession(t *testing.T) {
+	tree := New()
+	err := tree.AddPane("missing", Pane{Name: "agent"})
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("AddPane(missing session) = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestRemovePaneShiftsActiveToSlot is the load-bearing "focus follows
+// the slot" invariant. Removing the active pane should snap focus to
+// whatever pane now occupies that slice index — matches tmux's
+// kill-pane behaviour and is what the renderer ends up coding against.
+func TestRemovePaneShiftsActiveToSlot(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	mustAddPane(t, tree, "s", "term")
+	mustAddPane(t, tree, "s", "edit")
+
+	// Activate middle pane and remove it. The slot is taken by "edit".
+	if err := tree.ActivatePane("s", "term"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemovePane("s", "term"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := tree.ActivePaneName("s")
+	if got != "edit" {
+		t.Errorf("after removing middle active pane, ActivePane = %q, want edit", got)
+	}
+}
+
+// TestRemovePaneFromTailFallsBack — when the active pane is the last
+// one in the slice and gets removed, focus falls back to the new last.
+func TestRemovePaneFromTailFallsBack(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	mustAddPane(t, tree, "s", "term")
+	if err := tree.ActivatePane("s", "term"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.RemovePane("s", "term"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := tree.ActivePaneName("s")
+	if got != "agent" {
+		t.Errorf("after removing tail active pane, ActivePane = %q, want agent", got)
+	}
+}
+
+// TestRemovePaneLeavesActiveAloneIfNotActive — removing a non-active
+// pane must NOT shift focus.
+func TestRemovePaneLeavesActiveAloneIfNotActive(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	mustAddPane(t, tree, "s", "term")
+	mustAddPane(t, tree, "s", "edit")
+	if err := tree.RemovePane("s", "edit"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := tree.ActivePaneName("s")
+	if got != "agent" {
+		t.Errorf("removing non-active pane shifted focus: %q, want agent", got)
+	}
+}
+
+// TestRemovePaneEmptiesSession — removing the only pane clears
+// ActivePane back to "".
+func TestRemovePaneEmptiesSession(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	if err := tree.RemovePane("s", "agent"); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := tree.ActivePaneName("s")
+	if !ok || got != "" {
+		t.Errorf("after removing last pane, ActivePaneName = (%q, %v), want (\"\", true)", got, ok)
+	}
+}
+
+func TestRemovePaneUnknown(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	if err := tree.RemovePane("s", "missing"); !errors.Is(err, ErrPaneNotFound) {
+		t.Errorf("RemovePane(missing) = %v, want ErrPaneNotFound", err)
+	}
+	if err := tree.RemovePane("nope", "agent"); !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("RemovePane(missing session) = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestActivatePane pins the lookup path: activate a known pane,
+// reject an unknown one.
+func TestActivatePane(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	mustAddPane(t, tree, "s", "term")
+	if err := tree.ActivatePane("s", "term"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := tree.ActivePaneName("s")
+	if got != "term" {
+		t.Errorf("ActivePane = %q, want term", got)
+	}
+	if err := tree.ActivatePane("s", "missing"); !errors.Is(err, ErrPaneNotFound) {
+		t.Errorf("ActivatePane(missing) = %v, want ErrPaneNotFound", err)
+	}
+	if err := tree.ActivatePane("nope", "agent"); !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("ActivatePane(missing session) = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// TestActivateSession pins the tree-level focus pointer.
+func TestActivateSession(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	if err := tree.ActivateSession("s"); err != nil {
+		t.Fatal(err)
+	}
+	if got := tree.ActiveSessionID(); got != "s" {
+		t.Errorf("ActiveSessionID = %q, want s", got)
+	}
+
+	// Empty string clears.
+	if err := tree.ActivateSession(""); err != nil {
+		t.Fatalf("ActivateSession(empty) = %v, want nil", err)
+	}
+	if got := tree.ActiveSessionID(); got != "" {
+		t.Errorf("ActiveSessionID after clear = %q, want empty", got)
+	}
+
+	// Unknown ID returns an error and does not change state.
+	if err := tree.ActivateSession("ghost"); !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("ActivateSession(ghost) = %v, want ErrSessionNotFound", err)
+	}
+	if got := tree.ActiveSessionID(); got != "" {
+		t.Errorf("ActiveSessionID unexpectedly set to %q after failed Activate", got)
+	}
+}
+
+// TestNextPrevPaneCycles drives the cycling invariants: forward wraps
+// at the end, backward wraps at the start, single-pane is a no-op,
+// empty session reports ErrNoPanes.
+func TestNextPrevPaneCycles(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	mustAddPane(t, tree, "s", "term")
+	mustAddPane(t, tree, "s", "edit")
+
+	// Forward through three panes and wrap.
+	want := []string{"term", "edit", "agent", "term"}
+	for i, w := range want {
+		got, err := tree.NextPane("s")
+		if err != nil {
+			t.Fatalf("NextPane #%d: %v", i, err)
+		}
+		if got != w {
+			t.Errorf("NextPane #%d = %q, want %q", i, got, w)
+		}
+	}
+
+	// PrevPane reverses.
+	got, err := tree.PrevPane("s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "agent" {
+		t.Errorf("PrevPane = %q, want agent", got)
+	}
+
+	// Wrap backward across the start.
+	got, err = tree.PrevPane("s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "edit" {
+		t.Errorf("PrevPane wrap = %q, want edit", got)
+	}
+}
+
+func TestNextPaneEmptySession(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	if _, err := tree.NextPane("s"); !errors.Is(err, ErrNoPanes) {
+		t.Errorf("NextPane(empty) = %v, want ErrNoPanes", err)
+	}
+	if _, err := tree.PrevPane("s"); !errors.Is(err, ErrNoPanes) {
+		t.Errorf("PrevPane(empty) = %v, want ErrNoPanes", err)
+	}
+}
+
+func TestNextPaneSinglePaneIsIdempotent(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+	for i := 0; i < 3; i++ {
+		got, err := tree.NextPane("s")
+		if err != nil || got != "agent" {
+			t.Fatalf("NextPane #%d = (%q, %v), want (agent, nil)", i, got, err)
+		}
+	}
+}
+
+// TestNextPaneSeedsFromFirstWhenActiveEmpty — if for some reason
+// ActivePane is empty but panes exist (e.g. caller built the session
+// from JSON without setting ActivePane), NextPane should drop into the
+// first pane rather than report an error.
+func TestNextPaneSeedsFromFirstWhenActiveEmpty(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{
+		ID:    "s",
+		Repo:  "r",
+		Panes: []Pane{{Name: "agent"}, {Name: "term"}},
+	})
+	// AddSession auto-activates the first pane. Manually clear via a
+	// direct manipulation through the lock so we can exercise the seed
+	// branch.
+	tree.mu.Lock()
+	tree.state.Sessions["s"].ActivePane = ""
+	tree.mu.Unlock()
+
+	got, err := tree.NextPane("s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "agent" {
+		t.Errorf("NextPane(seed) = %q, want agent", got)
+	}
+}
+
+// --- Session value passed into AddSession with pre-existing panes ----------
+
+// TestAddSessionWithPreloadedPanes verifies that a Session carrying
+// panes at AddSession time is accepted, panes are deep-copied (mutating
+// the caller's slice after AddSession does not affect the tree), and the
+// first pane is auto-activated if ActivePane was left empty.
+func TestAddSessionWithPreloadedPanes(t *testing.T) {
+	tree := New()
+	panes := []Pane{{Name: "agent"}, {Name: "term"}}
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r", Panes: panes})
+
+	// Mutate the caller's slice; the tree must not observe.
+	panes[0].Name = "tampered"
+
+	got, _ := tree.Session("s")
+	if got.Panes[0].Name != "agent" {
+		t.Errorf("AddSession kept a shared reference: pane 0 = %q, want agent", got.Panes[0].Name)
+	}
+	if got.ActivePane != "agent" {
+		t.Errorf("AddSession did not auto-activate first pane: ActivePane = %q", got.ActivePane)
+	}
+}
+
+// TestAddSessionRejectsDuplicatePaneInPreload and
+// TestAddSessionRejectsActivePaneNotInSlice pin the schema checks on the
+// preload path.
+func TestAddSessionRejectsDuplicatePaneInPreload(t *testing.T) {
+	tree := New()
+	err := tree.AddSession(Session{
+		ID: "s", Repo: "r",
+		Panes: []Pane{{Name: "agent"}, {Name: "agent"}},
+	})
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("AddSession(duplicate pane) = %v, want ErrInvalidSession", err)
+	}
+}
+
+func TestAddSessionRejectsActivePaneNotInSlice(t *testing.T) {
+	tree := New()
+	err := tree.AddSession(Session{
+		ID: "s", Repo: "r",
+		Panes:      []Pane{{Name: "agent"}},
+		ActivePane: "term",
+	})
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Errorf("AddSession(bad ActivePane) = %v, want ErrInvalidSession", err)
+	}
+}
+
+// --- Snapshot isolation -----------------------------------------------------
+
+// TestSessionAccessorReturnsDeepCopy pins the "callers never get a
+// pointer into our state" contract. Mutating the returned Session's
+// Panes slice must not mutate the tree.
+func TestSessionAccessorReturnsDeepCopy(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	mustAddPane(t, tree, "s", "agent")
+
+	got, _ := tree.Session("s")
+	got.Panes[0].Name = "tampered"
+
+	again, _ := tree.Session("s")
+	if again.Panes[0].Name != "agent" {
+		t.Errorf("Session returned aliased slice: pane 0 = %q", again.Panes[0].Name)
+	}
+}
+
+// --- JSON round-trip --------------------------------------------------------
+
+// TestJSONRoundTrip is the smoke test for the persist layer in #2156 —
+// a complex tree marshals, unmarshals, and compares equal under the
+// accessor surface. Equality is by accessor output (Repos, Sessions in
+// order, ActiveSession, ActivePane per session) — internal map iteration
+// order is intentionally not part of the contract.
+func TestJSONRoundTrip(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{
+		ID: "nixos-config@main", Repo: "nixos-config", Branch: "main",
+		Worktree: "/home/ben/code/nixos-config", AgentRole: "coordinator",
+		SidecarAddr: "/run/prism/host.sock",
+	})
+	mustAddSession(t, tree, Session{
+		ID: "nixos-config@2141-mux-spike", Repo: "nixos-config",
+		Branch: "2141-mux-spike", AgentRole: "worker",
+	})
+	mustAddSession(t, tree, Session{
+		ID: "nixos-config@2141-mux-spike~review-1-review-code",
+		ParentID: "nixos-config@2141-mux-spike", AgentRole: "review-code",
+	})
+	mustAddSession(t, tree, Session{
+		ID: "home-ops@main", Repo: "home-ops", AgentRole: "coordinator",
+	})
+	mustAddPane(t, tree, "nixos-config@main", "agent")
+	mustAddPane(t, tree, "nixos-config@main", "term")
+	mustAddPane(t, tree, "nixos-config@main", "edit")
+	if err := tree.ActivatePane("nixos-config@main", "term"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.ActivateSession("nixos-config@2141-mux-spike"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := json.Marshal(tree)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	restored := New()
+	if err := json.Unmarshal(data, restored); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if got, want := restored.Repos(), tree.Repos(); !reflect.DeepEqual(got, want) {
+		t.Errorf("Repos mismatch: got %v want %v", got, want)
+	}
+	if got, want := sessionIDs(restored.Sessions()), sessionIDs(tree.Sessions()); !reflect.DeepEqual(got, want) {
+		t.Errorf("Sessions order mismatch:\n got  %v\n want %v", got, want)
+	}
+	if got, want := restored.ActiveSessionID(), tree.ActiveSessionID(); got != want {
+		t.Errorf("ActiveSessionID mismatch: got %q want %q", got, want)
+	}
+	gotPane, _ := restored.ActivePaneName("nixos-config@main")
+	wantPane, _ := tree.ActivePaneName("nixos-config@main")
+	if gotPane != wantPane {
+		t.Errorf("ActivePane on nixos-config@main mismatch: got %q want %q", gotPane, wantPane)
+	}
+	if err := restored.Validate(); err != nil {
+		t.Errorf("Validate after round-trip: %v", err)
+	}
+}
+
+// TestJSONRoundTripEmpty verifies the zero-state survives the round
+// trip — important because persist will marshal an empty tree on first
+// startup before any session lands.
+func TestJSONRoundTripEmpty(t *testing.T) {
+	tree := New()
+	data, err := json.Marshal(tree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := New()
+	if err := json.Unmarshal(data, restored); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if restored.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", restored.Len())
+	}
+	if err := restored.Validate(); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+}
+
+// TestUnmarshalRejectsOrphanReview pins the §3.1 invariant on the
+// load path. A snapshot whose ChildOrder names a child whose ParentID
+// doesn't match must be rejected — silent acceptance here would let
+// tampered persisted state leak into the live tree.
+func TestUnmarshalRejectsOrphanReview(t *testing.T) {
+	// Construct a deliberately inconsistent JSON: a child whose
+	// ParentID names a session that isn't actually a parent (the
+	// ChildOrder entry is missing).
+	bad := `{
+		"sessions": {
+			"a@x":         {"id":"a@x","repo":"a","panes":[],"active_pane":""},
+			"a@x~review-1":{"id":"a@x~review-1","parent_id":"a@x"}
+		},
+		"repo_order":     ["a"],
+		"session_order":  {"a":["a@x"]},
+		"child_order":    {},
+		"active_session": ""
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(orphan review) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRejectsMissingRepoInOrder(t *testing.T) {
+	bad := `{
+		"sessions": {"r@x":{"id":"r@x","repo":"r"}},
+		"repo_order": ["r","ghost"],
+		"session_order": {"r":["r@x"]},
+		"child_order": {},
+		"active_session": ""
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(ghost repo) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRejectsActiveSessionUnknown(t *testing.T) {
+	bad := `{
+		"sessions": {"r@x":{"id":"r@x","repo":"r"}},
+		"repo_order": ["r"],
+		"session_order": {"r":["r@x"]},
+		"child_order": {},
+		"active_session": "ghost"
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(ghost active) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRejectsTopLevelWithoutRepo(t *testing.T) {
+	bad := `{
+		"sessions": {"x":{"id":"x"}},
+		"repo_order": [""],
+		"session_order": {"":["x"]},
+		"child_order": {}
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(top-level without repo) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRejectsDuplicatePane(t *testing.T) {
+	bad := `{
+		"sessions": {"r@x":{"id":"r@x","repo":"r","panes":[{"name":"a"},{"name":"a"}]}},
+		"repo_order": ["r"],
+		"session_order": {"r":["r@x"]},
+		"child_order": {}
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(duplicate pane) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRejectsActivePaneNotInSlice(t *testing.T) {
+	bad := `{
+		"sessions": {"r@x":{"id":"r@x","repo":"r","panes":[{"name":"a"}],"active_pane":"ghost"}},
+		"repo_order": ["r"],
+		"session_order": {"r":["r@x"]},
+		"child_order": {}
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(bad active pane) = %v, want ErrInconsistent", err)
+	}
+}
+
+// TestUnmarshalRejectsReviewParentingReview pins the §3.1 two-level
+// invariant on the load path.
+func TestUnmarshalRejectsReviewParentingReview(t *testing.T) {
+	bad := `{
+		"sessions": {
+			"a@x":              {"id":"a@x","repo":"a"},
+			"a@x~r1":            {"id":"a@x~r1","parent_id":"a@x","repo":"a"},
+			"a@x~r1~r2":         {"id":"a@x~r1~r2","parent_id":"a@x~r1","repo":"a"}
+		},
+		"repo_order": ["a"],
+		"session_order": {"a":["a@x"]},
+		"child_order": {"a@x":["a@x~r1"],"a@x~r1":["a@x~r1~r2"]}
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(nested review) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRejectsOrphanedSession(t *testing.T) {
+	// A session not referenced by either SessionOrder or ChildOrder.
+	bad := `{
+		"sessions": {
+			"r@x":  {"id":"r@x","repo":"r"},
+			"r@y":  {"id":"r@y","repo":"r"}
+		},
+		"repo_order": ["r"],
+		"session_order": {"r":["r@x"]},
+		"child_order": {}
+	}`
+	tree := New()
+	err := json.Unmarshal([]byte(bad), tree)
+	if !errors.Is(err, ErrInconsistent) {
+		t.Errorf("Unmarshal(orphaned session) = %v, want ErrInconsistent", err)
+	}
+}
+
+func TestUnmarshalRebuildsNilMaps(t *testing.T) {
+	// Minimal JSON: just an empty active_session string. The
+	// constructor should reinitialise the nil maps so subsequent
+	// AddSession calls work without panic.
+	tree := New()
+	if err := json.Unmarshal([]byte(`{}`), tree); err != nil {
+		t.Fatal(err)
+	}
+	mustAddSession(t, tree, Session{ID: "s", Repo: "r"})
+	if tree.Len() != 1 {
+		t.Errorf("after Unmarshal({}) + AddSession, Len = %d, want 1", tree.Len())
+	}
+}
+
+// --- Validate after a sequence of operations -------------------------------
+
+// TestValidateAfterMixedSequence builds up the canonical §3.1 example
+// from docs (`nixos-config` with a mux-spike session, several review
+// subs, plus a home-ops cluster) through the public API and then asserts
+// every invariant holds.
+func TestValidateAfterMixedSequence(t *testing.T) {
+	tree := New()
+	mustAddSession(t, tree, Session{ID: "nixos-config@main", Repo: "nixos-config"})
+	mustAddSession(t, tree, Session{ID: "nixos-config@2141-mux-spike", Repo: "nixos-config"})
+	for _, agent := range []string{"code", "goal", "qa", "security", "context"} {
+		mustAddSession(t, tree, Session{
+			ID:       "nixos-config@2141-mux-spike~review-1-review-" + agent,
+			ParentID: "nixos-config@2141-mux-spike",
+		})
+	}
+	mustAddSession(t, tree, Session{ID: "home-ops@main", Repo: "home-ops"})
+	mustAddSession(t, tree, Session{ID: "home-ops@plex-image-bump", Repo: "home-ops"})
+
+	mustAddPane(t, tree, "nixos-config@main", "agent")
+	mustAddPane(t, tree, "nixos-config@main", "term")
+	mustAddPane(t, tree, "nixos-config@2141-mux-spike", "agent")
+
+	if err := tree.ActivateSession("nixos-config@2141-mux-spike"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.Validate(); err != nil {
+		t.Fatalf("Validate after mixed sequence: %v", err)
+	}
+
+	// Remove the mux-spike session: cascade-removes all five review
+	// subs. Validate again — still consistent.
+	if err := tree.RemoveSession("nixos-config@2141-mux-spike"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tree.Validate(); err != nil {
+		t.Fatalf("Validate after cascade: %v", err)
+	}
+	if tree.ActiveSessionID() != "" {
+		t.Errorf("ActiveSessionID should clear when active session removed")
+	}
+	if !tree.HasSession("nixos-config@main") || !tree.HasSession("home-ops@plex-image-bump") {
+		t.Errorf("unrelated sessions should survive cascade")
+	}
+	for _, agent := range []string{"code", "goal", "qa", "security", "context"} {
+		id := "nixos-config@2141-mux-spike~review-1-review-" + agent
+		if tree.HasSession(id) {
+			t.Errorf("review subsession %q should have been cascade-removed", id)
+		}
+	}
+}
+
+// --- Error message ergonomics ---------------------------------------------
+
+// TestErrorsCarryContext spot-checks that errors include the offending
+// ID — server callers (#2153) surface these to the CLI client, and a
+// bare "session not found" is much less useful than "session not found:
+// nixos-config@feature".
+func TestErrorsCarryContext(t *testing.T) {
+	tree := New()
+	err := tree.RemoveSession("nixos-config@feature")
+	if err == nil || !strings.Contains(err.Error(), "nixos-config@feature") {
+		t.Errorf("error %q should mention the missing ID", err)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func sessionIDs(sessions []Session) []string {
+	out := make([]string, len(sessions))
+	for i, s := range sessions {
+		out[i] = s.ID
+	}
+	return out
+}

--- a/modules/programs/prism/prism/internal/mux/pane/race_test.go
+++ b/modules/programs/prism/prism/internal/mux/pane/race_test.go
@@ -32,12 +32,10 @@ func TestConcurrentAddSession(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			defer wg.Done()
-			id := fmt.Sprintf("repo-%d@main", i%4)
 			_ = tree.AddSession(Session{
 				ID:   fmt.Sprintf("repo-%d@worker-%d", i%4, i),
 				Repo: fmt.Sprintf("repo-%d", i%4),
 			})
-			_ = id // keep the formatter from eliding
 		}(i)
 	}
 	wg.Wait()

--- a/modules/programs/prism/prism/internal/mux/pane/race_test.go
+++ b/modules/programs/prism/prism/internal/mux/pane/race_test.go
@@ -1,0 +1,215 @@
+// Concurrency stress tests. The AC on #2151 calls out -race cleanliness
+// explicitly; this file holds the goroutine fan-outs that exercise the
+// SessionTree mutex under load. Tests are deliberately not "stress
+// benchmarks" — they fan out a moderate number of goroutines and
+// exercise every mutating operation, which is enough to flush any
+// missing lock acquisition that the Go race detector cares about.
+//
+// All operations against the tree go through the public API, so the
+// tests double as a smoke check that the public surface holds together
+// under contention. They never assert exact final-state values
+// (interleavings make that brittle); they assert structural invariants
+// after the storm via Validate.
+package pane
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestConcurrentAddSession fans out N goroutines that each add a
+// distinct top-level session. After Wait, every session must be in
+// the tree and Validate must pass. The race detector catches any
+// missing lock acquisition on the SessionOrder / RepoOrder writes.
+func TestConcurrentAddSession(t *testing.T) {
+	tree := New()
+	const n = 64
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("repo-%d@main", i%4)
+			_ = tree.AddSession(Session{
+				ID:   fmt.Sprintf("repo-%d@worker-%d", i%4, i),
+				Repo: fmt.Sprintf("repo-%d", i%4),
+			})
+			_ = id // keep the formatter from eliding
+		}(i)
+	}
+	wg.Wait()
+
+	if got := tree.Len(); got != n {
+		t.Errorf("Len after %d concurrent adds = %d, want %d", n, got, n)
+	}
+	if err := tree.Validate(); err != nil {
+		t.Errorf("Validate after concurrent adds: %v", err)
+	}
+}
+
+// TestConcurrentMixedOperations exercises every mutating operation
+// against a shared tree while a second pool of goroutines reads
+// continuously. The shape is intentionally chaotic — no goroutine
+// owns a session ID, and several goroutines deliberately race on the
+// same ID via AddSession+RemoveSession+AddPane+ActivatePane. Once the
+// storm subsides, Validate must still pass.
+//
+// Errors from individual operations are ignored (the race may legitimately
+// cause AddPane on a session that was just removed) — the point is that
+// no operation panics, no operation corrupts the tree, and Validate is
+// happy at the end.
+func TestConcurrentMixedOperations(t *testing.T) {
+	tree := New()
+
+	// Pre-populate a fixed set of sessions so AddPane / ActivatePane /
+	// NextPane have something to race on from the start.
+	const baseSessions = 8
+	for i := 0; i < baseSessions; i++ {
+		mustAddSession(t, tree, Session{
+			ID:   fmt.Sprintf("base@%d", i),
+			Repo: "base",
+		})
+	}
+
+	const writers = 16
+	const opsPerWriter = 200
+	var wg sync.WaitGroup
+	wg.Add(writers)
+
+	// Counter so each writer picks a unique-ish ID range while still
+	// overlapping with neighbours to exercise duplicate-add paths.
+	var counter atomic.Int64
+
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for op := 0; op < opsPerWriter; op++ {
+				switch op % 8 {
+				case 0:
+					id := fmt.Sprintf("dyn@%d", counter.Add(1)%(int64(writers)*8))
+					_ = tree.AddSession(Session{ID: id, Repo: "dyn"})
+				case 1:
+					id := fmt.Sprintf("dyn@%d", counter.Add(1)%(int64(writers)*8))
+					_ = tree.RemoveSession(id)
+				case 2:
+					id := fmt.Sprintf("base@%d", op%baseSessions)
+					_ = tree.AddPane(id, Pane{Name: fmt.Sprintf("p-%d-%d", w, op)})
+				case 3:
+					id := fmt.Sprintf("base@%d", op%baseSessions)
+					if names := paneNames(tree, id); len(names) > 0 {
+						_ = tree.RemovePane(id, names[0])
+					}
+				case 4:
+					id := fmt.Sprintf("base@%d", op%baseSessions)
+					_, _ = tree.NextPane(id)
+				case 5:
+					id := fmt.Sprintf("base@%d", op%baseSessions)
+					_, _ = tree.PrevPane(id)
+				case 6:
+					id := fmt.Sprintf("base@%d", op%baseSessions)
+					_ = tree.ActivateSession(id)
+				case 7:
+					id := fmt.Sprintf("base@%d", op%baseSessions)
+					if names := paneNames(tree, id); len(names) > 0 {
+						_ = tree.ActivatePane(id, names[0])
+					}
+				}
+			}
+		}(w)
+	}
+
+	// Reader pool — keeps the read side busy so the race detector sees
+	// reads concurrent with writes.
+	const readers = 8
+	stop := make(chan struct{})
+	var rwg sync.WaitGroup
+	rwg.Add(readers)
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer rwg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = tree.Sessions()
+				_ = tree.Repos()
+				_ = tree.Len()
+				_ = tree.ActiveSessionID()
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(stop)
+	rwg.Wait()
+
+	if err := tree.Validate(); err != nil {
+		t.Errorf("Validate after concurrent storm: %v", err)
+	}
+}
+
+// TestConcurrentJSONMarshalDuringWrites pushes the MarshalJSON path
+// under contention. The marshal goroutine holds the read lock while
+// json.Marshal walks the inner state — the writers must not be able to
+// mutate maps mid-walk, which would otherwise trip the runtime's
+// concurrent-map-iteration detector and crash with "fatal error".
+func TestConcurrentJSONMarshalDuringWrites(t *testing.T) {
+	tree := New()
+	const writers = 8
+
+	stop := make(chan struct{})
+	var wwg sync.WaitGroup
+	wwg.Add(writers)
+
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wwg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				id := fmt.Sprintf("rw-%d@%d", w, i)
+				_ = tree.AddSession(Session{ID: id, Repo: fmt.Sprintf("rw-%d", w)})
+				_ = tree.AddPane(id, Pane{Name: "agent"})
+				_ = tree.RemoveSession(id)
+				i++
+			}
+		}(w)
+	}
+
+	// Marshal in a tight loop on the main goroutine.
+	for i := 0; i < 500; i++ {
+		if _, err := tree.MarshalJSON(); err != nil {
+			t.Fatalf("MarshalJSON iter %d: %v", i, err)
+		}
+	}
+	close(stop)
+	wwg.Wait()
+
+	if err := tree.Validate(); err != nil {
+		t.Errorf("Validate after marshal storm: %v", err)
+	}
+}
+
+// paneNames is a test helper: snapshot the pane names of a session.
+// Used by the chaotic writer pool to pick a pane name to operate on.
+// Lifting it into a helper keeps the writer's switch readable.
+func paneNames(tree *SessionTree, sessionID string) []string {
+	s, ok := tree.Session(sessionID)
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(s.Panes))
+	for i, p := range s.Panes {
+		out[i] = p.Name
+	}
+	return out
+}


### PR DESCRIPTION
Second sequential foundation PR of the multiplexer programme (#2147),
sitting on top of the spike promotion in #2162. Pure data model — no
I/O, no PTY interaction, no rendering — that the four parallel
consumer packages (#2152 render, #2153 server, #2155 state, #2156
persist) will all sit on top of.

Closes #2151.
Refs #2147.

## Types added

- `Pane` — one named pane within a session. `Name` is a string so the
  §3.1 initial set of `agent` / `term` / `edit` can grow without a
  model change.
- `Session` — `ID`, `Repo` (cluster name), `Branch`, `Worktree`,
  `AgentRole`, `SidecarAddr`, `ParentID` (empty for top-level, set for
  review subsessions), `Panes`, `ActivePane`.
- `SessionTree` — the repo cluster → session → review subsession
  hierarchy from §3.1, with the "exactly two levels" invariant enforced
  on every mutation and revalidated on every JSON unmarshal.

IDs follow the issue's suggested convention without the model parsing
them: top-level sessions take prism's existing `<repo>@<branch>` shape,
review subsessions take `<parent>~review-<N>-<agent>`. The model only
requires IDs be non-empty strings and unique within the tree — it does
not interpret or rebuild the structure.

## Operations

Each operation is a single transactional state change under the tree's
mutex:

- `AddSession` / `RemoveSession` — cascade-removes review subsessions
  when their parent is removed; drops empty repos from `RepoOrder`.
- `AddPane` / `RemovePane` — focus-follows-the-slot when the active
  pane is removed (matches tmux's kill-pane behaviour); clears
  `ActivePane` when the last pane goes.
- `ActivatePane` / `ActivateSession` — sets the per-session / tree-
  level focus pointers; rejects unknown IDs.
- `NextPane` / `PrevPane` — wrap-around cycling through the pane
  insertion order; seeds from the first pane when `ActivePane` is
  empty but panes exist.

## Concurrency story

Mirrors the `vt.Host` pattern from #2162: a single `sync.RWMutex` on
the `SessionTree` serialises every state transition and every read.
Readers receive deep-copied snapshots (`Session()`, `Sessions()`,
`Repos()`, `Children()`, …) so no caller ever holds a pointer into the
tree's internal state. The inner `treeState` is a private, JSON-tagged
struct — `MarshalJSON` / `UnmarshalJSON` lock the mutex too, so the
persist layer (#2156) does not need to serialise its access externally.

## JSON-tag choices

- All maps and slices use plain JSON tags; `omitempty` is set on every
  field that has a meaningful zero value (`Branch`, `Worktree`,
  `AgentRole`, `SidecarAddr`, `ParentID`, `Panes`, `ActivePane`,
  `ActiveSession`).
- Top-level state shape: `sessions` (map), `repo_order` (slice),
  `session_order` (map of slices, repo → top-level IDs),
  `child_order` (map of slices, parent ID → review IDs),
  `active_session` (string).
- `UnmarshalJSON` revalidates every invariant against the parsed
  blob — no orphan reviews, no nested reviews, no top-level session
  missing its `Repo`, `RepoOrder` matches `SessionOrder`'s key set,
  `ActiveSession` (if set) references an existing session, pane names
  are unique within each session. Failures return wrapped
  `ErrInconsistent`, so the persist layer can surface "the on-disk
  snapshot is broken, falling back to empty tree" without parsing
  error strings.

## Error handling

No `panic` / `log.Fatal` paths — every failure returns a wrapped
sentinel error so consumers (the server especially) can map specific
modes to specific socket-protocol responses with `errors.Is`:

`ErrSessionExists`, `ErrSessionNotFound`, `ErrParentNotFound`,
`ErrParentIsReview`, `ErrPaneExists`, `ErrPaneNotFound`, `ErrNoPanes`,
`ErrInvalidSession`, `ErrInconsistent`.

## Test coverage

41 cases under `go test -race`. Highlights:

- Tree consistency for every operation, including cascade-remove,
  `RepoOrder` bookkeeping when the last session leaves a repo, and
  `ActiveSession` clearing when its target is cascade-removed.
- Focus-follows-slot for `RemovePane`, with separate cases for
  removing the middle, tail, and only pane.
- `NextPane` / `PrevPane` wrap-around plus the seed-from-first branch
  when `ActivePane` is empty but panes exist.
- JSON round-trip on a §3.1-shaped tree (nixos-config cluster with a
  worker session plus five review subs, home-ops cluster, focus
  pointers set on both axes).
- `UnmarshalJSON` rejection cases for every invariant-breaking blob:
  orphan review (missing from `ChildOrder`), ghost repo in
  `RepoOrder`, ghost `ActiveSession`, top-level session with empty
  `Repo`, duplicate pane name, `ActivePane` not in `Panes`, review
  parenting a review, orphaned session.
- Race tests under `-race`: 64 concurrent `AddSession`; 16 writers ×
  200 mixed ops + 8 readers + final `Validate`; concurrent
  `MarshalJSON` while writers churn the maps.

Per the `verify your tests aren't no-ops` rule, two of the more
load-bearing assertions were spot-checked by mutating production code
(removing the `ErrParentIsReview` check; mis-indexing the
focus-follows-slot computation) and confirming the matching test
flipped to FAIL, then reverted.

## Local self-check

- `go build ./...` ✅
- `go test ./... -race` ✅
- `nix build .#prism` ✅
- `nix flake check` ✅
- `nix build … prism.override { runChecks = true; }` (homeless-shelter
  sandbox) ✅

## Out of scope (per #2151)

- Rendering logic — #2152.
- Socket / RPC code — #2153.
- Persistence I/O — #2156.
- Sidecar subscription — #2155.
- Hooking into existing `internal/session/` or `internal/sidecar/` —
  the model is a self-contained package with no upstream prism
  dependencies in this PR.