### PR TITLE
mux/server: internal/mux/server/ — Unix socket API

### DIFF
--- a/modules/programs/prism/prism/internal/mux/server/doc.go
+++ b/modules/programs/prism/prism/internal/mux/server/doc.go
@@ -1,0 +1,65 @@
+// Package server is the Unix-socket API layer of the prism-native
+// multiplexer (issue #2153, programme #2147). It exposes the
+// internal/mux/pane.SessionTree to CLI clients over a Unix domain socket
+// so that prism subcommands (and eventually the 33 callers currently
+// using internal/tmux) can mutate the workspace model without sharing
+// process memory.
+//
+// # Wire shape
+//
+// HTTP/1.1 over Unix socket with JSON request and response bodies. This
+// mirrors the existing prism host-API server in
+// internal/sidecar/host_api.go — the same client transport
+// (http.Client with a custom net.Dialer that dials a Unix path) works
+// against either socket. The §3 architecture table in
+// docs/multiplexer-proposal.md sketches a JSONL framing as one option;
+// the issue #2153 AC explicitly says "JSON-RPC over newline-delimited
+// frames OR the equivalent prism convention used by the sidecar host-API
+// today" — we pick the latter so the CLI client gets to reuse the
+// idioms already proven in the host-API path and there is only one wire
+// shape for reviewers to think about.
+//
+// The "method surface" requested by the ACs (session.create,
+// pane.send_input, …) maps to URL paths by replacing the dot with a
+// slash: session.create → POST /session/create, pane.send_input →
+// POST /pane/send_input. List endpoints use GET; mutating endpoints use
+// POST.
+//
+// # Socket path
+//
+// Default location:
+//
+//	$XDG_STATE_HOME/prism/run/<12-hex-of-sha256("prism-mux")>/mux.sock
+//
+// The hashed-directory layout mirrors
+// internal/session.SidecarHostAPIPath — both for path-length budgeting
+// against sun_path (Linux 108 bytes, Darwin 104) and so existing prism
+// tooling that walks $XDG_STATE_HOME/prism/run/ keeps working. The
+// daemon is singleton-per-user (no session name to disambiguate), so
+// the SHA-256 input is a fixed string "prism-mux" rather than a session
+// name. A hypothetical real session literally named "prism-mux" would
+// produce a different hash because real sessions are conventionally
+// "<repo>@<branch>"; even if a collision did occur, the file names
+// (hostapi.sock vs mux.sock) inside the directory differ, so the two
+// sockets coexist cleanly.
+//
+// # Concurrency
+//
+// One socket connection per CLI invocation; the net/http server accepts
+// many connections in parallel (one goroutine per connection). All
+// mutations on the SessionTree go through its existing mutex (see
+// internal/mux/pane), so the server itself holds no additional locks.
+//
+// # Errors
+//
+// Every error response carries a structured JSON body:
+//
+//	{"code":"<stable_code>","message":"<human readable>","data":{...}}
+//
+// The stable codes (see errors.go) map 1:1 to the typed sentinels
+// exported by internal/mux/pane (ErrSessionExists, ErrPaneNotFound, …)
+// so a client can branch on `code` without string-matching the
+// `message`. HTTP status codes are set in parallel — 404 for not-found,
+// 409 for conflicts, 400 for invalid input, 405 for wrong method, 500
+// for unexpected internal failures.
+package server

--- a/modules/programs/prism/prism/internal/mux/server/errors.go
+++ b/modules/programs/prism/prism/internal/mux/server/errors.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+)
+
+// errorResponse is the canonical JSON shape every error response carries.
+// `Code` is a stable identifier suitable for programmatic branching;
+// `Message` is human-readable; `Data` is an optional map of extra
+// context (e.g. {"session_id":"foo"}). The fields use snake_case to
+// match the prism convention.
+type errorResponse struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data,omitempty"`
+}
+
+// Error code constants — stable identifiers used by clients to branch
+// on failure modes without string-matching the message.
+const (
+	codeMethodNotAllowed = "method_not_allowed"
+	codeBadRequest       = "bad_request"
+	codeInternal         = "internal_error"
+
+	codeSessionExists   = "session_exists"
+	codeSessionNotFound = "session_not_found"
+	codeParentNotFound  = "parent_not_found"
+	codeParentIsReview  = "parent_is_review"
+	codeInvalidSession  = "invalid_session"
+	codePaneExists      = "pane_exists"
+	codePaneNotFound    = "pane_not_found"
+	codeNoPanes         = "no_panes"
+)
+
+// statusAndCodeForPaneErr maps a typed sentinel from internal/mux/pane
+// to (http_status, stable_code). Callers should pass err already
+// wrapped as the pane.* sentinel — errors.Is is used to detect the
+// match. When err matches none of the typed sentinels, the caller's
+// fallback (500 / internal_error) applies.
+func statusAndCodeForPaneErr(err error) (int, string, bool) {
+	switch {
+	case errors.Is(err, pane.ErrSessionExists):
+		return http.StatusConflict, codeSessionExists, true
+	case errors.Is(err, pane.ErrSessionNotFound):
+		return http.StatusNotFound, codeSessionNotFound, true
+	case errors.Is(err, pane.ErrParentNotFound):
+		return http.StatusNotFound, codeParentNotFound, true
+	case errors.Is(err, pane.ErrParentIsReview):
+		return http.StatusBadRequest, codeParentIsReview, true
+	case errors.Is(err, pane.ErrInvalidSession):
+		return http.StatusBadRequest, codeInvalidSession, true
+	case errors.Is(err, pane.ErrPaneExists):
+		return http.StatusConflict, codePaneExists, true
+	case errors.Is(err, pane.ErrPaneNotFound):
+		return http.StatusNotFound, codePaneNotFound, true
+	case errors.Is(err, pane.ErrNoPanes):
+		return http.StatusBadRequest, codeNoPanes, true
+	}
+	return 0, "", false
+}
+
+// writeError serialises an errorResponse and writes it with the given
+// HTTP status. The Content-Type is forced to application/json so the
+// CLI client never has to sniff. Marshalling failures are extremely
+// unlikely (the type is fully concrete) but if one occurs we fall back
+// to a hardcoded JSON literal so the client still gets a parseable
+// body.
+func writeError(w http.ResponseWriter, status int, code, message string, data map[string]any) {
+	body, err := json.Marshal(errorResponse{Code: code, Message: message, Data: data})
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"internal_error","message":"marshal error response"}`))
+		return
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+// writePaneErr inspects err for a typed pane.* sentinel and writes the
+// matching structured response. When no typed sentinel matches, it
+// writes a 500/internal_error carrying the underlying error message.
+// The optional data map is included verbatim in the response body.
+func writePaneErr(w http.ResponseWriter, err error, data map[string]any) {
+	if status, code, ok := statusAndCodeForPaneErr(err); ok {
+		writeError(w, status, code, err.Error(), data)
+		return
+	}
+	writeError(w, http.StatusInternalServerError, codeInternal, err.Error(), data)
+}

--- a/modules/programs/prism/prism/internal/mux/server/server.go
+++ b/modules/programs/prism/prism/internal/mux/server/server.go
@@ -1,0 +1,672 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+)
+
+// maxRequestBodyBytes caps inbound JSON payloads. The largest legitimate
+// body is pane.send_input — a single keystroke or paste from the CLI.
+// 1 MiB is comfortable headroom while still bounding memory exposure
+// to malformed or hostile clients.
+const maxRequestBodyBytes = 1 << 20 // 1 MiB
+
+// shutdownGrace is the timeout passed to http.Server.Shutdown when the
+// caller's context is cancelled. It bounds how long in-flight requests
+// have to drain before we close their connections.
+const shutdownGrace = 2 * time.Second
+
+// Server is the prism mux Unix-socket API server. It owns no state of
+// its own beyond a pointer to the underlying SessionTree; all
+// concurrency is serialised through the tree's existing mutex.
+//
+// The zero value is NOT ready for use — construct with New.
+type Server struct {
+	tree   *pane.SessionTree
+	logger *log.Logger
+}
+
+// Option configures a Server constructed by New.
+type Option func(*Server)
+
+// WithLogger overrides the default logger (log.Default()). Useful in
+// tests that want to silence warnings.
+func WithLogger(l *log.Logger) Option {
+	return func(s *Server) {
+		if l != nil {
+			s.logger = l
+		}
+	}
+}
+
+// New returns a Server backed by tree. Panics if tree is nil — the
+// server is meaningless without a model to mutate, and a panic at
+// construction time is preferable to a nil-deref deep inside a handler.
+func New(tree *pane.SessionTree, opts ...Option) *Server {
+	if tree == nil {
+		panic("mux/server: New called with nil tree")
+	}
+	s := &Server{
+		tree:   tree,
+		logger: log.Default(),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Tree returns the SessionTree the server is bound to. Provided so
+// tests and in-process callers can introspect server state without
+// going through the socket.
+func (s *Server) Tree() *pane.SessionTree { return s.tree }
+
+// Handler returns the http.Handler implementing the mux API. Exposed
+// independently of ListenAndServe so in-process tests can drive the
+// server with httptest.NewServer or a custom listener.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/session/create", s.handleSessionCreate)
+	mux.HandleFunc("/session/destroy", s.handleSessionDestroy)
+	mux.HandleFunc("/session/list", s.handleSessionList)
+	mux.HandleFunc("/session/switch", s.handleSessionSwitch)
+
+	mux.HandleFunc("/pane/create", s.handlePaneCreate)
+	mux.HandleFunc("/pane/destroy", s.handlePaneDestroy)
+	mux.HandleFunc("/pane/list", s.handlePaneList)
+	mux.HandleFunc("/pane/switch", s.handlePaneSwitch)
+	mux.HandleFunc("/pane/resize", s.handlePaneResize)
+	mux.HandleFunc("/pane/send_input", s.handlePaneSendInput)
+
+	// Fall-through: anything not matched above is a 404 with a structured
+	// body so the CLI client gets a consistent error shape regardless of
+	// which path it dialed.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeError(w, http.StatusNotFound, codeBadRequest,
+			fmt.Sprintf("no such method: %s %s", r.Method, r.URL.Path), nil)
+	})
+
+	return mux
+}
+
+// ListenAndServe binds a Unix socket at sockPath and serves the API
+// until ctx is cancelled or the listener fails. When sockPath is empty,
+// DefaultSocketPath() is used.
+//
+// Lifecycle details:
+//
+//   - The socket's parent directory is created with mode 0700 if it
+//     does not exist (matches the sidecar's host-API setup —
+//     internal/sidecar/sidecar.go).
+//   - A stale socket file at sockPath is unlinked before bind so a
+//     prior unclean shutdown does not block startup. This mirrors the
+//     sidecar's "_ = os.Remove(...)" before net.Listen.
+//   - On ctx cancellation, http.Server.Shutdown is called with a
+//     bounded grace period so in-flight handlers drain.
+//   - On return, the socket file is unlinked (best-effort) so the next
+//     start does not have to discover stale state.
+func (s *Server) ListenAndServe(ctx context.Context, sockPath string) error {
+	if sockPath == "" {
+		var err error
+		sockPath, err = DefaultSocketPath()
+		if err != nil {
+			return fmt.Errorf("resolve default socket path: %w", err)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0o700); err != nil {
+		return fmt.Errorf("create socket dir %q: %w", filepath.Dir(sockPath), err)
+	}
+	// Clear stale socket; the error is ignored intentionally — if the
+	// path does not exist we fall through to bind, and if it cannot be
+	// removed the bind below will surface the real failure.
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("listen unix %q: %w", sockPath, err)
+	}
+
+	return s.Serve(ctx, ln)
+}
+
+// Serve drives the API server against an already-bound listener. The
+// listener is closed when the function returns. Useful in tests where
+// a t.TempDir()-scoped socket is created externally so that on a
+// failing assertion the path is preserved for inspection.
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
+	srv := &http.Server{
+		Handler: s.Handler(),
+		// Per-request read/write timeouts are intentionally NOT set:
+		// our handlers do not stream, and a Unix-socket peer can stall
+		// for legitimate reasons (a CLI process briefly suspended).
+		// Body size is bounded inside each handler via
+		// http.MaxBytesReader instead.
+	}
+
+	// Track listener close so the goroutine below does not race with
+	// the deferred ln.Close.
+	var closed sync.Once
+	closeLn := func() { closed.Do(func() { _ = ln.Close() }) }
+	defer closeLn()
+
+	// Shutdown when ctx is done. Use a fresh context bounded by
+	// shutdownGrace so even a stuck handler cannot keep us alive.
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			s.logger.Printf("mux/server: shutdown: %v", err)
+		}
+		closeLn()
+	}()
+
+	serveErr := srv.Serve(ln)
+	if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) && !errors.Is(serveErr, net.ErrClosed) {
+		return fmt.Errorf("serve: %w", serveErr)
+	}
+
+	// Best-effort: unlink the Unix socket so the next start does not
+	// have to clean up. We only do this for Unix listeners; other
+	// listener kinds (e.g. an httptest one) have no path to remove.
+	if addr := ln.Addr(); addr != nil && addr.Network() == "unix" {
+		_ = os.Remove(addr.String())
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Request decoding helpers
+// ---------------------------------------------------------------------------
+
+// requireMethod writes 405 and returns false if r.Method does not match.
+// Logging is deliberately omitted — wrong-method requests are routine
+// from buggy clients and do not warrant log noise.
+func requireMethod(w http.ResponseWriter, r *http.Request, want string) bool {
+	if r.Method != want {
+		writeError(w, http.StatusMethodNotAllowed, codeMethodNotAllowed,
+			fmt.Sprintf("method not allowed: want %s, got %s", want, r.Method), nil)
+		return false
+	}
+	return true
+}
+
+// decodeJSON reads a length-capped JSON body into dst. On error it
+// writes a 400 with codeBadRequest and returns false. An empty body
+// (Content-Length 0 or EOF on first read) decodes as the zero value of
+// dst, which is the natural shape for endpoints like /session/list.
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		// An empty body returns io.EOF — treat that as "no input",
+		// which is fine for endpoints whose request struct is all
+		// optional. Endpoints with required fields validate them
+		// below regardless of this path.
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			fmt.Sprintf("decode json: %v", err), nil)
+		return false
+	}
+	return true
+}
+
+// writeJSON serialises v with a 200 OK. On marshal failure it falls
+// back to writeError(500, internal_error, ...). The success path sets
+// Content-Type before WriteHeader so net/http does not auto-detect.
+func writeJSON(w http.ResponseWriter, v any) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, codeInternal,
+			fmt.Sprintf("marshal response: %v", err), nil)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// ---------------------------------------------------------------------------
+// session.* handlers
+// ---------------------------------------------------------------------------
+
+// sessionCreateRequest is the wire shape for POST /session/create. The
+// fields mirror pane.Session 1:1; we keep this struct distinct so the
+// model can grow internal fields without forcing a wire change.
+type sessionCreateRequest struct {
+	ID          string       `json:"id"`
+	Repo        string       `json:"repo,omitempty"`
+	Branch      string       `json:"branch,omitempty"`
+	Worktree    string       `json:"worktree,omitempty"`
+	AgentRole   string       `json:"agent_role,omitempty"`
+	SidecarAddr string       `json:"sidecar_addr,omitempty"`
+	ParentID    string       `json:"parent_id,omitempty"`
+	Panes       []paneInput  `json:"panes,omitempty"`
+	ActivePane  string       `json:"active_pane,omitempty"`
+}
+
+// paneInput is the JSON shape for pane entries inside a
+// sessionCreateRequest. Distinct from pane.Pane so the wire format is
+// pinned independently of any internal fields the model may grow.
+type paneInput struct {
+	Name string `json:"name"`
+}
+
+// sessionResponse wraps a pane.Session for transport. The model's JSON
+// tags already include all the fields we want, so this is a thin
+// envelope rather than a remapping.
+type sessionResponse struct {
+	Session pane.Session `json:"session"`
+}
+
+func (s *Server) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req sessionCreateRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.ID == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"id is required", nil)
+		return
+	}
+
+	panes := make([]pane.Pane, 0, len(req.Panes))
+	for _, p := range req.Panes {
+		panes = append(panes, pane.Pane{Name: p.Name})
+	}
+
+	sess := pane.Session{
+		ID:          req.ID,
+		Repo:        req.Repo,
+		Branch:      req.Branch,
+		Worktree:    req.Worktree,
+		AgentRole:   req.AgentRole,
+		SidecarAddr: req.SidecarAddr,
+		ParentID:    req.ParentID,
+		Panes:       panes,
+		ActivePane:  req.ActivePane,
+	}
+	if err := s.tree.AddSession(sess); err != nil {
+		writePaneErr(w, err, map[string]any{"id": req.ID})
+		return
+	}
+
+	// Return the canonical post-insert view so callers can observe any
+	// auto-applied defaults (e.g. ActivePane defaulting to the first
+	// pane) without a follow-up list call.
+	created, ok := s.tree.Session(req.ID)
+	if !ok {
+		// Should be impossible immediately after a successful
+		// AddSession — log and return a structured 500 rather than
+		// panic so the CLI sees a clean error.
+		s.logger.Printf("mux/server: session %q vanished between AddSession and Session()", req.ID)
+		writeError(w, http.StatusInternalServerError, codeInternal,
+			"session vanished after create", map[string]any{"id": req.ID})
+		return
+	}
+	writeJSON(w, sessionResponse{Session: created})
+}
+
+// sessionDestroyRequest is the wire shape for POST /session/destroy.
+type sessionDestroyRequest struct {
+	ID string `json:"id"`
+}
+
+func (s *Server) handleSessionDestroy(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req sessionDestroyRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.ID == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"id is required", nil)
+		return
+	}
+	if err := s.tree.RemoveSession(req.ID); err != nil {
+		writePaneErr(w, err, map[string]any{"id": req.ID})
+		return
+	}
+	writeJSON(w, struct{}{})
+}
+
+// sessionListResponse is the wire shape for GET /session/list. The
+// sessions are in the same order the underlying tree iterates them:
+// repo-cluster-major, then top-level by insertion, then children.
+type sessionListResponse struct {
+	Sessions      []pane.Session `json:"sessions"`
+	ActiveSession string         `json:"active_session,omitempty"`
+}
+
+func (s *Server) handleSessionList(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	sessions := s.tree.Sessions()
+	// Sessions() may return nil for an empty tree; normalise to an
+	// empty slice so the wire shape is "sessions":[] not
+	// "sessions":null, which would force the client to special-case
+	// the JSON null.
+	if sessions == nil {
+		sessions = []pane.Session{}
+	}
+	writeJSON(w, sessionListResponse{
+		Sessions:      sessions,
+		ActiveSession: s.tree.ActiveSessionID(),
+	})
+}
+
+// sessionSwitchRequest is the wire shape for POST /session/switch. An
+// empty ID clears the focus pointer (matches
+// pane.SessionTree.ActivateSession("")).
+type sessionSwitchRequest struct {
+	ID string `json:"id"`
+}
+
+// sessionSwitchResponse echoes the new active-session pointer so the
+// caller does not need a follow-up list call to confirm.
+type sessionSwitchResponse struct {
+	ActiveSession string `json:"active_session"`
+}
+
+func (s *Server) handleSessionSwitch(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req sessionSwitchRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if err := s.tree.ActivateSession(req.ID); err != nil {
+		writePaneErr(w, err, map[string]any{"id": req.ID})
+		return
+	}
+	writeJSON(w, sessionSwitchResponse{ActiveSession: s.tree.ActiveSessionID()})
+}
+
+// ---------------------------------------------------------------------------
+// pane.* handlers
+// ---------------------------------------------------------------------------
+
+// paneCreateRequest is the wire shape for POST /pane/create.
+type paneCreateRequest struct {
+	SessionID string `json:"session_id"`
+	Name      string `json:"name"`
+}
+
+func (s *Server) handlePaneCreate(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req paneCreateRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.SessionID == "" || req.Name == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id and name are required", nil)
+		return
+	}
+	if err := s.tree.AddPane(req.SessionID, pane.Pane{Name: req.Name}); err != nil {
+		writePaneErr(w, err, map[string]any{
+			"session_id": req.SessionID,
+			"name":       req.Name,
+		})
+		return
+	}
+	writeJSON(w, struct{}{})
+}
+
+// paneDestroyRequest is the wire shape for POST /pane/destroy.
+type paneDestroyRequest struct {
+	SessionID string `json:"session_id"`
+	Name      string `json:"name"`
+}
+
+func (s *Server) handlePaneDestroy(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req paneDestroyRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.SessionID == "" || req.Name == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id and name are required", nil)
+		return
+	}
+	if err := s.tree.RemovePane(req.SessionID, req.Name); err != nil {
+		writePaneErr(w, err, map[string]any{
+			"session_id": req.SessionID,
+			"name":       req.Name,
+		})
+		return
+	}
+	writeJSON(w, struct{}{})
+}
+
+// paneListResponse is the wire shape for GET /pane/list. The slice is
+// in pane insertion order — the same order NextPane / PrevPane cycle.
+type paneListResponse struct {
+	Panes      []pane.Pane `json:"panes"`
+	ActivePane string      `json:"active_pane,omitempty"`
+}
+
+func (s *Server) handlePaneList(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	sessID := r.URL.Query().Get("session_id")
+	if sessID == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id query parameter is required", nil)
+		return
+	}
+	sess, ok := s.tree.Session(sessID)
+	if !ok {
+		writeError(w, http.StatusNotFound, codeSessionNotFound,
+			fmt.Sprintf("session %q not found", sessID),
+			map[string]any{"session_id": sessID})
+		return
+	}
+	// sess.Panes is already a deep copy (Session() clones), so we can
+	// hand it straight to writeJSON. Normalise nil to []pane.Pane{} so
+	// the wire shape never carries "panes":null.
+	panes := sess.Panes
+	if panes == nil {
+		panes = []pane.Pane{}
+	}
+	writeJSON(w, paneListResponse{
+		Panes:      panes,
+		ActivePane: sess.ActivePane,
+	})
+}
+
+// paneSwitchRequest is the wire shape for POST /pane/switch. Exactly
+// one of {Name, Direction} must be set. Direction may be "next" or
+// "prev"; everything else is rejected with a 400.
+type paneSwitchRequest struct {
+	SessionID string `json:"session_id"`
+	Name      string `json:"name,omitempty"`
+	Direction string `json:"direction,omitempty"`
+}
+
+// paneSwitchResponse echoes the resulting active pane so the caller
+// can confirm without a follow-up pane.list.
+type paneSwitchResponse struct {
+	ActivePane string `json:"active_pane"`
+}
+
+func (s *Server) handlePaneSwitch(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req paneSwitchRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.SessionID == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id is required", nil)
+		return
+	}
+	// XOR-ish validation: exactly one of name / direction.
+	hasName := req.Name != ""
+	hasDir := req.Direction != ""
+	if hasName == hasDir {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"exactly one of name or direction must be set", nil)
+		return
+	}
+
+	var (
+		newActive string
+		err       error
+	)
+	switch {
+	case hasName:
+		err = s.tree.ActivatePane(req.SessionID, req.Name)
+		newActive = req.Name
+	case req.Direction == "next":
+		newActive, err = s.tree.NextPane(req.SessionID)
+	case req.Direction == "prev":
+		newActive, err = s.tree.PrevPane(req.SessionID)
+	default:
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			fmt.Sprintf("invalid direction %q (want \"next\" or \"prev\")", req.Direction), nil)
+		return
+	}
+	if err != nil {
+		writePaneErr(w, err, map[string]any{
+			"session_id": req.SessionID,
+			"name":       req.Name,
+			"direction":  req.Direction,
+		})
+		return
+	}
+	writeJSON(w, paneSwitchResponse{ActivePane: newActive})
+}
+
+// paneResizeRequest is the wire shape for POST /pane/resize. Cols and
+// Rows are validated as non-negative; the actual resize effect lands in
+// the PTY layer (separate package) but this handler still validates
+// session/pane existence so the CLI gets a structured error today.
+type paneResizeRequest struct {
+	SessionID string `json:"session_id"`
+	Name      string `json:"name"`
+	Cols      int    `json:"cols"`
+	Rows      int    `json:"rows"`
+}
+
+func (s *Server) handlePaneResize(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req paneResizeRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.SessionID == "" || req.Name == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id and name are required", nil)
+		return
+	}
+	if req.Cols < 0 || req.Rows < 0 {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"cols and rows must be non-negative",
+			map[string]any{"cols": req.Cols, "rows": req.Rows})
+		return
+	}
+	if err := s.checkPaneExists(req.SessionID, req.Name); err != nil {
+		writePaneErr(w, err, map[string]any{
+			"session_id": req.SessionID,
+			"name":       req.Name,
+		})
+		return
+	}
+	// Model is geometry-free; the effective resize is dispatched by
+	// the PTY/render layers in a follow-on PR (see
+	// docs/multiplexer-proposal.md §3). The handler still returns
+	// success so a CLI that drives pane.resize today has a stable
+	// wire contract.
+	writeJSON(w, struct{}{})
+}
+
+// paneSendInputRequest is the wire shape for POST /pane/send_input.
+// Data is sent as a string — callers that need to deliver binary
+// keystrokes can encode them however the eventual PTY-layer client
+// agrees on (base64 is the most likely scheme). At this layer the
+// payload is opaque and not interpreted; only its length is bounded
+// by the body cap.
+type paneSendInputRequest struct {
+	SessionID string `json:"session_id"`
+	Name      string `json:"name"`
+	Data      string `json:"data"`
+}
+
+func (s *Server) handlePaneSendInput(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req paneSendInputRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.SessionID == "" || req.Name == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id and name are required", nil)
+		return
+	}
+	if err := s.checkPaneExists(req.SessionID, req.Name); err != nil {
+		writePaneErr(w, err, map[string]any{
+			"session_id": req.SessionID,
+			"name":       req.Name,
+		})
+		return
+	}
+	// As with /pane/resize: the model carries no input channel; the
+	// actual delivery lands in the PTY layer. Return success so the
+	// wire contract is stable.
+	writeJSON(w, struct{}{})
+}
+
+// checkPaneExists returns a typed pane.* error when the named pane is
+// missing from the session, or when the session itself is missing. Used
+// by the handlers that take a (session, pane) tuple but have no model
+// operation of their own — pane.resize and pane.send_input.
+func (s *Server) checkPaneExists(sessionID, paneName string) error {
+	sess, ok := s.tree.Session(sessionID)
+	if !ok {
+		return fmt.Errorf("%w: %q", pane.ErrSessionNotFound, sessionID)
+	}
+	for _, p := range sess.Panes {
+		if p.Name == paneName {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: session %q has no pane %q",
+		pane.ErrPaneNotFound, sessionID, paneName)
+}

--- a/modules/programs/prism/prism/internal/mux/server/server.go
+++ b/modules/programs/prism/prism/internal/mux/server/server.go
@@ -251,15 +251,15 @@ func writeJSON(w http.ResponseWriter, v any) {
 // fields mirror pane.Session 1:1; we keep this struct distinct so the
 // model can grow internal fields without forcing a wire change.
 type sessionCreateRequest struct {
-	ID          string       `json:"id"`
-	Repo        string       `json:"repo,omitempty"`
-	Branch      string       `json:"branch,omitempty"`
-	Worktree    string       `json:"worktree,omitempty"`
-	AgentRole   string       `json:"agent_role,omitempty"`
-	SidecarAddr string       `json:"sidecar_addr,omitempty"`
-	ParentID    string       `json:"parent_id,omitempty"`
-	Panes       []paneInput  `json:"panes,omitempty"`
-	ActivePane  string       `json:"active_pane,omitempty"`
+	ID          string      `json:"id"`
+	Repo        string      `json:"repo,omitempty"`
+	Branch      string      `json:"branch,omitempty"`
+	Worktree    string      `json:"worktree,omitempty"`
+	AgentRole   string      `json:"agent_role,omitempty"`
+	SidecarAddr string      `json:"sidecar_addr,omitempty"`
+	ParentID    string      `json:"parent_id,omitempty"`
+	Panes       []paneInput `json:"panes,omitempty"`
+	ActivePane  string      `json:"active_pane,omitempty"`
 }
 
 // paneInput is the JSON shape for pane entries inside a

--- a/modules/programs/prism/prism/internal/mux/server/server_test.go
+++ b/modules/programs/prism/prism/internal/mux/server/server_test.go
@@ -711,7 +711,7 @@ func TestConcurrent_Mutations(t *testing.T) {
 	c, _ := newTestServer(t)
 
 	const (
-		workers  = 16
+		workers   = 16
 		perWorker = 8
 	)
 	var (
@@ -757,11 +757,11 @@ func TestConcurrent_DuplicateIDs(t *testing.T) {
 
 	const workers = 32
 	var (
-		wg          sync.WaitGroup
-		successes   atomic.Int32
-		conflicts   atomic.Int32
-		unexpected  atomic.Int32
-		unexpResp   atomic.Pointer[errorResponse]
+		wg         sync.WaitGroup
+		successes  atomic.Int32
+		conflicts  atomic.Int32
+		unexpected atomic.Int32
+		unexpResp  atomic.Pointer[errorResponse]
 	)
 	for w := 0; w < workers; w++ {
 		wg.Add(1)

--- a/modules/programs/prism/prism/internal/mux/server/server_test.go
+++ b/modules/programs/prism/prism/internal/mux/server/server_test.go
@@ -1,0 +1,920 @@
+// Tests for the mux server package. The suite exercises the full
+// socket round-trip — bind a real net.Listener on a t.TempDir() path,
+// run the server in a background goroutine, and drive every method
+// surface from a vanilla http.Client over a Unix-socket transport.
+//
+// Two layers of coverage:
+//
+//  1. Method-by-method success and structured-error assertions.
+//     Inputs are validated, error codes match the typed pane.*
+//     sentinels, and the resulting tree state is verified via the
+//     list endpoints (the AC for #2153 calls this out explicitly).
+//
+//  2. Concurrency: the suite runs a fan-out of mutating requests
+//     under -race to confirm the server's lack of internal locking
+//     does not regress the SessionTree's own mutex contract.
+//
+// Tests construct their own t.TempDir()-scoped sockets and never
+// touch $HOME or $XDG_STATE_HOME — the file is therefore
+// homeless-shelter-clean (see AGENTS.md).
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+)
+
+// testClient bundles an http.Client (dialing a Unix socket) with the
+// fake-host base URL the client uses. The test helpers below all hang
+// off this type so individual cases stay short.
+type testClient struct {
+	http *http.Client
+	base string // e.g. "http://mux"
+}
+
+// newTestServer binds a Unix socket inside t.TempDir(), starts the
+// server in a goroutine, and returns a testClient that talks to it.
+// All resources are released via t.Cleanup so test bodies stay linear.
+//
+// The socket path is kept short on purpose — t.TempDir() roots can
+// already approach the sun_path budget on Darwin (104 bytes), and
+// nesting a directory below it would push some test names over.
+func newTestServer(t *testing.T) (*testClient, *Server) {
+	t.Helper()
+
+	tree := pane.New()
+	srv := New(tree)
+
+	sockPath := filepath.Join(t.TempDir(), "s")
+	if len(sockPath) >= 104 {
+		t.Fatalf("test socket path too long (%d bytes): %s", len(sockPath), sockPath)
+	}
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %q: %v", sockPath, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.Serve(ctx, ln) }()
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-serveDone:
+			if err != nil {
+				t.Logf("server.Serve returned: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Errorf("server did not shut down within 3s")
+		}
+	})
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	return &testClient{http: client, base: "http://mux"}, srv
+}
+
+// do issues an HTTP request and decodes the JSON body into out (when
+// non-nil). The returned status code is the raw HTTP code; assertions
+// check both that and the JSON body shape so a wrong-status response
+// fails the test even when the body happens to match.
+func (c *testClient) do(t *testing.T, method, path string, body any, out any) int {
+	t.Helper()
+	var reqBody io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		reqBody = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, c.base+path, reqBody)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if out != nil && len(raw) > 0 {
+		if err := json.Unmarshal(raw, out); err != nil {
+			t.Fatalf("decode response (status %d, body %q): %v", resp.StatusCode, raw, err)
+		}
+	}
+	return resp.StatusCode
+}
+
+// expectError issues a request expected to fail with the given HTTP
+// status and structured-error code, and returns the parsed body so the
+// caller can assert on data fields. Centralising this keeps each error
+// test case to one line of meaningful assertion.
+func (c *testClient) expectError(t *testing.T, method, path string, body any, wantStatus int, wantCode string) errorResponse {
+	t.Helper()
+	var got errorResponse
+	gotStatus := c.do(t, method, path, body, &got)
+	if gotStatus != wantStatus {
+		t.Errorf("status = %d, want %d (body: %+v)", gotStatus, wantStatus, got)
+	}
+	if got.Code != wantCode {
+		t.Errorf("error code = %q, want %q (body: %+v)", got.Code, wantCode, got)
+	}
+	if got.Message == "" {
+		t.Errorf("error message is empty (body: %+v)", got)
+	}
+	return got
+}
+
+// ---------------------------------------------------------------------------
+// DefaultSocketPath / hashing determinism
+// ---------------------------------------------------------------------------
+
+// TestDefaultSocketPath_Deterministic pins the path layout — the
+// 12-hex SHA-256 prefix of "prism-mux" is the *whole* point of the
+// hashed directory, so a refactor that silently changes the input
+// would break every CLI client at once. Pinning the exact prefix
+// catches that immediately.
+func TestDefaultSocketPath_Deterministic(t *testing.T) {
+	// Force a known XDG_STATE_HOME so the assertion is byte-exact.
+	t.Setenv("XDG_STATE_HOME", "/x")
+
+	got, err := DefaultSocketPath()
+	if err != nil {
+		t.Fatalf("DefaultSocketPath: %v", err)
+	}
+	// SHA-256("prism-mux") = 30acb169c... — pin only the 12-hex prefix
+	// to keep the assertion narrow but specific.
+	wantPrefix := "/x/prism/run/"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("path = %q, want prefix %q", got, wantPrefix)
+	}
+	if !strings.HasSuffix(got, "/mux.sock") {
+		t.Errorf("path = %q, want suffix %q", got, "/mux.sock")
+	}
+	// Re-deriving must produce the exact same path — no env reads, no
+	// time-based salting, etc.
+	got2, _ := DefaultSocketPath()
+	if got != got2 {
+		t.Errorf("path is not deterministic: %q vs %q", got, got2)
+	}
+	// Confirm the directory hash is exactly socketDirHashLen chars.
+	dirName := filepath.Base(filepath.Dir(got))
+	if len(dirName) != socketDirHashLen {
+		t.Errorf("dir name %q has length %d, want %d", dirName, len(dirName), socketDirHashLen)
+	}
+}
+
+// TestDefaultSocketPath_XDGFallback covers the case where
+// XDG_STATE_HOME is unset — we fall back to $HOME/.local/state to
+// match internal/session.sidecarStateDir.
+func TestDefaultSocketPath_XDGFallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "/h")
+
+	got, err := DefaultSocketPath()
+	if err != nil {
+		t.Fatalf("DefaultSocketPath: %v", err)
+	}
+	if !strings.HasPrefix(got, "/h/.local/state/prism/run/") {
+		t.Errorf("path = %q, want prefix %q", got, "/h/.local/state/prism/run/")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Constructor invariants
+// ---------------------------------------------------------------------------
+
+// TestNew_NilTreePanics asserts the "panic at construction, not on
+// first request" contract documented on New. The recover-from-panic
+// pattern is the standard Go test for this.
+func TestNew_NilTreePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("New(nil) did not panic")
+		}
+	}()
+	_ = New(nil)
+}
+
+// ---------------------------------------------------------------------------
+// session.* happy path
+// ---------------------------------------------------------------------------
+
+// TestSessionCreate_HappyPath exercises POST /session/create with a
+// minimal top-level session and asserts:
+//
+//   - 200 OK with the canonical post-insert view as the response body
+//   - ActivePane defaulted to the first pane (model behaviour)
+//   - GET /session/list sees the new session
+//
+// This is the smallest test that walks the full encode → server →
+// decode → introspect loop, so it serves as the canary for the wire
+// shape as a whole.
+func TestSessionCreate_HappyPath(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	var got sessionResponse
+	status := c.do(t, http.MethodPost, "/session/create", sessionCreateRequest{
+		ID:   "repo@feat",
+		Repo: "repo",
+		Panes: []paneInput{
+			{Name: "agent"},
+			{Name: "term"},
+		},
+	}, &got)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %+v)", status, got)
+	}
+	if got.Session.ID != "repo@feat" {
+		t.Errorf("session.id = %q, want %q", got.Session.ID, "repo@feat")
+	}
+	if got.Session.ActivePane != "agent" {
+		t.Errorf("session.active_pane = %q, want %q (model should default to first pane)",
+			got.Session.ActivePane, "agent")
+	}
+
+	// list shows the new session.
+	var listed sessionListResponse
+	if s := c.do(t, http.MethodGet, "/session/list", nil, &listed); s != http.StatusOK {
+		t.Fatalf("list status = %d, want 200", s)
+	}
+	if len(listed.Sessions) != 1 || listed.Sessions[0].ID != "repo@feat" {
+		t.Errorf("listed sessions = %+v, want one session 'repo@feat'", listed.Sessions)
+	}
+}
+
+// TestSessionCreate_ReviewSubsession covers the two-level hierarchy:
+// a review subsession's parent must already exist and the response
+// echoes the inherited Repo field.
+func TestSessionCreate_ReviewSubsession(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	// Parent first.
+	if s := c.do(t, http.MethodPost, "/session/create", sessionCreateRequest{
+		ID: "repo@feat", Repo: "repo",
+	}, nil); s != http.StatusOK {
+		t.Fatalf("create parent: status %d", s)
+	}
+
+	var got sessionResponse
+	status := c.do(t, http.MethodPost, "/session/create", sessionCreateRequest{
+		ID:        "repo@feat~review-1-review-code",
+		ParentID:  "repo@feat",
+		AgentRole: "review-code",
+	}, &got)
+	if status != http.StatusOK {
+		t.Fatalf("create child status = %d (body %+v)", status, got)
+	}
+	if got.Session.Repo != "repo" {
+		t.Errorf("child Repo = %q, want %q (inherit from parent)", got.Session.Repo, "repo")
+	}
+	if got.Session.ParentID != "repo@feat" {
+		t.Errorf("child ParentID = %q, want %q", got.Session.ParentID, "repo@feat")
+	}
+}
+
+// TestSessionDestroy_HappyPath asserts a destroy round-trip — create,
+// destroy, list — and that destroying a top-level session with a
+// child cascades (the model cascades; the server should propagate
+// that behaviour transparently).
+func TestSessionDestroy_HappyPath(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	if s := c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b", Repo: "r"}, nil); s != http.StatusOK {
+		t.Fatalf("create parent: %d", s)
+	}
+	if s := c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b~r-1-x", ParentID: "r@b"}, nil); s != http.StatusOK {
+		t.Fatalf("create child: %d", s)
+	}
+
+	if s := c.do(t, http.MethodPost, "/session/destroy",
+		sessionDestroyRequest{ID: "r@b"}, nil); s != http.StatusOK {
+		t.Fatalf("destroy: %d", s)
+	}
+
+	var listed sessionListResponse
+	c.do(t, http.MethodGet, "/session/list", nil, &listed)
+	if len(listed.Sessions) != 0 {
+		t.Errorf("after cascade destroy, sessions = %+v, want empty", listed.Sessions)
+	}
+}
+
+// TestSessionSwitch_HappyPath drives /session/switch and asserts both
+// the response echo and the subsequent /session/list active_session
+// pointer.
+func TestSessionSwitch_HappyPath(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "a@1", Repo: "a"}, nil)
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "a@2", Repo: "a"}, nil)
+
+	var sw sessionSwitchResponse
+	if s := c.do(t, http.MethodPost, "/session/switch",
+		sessionSwitchRequest{ID: "a@2"}, &sw); s != http.StatusOK {
+		t.Fatalf("switch status = %d", s)
+	}
+	if sw.ActiveSession != "a@2" {
+		t.Errorf("ActiveSession = %q, want %q", sw.ActiveSession, "a@2")
+	}
+
+	var listed sessionListResponse
+	c.do(t, http.MethodGet, "/session/list", nil, &listed)
+	if listed.ActiveSession != "a@2" {
+		t.Errorf("listed.ActiveSession = %q, want %q", listed.ActiveSession, "a@2")
+	}
+
+	// Empty ID clears focus.
+	c.do(t, http.MethodPost, "/session/switch", sessionSwitchRequest{ID: ""}, &sw)
+	if sw.ActiveSession != "" {
+		t.Errorf("ActiveSession after clear = %q, want empty", sw.ActiveSession)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pane.* happy paths
+// ---------------------------------------------------------------------------
+
+// TestPane_FullLifecycle drives every pane.* method in sequence. Each
+// step asserts both the response and the resulting tree state via
+// /pane/list — together they cover the AC "verify resulting state via
+// session.list / pane.list" in one composable case.
+func TestPane_FullLifecycle(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b", Repo: "r"}, nil)
+
+	// create two panes.
+	for _, name := range []string{"agent", "term"} {
+		if s := c.do(t, http.MethodPost, "/pane/create",
+			paneCreateRequest{SessionID: "r@b", Name: name}, nil); s != http.StatusOK {
+			t.Fatalf("pane.create %q status %d", name, s)
+		}
+	}
+
+	listURL := "/pane/list?" + url.Values{"session_id": {"r@b"}}.Encode()
+
+	var lst paneListResponse
+	c.do(t, http.MethodGet, listURL, nil, &lst)
+	if len(lst.Panes) != 2 || lst.Panes[0].Name != "agent" || lst.Panes[1].Name != "term" {
+		t.Errorf("panes after create = %+v, want [agent, term]", lst.Panes)
+	}
+	if lst.ActivePane != "agent" {
+		t.Errorf("active_pane = %q, want agent (first pane should auto-activate)", lst.ActivePane)
+	}
+
+	// switch by name.
+	var sw paneSwitchResponse
+	c.do(t, http.MethodPost, "/pane/switch",
+		paneSwitchRequest{SessionID: "r@b", Name: "term"}, &sw)
+	if sw.ActivePane != "term" {
+		t.Errorf("switch-by-name ActivePane = %q, want term", sw.ActivePane)
+	}
+
+	// switch by direction next: wraps to agent.
+	c.do(t, http.MethodPost, "/pane/switch",
+		paneSwitchRequest{SessionID: "r@b", Direction: "next"}, &sw)
+	if sw.ActivePane != "agent" {
+		t.Errorf("switch-next ActivePane = %q, want agent (wrap)", sw.ActivePane)
+	}
+
+	// switch by direction prev: wraps to term.
+	c.do(t, http.MethodPost, "/pane/switch",
+		paneSwitchRequest{SessionID: "r@b", Direction: "prev"}, &sw)
+	if sw.ActivePane != "term" {
+		t.Errorf("switch-prev ActivePane = %q, want term", sw.ActivePane)
+	}
+
+	// resize is a validate-only no-op at this layer; just confirm 200.
+	if s := c.do(t, http.MethodPost, "/pane/resize",
+		paneResizeRequest{SessionID: "r@b", Name: "term", Cols: 80, Rows: 24},
+		nil); s != http.StatusOK {
+		t.Errorf("resize status = %d, want 200", s)
+	}
+
+	// send_input is also a validate-only no-op at this layer.
+	if s := c.do(t, http.MethodPost, "/pane/send_input",
+		paneSendInputRequest{SessionID: "r@b", Name: "term", Data: "ls\n"},
+		nil); s != http.StatusOK {
+		t.Errorf("send_input status = %d, want 200", s)
+	}
+
+	// destroy and confirm the list shrinks.
+	c.do(t, http.MethodPost, "/pane/destroy",
+		paneDestroyRequest{SessionID: "r@b", Name: "agent"}, nil)
+	c.do(t, http.MethodGet, listURL, nil, &lst)
+	if len(lst.Panes) != 1 || lst.Panes[0].Name != "term" {
+		t.Errorf("panes after destroy = %+v, want [term]", lst.Panes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Structured errors — one case per typed pane.* sentinel so the
+// statusAndCodeForPaneErr mapping is fully covered.
+// ---------------------------------------------------------------------------
+
+// TestErrors_StructuredResponses asserts the full table of typed
+// pane.* errors maps to the expected (HTTP status, stable code)
+// pair. The cases are co-located so a refactor of the mapping has a
+// single place to update.
+func TestErrors_StructuredResponses(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	// Pre-populate so we have valid targets for the success-leading
+	// paths each negative case branches off.
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b", Repo: "r"}, nil)
+	c.do(t, http.MethodPost, "/pane/create",
+		paneCreateRequest{SessionID: "r@b", Name: "agent"}, nil)
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		body       any
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "session_exists",
+			method:     http.MethodPost,
+			path:       "/session/create",
+			body:       sessionCreateRequest{ID: "r@b", Repo: "r"},
+			wantStatus: http.StatusConflict,
+			wantCode:   codeSessionExists,
+		},
+		{
+			name:       "session_not_found_on_destroy",
+			method:     http.MethodPost,
+			path:       "/session/destroy",
+			body:       sessionDestroyRequest{ID: "nope"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   codeSessionNotFound,
+		},
+		{
+			name:       "session_not_found_on_switch",
+			method:     http.MethodPost,
+			path:       "/session/switch",
+			body:       sessionSwitchRequest{ID: "nope"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   codeSessionNotFound,
+		},
+		{
+			name:       "parent_not_found",
+			method:     http.MethodPost,
+			path:       "/session/create",
+			body:       sessionCreateRequest{ID: "x", ParentID: "nope"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   codeParentNotFound,
+		},
+		{
+			name:       "invalid_session_top_level_no_repo",
+			method:     http.MethodPost,
+			path:       "/session/create",
+			body:       sessionCreateRequest{ID: "x"},
+			wantStatus: http.StatusBadRequest,
+			wantCode:   codeInvalidSession,
+		},
+		{
+			name:       "pane_exists",
+			method:     http.MethodPost,
+			path:       "/pane/create",
+			body:       paneCreateRequest{SessionID: "r@b", Name: "agent"},
+			wantStatus: http.StatusConflict,
+			wantCode:   codePaneExists,
+		},
+		{
+			name:       "pane_not_found_on_destroy",
+			method:     http.MethodPost,
+			path:       "/pane/destroy",
+			body:       paneDestroyRequest{SessionID: "r@b", Name: "nope"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   codePaneNotFound,
+		},
+		{
+			name:       "pane_not_found_on_switch_by_name",
+			method:     http.MethodPost,
+			path:       "/pane/switch",
+			body:       paneSwitchRequest{SessionID: "r@b", Name: "nope"},
+			wantStatus: http.StatusNotFound,
+			wantCode:   codePaneNotFound,
+		},
+		{
+			name:       "pane_not_found_on_resize",
+			method:     http.MethodPost,
+			path:       "/pane/resize",
+			body:       paneResizeRequest{SessionID: "r@b", Name: "nope", Cols: 1, Rows: 1},
+			wantStatus: http.StatusNotFound,
+			wantCode:   codePaneNotFound,
+		},
+		{
+			name:       "session_not_found_on_pane_list",
+			method:     http.MethodGet,
+			path:       "/pane/list?session_id=nope",
+			body:       nil,
+			wantStatus: http.StatusNotFound,
+			wantCode:   codeSessionNotFound,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.expectError(t, tc.method, tc.path, tc.body, tc.wantStatus, tc.wantCode)
+		})
+	}
+}
+
+// TestErrors_NoPanesOnCycle exercises pane.ErrNoPanes — a session
+// with zero panes returns 400/no_panes from /pane/switch direction.
+func TestErrors_NoPanesOnCycle(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b", Repo: "r"}, nil)
+
+	c.expectError(t, http.MethodPost, "/pane/switch",
+		paneSwitchRequest{SessionID: "r@b", Direction: "next"},
+		http.StatusBadRequest, codeNoPanes)
+}
+
+// TestErrors_ParentIsReview exercises the §3.1 two-level invariant:
+// a review subsession cannot itself be a parent. The server must
+// propagate pane.ErrParentIsReview as 400/parent_is_review.
+func TestErrors_ParentIsReview(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b", Repo: "r"}, nil)
+	c.do(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "r@b~r-1-x", ParentID: "r@b"}, nil)
+
+	c.expectError(t, http.MethodPost, "/session/create",
+		sessionCreateRequest{ID: "deep", ParentID: "r@b~r-1-x"},
+		http.StatusBadRequest, codeParentIsReview)
+}
+
+// ---------------------------------------------------------------------------
+// Bad-request paths — pre-model validation in the server itself
+// ---------------------------------------------------------------------------
+
+// TestBadRequest_MissingFields covers the handler-level validation
+// (empty session_id / name / id) that fires before the model is
+// touched. These are 400/bad_request, not the typed pane.* codes.
+func TestBadRequest_MissingFields(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   any
+	}{
+		{"session_create_no_id", http.MethodPost, "/session/create", sessionCreateRequest{}},
+		{"session_destroy_no_id", http.MethodPost, "/session/destroy", sessionDestroyRequest{}},
+		{"pane_create_no_session_id", http.MethodPost, "/pane/create", paneCreateRequest{Name: "x"}},
+		{"pane_create_no_name", http.MethodPost, "/pane/create", paneCreateRequest{SessionID: "y"}},
+		{"pane_destroy_no_session_id", http.MethodPost, "/pane/destroy", paneDestroyRequest{Name: "x"}},
+		{"pane_list_no_session_id", http.MethodGet, "/pane/list", nil},
+		{"pane_switch_no_session_id", http.MethodPost, "/pane/switch", paneSwitchRequest{Name: "x"}},
+		{"pane_switch_neither_name_nor_direction", http.MethodPost, "/pane/switch", paneSwitchRequest{SessionID: "x"}},
+		{"pane_switch_both_name_and_direction", http.MethodPost, "/pane/switch", paneSwitchRequest{SessionID: "x", Name: "y", Direction: "next"}},
+		{"pane_switch_invalid_direction", http.MethodPost, "/pane/switch", paneSwitchRequest{SessionID: "x", Direction: "sideways"}},
+		{"pane_resize_no_session_id", http.MethodPost, "/pane/resize", paneResizeRequest{Name: "x"}},
+		{"pane_resize_negative_cols", http.MethodPost, "/pane/resize", paneResizeRequest{SessionID: "x", Name: "y", Cols: -1}},
+		{"pane_send_input_no_session_id", http.MethodPost, "/pane/send_input", paneSendInputRequest{Name: "x"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c.expectError(t, tc.method, tc.path, tc.body, http.StatusBadRequest, codeBadRequest)
+		})
+	}
+}
+
+// TestBadRequest_MalformedJSON covers the JSON-decoder error path —
+// the body must be rejected with 400/bad_request and a parseable
+// errorResponse.
+func TestBadRequest_MalformedJSON(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	req, err := http.NewRequest(http.MethodPost, c.base+"/session/create",
+		strings.NewReader("not json"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	var got errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Code != codeBadRequest {
+		t.Errorf("code = %q, want %q", got.Code, codeBadRequest)
+	}
+}
+
+// TestBadRequest_UnknownField asserts DisallowUnknownFields is wired
+// in — an unknown JSON key should be rejected so typos in the wire
+// shape do not pass silently.
+func TestBadRequest_UnknownField(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	c.expectError(t, http.MethodPost, "/session/create",
+		map[string]any{"id": "x", "repo": "r", "garbage": true},
+		http.StatusBadRequest, codeBadRequest)
+}
+
+// ---------------------------------------------------------------------------
+// Method routing — wrong method, unknown path
+// ---------------------------------------------------------------------------
+
+// TestMethodNotAllowed asserts every endpoint enforces its HTTP verb
+// and returns 405/method_not_allowed.
+func TestMethodNotAllowed(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	// /session/list is GET-only; POST should fail.
+	c.expectError(t, http.MethodPost, "/session/list", nil,
+		http.StatusMethodNotAllowed, codeMethodNotAllowed)
+	// /session/create is POST-only; GET should fail.
+	c.expectError(t, http.MethodGet, "/session/create", nil,
+		http.StatusMethodNotAllowed, codeMethodNotAllowed)
+}
+
+// TestUnknownPath covers the "/" fall-through — anything outside the
+// registered routes is a 404/bad_request with a clear message.
+func TestUnknownPath(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	got := c.expectError(t, http.MethodPost, "/no/such/method", nil,
+		http.StatusNotFound, codeBadRequest)
+	if !strings.Contains(got.Message, "no such method") {
+		t.Errorf("message = %q, want substring %q", got.Message, "no such method")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency — verify the server accepts many connections in
+// parallel and serialises mutations via the underlying tree.
+// ---------------------------------------------------------------------------
+
+// TestConcurrent_Mutations fans out a swarm of /session/create calls
+// from many goroutines. The AC requires "the server accepts multiple
+// connections simultaneously and serialises model mutations through
+// the model" — this test exercises that explicitly under -race.
+//
+// Each goroutine creates a uniquely-named session in a unique repo so
+// the model has plenty of opportunity to interleave writes. After the
+// fan-out we assert the final tree contains exactly N sessions and
+// that the list endpoint sees them all.
+func TestConcurrent_Mutations(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	const (
+		workers  = 16
+		perWorker = 8
+	)
+	var (
+		wg      sync.WaitGroup
+		failure atomic.Int32
+	)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				id := fmt.Sprintf("r%d@b%d", w, i)
+				var got sessionResponse
+				status := c.do(t, http.MethodPost, "/session/create",
+					sessionCreateRequest{ID: id, Repo: fmt.Sprintf("r%d", w)}, &got)
+				if status != http.StatusOK {
+					t.Errorf("worker %d create %d: status %d", w, i, status)
+					failure.Add(1)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	if failure.Load() > 0 {
+		t.FailNow()
+	}
+
+	var listed sessionListResponse
+	c.do(t, http.MethodGet, "/session/list", nil, &listed)
+	if len(listed.Sessions) != workers*perWorker {
+		t.Errorf("session count = %d, want %d", len(listed.Sessions), workers*perWorker)
+	}
+}
+
+// TestConcurrent_DuplicateIDs hammers a single ID from many
+// goroutines: exactly one must win with 200, all others must lose
+// with 409/session_exists. This is the strongest assertion that the
+// server serialises through the model's mutex rather than letting
+// two AddSession calls land in parallel.
+func TestConcurrent_DuplicateIDs(t *testing.T) {
+	c, _ := newTestServer(t)
+
+	const workers = 32
+	var (
+		wg          sync.WaitGroup
+		successes   atomic.Int32
+		conflicts   atomic.Int32
+		unexpected  atomic.Int32
+		unexpResp   atomic.Pointer[errorResponse]
+	)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var got errorResponse
+			status := c.do(t, http.MethodPost, "/session/create",
+				sessionCreateRequest{ID: "the-one", Repo: "r"}, &got)
+			switch {
+			case status == http.StatusOK:
+				successes.Add(1)
+			case status == http.StatusConflict && got.Code == codeSessionExists:
+				conflicts.Add(1)
+			default:
+				unexpected.Add(1)
+				captured := got
+				unexpResp.Store(&captured)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := successes.Load(); got != 1 {
+		t.Errorf("successes = %d, want exactly 1", got)
+	}
+	if got := conflicts.Load(); got != workers-1 {
+		t.Errorf("conflicts = %d, want %d", got, workers-1)
+	}
+	if got := unexpected.Load(); got != 0 {
+		var lastSeen errorResponse
+		if p := unexpResp.Load(); p != nil {
+			lastSeen = *p
+		}
+		t.Errorf("unexpected responses = %d (last: %+v)", got, lastSeen)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListenAndServe lifecycle — the public entry point used by the
+// daemon binary in a later PR.
+// ---------------------------------------------------------------------------
+
+// TestListenAndServe_HappyPath exercises the public ListenAndServe
+// entry point against an explicit path inside t.TempDir(). Confirms:
+//
+//   - the socket file is created
+//   - a real client can hit /session/list
+//   - context cancellation drains and the socket is unlinked
+func TestListenAndServe_HappyPath(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "p")
+	if len(sockPath) >= 104 {
+		t.Skipf("temp socket path too long for sun_path: %s", sockPath)
+	}
+
+	tree := pane.New()
+	srv := New(tree)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.ListenAndServe(ctx, sockPath) }()
+
+	// Poll for socket existence.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("socket not created: %v", err)
+	}
+
+	// Hit /session/list to prove the server is actually serving.
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Get("http://mux/session/list")
+	if err != nil {
+		t.Fatalf("get /session/list: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Cancel and wait for ListenAndServe to return.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("ListenAndServe returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListenAndServe did not return within 3s of cancel")
+	}
+
+	// Socket file should be unlinked on exit.
+	if _, err := os.Stat(sockPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket %q still exists after shutdown (err=%v); want unlinked",
+			sockPath, err)
+	}
+}
+
+// TestListenAndServe_StaleSocketReplaced asserts the server unlinks a
+// stale socket file at the bind path before binding — without this,
+// any prior unclean shutdown would block the next start. Pre-create a
+// stale file at the path, then prove ListenAndServe succeeds and
+// serves real requests through it.
+func TestListenAndServe_StaleSocketReplaced(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "p")
+	if len(sockPath) >= 104 {
+		t.Skipf("temp socket path too long for sun_path: %s", sockPath)
+	}
+	// Plant a stale regular file at the bind path.
+	if err := os.WriteFile(sockPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("plant stale file: %v", err)
+	}
+
+	tree := pane.New()
+	srv := New(tree)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.ListenAndServe(ctx, sockPath) }()
+
+	// Wait for the socket to be (re)created — we can detect it by
+	// successfully dialling and getting a 200 from /session/list.
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+		Timeout: 250 * time.Millisecond,
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get("http://mux/session/list")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				cancel()
+				<-done
+				return
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatal("stale-socket replacement: never observed a serving listener")
+}

--- a/modules/programs/prism/prism/internal/mux/server/socket.go
+++ b/modules/programs/prism/prism/internal/mux/server/socket.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// socketDirHashLen matches the per-session directory length used by
+// internal/session.SessionDirName (12 hex chars = 48 bits of SHA-256).
+// We mirror it so the mux socket directory looks structurally identical
+// to a sidecar's per-session run/ directory and any path-walking tool
+// that already understands one understands the other.
+const socketDirHashLen = 12
+
+// socketDirInput is the fixed SHA-256 input used to derive the mux
+// daemon's run/ subdirectory name. It is deliberately distinct from any
+// real session name (sessions are conventionally "<repo>@<branch>") so
+// that the daemon's mux.sock never collides with a session's
+// hostapi.sock — and even if it did, the file names differ.
+const socketDirInput = "prism-mux"
+
+// socketFileName is the well-known basename of the mux daemon's Unix
+// socket. The two-part path (dir name = hash, file name = "mux.sock")
+// mirrors the sidecar's (dir name = hash, file name = "hostapi.sock")
+// layout from internal/session.SidecarHostAPIPath.
+const socketFileName = "mux.sock"
+
+// DefaultSocketPath returns the canonical Unix socket path for the
+// prism mux daemon: $XDG_STATE_HOME/prism/run/<12-hex>/mux.sock.
+//
+// The $XDG_STATE_HOME fallback mirrors what internal/session does:
+// when the variable is unset we use $HOME/.local/state. An error is
+// returned only when $HOME itself cannot be resolved.
+func DefaultSocketPath() (string, error) {
+	base, err := stateBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "run", socketDirName(), socketFileName), nil
+}
+
+// stateBaseDir returns the $XDG_STATE_HOME/prism base directory,
+// resolving $HOME if the variable is unset.
+func stateBaseDir() (string, error) {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "prism"), nil
+}
+
+// socketDirName returns the 12-hex-char SHA-256 prefix of socketDirInput.
+// Exposed as a function so tests can assert on its determinism without
+// duplicating the hashing.
+func socketDirName() string {
+	sum := sha256.Sum256([]byte(socketDirInput))
+	return hex.EncodeToString(sum[:])[:socketDirHashLen]
+}


### PR DESCRIPTION
PR #4 of the multiplexer programme (#2147). Builds the CLI-facing
socket API on top of the `internal/mux/pane.SessionTree` data model
landed in #2163.

## Wire shape

**HTTP/1.1 over Unix socket with JSON request and response bodies**,
mirroring `internal/sidecar/host_api.go`. The §3 architecture table in
`docs/multiplexer-proposal.md` sketches JSONL framing as one option,
but the issue AC explicitly allows "JSON-RPC over newline-delimited
frames OR the equivalent prism convention used by the sidecar host-API
today" — we pick the latter so:

- the CLI client gets to reuse the same `http.Client` + Unix-socket
  `Dialer` pattern that `host_api.go`'s `dialUnixAndPost` already
  uses (see `host_api.go:3175`);
- reviewers only have one wire shape to keep in their heads across
  the two sockets;
- structured error responses come naturally from HTTP status +
  JSON body.

The dotted method names from the AC (`session.create`,
`pane.send_input`, …) map to URL paths by substituting the dot for a
slash. List endpoints use `GET`; mutating endpoints use `POST`.

## Socket path

```
$XDG_STATE_HOME/prism/run/<12-hex-of-sha256("prism-mux")>/mux.sock
```

The hashed-directory layout mirrors
`internal/session.SidecarHostAPIPath` for `sun_path`-budget reasons
(Linux 108 / Darwin 104) and so existing prism tooling that walks
`$XDG_STATE_HOME/prism/run/` keeps working. The daemon is
singleton-per-user; the SHA-256 input is a **fixed string** (not a
session name) so the directory never collides with a real session's
`hostapi.sock`. Even if a hypothetical session were named
\`\`prism-mux\`\`, the file names (\`hostapi.sock\` vs \`mux.sock\`) inside the
directory differ and the two sockets coexist cleanly.

## Method surface

All ten methods from the AC are wired:

| Method                  | URL                       |
| ----------------------- | ------------------------- |
| \`session.create\`      | \`POST /session/create\`  |
| \`session.destroy\`     | \`POST /session/destroy\` |
| \`session.list\`        | \`GET  /session/list\`    |
| \`session.switch\`      | \`POST /session/switch\`  |
| \`pane.create\`         | \`POST /pane/create\`     |
| \`pane.destroy\`        | \`POST /pane/destroy\`    |
| \`pane.list\`           | \`GET  /pane/list\`       |
| \`pane.switch\`         | \`POST /pane/switch\` (by name or \`direction\`) |
| \`pane.resize\`         | \`POST /pane/resize\`     |
| \`pane.send_input\`     | \`POST /pane/send_input\` |

\`pane.resize\` and \`pane.send_input\` are validate-only at this layer
— the model carries no geometry or input channel. The handlers
validate \`(session, pane)\` existence and return 200 so the wire
contract is stable; actual PTY-layer effects land in later PRs (#2152
render / future PRs against \`internal/mux/pty/\`).

## Errors

Every non-2xx response carries a structured JSON body:

\`\`\`json
{"code":"<stable_code>","message":"<human readable>","data":{...}}
\`\`\`

Typed \`pane.*\` sentinels (\`ErrSessionExists\`, \`ErrPaneNotFound\`, …)
map 1:1 to stable code strings (\`session_exists\`, \`pane_not_found\`,
…); the HTTP status (409 for conflicts, 404 for not-found, 400 for
bad input, 405 for wrong method) lines up in parallel so HTTP-level
and code-aware clients both work without string-matching.

## Concurrency

\`net/http\` handles connections in parallel (one goroutine per
connection); the \`SessionTree\`'s existing mutex serialises mutations.
The server holds no additional locks. The round-trip test exercises
this explicitly under \`-race\`:

- \`TestConcurrent_Mutations\` — 16×8 unique sessions, fan-out
- \`TestConcurrent_DuplicateIDs\` — 32 goroutines creating the same
  ID; asserts **exactly one** wins with 200, the rest get
  409/\`session_exists\`

## Tests

\`server_test.go\` covers:

- happy paths for every method
- one structured-error case per typed \`pane.*\` sentinel
- missing-field / wrong-method / malformed-JSON / unknown-field / unknown-path
- the two concurrent cases above
- \`ListenAndServe\` lifecycle: socket created, served, unlinked on
  cancel; stale socket file replaced on next start

\`go test ./... -race\` passes; the homeless-shelter sandbox build
(\`prism.override { runChecks = true; }\`) passes; \`nix flake check\`
clean.

## go.mod / vendor

Stdlib-only. \`go.mod\` and \`pkgs/prism.nix:vendorHash\` are
untouched — no overlap with the three parallel Wave B branches.

Closes #2153.