### PR TITLE
mux/state: subscribe to agent_events for sidebar state colours

### DIFF
--- a/modules/programs/prism/prism/docs/multiplexer-proposal.md
+++ b/modules/programs/prism/prism/docs/multiplexer-proposal.md
@@ -164,17 +164,33 @@ internal/mux/
 ├── pty/        # creack/pty wiring; signal forwarding; resize handling
 ├── vt/         # x/vt host: cell-grid extraction, alt-screen, scroll-back
 ├── render/     # bubbletea program + lipgloss styles; sidebar widget
-├── workspace/  # workspace/tab/pane model; persistence to prism.db
+├── pane/       # session/repo/pane data model (#2151, landed)
+├── state/      # subscriber for the sidecar /events stream (#2155)
 ├── input/      # host-key dispatch; app-forwarding; OSC52 clipboard
 ├── socket/     # JSONL-framed Unix socket API for the CLI
 ├── ssh/        # wish-based remote-attach server; client-side dialer
 └── testdata/   # corpus from #2141 → corpus.toml lives here post-spike
 ```
 
-`internal/mux/workspace/` persists its model to **`prism.db`**, not a
-flat file. The sidecar already owns the DB connection lifecycle; we
-reuse it. The workspace model — sessions, tabs, panes, focus state —
-is small relative to the existing `agent_events` table.
+**State plumbing — push, not poll.** Per session glyph + colour state is
+driven by a subscription, never by a polling loop. The sidecar exposes
+`GET /events` on its existing host-API Unix socket (issue #2155): a
+long-lived SSE stream that emits one `state_snapshot` envelope per
+matching session on subscribe and then live `state_change` deltas as
+the agent transitions. `internal/mux/state/` opens one such stream per
+sidecar, applies each envelope into a small in-process Store keyed by
+session ID, and fires registered listeners so the renderer
+(§3.1) can repaint within one frame of an event arriving. Reconnection
+is exponential-backoff; on every reconnect the sidecar's snapshot
+resyncs the Store before resuming deltas, so a sidecar restart never
+leaves a stale colour in the sidebar.
+
+`internal/mux/pane/` (formerly sketched as `workspace/` in the original
+proposal) persists its model via the snapshot/restore layer in
+`internal/mux/persist/` (#2156) to **`prism.db`**, not a flat file.
+The sidecar already owns the DB connection lifecycle; we reuse it.
+The pane model — sessions, panes, focus state — is small relative to
+the existing `agent_events` table.
 
 ### 3.1 UI reference: sidebar
 

--- a/modules/programs/prism/prism/internal/mux/state/integration_test.go
+++ b/modules/programs/prism/prism/internal/mux/state/integration_test.go
@@ -1,0 +1,345 @@
+// integration_test.go drives Subscriber.Run against a fake sidecar that
+// emits a scripted SSE stream. The fake is a httptest.Server so the test
+// is fully in-process and never touches a real Unix socket — a hard
+// requirement under the nix-build sandbox where $HOME=/homeless-shelter
+// (see modules/programs/prism/AGENTS.md § Prism for the sandbox-isolation
+// convention).
+//
+// Coverage:
+//
+//   - "fake sidecar emits events; model state updates per event"
+//     (AC: integration test).
+//   - Snapshot-then-deltas ordering matches the wire contract.
+//   - Reconnect after the fake closes the stream: a second event delivered
+//     after reconnect lands in the Store.
+
+package state
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// fakeSidecar serves GET /events with a scripted sequence of frames. The
+// test plays each frame out via the Frames channel; the fake closes the
+// connection cleanly after the last frame so the Subscriber's reconnect
+// path is exercised.
+type fakeSidecar struct {
+	mu          sync.Mutex
+	connections atomic.Int32
+	srv         *httptest.Server
+	frames      []string
+	// onConnect optionally fires once per accepted connection. Used to
+	// drive deterministic reconnect tests.
+	onConnect func(connNum int)
+}
+
+func newFakeSidecar(t *testing.T, frames []string) *fakeSidecar {
+	t.Helper()
+	f := &fakeSidecar{frames: frames}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		n := int(f.connections.Add(1))
+		if f.onConnect != nil {
+			f.onConnect(n)
+		}
+		// Honour the client's context: when ctx fires (test teardown),
+		// stop writing rather than block on a dead socket.
+		f.mu.Lock()
+		framesCopy := append([]string{}, f.frames...)
+		f.mu.Unlock()
+		for _, frame := range framesCopy {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			if _, err := fmt.Fprint(w, frame); err != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		// Close the connection cleanly after the scripted frames have
+		// been delivered. The Subscriber's underlying sse.Client will
+		// see EOF and (depending on the test) either exit or reconnect.
+	})
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// setFrames replaces the scripted frame list. Subsequent reconnects will
+// observe the new frames.
+func (f *fakeSidecar) setFrames(frames []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.frames = frames
+}
+
+// connectionCount returns how many /events connections the fake has
+// accepted so far.
+func (f *fakeSidecar) connectionCount() int { return int(f.connections.Load()) }
+
+// frameStateChange builds one SSE frame carrying a state_change event for
+// the named session.
+func frameStateChange(sessionName, state string) string {
+	return fmt.Sprintf(
+		"event: state_change\ndata: {\"type\":\"state_change\",\"session_name\":%q,\"payload\":{\"state\":%q},\"created_at_ms\":1}\n\n",
+		sessionName, state,
+	)
+}
+
+// frameSnapshot builds one SSE frame carrying a state_snapshot event for
+// the named session.
+func frameSnapshot(sessionName, state string) string {
+	return fmt.Sprintf(
+		"event: state_snapshot\ndata: {\"type\":\"state_snapshot\",\"session_name\":%q,\"payload\":{\"state\":%q},\"created_at_ms\":1,\"snapshot\":true}\n\n",
+		sessionName, state,
+	)
+}
+
+// waitForState polls store until SessionState(id) returns want, or fails
+// after a generous timeout. Used after Run launches because the
+// Subscriber goroutine applies events asynchronously.
+func waitForState(t *testing.T, store *Store, id string, want agent.AgentState) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, ok := store.SessionState(id)
+		if ok && got == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waitForState(%q) = (%q, %v), want %q", id, got, ok, want)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// runSubscriberInBackground starts s.Run and registers a cleanup that
+// cancels the context. Returns a wait function that the test can call to
+// confirm Run returned cleanly.
+func runSubscriberInBackground(t *testing.T, s *Subscriber) func() {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Subscriber.Run returned: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Errorf("Subscriber.Run did not return after cancel")
+		}
+	})
+	return func() {
+		cancel()
+		<-done
+	}
+}
+
+func TestSubscriber_AppliesScriptedSequence(t *testing.T) {
+	// AC: spawn a fake sidecar emitting a scripted sequence of events;
+	// assert that the model state updates per event in the correct
+	// order. This is the canonical integration assertion.
+	frames := []string{
+		frameSnapshot("alpha", "idle"),
+		frameStateChange("alpha", "active"),
+		frameStateChange("alpha", "waiting"),
+		frameStateChange("alpha", "active"),
+		frameStateChange("alpha", "reviewing"),
+		frameStateChange("alpha", "finished"),
+	}
+	fake := newFakeSidecar(t, frames)
+
+	store := New(nil)
+
+	// Listener captures the observed state sequence — we assert on this
+	// sequence rather than just the final state so a reordered apply
+	// path is caught.
+	var (
+		seenMu sync.Mutex
+		seen   []agent.AgentState
+	)
+	store.AddListener(func() {
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		if v, ok := store.SessionState("alpha"); ok {
+			seen = append(seen, v)
+		}
+	})
+
+	sub := &Subscriber{
+		Store: store,
+		// Skip the host_api Unix socket; talk to the fake httptest
+		// server directly.
+		httpClient:        fake.srv.Client(),
+		baseURL:           fake.srv.URL,
+		InitialRetryDelay: 5 * time.Millisecond,
+		MaxRetryDelay:     20 * time.Millisecond,
+	}
+	runSubscriberInBackground(t, sub)
+
+	waitForState(t, store, "alpha", agent.StateFinished)
+
+	want := []agent.AgentState{
+		agent.StateIdle,
+		agent.StateActive,
+		agent.StateWaiting,
+		agent.StateActive,
+		agent.StateReviewing,
+		agent.StateFinished,
+	}
+	seenMu.Lock()
+	defer seenMu.Unlock()
+	if len(seen) < len(want) {
+		t.Fatalf("captured %d states, want at least %d: %v", len(seen), len(want), seen)
+	}
+	// The observed sequence must contain `want` as a contiguous prefix
+	// after reconnect dedup; allow trailing duplicates (a no-op apply
+	// still fires the listener? — no, ApplyEvent returns false and does
+	// not call SetSessionState. So the prefix is exact).
+	for i, w := range want {
+		if seen[i] != w {
+			t.Fatalf("seen[%d] = %q, want %q (full: %v)", i, seen[i], w, seen)
+		}
+	}
+}
+
+func TestSubscriber_ReconnectsAndResyncs(t *testing.T) {
+	// The fake delivers a first batch on connection 1, closes the
+	// stream, then delivers a different batch on connection 2. The
+	// Subscriber's reconnect path must pick up the second batch without
+	// the test having to recreate it.
+	first := []string{
+		frameSnapshot("alpha", "idle"),
+		frameStateChange("alpha", "active"),
+	}
+	second := []string{
+		// Reconnect resync — the snapshot reports the authoritative
+		// state at reconnect time.
+		frameSnapshot("alpha", "active"),
+		frameStateChange("alpha", "reviewing"),
+		frameStateChange("alpha", "finished"),
+	}
+	fake := newFakeSidecar(t, first)
+
+	// On the second connect, swap the frames to the second batch so
+	// the reconnect path observes them.
+	fake.onConnect = func(n int) {
+		if n == 2 {
+			fake.setFrames(second)
+		}
+	}
+
+	store := New(nil)
+	sub := &Subscriber{
+		Store:             store,
+		httpClient:        fake.srv.Client(),
+		baseURL:           fake.srv.URL,
+		InitialRetryDelay: 5 * time.Millisecond,
+		MaxRetryDelay:     20 * time.Millisecond,
+	}
+	runSubscriberInBackground(t, sub)
+
+	// After the full sequence (across both connections), the store must
+	// settle on finished. waitForState polls and is the canonical
+	// "drainage" check.
+	waitForState(t, store, "alpha", agent.StateFinished)
+
+	if got := fake.connectionCount(); got < 2 {
+		t.Fatalf("connectionCount = %d, want >= 2 (reconnect path not exercised)", got)
+	}
+}
+
+func TestSubscriber_FilterFiltersAtTheWire(t *testing.T) {
+	// When Sessions is non-empty the Subscriber must encode session= query
+	// parameters into the URL. The fake captures the URL of the first
+	// request to assert on.
+	var (
+		capturedMu sync.Mutex
+		captured   string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		capturedMu.Lock()
+		captured = r.URL.RawQuery
+		capturedMu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, frameSnapshot("alpha", "active"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	store := New(nil)
+	sub := &Subscriber{
+		Store:             store,
+		Sessions:          []string{"alpha", "beta"},
+		httpClient:        srv.Client(),
+		baseURL:           srv.URL,
+		InitialRetryDelay: 5 * time.Millisecond,
+		MaxRetryDelay:     20 * time.Millisecond,
+	}
+	runSubscriberInBackground(t, sub)
+	waitForState(t, store, "alpha", agent.StateActive)
+
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	if captured == "" {
+		t.Fatalf("captured query = empty; want session= params")
+	}
+	// url.Values.Encode sorts keys but preserves slice order — there's
+	// only one key here so either order is acceptable. Just make sure
+	// both names appear.
+	if !contains(captured, "session=alpha") || !contains(captured, "session=beta") {
+		t.Fatalf("captured query %q does not include both session filters", captured)
+	}
+}
+
+func TestSubscriber_RequiresStore(t *testing.T) {
+	sub := &Subscriber{SockPath: "/tmp/anything.sock"}
+	err := sub.Run(context.Background())
+	if err == nil {
+		t.Fatalf("Run with nil Store returned nil; want error")
+	}
+}
+
+func TestSubscriber_RequiresSockPathOrClient(t *testing.T) {
+	sub := &Subscriber{Store: New(nil)}
+	err := sub.Run(context.Background())
+	if err == nil {
+		t.Fatalf("Run with no SockPath or httpClient returned nil; want error")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/modules/programs/prism/prism/internal/mux/state/state.go
+++ b/modules/programs/prism/prism/internal/mux/state/state.go
@@ -1,0 +1,357 @@
+// Package state is the multiplexer-side consumer of the sidecar's GET
+// /events stream (issue #2155 — part of the prism-native multiplexer
+// programme tracked by #2147).
+//
+// The package has two responsibilities:
+//
+//  1. Maintain a Store that maps each session ID to its current
+//     agent.AgentState. The render layer (#2152) reads from the Store to
+//     drive the sidebar's per-session glyph and colour, per the §3.1
+//     state → glyph + colour table.
+//
+//  2. Run one Subscriber per sidecar, each of which holds a long-lived SSE
+//     connection to the sidecar's host-API socket and applies incoming
+//     events to the Store. Subscriptions survive sidecar restarts via
+//     exponential-backoff reconnect; on every reconnect the sidecar
+//     emits a fresh snapshot, so the Store resyncs to authoritative state
+//     before consuming further deltas.
+//
+// # Threading
+//
+// The Store is goroutine-safe — every read and write acquires its mutex.
+// Subscribers run in their own goroutine and write to the Store directly;
+// the render layer reads via SessionState / Snapshot.
+//
+// The Store does NOT own a *pane.SessionTree, but it can be configured
+// with one so that ActivateSession events emitted by the sidecar can be
+// translated into pane.SessionTree.ActivateSession calls. Translating
+// state_change events into pane operations is out of scope for this
+// package — only state colours flow into the Store.
+//
+// # Reconnect strategy
+//
+// On each connection attempt:
+//
+//   - On success, reset the backoff to InitialRetryDelay and consume the
+//     stream until it errors or the context is cancelled.
+//   - On error, sleep for the current backoff then double it (capped at
+//     MaxRetryDelay) before retrying.
+//
+// The strategy mirrors internal/sse.Client.reconnect — we use that
+// package directly via its public Connect API so the wire-level details
+// stay in one place.
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+	"github.com/prismatic-koi/prism/internal/sse"
+)
+
+// Event is the JSON envelope emitted by the sidecar GET /events endpoint.
+// The shape is duplicated here (rather than imported from internal/sidecar)
+// because the mux process must not pull the sidecar package's transitive
+// dependencies (DB, harness, container) into its own binary.
+//
+// Both live deltas and snapshot events use this envelope. Snapshot events
+// have Snapshot=true and Type="state_snapshot"; live events use the
+// agent_events row type ("state_change", "message_updated", etc.).
+type Event struct {
+	Type        string          `json:"type"`
+	SessionName string          `json:"session_name"`
+	Payload     json.RawMessage `json:"payload"`
+	CreatedAtMs int64           `json:"created_at_ms"`
+	Snapshot    bool            `json:"snapshot,omitempty"`
+}
+
+// statePayload is the payload shape for state_change and state_snapshot
+// events. The sidecar emits {"state":"<value>"} for both; using a typed
+// payload keeps the per-event branch readable without a map[string]any.
+type statePayload struct {
+	State string `json:"state"`
+}
+
+// Store holds per-session agent.AgentState keyed by session ID. The render
+// layer reads via SessionState; the Subscriber writes via SetSessionState
+// and ApplyEvent.
+//
+// The zero value is NOT ready for use — call New(). The constructor exists
+// so the listener slice and the inner map are non-nil from the start.
+type Store struct {
+	mu        sync.RWMutex
+	states    map[string]agent.AgentState
+	tree      *pane.SessionTree
+	listeners []func()
+}
+
+// New returns an empty Store. tree may be nil; when non-nil, the Store
+// holds a reference but does not mutate it from inside SetSessionState
+// or ApplyEvent (the consumer does that explicitly via the public
+// SessionTree API). Holding the reference lets the Subscriber discover
+// which sessions to filter for in a single read.
+func New(tree *pane.SessionTree) *Store {
+	return &Store{
+		states: make(map[string]agent.AgentState),
+		tree:   tree,
+	}
+}
+
+// SessionTree returns the *pane.SessionTree this Store was constructed
+// with, or nil if none was supplied. Useful for the Subscriber so it can
+// compute its session filter from the tree without holding a separate
+// reference.
+func (s *Store) SessionTree() *pane.SessionTree { return s.tree }
+
+// SessionState returns the most recently observed agent.AgentState for
+// the named session ID, or ("", false) if the session has never had a
+// state event applied.
+func (s *Store) SessionState(id string) (agent.AgentState, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	st, ok := s.states[id]
+	return st, ok
+}
+
+// Snapshot returns a copy of every session-state mapping currently in the
+// Store. The returned map is owned by the caller and may be mutated
+// without affecting the Store. Order is unspecified.
+func (s *Store) Snapshot() map[string]agent.AgentState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]agent.AgentState, len(s.states))
+	for k, v := range s.states {
+		out[k] = v
+	}
+	return out
+}
+
+// SetSessionState records st as the current state for the named session.
+// Fires every registered listener after the write (outside the lock) so a
+// render goroutine subscribed via AddListener can repaint.
+//
+// Empty st is treated as a clear: the session entry is deleted.
+func (s *Store) SetSessionState(id string, st agent.AgentState) {
+	s.mu.Lock()
+	if st == "" {
+		delete(s.states, id)
+	} else {
+		s.states[id] = st
+	}
+	listeners := make([]func(), len(s.listeners))
+	copy(listeners, s.listeners)
+	s.mu.Unlock()
+	for _, fn := range listeners {
+		fn()
+	}
+}
+
+// AddListener registers fn to be called every time SetSessionState (or
+// ApplyEvent, indirectly) records a transition. Listeners are called
+// outside the lock so they may call back into the Store without
+// deadlocking.
+//
+// There is no Remove — listeners live for the lifetime of the Store. The
+// render layer's update loop is the only intended consumer; multiple
+// repaints in quick succession are harmless.
+func (s *Store) AddListener(fn func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listeners = append(s.listeners, fn)
+}
+
+// ApplyEvent applies one Event to the Store. state_change and
+// state_snapshot events update the Store; every other type is ignored
+// (the package is intentionally narrow — broader event-driven model
+// updates belong to other packages so the consumer surface stays
+// auditable).
+//
+// Returns true if the event resulted in a state change, false otherwise.
+// The boolean lets callers (tests, debug tooling) gate work on whether
+// the event was a no-op.
+func (s *Store) ApplyEvent(evt Event) bool {
+	switch evt.Type {
+	case "state_change", "state_snapshot":
+		// fall through
+	default:
+		return false
+	}
+	var p statePayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		return false
+	}
+	if p.State == "" {
+		return false
+	}
+	current, ok := s.SessionState(evt.SessionName)
+	st := agent.AgentState(p.State)
+	if ok && current == st {
+		return false
+	}
+	s.SetSessionState(evt.SessionName, st)
+	return true
+}
+
+// Subscriber maintains a long-lived SSE subscription to a single
+// sidecar's GET /events endpoint and applies incoming events to a Store.
+//
+// Run blocks until ctx is cancelled. The Subscriber is intended to be
+// driven by one goroutine per sidecar; the model's mutex (held inside the
+// Store) serialises all writes.
+type Subscriber struct {
+	// SockPath is the Unix-socket path of the sidecar's host-API. Required.
+	SockPath string
+
+	// Sessions filters the subscription. An empty slice means "every
+	// session this sidecar can see" — the wire-level wildcard.
+	Sessions []string
+
+	// Store receives applied events. Required.
+	Store *Store
+
+	// Logger is the logger used for connection / error messages. If nil,
+	// log.Default() is used.
+	Logger *log.Logger
+
+	// InitialRetryDelay and MaxRetryDelay control the exponential
+	// backoff between reconnect attempts. When zero, the defaults from
+	// internal/sse (1s and 30s) apply.
+	InitialRetryDelay time.Duration
+	MaxRetryDelay     time.Duration
+
+	// httpClient is overridable for tests that need to drive the
+	// subscriber against an httptest.Server. When nil, Run constructs a
+	// Unix-socket-dialling http.Client from SockPath.
+	httpClient *http.Client
+
+	// baseURL is overridable for tests. When non-empty, it replaces the
+	// default "http://prism-sidecar" base. Required when httpClient is
+	// set (so the test points the request at the httptest.Server).
+	baseURL string
+}
+
+// SetHTTPClient overrides the default Unix-socket-dialling http.Client.
+// Intended for tests that drive the Subscriber against an httptest.Server;
+// pair with SetBaseURL so the request resolves to the test server.
+func (s *Subscriber) SetHTTPClient(c *http.Client) { s.httpClient = c }
+
+// SetBaseURL overrides the default "http://prism-sidecar" base used to
+// construct the events URL. Intended for tests; production callers leave
+// this unset and Run derives the URL from SockPath.
+func (s *Subscriber) SetBaseURL(u string) { s.baseURL = u }
+
+func (s *Subscriber) logger() *log.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return log.Default()
+}
+
+// Run blocks until ctx is cancelled, maintaining a long-lived subscription
+// to the configured sidecar. Reconnection is handled internally by the
+// underlying sse.Client; this method orchestrates one outer pass per
+// connection so a fatal initial-connect error can still surface to the
+// caller via ctx-aware shutdown.
+//
+// Returns nil when ctx is cancelled normally; returns a wrapped error
+// only when configuration is invalid (missing SockPath, nil Store).
+func (s *Subscriber) Run(ctx context.Context) error {
+	if s.Store == nil {
+		return errors.New("state: Subscriber.Run: Store is required")
+	}
+	if s.SockPath == "" && s.httpClient == nil {
+		return errors.New("state: Subscriber.Run: SockPath or httpClient is required")
+	}
+
+	client := s.httpClient
+	if client == nil {
+		client = newUnixSocketClient(s.SockPath)
+	}
+	base := s.baseURL
+	if base == "" {
+		base = "http://prism-sidecar"
+	}
+
+	streamURL := base + "/events"
+	if q := buildQuery(s.Sessions); q != "" {
+		streamURL += "?" + q
+	}
+
+	sseClient := &sse.Client{
+		HTTPClient:        client,
+		InitialRetryDelay: s.InitialRetryDelay,
+		MaxRetryDelay:     s.MaxRetryDelay,
+	}
+
+	events, err := sseClient.Connect(ctx, streamURL)
+	if err != nil {
+		// Connect only returns an error when ctx fires before the first
+		// connect succeeds; treat as a clean shutdown.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("state: Subscriber.Run: sse connect: %w", err)
+	}
+
+	for evt := range events {
+		// The sidecar serialises every envelope as a single data: line.
+		var env Event
+		if err := json.Unmarshal([]byte(evt.Data), &env); err != nil {
+			s.logger().Printf("state: Subscriber: unmarshal event: %v: %s", err, evt.Data)
+			continue
+		}
+		if env.Type == "" && evt.Type != "" {
+			// The sidecar always sets `event: <type>`; treat the SSE
+			// event field as a fallback for clients that buffer
+			// across reconnects.
+			env.Type = evt.Type
+		}
+		s.Store.ApplyEvent(env)
+	}
+	return nil
+}
+
+// buildQuery returns the URL-encoded ?session=... portion of the
+// subscription URL. Empty sessions means "no filter" (the wildcard) and
+// returns an empty string so the URL is just /events.
+func buildQuery(sessions []string) string {
+	if len(sessions) == 0 {
+		return ""
+	}
+	vals := url.Values{}
+	for _, s := range sessions {
+		if s == "" {
+			continue
+		}
+		vals.Add("session", s)
+	}
+	enc := vals.Encode()
+	return enc
+}
+
+// newUnixSocketClient returns an http.Client whose Transport dials sockPath
+// for every request. Used for production sidecar subscriptions; tests
+// override via Subscriber.SetHTTPClient.
+//
+// The client carries no overall timeout because GET /events is a long-
+// lived stream — a Client.Timeout would terminate the read after its
+// deadline regardless of whether events were still flowing.
+func newUnixSocketClient(sockPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		},
+	}
+}

--- a/modules/programs/prism/prism/internal/mux/state/state_test.go
+++ b/modules/programs/prism/prism/internal/mux/state/state_test.go
@@ -1,0 +1,225 @@
+// state_test.go — unit tests for the Store half of internal/mux/state.
+//
+// The Subscriber's wire behaviour is exercised by integration_test.go via a
+// fake sidecar; the tests here focus on the Store's contract (apply, listener
+// firing order, snapshot copy semantics, no-op gating).
+
+package state
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+)
+
+func TestStore_SetSessionState_Roundtrip(t *testing.T) {
+	s := New(nil)
+	s.SetSessionState("alpha", agent.StateActive)
+	got, ok := s.SessionState("alpha")
+	if !ok || got != agent.StateActive {
+		t.Fatalf("SessionState(alpha) = (%q, %v), want (active, true)", got, ok)
+	}
+}
+
+func TestStore_SetSessionState_EmptyClears(t *testing.T) {
+	s := New(nil)
+	s.SetSessionState("alpha", agent.StateActive)
+	s.SetSessionState("alpha", "")
+	if _, ok := s.SessionState("alpha"); ok {
+		t.Fatalf("SessionState(alpha) still present after clear")
+	}
+}
+
+func TestStore_Snapshot_IsCopy(t *testing.T) {
+	s := New(nil)
+	s.SetSessionState("alpha", agent.StateActive)
+	snap := s.Snapshot()
+	snap["alpha"] = agent.StateError
+	got, _ := s.SessionState("alpha")
+	if got != agent.StateActive {
+		t.Fatalf("mutation of snapshot leaked into store: got %q, want active", got)
+	}
+}
+
+func TestStore_ApplyEvent_StateChange(t *testing.T) {
+	s := New(nil)
+	evt := Event{
+		Type:        "state_change",
+		SessionName: "alpha",
+		Payload:     mustJSON(t, map[string]string{"state": "waiting"}),
+	}
+	if !s.ApplyEvent(evt) {
+		t.Fatalf("ApplyEvent returned false for first state change")
+	}
+	got, _ := s.SessionState("alpha")
+	if got != agent.StateWaiting {
+		t.Fatalf("after ApplyEvent: %q, want waiting", got)
+	}
+}
+
+func TestStore_ApplyEvent_SnapshotEqualsChange(t *testing.T) {
+	// The Store must treat state_snapshot the same way as state_change so
+	// the reconnect-resync path lands on identical state without a
+	// special branch.
+	s := New(nil)
+	evt := Event{
+		Type:        "state_snapshot",
+		SessionName: "alpha",
+		Payload:     mustJSON(t, map[string]string{"state": "reviewing"}),
+		Snapshot:    true,
+	}
+	if !s.ApplyEvent(evt) {
+		t.Fatalf("ApplyEvent(state_snapshot) returned false")
+	}
+	got, _ := s.SessionState("alpha")
+	if got != agent.StateReviewing {
+		t.Fatalf("snapshot apply: got %q, want reviewing", got)
+	}
+}
+
+func TestStore_ApplyEvent_DuplicateNoOp(t *testing.T) {
+	s := New(nil)
+	evt := Event{
+		Type:        "state_change",
+		SessionName: "alpha",
+		Payload:     mustJSON(t, map[string]string{"state": "active"}),
+	}
+	if !s.ApplyEvent(evt) {
+		t.Fatalf("first ApplyEvent returned false")
+	}
+	if s.ApplyEvent(evt) {
+		t.Fatalf("duplicate ApplyEvent returned true, want false (no-op)")
+	}
+}
+
+func TestStore_ApplyEvent_IgnoresUnknownType(t *testing.T) {
+	// The package is intentionally narrow — non-state events flow through
+	// other consumers. ApplyEvent must drop them rather than write
+	// garbage into the Store.
+	s := New(nil)
+	evt := Event{
+		Type:        "message_updated",
+		SessionName: "alpha",
+		Payload:     mustJSON(t, map[string]string{"role": "assistant"}),
+	}
+	if s.ApplyEvent(evt) {
+		t.Fatalf("ApplyEvent(message_updated) returned true; should be no-op")
+	}
+	if _, ok := s.SessionState("alpha"); ok {
+		t.Fatalf("Store gained an alpha entry from an unrelated event")
+	}
+}
+
+func TestStore_ApplyEvent_IgnoresMalformedPayload(t *testing.T) {
+	s := New(nil)
+	evt := Event{
+		Type:        "state_change",
+		SessionName: "alpha",
+		Payload:     json.RawMessage([]byte("not json")),
+	}
+	if s.ApplyEvent(evt) {
+		t.Fatalf("ApplyEvent on malformed payload returned true")
+	}
+	if _, ok := s.SessionState("alpha"); ok {
+		t.Fatalf("Store gained an alpha entry from a malformed event")
+	}
+}
+
+func TestStore_Listener_FiresAfterWrite(t *testing.T) {
+	s := New(nil)
+
+	var (
+		calls      atomic.Int32
+		lastSeen   string
+		lastSeenMu sync.Mutex
+	)
+	s.AddListener(func() {
+		calls.Add(1)
+		lastSeenMu.Lock()
+		defer lastSeenMu.Unlock()
+		// Reading from inside the listener proves the Store is
+		// readable while a write is in flight (listeners fire outside
+		// the lock).
+		if v, ok := s.SessionState("alpha"); ok {
+			lastSeen = string(v)
+		}
+	})
+
+	s.SetSessionState("alpha", agent.StateActive)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("listener calls: got %d, want 1", got)
+	}
+	lastSeenMu.Lock()
+	defer lastSeenMu.Unlock()
+	if lastSeen != string(agent.StateActive) {
+		t.Fatalf("listener saw %q, want active", lastSeen)
+	}
+}
+
+func TestStore_SessionTree_Reference(t *testing.T) {
+	tree := pane.New()
+	s := New(tree)
+	if s.SessionTree() != tree {
+		t.Fatalf("Store did not retain the supplied SessionTree")
+	}
+	if New(nil).SessionTree() != nil {
+		t.Fatalf("nil SessionTree should round-trip as nil")
+	}
+}
+
+func TestStore_AllSidebarStates_RoundTrip(t *testing.T) {
+	// AC: the Store must accept every state from prism's eight-state enum
+	// — six "real" states from §3.1 plus the two transitional ones
+	// (compacting, interrupted). Implicit error and deleted are also
+	// produced by the sidecar; they pass through unchanged.
+	s := New(nil)
+	want := []agent.AgentState{
+		agent.StateActive,
+		agent.StateIdle,
+		agent.StateWaiting,
+		agent.StateReviewing,
+		agent.StateEscalated,
+		agent.StateFinished,
+		agent.StateCompacting,
+		agent.StateInterrupted,
+		agent.StateError,
+		agent.StateDeleted,
+	}
+	for i, st := range want {
+		s.SetSessionState("alpha", st)
+		got, ok := s.SessionState("alpha")
+		if !ok || got != st {
+			t.Fatalf("iteration %d: got (%q, %v), want (%q, true)", i, got, ok, st)
+		}
+	}
+}
+
+func TestBuildQuery_NoSessions_EmptyString(t *testing.T) {
+	if got := buildQuery(nil); got != "" {
+		t.Fatalf("buildQuery(nil) = %q, want empty (wildcard)", got)
+	}
+}
+
+func TestBuildQuery_SkipsEmptyEntries(t *testing.T) {
+	got := buildQuery([]string{"alpha", "", "beta"})
+	// url.Values uses url.QueryEscape, which preserves alphanumerics
+	// — so the order is deterministic and the empty value is skipped.
+	want1 := "session=alpha&session=beta"
+	want2 := "session=beta&session=alpha"
+	if got != want1 && got != want2 {
+		t.Fatalf("buildQuery = %q, want %q or %q", got, want1, want2)
+	}
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/modules/programs/prism/prism/internal/sidecar/events_subscription.go
+++ b/modules/programs/prism/prism/internal/sidecar/events_subscription.go
@@ -1,0 +1,369 @@
+// Package sidecar — events_subscription.go
+//
+// This file implements the GET /events streaming endpoint on the host-API
+// socket (issue #2155 — part of the prism-native multiplexer programme
+// tracked by #2147). The mux process subscribes to this surface so the
+// sidebar widget can repaint within one frame of a state transition,
+// replacing the dashboard's pre-existing DB-polling loop.
+//
+// # Protocol
+//
+// `GET /events` opens a long-lived Server-Sent Events stream. Each frame is
+// one SSE event whose `data:` line is a single JSON object:
+//
+//	{
+//	  "type": "state_change",
+//	  "session_name": "nixos-config@main",
+//	  "payload": {"state":"active"},
+//	  "created_at_ms": 1717635600000
+//	}
+//
+// The SSE `event:` field is the same string as the JSON `type` so a
+// consumer that filters by event type without parsing the JSON envelope
+// can still do the right thing.
+//
+// ## Query parameters
+//
+//   - `session` (repeatable): restrict the stream to events whose
+//     `session_name` matches one of the supplied values. Omitting the
+//     parameter, or supplying the literal string `*`, streams every event
+//     the sidecar emits.
+//
+// ## Snapshot on subscribe
+//
+// Before the live stream begins, the server emits one synthetic
+// `state_snapshot` event per matching session, sourced from
+// agent_status.CurrentStatus. The payload is the same shape as
+// state_change, with an additional `"snapshot":true` flag. The snapshot
+// lets a reconnecting client resync the current state before consuming
+// further deltas (AC: "Subscription survives sidecar restarts ... resyncs
+// current state before resuming the event stream").
+//
+// To avoid losing events that fire between the snapshot read and the
+// start of live streaming, the server registers the broker subscriber
+// *before* reading the snapshot. Live events that overlap the snapshot
+// are delivered twice but state transitions are idempotent — the model
+// converges on the same end state either way.
+//
+// ## Backpressure
+//
+// Each subscriber owns a bounded channel (eventSubscriberBufferSize). When
+// the channel is full — the consumer has fallen behind — the broker drops
+// the oldest pending event in favour of the newest. This matches the
+// snapshot-then-deltas contract: a slow subscriber that misses an event
+// will resync the next time it reconnects.
+//
+// ## Threading
+//
+// The broker uses a single sync.Mutex to guard its subscriber set. Publish
+// is non-blocking — each subscriber's channel send is in default-drop mode
+// — so the sidecar's HandleEvent path cannot stall on a slow consumer.
+// Subscribe/Unsubscribe are O(N) under the lock.
+
+package sidecar
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+)
+
+// eventSubscriberBufferSize is the per-subscriber outbound channel capacity.
+// State transitions are bursty around session start/finish but the steady-
+// state rate is one event per second or so; 256 is a comfortable margin
+// without committing significant memory per consumer.
+const eventSubscriberBufferSize = 256
+
+// eventSubscriberPingInterval is the cadence at which the events handler
+// writes an SSE comment frame (": ping") when no real events have arrived.
+// Comment frames are silently ignored by SSE parsers per the spec but keep
+// HTTP intermediaries (and the kernel's idle-connection reaper) from closing
+// the stream while the agent is quiet.
+const eventSubscriberPingInterval = 15 * time.Second
+
+// envelope is the JSON shape emitted on the /events stream. Both live
+// events (state_change, message.updated, etc.) and synthetic snapshot
+// events share this envelope.
+type envelope struct {
+	Type        string          `json:"type"`
+	SessionName string          `json:"session_name"`
+	Payload     json.RawMessage `json:"payload"`
+	CreatedAtMs int64           `json:"created_at_ms"`
+	// Snapshot is true for the synthetic state_snapshot events emitted
+	// on subscribe. Live deltas omit the field.
+	Snapshot bool `json:"snapshot,omitempty"`
+}
+
+// eventSubscriber is one active connection to GET /events. The broker fans
+// publish() calls out to every subscriber whose filter matches.
+type eventSubscriber struct {
+	// sessions, when non-empty, restricts delivery to events whose
+	// session_name is a key in this map. An empty map means "all
+	// sessions" — equivalent to ?session=* or omitting the parameter.
+	sessions map[string]struct{}
+	ch       chan envelope
+}
+
+// matches reports whether sub wants to receive an event for the named
+// session. Empty filter == accept all.
+func (sub *eventSubscriber) matches(sessionName string) bool {
+	if len(sub.sessions) == 0 {
+		return true
+	}
+	_, ok := sub.sessions[sessionName]
+	return ok
+}
+
+// eventBroker is the in-process fan-out. Owned by *Sidecar; constructed in
+// New().
+type eventBroker struct {
+	mu          sync.Mutex
+	subscribers map[*eventSubscriber]struct{}
+}
+
+func newEventBroker() *eventBroker {
+	return &eventBroker{subscribers: make(map[*eventSubscriber]struct{})}
+}
+
+// subscribe registers a new subscriber. sessions may be empty (meaning all
+// sessions); otherwise the slice is converted into the filter set.
+// Returns the subscriber so the caller can drain its channel.
+func (b *eventBroker) subscribe(sessions []string) *eventSubscriber {
+	sub := &eventSubscriber{
+		sessions: make(map[string]struct{}, len(sessions)),
+		ch:       make(chan envelope, eventSubscriberBufferSize),
+	}
+	for _, s := range sessions {
+		if s == "" || s == "*" {
+			// Wildcard wipes any specific filter — the empty map below
+			// matches every session.
+			sub.sessions = map[string]struct{}{}
+			break
+		}
+		sub.sessions[s] = struct{}{}
+	}
+	b.mu.Lock()
+	b.subscribers[sub] = struct{}{}
+	b.mu.Unlock()
+	return sub
+}
+
+// unsubscribe removes sub from the broker. Safe to call multiple times.
+func (b *eventBroker) unsubscribe(sub *eventSubscriber) {
+	b.mu.Lock()
+	if _, ok := b.subscribers[sub]; ok {
+		delete(b.subscribers, sub)
+		close(sub.ch)
+	}
+	b.mu.Unlock()
+}
+
+// publish fans env out to every matching subscriber. Non-blocking: when a
+// subscriber's channel is full, the oldest pending envelope is dropped and
+// env is enqueued in its place. This trades best-effort delivery for the
+// guarantee that the sidecar's HandleEvent loop never stalls on a slow
+// consumer; clients recover by reconnecting and consuming the snapshot.
+func (b *eventBroker) publish(env envelope) {
+	b.mu.Lock()
+	subs := make([]*eventSubscriber, 0, len(b.subscribers))
+	for sub := range b.subscribers {
+		if sub.matches(env.SessionName) {
+			subs = append(subs, sub)
+		}
+	}
+	b.mu.Unlock()
+
+	for _, sub := range subs {
+		select {
+		case sub.ch <- env:
+		default:
+			// Channel full — drop the oldest, enqueue the newest.
+			select {
+			case <-sub.ch:
+			default:
+			}
+			select {
+			case sub.ch <- env:
+			default:
+				// Another concurrent publish raced ahead; give up
+				// on this delivery rather than block. The client
+				// will resync on reconnect.
+			}
+		}
+	}
+}
+
+// subscriberCount returns the current number of active subscribers.
+// Exposed for tests; not part of the host-API surface.
+func (b *eventBroker) subscriberCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.subscribers)
+}
+
+// publishEvent is the hook called from writeEvent in state.go on every
+// agent_events row write. Safe to call before the broker is wired up (the
+// nil check guards New() ordering and standalone tests that omit the
+// broker).
+func (s *Sidecar) publishEvent(eventType, sessionName string, payload []byte, createdAt time.Time) {
+	if s.events == nil {
+		return
+	}
+	s.events.publish(envelope{
+		Type:        eventType,
+		SessionName: sessionName,
+		Payload:     append(json.RawMessage(nil), payload...),
+		CreatedAtMs: createdAt.UnixMilli(),
+	})
+}
+
+// registerEventsRoute installs the GET /events handler on mux. Called from
+// hostAPIHandler so the route is part of the same listener used by every
+// other host-API endpoint.
+func (s *Sidecar) registerEventsRoute(mux *http.ServeMux) {
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, `{"error":"streaming unsupported"}`, http.StatusInternalServerError)
+			return
+		}
+
+		filter := r.URL.Query()["session"]
+		// SSE response headers — set BEFORE the first write so the client
+		// observes a streaming response immediately.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache, no-store, no-transform")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+
+		// Register the broker subscriber BEFORE reading the snapshot so
+		// any event written between the snapshot read and the start of
+		// streaming is captured on the channel rather than dropped on
+		// the floor. Duplicate state_change deltas are idempotent.
+		sub := s.events.subscribe(filter)
+		defer s.events.unsubscribe(sub)
+
+		// Snapshot: emit one synthetic state_snapshot event per matching
+		// session. For ?session=*, walk every session_name currently in
+		// agent_status; for specific filters, look up each by name.
+		snapshots := s.snapshotForFilter(filter)
+		for _, snap := range snapshots {
+			if err := writeSSEEvent(w, snap); err != nil {
+				s.logger().Printf("sidecar: /events: write snapshot: %v", err)
+				return
+			}
+		}
+		flusher.Flush()
+
+		ctx := r.Context()
+		ping := time.NewTicker(eventSubscriberPingInterval)
+		defer ping.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case env, ok := <-sub.ch:
+				if !ok {
+					return
+				}
+				if err := writeSSEEvent(w, env); err != nil {
+					s.logger().Printf("sidecar: /events: write delta: %v", err)
+					return
+				}
+				flusher.Flush()
+			case <-ping.C:
+				if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+					s.logger().Printf("sidecar: /events: ping: %v", err)
+					return
+				}
+				flusher.Flush()
+			}
+		}
+	})
+}
+
+// writeSSEEvent emits one envelope as a properly framed SSE event. The
+// SSE event: field carries the agent-event type so a consumer that filters
+// by event type without parsing JSON can still do the right thing; the
+// data: field carries the full envelope JSON.
+func writeSSEEvent(w http.ResponseWriter, env envelope) error {
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	// SSE forbids raw newlines inside a data: value; envelope JSON is
+	// single-line by construction (encoding/json's Marshal never emits a
+	// trailing newline), so a direct write is correct.
+	eventName := strings.ReplaceAll(env.Type, "\n", "")
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventName, data); err != nil {
+		return err
+	}
+	return nil
+}
+
+// snapshotForFilter reads agent_status rows from the DB matching the
+// requested filter and returns one envelope per row. For an empty/wildcard
+// filter, every session currently tracked in agent_status is included.
+// Returns an empty slice (never nil) so the handler loop is uniform.
+func (s *Sidecar) snapshotForFilter(filter []string) []envelope {
+	out := []envelope{}
+
+	wantAll := len(filter) == 0
+	for _, f := range filter {
+		if f == "" || f == "*" {
+			wantAll = true
+			break
+		}
+	}
+
+	if wantAll {
+		statuses, err := s.cfg.DB.AllActiveStatus()
+		if err != nil {
+			s.logger().Printf("sidecar: /events: snapshot AllActiveStatus: %v", err)
+			return out
+		}
+		for _, st := range statuses {
+			out = append(out, statusToEnvelope(st.SessionName, agent.AgentState(st.State), s.cfg.Clock.Now()))
+		}
+		return out
+	}
+
+	for _, name := range filter {
+		st, err := s.cfg.DB.CurrentStatus(name)
+		if err != nil {
+			s.logger().Printf("sidecar: /events: snapshot CurrentStatus %q: %v", name, err)
+			continue
+		}
+		if st == nil {
+			continue
+		}
+		out = append(out, statusToEnvelope(name, agent.AgentState(st.State), s.cfg.Clock.Now()))
+	}
+	return out
+}
+
+// statusToEnvelope formats a CurrentStatus row as a synthetic state_snapshot
+// envelope. The payload shape mirrors a state_change payload so consumers
+// can apply both without branching.
+func statusToEnvelope(sessionName string, state agent.AgentState, now time.Time) envelope {
+	payload, _ := json.Marshal(map[string]string{"state": string(state)})
+	return envelope{
+		Type:        "state_snapshot",
+		SessionName: sessionName,
+		Payload:     payload,
+		CreatedAtMs: now.UnixMilli(),
+		Snapshot:    true,
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/events_subscription.go
+++ b/modules/programs/prism/prism/internal/sidecar/events_subscription.go
@@ -55,10 +55,18 @@
 //
 // ## Threading
 //
-// The broker uses a single sync.Mutex to guard its subscriber set. Publish
-// is non-blocking — each subscriber's channel send is in default-drop mode
-// — so the sidecar's HandleEvent path cannot stall on a slow consumer.
-// Subscribe/Unsubscribe are O(N) under the lock.
+// The broker uses a single sync.Mutex to guard its subscriber set AND to
+// serialise every send into a subscriber's channel against the
+// unsubscribe path's close(sub.ch). This is the only safe arrangement
+// for a fan-out broker that closes channels on disconnect: any pattern
+// that releases the lock before the channel send creates a window in
+// which an unsubscribe can close the channel and the subsequent send
+// panics with "send on closed channel". Publish sends are non-blocking
+// (select with default-drop), so holding the lock for the duration of
+// the publish does not stall on a slow consumer — it only serialises
+// publishes against subscribe/unsubscribe, both of which are O(N) and
+// cheap. See PR #2167 round-1 review for the race that motivated this
+// arrangement.
 
 package sidecar
 
@@ -168,17 +176,23 @@ func (b *eventBroker) unsubscribe(sub *eventSubscriber) {
 // env is enqueued in its place. This trades best-effort delivery for the
 // guarantee that the sidecar's HandleEvent loop never stalls on a slow
 // consumer; clients recover by reconnecting and consuming the snapshot.
+//
+// The lock is held for the entire send loop. A previous revision released
+// b.mu before the send to maximise concurrency, but that arrangement
+// raced with unsubscribe — unsubscribe closes sub.ch under the lock, so
+// any send that ran after the unlock could observe a closed channel and
+// panic with "send on closed channel". The select-default fallback does
+// NOT protect against this: sends on closed channels panic outright
+// rather than falling through. Holding the lock for the send is the
+// minimal fix and adds no latency in practice (sends are non-blocking;
+// subscribe/unsubscribe are cheap). See PR #2167 round-1 review.
 func (b *eventBroker) publish(env envelope) {
 	b.mu.Lock()
-	subs := make([]*eventSubscriber, 0, len(b.subscribers))
+	defer b.mu.Unlock()
 	for sub := range b.subscribers {
-		if sub.matches(env.SessionName) {
-			subs = append(subs, sub)
+		if !sub.matches(env.SessionName) {
+			continue
 		}
-	}
-	b.mu.Unlock()
-
-	for _, sub := range subs {
 		select {
 		case sub.ch <- env:
 		default:

--- a/modules/programs/prism/prism/internal/sidecar/events_subscription_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/events_subscription_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -378,6 +379,98 @@ func waitForSubscribers(t *testing.T, sc *Sidecar, n int) {
 			t.Fatalf("waitForSubscribers(%d): got %d", n, sc.events.subscriberCount())
 		}
 		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestEventBroker_PublishConcurrentWithUnsubscribe_NoPanic is the
+// regression guard for the PR #2167 round-1 review finding. Before the
+// fix, publish snapshotted the subscriber set under the lock and then
+// sent into sub.ch after releasing the lock; unsubscribe closed sub.ch
+// under the lock. The narrow window between the snapshot and the send
+// allowed unsubscribe to close the channel and the send then panicked
+// with "send on closed channel".
+//
+// The test drives publishes from one goroutine and subscribe/unsubscribe
+// churn from another, both at high frequency, for a fixed duration. Any
+// surviving race manifests as a "send on closed channel" panic on the
+// publish goroutine — which the test thread observes via the
+// publisher's recover, failing the test. Under `-race` the analyser
+// also flags the unsynchronised send-vs-close as a data race.
+func TestEventBroker_PublishConcurrentWithUnsubscribe_NoPanic(t *testing.T) {
+	b := newEventBroker()
+
+	var panicked atomic.Value
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Publisher loop: publishes a steady stream of envelopes against
+	// the broker until the test deadline fires. Any panic in the send
+	// path is captured and re-checked on the test goroutine after the
+	// loops finish.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				panicked.Store(fmt.Sprintf("%v", r))
+			}
+		}()
+		env := envelope{
+			Type:        "state_change",
+			SessionName: "alpha",
+			Payload:     []byte(`{"state":"active"}`),
+			CreatedAtMs: 1,
+		}
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			b.publish(env)
+		}
+	}()
+
+	// Churn loop: subscribes and unsubscribes a fresh subscriber on
+	// every iteration so the publisher races against close(sub.ch).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				panicked.Store(fmt.Sprintf("%v", r))
+			}
+		}()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			sub := b.subscribe([]string{"alpha"})
+			// Drain a few envelopes to ensure the publish loop has
+			// observed this subscriber before we unsubscribe —
+			// otherwise the loop body becomes too short to expose
+			// the race on most schedulers.
+			for i := 0; i < 4; i++ {
+				select {
+				case <-sub.ch:
+				default:
+				}
+			}
+			b.unsubscribe(sub)
+		}
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if v := panicked.Load(); v != nil {
+		t.Fatalf("publish/unsubscribe race panicked: %v", v)
+	}
+	if got := b.subscriberCount(); got != 0 {
+		t.Errorf("subscriberCount after churn = %d, want 0", got)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/events_subscription_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/events_subscription_test.go
@@ -1,0 +1,454 @@
+// events_subscription_test.go — unit tests for the GET /events endpoint
+// added by issue #2155.
+//
+// All tests construct sidecars via sidecartest.NewIsolated so the host-
+// API socket paths, dashboard sentinel paths, and bus directories all
+// resolve under a per-test tempdir. This is the convention documented in
+// modules/programs/prism/AGENTS.md § Prism (issue #1608) — it keeps `go
+// test ./... -race` honest about the homeless-shelter sandbox.
+
+package sidecar
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	pih "github.com/prismatic-koi/prism/internal/harness/pi"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// newEventsSidecar returns a freshly constructed Sidecar with the broker
+// initialised, bus-backed DB, and a known session name. The handler is
+// constructed via hostAPIHandler() so the test exercises the real route
+// registration glue, not just the broker in isolation.
+func newEventsSidecar(t *testing.T) (*Sidecar, *httptest.Server, *sidecartest.Bus) {
+	t.Helper()
+	invoker := "prism-test@events-" + strings.ReplaceAll(t.Name(), "/", "-")
+	bus := sidecartest.NewIsolated(t, invoker)
+	cfg := Config{
+		SessionName: invoker,
+		Repo:        "prism-test",
+		DB:          bus.DB,
+		Clock:       newTestClock(),
+		HarnessName: "pi",
+		Harness:     pih.New("", "", ""),
+	}
+	sc := New(cfg)
+	srv := httptest.NewServer(sc.hostAPIHandler())
+	t.Cleanup(srv.Close)
+	return sc, srv, bus
+}
+
+// openEventsStream issues GET /events?<query> and returns the response
+// body so the caller can read SSE frames. The caller must close the
+// response body (or rely on the context cancel via the supplied ctx
+// closing the response).
+func openEventsStream(t *testing.T, ctx context.Context, srvURL, query string) *http.Response {
+	t.Helper()
+	url := srvURL + "/events"
+	if query != "" {
+		url += "?" + query
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /events: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("GET /events: status %d: %s", resp.StatusCode, body)
+	}
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/event-stream") {
+		resp.Body.Close()
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	return resp
+}
+
+// readEnvelope consumes one SSE event from r and returns the decoded
+// envelope. Comment frames (": ping") are silently skipped.
+func readEnvelope(t *testing.T, br *bufio.Reader) envelope {
+	t.Helper()
+	env, err := readEnvelopeMaybe(br)
+	if err != nil {
+		t.Fatalf("readEnvelope: %v", err)
+	}
+	return env
+}
+
+// readEnvelopeMaybe is the error-returning sibling of readEnvelope; used
+// by tests that race a read against a context-cancel and need to handle
+// the closed-connection error path gracefully.
+func readEnvelopeMaybe(br *bufio.Reader) (envelope, error) {
+	var dataLines []string
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return envelope{}, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			// End of event. If dataLines is empty, this was a heartbeat-
+			// only frame — loop and read the next event.
+			if len(dataLines) == 0 {
+				continue
+			}
+			break
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+		// event: lines are read but ignored — the JSON envelope
+		// carries the same information.
+	}
+	var env envelope
+	if err := json.Unmarshal([]byte(strings.Join(dataLines, "\n")), &env); err != nil {
+		return envelope{}, fmt.Errorf("unmarshal envelope: %w: %q", err, strings.Join(dataLines, "\n"))
+	}
+	return env, nil
+}
+
+// readUntilLiveDelta reads frames until a non-snapshot envelope arrives,
+// discarding any state_snapshot frames in the way. The snapshot read in
+// the production handler races against in-flight writeStateChange /
+// upsertState writes, so tests that want to assert on the live delta
+// branch must tolerate an unpredictable number of snapshot frames
+// preceding it.
+func readUntilLiveDelta(t *testing.T, br *bufio.Reader) envelope {
+	t.Helper()
+	for {
+		env := readEnvelope(t, br)
+		if env.Type != "state_snapshot" {
+			return env
+		}
+	}
+}
+
+func TestEventsRoute_WrongMethod_405(t *testing.T) {
+	_, srv, _ := newEventsSidecar(t)
+	resp, err := http.Post(srv.URL+"/events", "application/json", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST /events: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestEventsRoute_SnapshotOnSubscribe(t *testing.T) {
+	// AC: subscription survives sidecar restarts via resync. The wire-
+	// level realisation is "snapshot on subscribe" — on first connect
+	// the server emits one synthetic state_snapshot per matching session
+	// before live deltas begin. Seed the DB and assert the snapshot.
+	sc, srv, bus := newEventsSidecar(t)
+	if err := bus.DB.UpsertStatus(sc.cfg.SessionName, "prism-test", "", string(agent.StateActive), nil, nil); err != nil {
+		t.Fatalf("seed agent_status: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp := openEventsStream(t, ctx, srv.URL, "session="+sc.cfg.SessionName)
+	defer resp.Body.Close()
+	br := bufio.NewReader(resp.Body)
+
+	env := readEnvelope(t, br)
+	if env.Type != "state_snapshot" {
+		t.Fatalf("first env type = %q, want state_snapshot", env.Type)
+	}
+	if !env.Snapshot {
+		t.Fatalf("first env Snapshot = false, want true")
+	}
+	if env.SessionName != sc.cfg.SessionName {
+		t.Fatalf("first env session_name = %q, want %q", env.SessionName, sc.cfg.SessionName)
+	}
+	var p statePayloadShim
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if p.State != string(agent.StateActive) {
+		t.Fatalf("snapshot payload state = %q, want active", p.State)
+	}
+}
+
+// statePayloadShim mirrors the state_change payload shape — duplicated
+// here rather than reaching into events_subscription.go's package-private
+// statePayload because the production code uses an anonymous struct via
+// json.Marshal(map).
+type statePayloadShim struct {
+	State string `json:"state"`
+}
+
+func TestEventsRoute_StreamsLiveStateChange(t *testing.T) {
+	// AC: when a state change fires, every active subscriber observes
+	// the delta. Open the stream, drive a state transition through
+	// writeStateChange, then skip any snapshot frames (which are timing-
+	// dependent: the snapshot read in the handler races against the
+	// upsertState DB write inside writeStateChange) and assert that the
+	// live state_change delta arrives on the wire.
+	sc, srv, _ := newEventsSidecar(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp := openEventsStream(t, ctx, srv.URL, "")
+	defer resp.Body.Close()
+	br := bufio.NewReader(resp.Body)
+
+	waitForSubscribers(t, sc, 1)
+
+	sc.mu.Lock()
+	sc.writeStateChange(agent.StateActive)
+	sc.mu.Unlock()
+
+	env := readUntilLiveDelta(t, br)
+	if env.Type != "state_change" {
+		t.Fatalf("env type = %q, want state_change", env.Type)
+	}
+	var p statePayloadShim
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if p.State != string(agent.StateActive) {
+		t.Fatalf("env payload state = %q, want active", p.State)
+	}
+	if env.SessionName != sc.cfg.SessionName {
+		t.Fatalf("env session_name = %q, want %q", env.SessionName, sc.cfg.SessionName)
+	}
+}
+
+func TestEventsRoute_SessionFilter(t *testing.T) {
+	// A subscriber that requests session=other should not receive an
+	// event for THIS sidecar's session — the broker's matches() filter
+	// drops it.
+	sc, srv, _ := newEventsSidecar(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp := openEventsStream(t, ctx, srv.URL, "session=does-not-match")
+	br := bufio.NewReader(resp.Body)
+
+	waitForSubscribers(t, sc, 1)
+
+	sc.mu.Lock()
+	sc.writeStateChange(agent.StateActive)
+	sc.mu.Unlock()
+
+	// Read with a short deadline — the snapshot is empty (no agent_status
+	// row for "does-not-match") and the live event is filtered out, so
+	// we should time out waiting for a non-comment frame. The expected
+	// path is that the goroutine reading from br blocks indefinitely.
+	done := make(chan envelope, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		env, err := readEnvelopeMaybe(br)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		done <- env
+	}()
+	select {
+	case env := <-done:
+		resp.Body.Close()
+		t.Fatalf("subscriber received an event despite filter: %+v", env)
+	case <-errCh:
+		resp.Body.Close()
+		t.Fatalf("subscriber read errored unexpectedly")
+	case <-time.After(150 * time.Millisecond):
+		// Expected: no envelopes arrive.
+		resp.Body.Close()
+	}
+}
+
+func TestEventsRoute_WildcardReceivesAll(t *testing.T) {
+	// session=* must receive every event regardless of session_name.
+	sc, srv, _ := newEventsSidecar(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp := openEventsStream(t, ctx, srv.URL, "session=*")
+	defer resp.Body.Close()
+	br := bufio.NewReader(resp.Body)
+
+	waitForSubscribers(t, sc, 1)
+	sc.mu.Lock()
+	sc.writeStateChange(agent.StateActive)
+	sc.mu.Unlock()
+
+	env := readUntilLiveDelta(t, br)
+	if env.Type != "state_change" || env.SessionName != sc.cfg.SessionName {
+		t.Fatalf("wildcard envelope = %+v", env)
+	}
+}
+
+func TestEventsRoute_DisconnectUnsubscribes(t *testing.T) {
+	// Cancelling the request context must drain the subscriber from the
+	// broker so a future publish has no leak. We assert subscriberCount
+	// returns to zero after the response body is closed.
+	sc, srv, _ := newEventsSidecar(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resp := openEventsStream(t, ctx, srv.URL, "")
+	waitForSubscribers(t, sc, 1)
+
+	// Cancel and close — the handler's defer s.events.unsubscribe runs
+	// before the response body is fully closed.
+	cancel()
+	resp.Body.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if sc.events.subscriberCount() == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("subscriber not unsubscribed after disconnect: count=%d", sc.events.subscriberCount())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestEventsRoute_MultipleSubscribers_Fanout(t *testing.T) {
+	// Two concurrent subscribers must both receive the same delta.
+	sc, srv, _ := newEventsSidecar(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r1 := openEventsStream(t, ctx, srv.URL, "")
+	defer r1.Body.Close()
+	r2 := openEventsStream(t, ctx, srv.URL, "")
+	defer r2.Body.Close()
+	br1 := bufio.NewReader(r1.Body)
+	br2 := bufio.NewReader(r2.Body)
+
+	waitForSubscribers(t, sc, 2)
+	sc.mu.Lock()
+	sc.writeStateChange(agent.StateActive)
+	sc.mu.Unlock()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	checks := make(chan envelope, 2)
+	go func() { defer wg.Done(); checks <- readUntilLiveDelta(t, br1) }()
+	go func() { defer wg.Done(); checks <- readUntilLiveDelta(t, br2) }()
+	wg.Wait()
+	close(checks)
+	count := 0
+	for env := range checks {
+		count++
+		if env.Type != "state_change" {
+			t.Fatalf("subscriber received non-state_change: %+v", env)
+		}
+	}
+	if count != 2 {
+		t.Fatalf("fanout received %d envelopes, want 2", count)
+	}
+}
+
+// waitForSubscribers polls sc.events.subscriberCount until it reaches n,
+// failing the test after a generous deadline. Used after opening a stream
+// because the http handler runs in its own goroutine and the subscribe
+// call may not be observable from the test thread immediately.
+func waitForSubscribers(t *testing.T, sc *Sidecar, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if sc.events.subscriberCount() >= n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waitForSubscribers(%d): got %d", n, sc.events.subscriberCount())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestEventBroker_PublishWithoutSubscribers(t *testing.T) {
+	// Publish with zero subscribers must be a cheap no-op — the broker
+	// short-circuits before allocating the subs slice.
+	b := newEventBroker()
+	b.publish(envelope{Type: "state_change", SessionName: "ghost"})
+	if got := b.subscriberCount(); got != 0 {
+		t.Fatalf("subscriberCount after publish = %d, want 0", got)
+	}
+}
+
+func TestEventBroker_PublishDropsOldestWhenFull(t *testing.T) {
+	// Backpressure contract: when the subscriber channel is full, the
+	// oldest envelope is dropped to make room for the newest. We
+	// construct a subscriber with a tiny buffer to exercise this.
+	b := newEventBroker()
+	sub := b.subscribe([]string{"alpha"})
+	// Drain the auto-allocated channel and replace with a 1-slot
+	// channel so the test can deterministically fill it. This pokes at
+	// internal state intentionally — it is the only knob the broker
+	// exposes for this property.
+	sub.ch = make(chan envelope, 1)
+
+	first := envelope{Type: "state_change", SessionName: "alpha", Payload: []byte(`{"state":"active"}`)}
+	second := envelope{Type: "state_change", SessionName: "alpha", Payload: []byte(`{"state":"waiting"}`)}
+
+	b.publish(first)
+	b.publish(second)
+
+	got, ok := <-sub.ch
+	if !ok {
+		t.Fatalf("channel closed after publish")
+	}
+	// Either `second` (oldest-drop-newest-kept) — the broker keeps the
+	// newest envelope.
+	var p statePayloadShim
+	_ = json.Unmarshal(got.Payload, &p)
+	if p.State != "waiting" {
+		t.Fatalf("got payload state = %q, want waiting (the newest)", p.State)
+	}
+}
+
+// TestEventsRoute_WritesViaSidecar_FlowsToSubscriber is the bridge
+// assertion: a state change initiated by HandleEvent (production path)
+// is observed by a /events subscriber. This protects against future
+// refactors that route state writes around writeEvent.
+func TestEventsRoute_WritesViaSidecar_FlowsToSubscriber(t *testing.T) {
+	sc, srv, _ := newEventsSidecar(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	resp := openEventsStream(t, ctx, srv.URL, fmt.Sprintf("session=%s", sc.cfg.SessionName))
+	defer resp.Body.Close()
+	br := bufio.NewReader(resp.Body)
+
+	waitForSubscribers(t, sc, 1)
+
+	// Drive a write via the public path — same path the production
+	// sidecar uses when the harness emits session.updated.
+	sc.mu.Lock()
+	sc.upsertState(agent.StateActive, nil, nil)
+	sc.writeStateChange(agent.StateActive)
+	sc.mu.Unlock()
+
+	env := readUntilLiveDelta(t, br)
+	if env.Type != "state_change" {
+		t.Fatalf("env type = %q, want state_change", env.Type)
+	}
+	if env.CreatedAtMs == 0 {
+		t.Errorf("env created_at_ms = 0; want non-zero from the clock")
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -2945,6 +2945,14 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		s.hostAPIDBTables(w, r)
 	})
 
+	// GET /events — long-lived SSE stream of agent_events row writes.
+	// Defined in events_subscription.go (issue #2155). Kept in a separate
+	// file so the parallel multiplexer programme work (#2153) can extend
+	// the host-API surface without conflicting line-by-line with this
+	// handler. See events_subscription.go for the wire protocol and
+	// snapshot-on-subscribe contract.
+	s.registerEventsRoute(mux)
+
 	return mux
 }
 

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -482,6 +482,12 @@ type Sidecar struct {
 	// Protected by s.mu.
 	lastInvestigatorText string
 
+	// events is the in-process broker that fans state_change / agent_event
+	// writes out to GET /events SSE subscribers. Always non-nil after New().
+	// The broker is goroutine-safe; callers may publish without holding s.mu.
+	// See events_subscription.go for the protocol and backpressure contract.
+	events *eventBroker
+
 	// promptDedup is the bounded in-memory dedup set for /prompt deliveries.
 	// Each /prompt request carries a delivery_id (UUID minted by the sender);
 	// repeats whose ID has been seen recently are dropped before they reach
@@ -624,6 +630,7 @@ func New(cfg Config) *Sidecar {
 		ttftByMessage:   newBoundedMap[int64](messageTrackingCap),
 		seenUnknown:     make(map[string]bool),
 		promptDedup:     newDeliveryDedup(deliveryDedupCapacity),
+		events:          newEventBroker(),
 	}
 	// Pre-set rootAgent from the configured agent role so that subagent user
 	// messages (which have a non-empty agent field in SSE events) do not

--- a/modules/programs/prism/prism/internal/sidecar/state.go
+++ b/modules/programs/prism/prism/internal/sidecar/state.go
@@ -244,6 +244,12 @@ func (s *Sidecar) writeEvent(eventType string, payload any, harnessSessionID *st
 	if err := s.cfg.DB.WriteEvent(e); err != nil {
 		s.logger().Printf("sidecar: WriteEvent(%s) failed: %v", eventType, err)
 	}
+
+	// Fan the same write out to any live GET /events subscribers (#2155).
+	// publishEvent is a no-op when s.events is nil (which is impossible
+	// after New() but defensive against tests that construct *Sidecar
+	// without the constructor).
+	s.publishEvent(eventType, s.cfg.SessionName, data, e.CreatedAt)
 }
 
 // writeStartupError writes StateError to the DB and, when this session is a


### PR DESCRIPTION
Closes #2155.
Refs #2147 (multiplexer programme), #2151/#2163 (pane data model).

## What this PR does

Adds a long-lived SSE streaming surface on the sidecar's existing host-API
socket (`GET /events`) and a multiplexer-side consumer in
`internal/mux/state/` that subscribes to it and feeds state-change events
into an in-process `Store` keyed by session ID. The render layer (#2152)
reads from the `Store` to repaint the sidebar's per-session glyph and
colour within one frame of an event arriving — replacing the
dashboard's pre-existing DB-polling shape with a real subscription.

## Sidecar extension — `GET /events`

(`internal/sidecar/events_subscription.go`, plus a one-line registration
hook in `host_api.go` to stay out of `#2153`'s lane.)

- In-process event broker, fanned out from every `writeEvent` call.
  Publish is non-blocking — bounded per-subscriber channel,
  oldest-drop-newest-keep semantics — so a slow consumer can never
  stall the sidecar's `HandleEvent` path.
- SSE framing. The `event:` line carries the agent_events row type;
  the `data:` line carries a single-line JSON envelope:
  `{type, session_name, payload, created_at_ms, snapshot}`.
- `?session=<name>` is repeatable; `?session=*` (or no parameter)
  selects the wildcard.
- **Snapshot on subscribe.** Before live deltas begin, the server emits
  one `state_snapshot` envelope per matching session sourced from
  `agent_status.CurrentStatus` / `AllActiveStatus`. This is the
  reconnect-resync path — clients catch up to authoritative state
  without a separate round trip. The broker subscriber is registered
  *before* the snapshot read so events arriving between snapshot and
  live-stream start are not lost; duplicates across the two phases are
  idempotent.

## Multiplexer consumer — `internal/mux/state/`

- `Store`: `map[sessionID]agent.AgentState` with mutex-guarded reads
  and writes; `SessionState`, `Snapshot`, `SetSessionState`, and a
  listener hook `AddListener` the renderer uses for repaint signalling.
  Listeners fire outside the lock so callbacks may call back into the
  Store without deadlocking.
- `Subscriber`: one goroutine per sidecar; long-lived SSE via
  `internal/sse.Client` (exponential backoff via that package's
  reconnect path, with `InitialRetryDelay` / `MaxRetryDelay` knobs).
  Unix-socket dial wrapped in a custom `http.Client`; `baseURL` /
  `httpClient` injection points exist for tests that drive the
  subscriber against an `httptest.Server`.

## Reconnect strategy

Connections drop → backoff via the underlying `sse.Client` (1s
initial, 30s cap; overridable per Subscriber). On every reconnect the
sidecar emits a fresh snapshot, so the Store resyncs to authoritative
state before consuming further deltas. This is covered end-to-end by
`TestSubscriber_ReconnectsAndResyncs`.

## Test coverage

**Sidecar-side** (`internal/sidecar/events_subscription_test.go`):
constructed via `sidecartest.NewIsolated` so every host-API socket
path, dashboard sentinel path, and bus directory resolves under a
per-test tempdir — the homeless-shelter convention.
- Method check (405 on POST).
- Snapshot-on-subscribe with a seeded `agent_status` row.
- Live state_change fanout via `writeStateChange`.
- Session filtering: a non-matching filter receives no envelope.
- Wildcard receives everything.
- Disconnect drains the broker subscriber set.
- Multi-subscriber fanout.
- Broker publish-without-subscribers no-op.
- Broker backpressure: oldest-drop, newest-keep.
- End-to-end via `upsertState` + `writeStateChange` (the production path).

**Multiplexer-side** (`internal/mux/state/state_test.go` and
`integration_test.go`):
- Store: roundtrip, clear-via-empty, snapshot copy semantics, apply
  for both `state_change` and `state_snapshot`, duplicate-no-op,
  malformed-payload no-op, unknown-type no-op, listener-fires-after-
  write, SessionTree reference passthrough.
- Every state in prism's eight-state enum (§3.1 table) round-trips
  through the Store.
- `buildQuery` filter-set encoding.
- **Integration — fake sidecar emits a scripted sequence; assert
  model state updates per event in the correct order.** This is the
  canonical AC.
- Integration — reconnect-and-resync across two connections.
- Integration — Sessions filter encodes `session=` query parameters
  at the wire.

**Vacuous-pass check.** I verified both of the headline integration
tests (`TestEventsRoute_WritesViaSidecar_FlowsToSubscriber` and
`TestSubscriber_ReconnectsAndResyncs`) fail with the expected
`want state_change` / `waitForState(...) = ("", false)` message
when the production apply paths are removed.

## Doc update

`docs/multiplexer-proposal.md` §3:
- Updated the proposed layout to include `pane/` (landed in #2163)
  and `state/` (this PR).
- New "State plumbing — push, not poll" paragraph describing the
  snapshot+deltas contract this PR implements.
- Corrected the workspace/pane note to point at `internal/mux/pane/`
  + `internal/mux/persist/` rather than the original `workspace/`
  sketch.

## Local quality gates

```
go build ./...                                        — clean
go test ./... -race                                   — all green
nix build .#prism                                     — clean
nix flake check                                       — all checks passed
nix build --impure --no-link --expr '...packages.x86_64-linux.prism.override { runChecks = true; }'
                                                      — clean (homeless-shelter sandbox)
```

## Coordination notes

- Path chosen: option 1 from the spawn brief — the `/events` route lives
  in its own `events_subscription.go`. `host_api.go` is touched only
  by a one-line `s.registerEventsRoute(mux)` call inside `hostAPIHandler`,
  to keep `#2153`'s same-file edits from colliding.
- This PR does not touch `internal/mux/render/`, `internal/mux/server/`,
  or `internal/mux/persist/` — strict scope under `internal/mux/state/`
  + the sidecar extension.

