### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780700792,
-        "narHash": "sha256-sGCauddYNF1Nymtdjnl3xx2fkJl8yZ4HgW/ucuEnSb8=",
+        "lastModified": 1780810517,
+        "narHash": "sha256-sJCsayXrKAAvuDhMMLtdDXhO5lzlcAJcPkIj53ug5Ys=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0381b3037a2256efc2b54b9c5f16b71d48e7d9a0",
+        "rev": "26f7554183bae4c4dc750fcd3478d1adae642985",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/27084242568

## Closure diff: navi

```
discord: 1.0.138 → 1.0.141, 984.9 KiB
```

## Closure diff: tui

```
discord: 1.0.138 → 1.0.141, 984.9 KiB
```