### PR TITLE
pkgs/prism.nix: restore homeless-shelter gate for subpackages

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -442,6 +442,11 @@ func containsAt(s, substr string) bool {
 // Manager.PrepareSandboxExec pass validation when the on-disk profile is
 // present.
 func TestValidateSandboxExecArgs_OK(t *testing.T) {
+	// PrepareSandboxExec derives the staging HOME from os.UserHomeDir(); in
+	// the nix build sandbox $HOME is /homeless-shelter (unwritable). Redirect
+	// to a tempdir so the staging-home MkdirAll succeeds. AGENTS.md § "the
+	// homeless-shelter failure class" + issue #2168.
+	t.Setenv("HOME", t.TempDir())
 	m := container.New(container.Config{
 		SessionName:   "repo@feat",
 		AllocatedPort: 14010,
@@ -471,6 +476,9 @@ func TestValidateSandboxExecArgs_OK(t *testing.T) {
 // when the profile-temp file is missing or unreadable, validation returns a
 // clear error containing the path and the underlying stat error.
 func TestValidateSandboxExecArgs_MissingProfile(t *testing.T) {
+	// Redirect HOME for the sandbox-exec staging-home path derivation. See
+	// TestValidateSandboxExecArgs_OK for the rationale.
+	t.Setenv("HOME", t.TempDir())
 	m := container.New(container.Config{
 		SessionName:   "repo@gone",
 		AllocatedPort: 14011,

--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -17,6 +17,7 @@ package cmd
 // tmux, sidecar, or a real agent.
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -588,9 +589,15 @@ func TestRenderCompareTable_LiveSessionStillShowsDash(t *testing.T) {
 		t.Errorf("rendered output missing profile_name on live session:\n%s", out)
 	}
 	// But aggregate axes must read "—" — the session is still in progress.
-	if strings.Contains(out, "100") || strings.Contains(out, "150") {
-		// "100" / "150" are the seeded tokens from writeAssistantTurn —
-		// they must not surface for a still-active session.
+	// "100" / "150" are the seeded tokens from writeAssistantTurn — they
+	// must not surface for a still-active session. Use word-boundary regex
+	// rather than substring containment because the instance_id row in the
+	// rendered table is a UUID and ~1/256 UUIDs happen to end in "100" or
+	// "150", triggering a false-positive leak detection (issue #2169 §
+	// Cluster 4). Word boundaries ensure we only match the token values
+	// (which are whitespace-surrounded in the table), not UUID substrings.
+	leakRe := regexp.MustCompile(`\b(100|150)\b`)
+	if leakRe.MatchString(out) {
 		t.Errorf("rendered output leaks aggregate data for an active session:\n%s", out)
 	}
 }

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -531,6 +531,12 @@ func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
 // per-session state dir and returns args of the shape
 // ["sandbox-exec", "-f", <profile_path>, <harness>, ...].
 func TestPrepareSandboxExec_WritesProfileAndReturnsArgs(t *testing.T) {
+	// PrepareSandboxExec derives the staging HOME from os.UserHomeDir(); in
+	// the nix build sandbox $HOME is /homeless-shelter (unwritable), so we
+	// redirect HOME to a tempdir. This is the AGENTS.md § "the
+	// homeless-shelter failure class" pattern — the gate this test exercises
+	// (issue #2168) exists to catch the inverse of this missing guard.
+	t.Setenv("HOME", t.TempDir())
 	m := newSandboxExecManager(Config{
 		SessionName:   "repo@feat",
 		Worktree:      t.TempDir(),
@@ -613,6 +619,9 @@ func TestPrepareSandboxExec_ProfilePathIsSessionScoped(t *testing.T) {
 // The session must NOT launch: no profile file is written and no
 // sandbox-exec subprocess is started (issue #1879).
 func TestSandboxExecPrepare_StagingHomeFailurePropagated(t *testing.T) {
+	// Redirect HOME for the sandbox-exec staging-home path derivation. See
+	// TestPrepareSandboxExec_WritesProfileAndReturnsArgs for the rationale.
+	t.Setenv("HOME", t.TempDir())
 	// Build the manager and derive the staging home path before injecting the
 	// failure, so we know which path to block.
 	m := newSandboxExecManagerWithInstance(Config{
@@ -673,6 +682,9 @@ func TestSandboxExecPrepare_StagingHomeFailurePropagated(t *testing.T) {
 // confirming no sandbox-exec argument list was produced for the caller to
 // use (regression guard for issue #1879).
 func TestSandboxExecPrepare_StagingHomeFailurePropagated_NilArgs(t *testing.T) {
+	// Redirect HOME for the sandbox-exec staging-home path derivation. See
+	// TestPrepareSandboxExec_WritesProfileAndReturnsArgs for the rationale.
+	t.Setenv("HOME", t.TempDir())
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@feat",
 		InstanceID:  "staging-home-fail-nil-args-test",

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -454,6 +455,16 @@ func TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir(t *testing.T) {
 		// the scratchpad fallback in restore. Both run with no agent.
 		// They legitimately leave PIExtensionDir empty and must NOT be
 		// blocked by the guard.
+		//
+		// LayoutBare opens a real tmux session, so the subtest requires
+		// tmux on PATH. tmux is intentionally NOT in nativeCheckInputs in
+		// pkgs/prism.nix (see the long comment there), so this subtest is
+		// skipped in the nix build sandbox. The sibling LayoutFull subtest
+		// above still runs because it asserts an error before any tmux
+		// call. Tracked in issue #2169 § Cluster 2.
+		if _, err := exec.LookPath("tmux"); err != nil {
+			t.Skip("tmux not found in PATH — skipping LayoutBare subtest; see issue #2169")
+		}
 		name := "unit-test-2065-bare"
 		defer tmux.KillSession(name)
 		err := Create(name, dir, Opts{

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
@@ -24,6 +24,7 @@ package sidecar
 import (
 	"bufio"
 	"encoding/json"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -36,6 +37,14 @@ import (
 // ShutdownDrainTimeout bound. Issue #1849 AC: "On a healthy connection,
 // Shutdown returns within ~10ms of the abort frame being flushed".
 func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
+	// In the nix build sandbox ($NIX_BUILD_TOP set), bwrap I/O overhead
+	// inflates the measured latency past the 50ms budget without indicating
+	// a real regression (observed: 104ms). The latency assertion's intent is
+	// "well under the old 100ms hard sleep on a host", and the nix sandbox
+	// is not a host. Tracked in issue #2169 § Cluster 3.
+	if os.Getenv("NIX_BUILD_TOP") != "" {
+		t.Skip("skipping latency-budget test in nix build sandbox: bwrap I/O overhead inflates measured latency past the 50ms budget; see issue #2169")
+	}
 	sockPath := shortSockPath(t)
 	sc := newSocketPipeSidecar(t, sockPath)
 	wait := runSocketPipeSidecar(sc)

--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -27,6 +27,36 @@ buildGoModule {
 
   doCheck = runChecks;
 
+  # Override checkPhase so the test suite covers ./..., not just the
+  # subPackages list. buildGoModule's default checkPhase iterates over
+  # `getGoDirs test`, which honours `subPackages` when set — so with
+  # `subPackages = [ "." ]` above (kept for buildPhase, which controls
+  # the binary output), the default check would only test the root
+  # package (`./.`), which has no test files. That silently masked the
+  # homeless-shelter sandbox signal for every subpackage under
+  # internal/... and cmd/... See issue tracking this regression and
+  # AGENTS.md § "the homeless-shelter failure class".
+  #
+  # The `GOFLAGS=${GOFLAGS//-trimpath/}` strip mirrors the default
+  # checkPhase: buildGoModule adds -trimpath to GOFLAGS, which breaks
+  # tests that reference assets via their source paths. Race detection
+  # is intentionally not enabled here — the `go-tests` CI job already
+  # runs `go test ./... -race` on an Ubuntu runner; this job's purpose
+  # is the $HOME=/homeless-shelter signal, not race coverage.
+  #
+  # The `-timeout 30m` flag overrides the default 10m per-package budget:
+  # the bwrap sandbox is slower than the host (the `internal/sidecar` and
+  # `internal/db` packages each push close to the default 10m limit there
+  # even when they finish in tens of seconds on a host). The sandbox
+  # slowdown is tracked in issue #2169 § Cluster 1; this is a sandbox
+  # workaround, not a logic fix.
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    go test -timeout 30m ./...
+    runHook postCheck
+  '';
+
   vendorHash = "sha256-QmGhhx3JmxoNj8cgTaOIS4nffHx/vrB/fgXFjmle1gA=";
 
   # reviewGoSHA is the SHA-256 of internal/review/review.go, computed at


### PR DESCRIPTION
## Summary

Surfaced during PR #2165 work: the `nix-build-prism-checked` CI job — the gate intended to surface the `$HOME=/homeless-shelter` failure class (PR #1455's whole point) — has not been exercising any subpackage tests for ~3 weeks. Only the root package's tests run, and the root package has no test files. The check has been silently green; every prism PR merged since 2026-05-15 has shipped without the homeless-shelter signal for `internal/...` or `cmd/...`. Full root-cause analysis in #2168.

## Root cause

PR #1650 (`a0d2aa64`, 2026-05-15) added `subPackages = [ "." ]` to `pkgs/prism.nix` to fix the bin/iris collision after PR #1508 (`6566a6aa`, 2026-05-08) introduced the `runChecks` gate. `buildGoModule`'s default `checkPhase` calls `getGoDirs test`, which honours `subPackages` when set — so the check ran against only the root package (empty). Each change is correct individually; they compose into the regression.

## Fix

`pkgs/prism.nix`: override `checkPhase` so it runs `go test -timeout 30m ./...` directly, bypassing the `subPackages`-restricted default. Keep `subPackages = [ "." ]` for the build phase (it controls the binary output, not test coverage). The override mirrors the default's `GOFLAGS` strip so tests referencing source-path assets still work, and the timeout bump is a sandbox workaround for the slow `internal/sidecar` / `internal/db` packages (#2169 § Cluster 1).

## Verification (probe-test trick)

Before the fix (on plain `main`):

```bash
cat > .../internal/mux/persist/probe_test.go <<'PROBE'
package persist_test
import ("os"; "path/filepath"; "testing")
func TestProbe(t *testing.T) {
  home, _ := os.UserHomeDir()
  if err := os.MkdirAll(filepath.Join(home, "probe"), 0o755); err != nil {
    t.Fatalf("mkdir: %v", err)
  }
}
PROBE
nix build --impure --no-link \
  --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
# Build SUCCEEDS — checkPhase only tests ./. (no test files).
```

After the fix, with the probe still in place:

```
prism> Running phase: checkPhase
prism> --- FAIL: TestProbe (0.00s)
prism>     probe_test.go:12: mkdir: mkdir /homeless-shelter: permission denied
prism> FAIL    github.com/prismatic-koi/prism/internal/mux/persist     0.003s
error: builder failed with exit code 1.
```

Gate restored.

After the fix, without the probe, the full suite passes in the sandbox (11m 26s checkPhase, all 24 packages with tests `ok`).

## Latent failures discovered when the gate went live

The moment the full suite started running in `$HOME=/homeless-shelter`, **nine** test failures surfaced — five `$HOME`-touching failures (the gate's actual purpose) and four sandbox-environment quirks unrelated to `$HOME`. Per the gate-restoration prompt's guidance, the homeless-shelter cluster is fixed inline; the non-`$HOME` quirks are skipped with explicit `t.Skip` calls that reference follow-up issue #2169 — so CI passes and nothing is silently green.

### Homeless-shelter cluster (fixed inline)

| File + test | Root cause | Fix |
|---|---|---|
| `internal/container/sandbox_exec_test.go::TestPrepareSandboxExec_WritesProfileAndReturnsArgs` | `PrepareSandboxExec` calls `os.UserHomeDir()` to derive staging-HOME path | `t.Setenv("HOME", t.TempDir())` |
| `internal/container/sandbox_exec_test.go::TestSandboxExecPrepare_StagingHomeFailurePropagated` | same | same |
| `internal/container/sandbox_exec_test.go::TestSandboxExecPrepare_StagingHomeFailurePropagated_NilArgs` | same | same |
| `cmd/agent_run_test.go::TestValidateSandboxExecArgs_OK` | same | same |
| `cmd/agent_run_test.go::TestValidateSandboxExecArgs_MissingProfile` | same | same |

### Sandbox-environment quirks (skipped with `t.Skip`; follow-up #2169)

| File + test | Root cause | Treatment in this PR |
|---|---|---|
| `internal/sidecar/sidecar_shutdown_abort_flush_test.go::TestShutdown_AbortFlush_HealthyPath_FastAck` | 50ms latency budget exceeded in bwrap (104ms observed) | skip when `$NIX_BUILD_TOP` is set |
| `internal/session/session_test.go::TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir/LayoutBare_…` | LayoutBare subtest calls real tmux; tmux intentionally not in `nativeCheckInputs` | skip when `exec.LookPath("tmux")` fails |
| `cmd/stats_compare_test.go::TestRenderCompareTable_LiveSessionStillShowsDash` | `strings.Contains(out, "100")` falsely matched 3 trailing chars of a UUID instance_id | replace with `\b(100\|150)\b` regex (the leak check still catches tokens-as-values, which are whitespace-surrounded) |
| `internal/db` + `internal/sidecar` slow-test budget | bwrap I/O overhead inflates per-package wall time past the default 10m per-package budget | `-timeout 30m` in the checkPhase override |

## Out of scope

- Backfilling PR #1455's specific test (already fixed).
- The original bin/iris collision PR #1650 fixed — `subPackages = [ "." ]` stays for `buildPhase`.
- Any change to the `go-tests` Ubuntu-runner job — that's a separate gate.
- Investigating the broader bwrap slowdown root cause — tracked in #2169 § Cluster 1.

Closes #2168.