### PR TITLE
mux/cutover: PRISM_USE_MUX=1 plumbing + server PTY hosting

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -224,7 +224,18 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 		} else {
 			_, _ = tmux.SwitchClientCurrent("scratchpad")
 		}
-		_ = tmux.KillSession(m.session)
+		// PRISM_USE_MUX cutover (#2158): under the gate the session is
+		// in the mux daemon's tree, not tmux — destroy it via the
+		// daemon's API (cascades PTY teardown). Without this gate, the
+		// interactive TUI path (the most common cleanup invocation
+		// during a soak) silently leaks the mux session. The sibling
+		// headless paths (headlessCleanupWithJSON / headlessCloseSessionWithJSON)
+		// already gate; this is the missing third site.
+		if muxCutoverEnabled() {
+			_ = prismSession.TeardownMuxSession(m.session)
+		} else {
+			_ = tmux.KillSession(m.session)
+		}
 		prismSession.KillSidecar(m.session)
 		// Orphan-sidecar safety net (issue #1751): SIGTERM any sidecar
 		// processes still alive for review-group or investigator-group
@@ -797,7 +808,15 @@ func closeSession(session string) error {
 	} else {
 		_, _ = tmux.SwitchClientCurrent("scratchpad")
 	}
-	_ = tmux.KillSession(session)
+	// PRISM_USE_MUX cutover (#2158): same gate as doCleanup above
+	// and the headless-soft-close mirror. closeSession is the
+	// interactive @main / non-worktree path; without the gate it
+	// leaks the mux session for every interactive soft-close.
+	if muxCutoverEnabled() {
+		_ = prismSession.TeardownMuxSession(session)
+	} else {
+		_ = tmux.KillSession(session)
+	}
 	prismSession.KillSidecar(session)
 	if d, err := openDB(); err == nil {
 		if isolationModeFromDB(d, session) != "host" {

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -675,7 +675,19 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 	}
 
 	printLine("killing session %s\n", session)
-	_ = tmux.KillSession(session)
+	if muxCutoverEnabled() {
+		// PRISM_USE_MUX cutover (#2158): destroy the session in the mux
+		// daemon. The daemon cascades to every pane's PTY (SIGTERM →
+		// grace → SIGKILL). A non-running daemon surfaces as a clear
+		// diagnostic via surfaceDaemonError below; an absent session
+		// (already destroyed, never registered) is swallowed by
+		// TeardownMuxSession so cleanup stays idempotent.
+		if muxErr := prismSession.TeardownMuxSession(session); muxErr != nil {
+			return surfaceDaemonError("prism cleanup", muxErr)
+		}
+	} else {
+		_ = tmux.KillSession(session)
+	}
 	prismSession.KillSidecar(session)
 	// Orphan-sidecar safety net (issue #1751): SIGTERM any sidecar
 	// processes still alive for review-group or investigator-group
@@ -874,7 +886,16 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 
 	printLine("killing session %s\n", session)
 	result.SessionKilled = true
-	_ = tmux.KillSession(session)
+	if muxCutoverEnabled() {
+		// PRISM_USE_MUX cutover (#2158): same as the full-cleanup path —
+		// destroy the mux session (cascades PTY teardown). Non-mux
+		// callers continue down the tmux path unchanged.
+		if muxErr := prismSession.TeardownMuxSession(session); muxErr != nil {
+			return surfaceDaemonError("prism cleanup", muxErr)
+		}
+	} else {
+		_ = tmux.KillSession(session)
+	}
 	prismSession.KillSidecar(session)
 	// Orphan-sidecar safety net (issue #1751): SIGTERM any sidecar
 	// processes still alive for review-group or investigator-group

--- a/modules/programs/prism/prism/cmd/mux_cutover.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover.go
@@ -32,15 +32,17 @@ import (
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
 
-// Indirections used by switchClientOrMuxSession so unit tests can
-// substitute the tmux side without standing up a real tmux server.
-// Production code passes the real internal/tmux functions through;
-// tests override via the package-private vars in mux_cutover_test.go.
+// Indirections used by switchClientOrMuxSession + liveSessionPredicate
+// so unit tests can substitute the tmux side without standing up a
+// real tmux server. Production code passes the real internal/tmux
+// functions through; tests override via the package-private vars in
+// mux_cutover_test.go.
 var (
 	tmuxCurrentClient       = tmux.CurrentClient
 	tmuxCallerClient        = tmux.CallerClient
 	tmuxSwitchClient        = tmux.SwitchClient
 	tmuxSwitchClientCurrent = tmux.SwitchClientCurrent
+	tmuxHasSession          = tmux.HasSession
 )
 
 // muxCutoverEnvVar is the sentinel the four CLI gates check. We test
@@ -158,6 +160,64 @@ func surfaceDaemonError(cmdName string, err error) error {
 // to. Centralised here so a future test fixture can substitute a
 // bytes.Buffer without touching every print call.
 func stdoutW() io.Writer { return os.Stdout }
+
+// muxLiveSessionSet returns the IDs of every session currently in
+// the mux daemon's session tree. Used as the substrate-side input to
+// liveSessionPredicate when PRISM_USE_MUX=1.
+//
+// A single round-trip per call; callers should grab the snapshot
+// once per CLI invocation and reuse the returned closure rather than
+// calling List for every per-row liveness check.
+//
+// Returns an empty (non-nil) set on a daemon error so the caller
+// gets the same "nothing is live" semantics tmux.HasSession would
+// produce against an unreachable tmux server — the picker / nav
+// reduces to a silent no-op rather than crashing.
+func muxLiveSessionSet() map[string]struct{} {
+	out := map[string]struct{}{}
+	mc, err := newMuxClient()
+	if err != nil {
+		return out
+	}
+	defer mc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), muxClientTimeout)
+	defer cancel()
+	list, err := mc.Sessions().List(ctx)
+	if err != nil {
+		return out
+	}
+	for _, s := range list.Sessions {
+		out[s.ID] = struct{}{}
+	}
+	return out
+}
+
+// liveSessionPredicate returns a "is this session alive in the
+// active substrate?" predicate. Under PRISM_USE_MUX=1 it captures
+// a one-shot snapshot of the daemon's session tree and returns a
+// closure that checks membership; in the default path it returns
+// tmux.HasSession unchanged.
+//
+// Used by nav and the switch picker's review-group filters —
+// without this gate, tmux.HasSession returns false for every
+// mux-hosted session and the picker / nav silently reduce to
+// no-ops, even though the round-1 routing fix is in place. The
+// routing is dead code if the entries it depends on never get
+// generated.
+//
+// Callers MUST invoke this once and reuse the returned closure for
+// the duration of one CLI invocation; calling it inside a per-row
+// loop would issue one round-trip per row.
+func liveSessionPredicate() func(string) bool {
+	if muxCutoverEnabled() {
+		live := muxLiveSessionSet()
+		return func(name string) bool {
+			_, ok := live[name]
+			return ok
+		}
+	}
+	return tmuxHasSession
+}
 
 // switchClientOrMuxSession routes a "switch the active session to
 // target" intent through the right substrate. Under PRISM_USE_MUX=1

--- a/modules/programs/prism/prism/cmd/mux_cutover.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover.go
@@ -1,0 +1,131 @@
+package cmd
+
+// PRISM_USE_MUX cutover plumbing.
+//
+// This file owns the per-command gate and the user-facing diagnostic
+// for the prismd-mux-not-running case. The four entry points
+// (`prism spawn`, `cleanup`, `switch`, `nav`) check muxCutoverEnabled
+// at the top of their run handlers and route through internal/mux/client
+// instead of internal/tmux when the gate is on.
+//
+// Design notes per issue #2158:
+//
+//   - Default off. The env var is the only signal; absent / set to
+//     anything other than "1" leaves the tmux path unchanged.
+//   - Never silently fall back. If the daemon is not reachable we
+//     surface a structured error with the canonical recovery steps
+//     (`prismd mux start`, the systemd / launchd commands) rather
+//     than pretending tmux is fine. The whole point of the flag is
+//     to exercise the mux path deterministically; a silent fallback
+//     would contaminate Ben's phase-3 soak.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/mux/client"
+)
+
+// muxCutoverEnvVar is the sentinel the four CLI gates check. We test
+// for the literal value "1" rather than a "truthy" parse so a typo
+// like PRISM_USE_MUX=yes does not silently enable the new path.
+const muxCutoverEnvVar = "PRISM_USE_MUX"
+
+// muxClientTimeout bounds a single round-trip to the daemon. 5 s
+// mirrors the host-API sidecar client and the mux client's own
+// default (internal/mux/client.defaultTimeout); we name it here so
+// the CLI cutover code reads as a self-contained block.
+const muxClientTimeout = 5 * time.Second
+
+// muxCutoverEnabled returns true when the four CLI gates should route
+// through internal/mux/client instead of internal/tmux. The check is
+// strict: PRISM_USE_MUX must be exactly "1".
+//
+// Exported as a function (rather than read inline) so a follow-up PR
+// can add a config-file fallback or a per-machine override without
+// touching every gate site.
+func muxCutoverEnabled() bool {
+	return os.Getenv(muxCutoverEnvVar) == "1"
+}
+
+// newMuxClient constructs a configured *client.Client for the cutover
+// gates. The socket path falls back to the daemon's canonical
+// $XDG_STATE_HOME/prism/run/<hash>/mux.sock; the per-request timeout
+// is muxClientTimeout. Callers are responsible for Close()-ing the
+// returned client when done with it.
+//
+// The function is deliberately tiny so the gates can call it without
+// hiding the construction shape. Tests that need to inject a different
+// socket path (e.g. against a t.TempDir() server) call client.New
+// directly with WithSocketPath instead.
+func newMuxClient() (*client.Client, error) {
+	return client.New(client.WithTimeout(muxClientTimeout))
+}
+
+// daemonNotRunningError formats the canonical "prismd mux daemon is
+// not running" diagnostic the four gates surface when client.New or
+// the first request returns client.ErrServerUnavailable. The shape
+// mirrors the issue text verbatim — Linux gets the systemd line,
+// Darwin gets the launchctl line, both get the "or run it directly"
+// fallback.
+//
+// cmdName is the calling subcommand name ("prism spawn", "prism
+// cleanup", etc.) so the operator can copy-paste the error message
+// straight into a bug report without losing context.
+func daemonNotRunningError(cmdName string) error {
+	platformHint := platformSupervisorHint()
+	return fmt.Errorf(`%s: prismd mux daemon is not running
+
+  %s
+
+Or run it directly:
+
+  prismd mux start`, cmdName, platformHint)
+}
+
+// platformSupervisorHint returns the OS-appropriate command for
+// starting the user's mux supervisor. Linux: systemctl --user.
+// Darwin: launchctl bootstrap. Other platforms: a generic stub that
+// directs the operator to "prismd mux start" only — the four gates
+// already mention that fallback.
+func platformSupervisorHint() string {
+	switch runtime.GOOS {
+	case "linux":
+		return "systemctl --user start prismd-mux         # Linux"
+	case "darwin":
+		// Resolve $UID via the env (cheap and stable; getuid()
+		// would require a syscall on every error path). Fallback to
+		// a literal "<uid>" placeholder when the var is unset.
+		uid := os.Getenv("UID")
+		if uid == "" {
+			uid = "<uid>"
+		}
+		return fmt.Sprintf("launchctl bootstrap user/%s ~/Library/LaunchAgents/org.nix-community.prismd-mux.plist   # Darwin", uid)
+	default:
+		return "# (no supervisor hint for runtime.GOOS=" + runtime.GOOS + ")"
+	}
+}
+
+// surfaceDaemonError checks whether err is the client-side
+// "daemon not reachable" sentinel and rewrites it into the canonical
+// CLI diagnostic. Other errors are returned unchanged. Callers wrap
+// every client.* call with this so the operator never sees a raw
+// "dial unix: no such file or directory" frame.
+func surfaceDaemonError(cmdName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, client.ErrServerUnavailable) {
+		return daemonNotRunningError(cmdName)
+	}
+	return err
+}
+
+// stdoutW returns the global stdout writer the cutover gates print
+// to. Centralised here so a future test fixture can substitute a
+// bytes.Buffer without touching every print call.
+func stdoutW() io.Writer { return os.Stdout }

--- a/modules/programs/prism/prism/cmd/mux_cutover.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover.go
@@ -20,6 +20,7 @@ package cmd
 //     would contaminate Ben's phase-3 soak.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -28,6 +29,18 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/mux/client"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// Indirections used by switchClientOrMuxSession so unit tests can
+// substitute the tmux side without standing up a real tmux server.
+// Production code passes the real internal/tmux functions through;
+// tests override via the package-private vars in mux_cutover_test.go.
+var (
+	tmuxCurrentClient       = tmux.CurrentClient
+	tmuxCallerClient        = tmux.CallerClient
+	tmuxSwitchClient        = tmux.SwitchClient
+	tmuxSwitchClientCurrent = tmux.SwitchClientCurrent
 )
 
 // muxCutoverEnvVar is the sentinel the four CLI gates check. We test
@@ -88,12 +101,28 @@ Or run it directly:
 }
 
 // platformSupervisorHint returns the OS-appropriate command for
-// starting the user's mux supervisor. Linux: systemctl --user.
-// Darwin: launchctl bootstrap. Other platforms: a generic stub that
-// directs the operator to "prismd mux start" only — the four gates
-// already mention that fallback.
+// starting the user's mux supervisor on the current host. It is a
+// thin wrapper over platformSupervisorHintFor(runtime.GOOS) — the
+// split lets tests pin the hint text for both Linux and Darwin
+// without requiring a cross-platform test runner.
 func platformSupervisorHint() string {
-	switch runtime.GOOS {
+	return platformSupervisorHintFor(runtime.GOOS)
+}
+
+// platformSupervisorHintFor returns the supervisor hint for the
+// named GOOS value. Exposed (lower-case, package-private) so the
+// test suite can assert both branches deterministically.
+//
+// Darwin path note: the plist filename must match what home-manager's
+// launchd module actually installs. home-manager hard-codes
+// `labelPrefix = "org.nix-community.home."` and combines it with the
+// service name (`prismd-mux`), so the on-disk file is
+// `~/Library/LaunchAgents/org.nix-community.home.prismd-mux.plist`.
+// A previous version of this string dropped the `home.` segment and
+// pointed Darwin operators at a non-existent file — see PR #2175
+// review-context.
+func platformSupervisorHintFor(goos string) string {
+	switch goos {
 	case "linux":
 		return "systemctl --user start prismd-mux         # Linux"
 	case "darwin":
@@ -104,9 +133,9 @@ func platformSupervisorHint() string {
 		if uid == "" {
 			uid = "<uid>"
 		}
-		return fmt.Sprintf("launchctl bootstrap user/%s ~/Library/LaunchAgents/org.nix-community.prismd-mux.plist   # Darwin", uid)
+		return fmt.Sprintf("launchctl bootstrap user/%s ~/Library/LaunchAgents/org.nix-community.home.prismd-mux.plist   # Darwin", uid)
 	default:
-		return "# (no supervisor hint for runtime.GOOS=" + runtime.GOOS + ")"
+		return "# (no supervisor hint for runtime.GOOS=" + goos + ")"
 	}
 }
 
@@ -129,3 +158,43 @@ func surfaceDaemonError(cmdName string, err error) error {
 // to. Centralised here so a future test fixture can substitute a
 // bytes.Buffer without touching every print call.
 func stdoutW() io.Writer { return os.Stdout }
+
+// switchClientOrMuxSession routes a "switch the active session to
+// target" intent through the right substrate. Under PRISM_USE_MUX=1
+// it tells the mux daemon to change its active-session pointer; in
+// the default path it falls back to tmux's switch-client primitive.
+//
+// Centralised here so every picker-driven entry point (the top-level
+// picker, the review-session attach, the review-group agent pick)
+// branches on the gate uniformly — a single function call instead of
+// a copy-pasted if/else at every site, and one place to audit when
+// the cutover invariant changes.
+//
+// cmdName is forwarded to surfaceDaemonError so the error message
+// names the calling subcommand ("prism switch" / "prism nav").
+func switchClientOrMuxSession(cmdName, target string) error {
+	if muxCutoverEnabled() {
+		mc, err := newMuxClient()
+		if err != nil {
+			return surfaceDaemonError(cmdName, err)
+		}
+		defer mc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), muxClientTimeout)
+		defer cancel()
+
+		if _, err := mc.Sessions().Switch(ctx, target); err != nil {
+			return surfaceDaemonError(cmdName, err)
+		}
+		return nil
+	}
+	client, _ := tmuxCurrentClient()
+	if client == "" {
+		client = tmuxCallerClient()
+	}
+	if client != "" {
+		return tmuxSwitchClient(client, target)
+	}
+	_, err := tmuxSwitchClientCurrent(target)
+	return err
+}

--- a/modules/programs/prism/prism/cmd/mux_cutover_parity_test.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover_parity_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+// Behavioural-parity smoke tests for the PRISM_USE_MUX cutover gate
+// (issue #2158). These tests exercise the early-failure paths shared
+// between the tmux and mux paths, confirming the gate does not change
+// flag validation, prompt resolution, or any pre-layout side effect.
+//
+// Each test runs once with the gate off (default) and once with the
+// gate on (PRISM_USE_MUX=1). For early-failure assertions, the two
+// runs must produce byte-identical errors because the gate only
+// affects the layout dispatch, which is past the failure point.
+//
+// The tests live in this file rather than alongside spawn_*_test.go
+// so the cutover surface stays scoped to one well-marked area while
+// the wider phase-3 soak runs.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runSpawnWithGate builds a minimal cobra command, sets the env, and
+// runs runSpawn. Returns the error so the caller can compare across
+// the two gate states.
+func runSpawnWithGate(t *testing.T, gateEnabled bool, branch, prompt string) error {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("pr", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().Bool("attach", false, "")
+	cmd.Flags().String("harness", "pi", "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().Bool("wait", false, "")
+	cmd.Flags().Duration("wait-timeout", 0, "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().Bool("reuse", false, "")
+	cmd.Flags().StringArray("abtest", nil, "")
+	cmd.Flags().StringArray("model-override", nil, "")
+	cmd.Flags().String("prompt-source", "", "")
+	addPromptFlags(cmd)
+	if branch != "" {
+		_ = cmd.Flags().Set("branch", branch)
+	}
+	if prompt != "" {
+		_ = cmd.Flags().Set("prompt", prompt)
+	}
+
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("PRISM_SPAWN_PATH", t.TempDir())
+	t.Setenv("PRISM_BARE_ROOT", "")
+	if gateEnabled {
+		t.Setenv(muxCutoverEnvVar, "1")
+	} else {
+		t.Setenv(muxCutoverEnvVar, "")
+	}
+
+	return runSpawn(cmd, nil)
+}
+
+// TestSpawn_GateOff_VsGateOn_EmptyPrompt confirms the gate does not
+// change the empty-prompt validation. Both paths must reject an empty
+// --prompt with the same error before any layout work is attempted.
+func TestSpawn_GateOff_VsGateOn_EmptyPrompt(t *testing.T) {
+	errOff := runSpawnWithGate(t, false, "test-cutover", "")
+	errOn := runSpawnWithGate(t, true, "test-cutover", "")
+
+	if errOff == nil || errOn == nil {
+		t.Fatalf("expected errors on empty prompt; got off=%v on=%v", errOff, errOn)
+	}
+	// Both errors should mention the empty-prompt path. We do not
+	// require byte-identical errors because the path-resolution
+	// step before the prompt check can produce env-dependent
+	// messages; the load-bearing assertion is that both reject.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"off", errOff},
+		{"on", errOn},
+	} {
+		t.Run("gate-"+tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.err.Error(), "prompt") &&
+				!strings.Contains(tc.err.Error(), "pane path") &&
+				!strings.Contains(tc.err.Error(), "git repo") {
+				t.Errorf("error does not mention expected pre-layout failure: %v", tc.err)
+			}
+		})
+	}
+}
+
+// TestSpawn_GateOn_DaemonNotRunning_HasDiagnostic confirms that when
+// the gate is on and the daemon is not reachable, the operator sees
+// the canonical recovery hint. This is the load-bearing "no silent
+// fallback" property of issue #2158: the CLI must never pretend the
+// tmux path is fine when the user has opted into the mux gate.
+//
+// The test exercises surfaceDaemonError directly because driving the
+// entire runSpawn flow to its layout dispatch requires a real worktree
+// and DB — the parity is already covered by the more focused tests
+// in mux_cutover_test.go (gate sentinel) and mux_layout_test.go
+// (daemon-not-running through TeardownMuxSession). Naming the
+// invariant here keeps the contract visible in the cmd-package
+// review surface.
+func TestSpawn_GateOn_DaemonNotRunning_HasDiagnostic(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv(muxCutoverEnvVar, "1")
+
+	from := "prism cleanup"
+	got := daemonNotRunningError(from)
+	if got == nil {
+		t.Fatal("daemonNotRunningError returned nil")
+	}
+	for _, want := range []string{
+		"prism cleanup: prismd mux daemon is not running",
+		"prismd mux start",
+	} {
+		if !strings.Contains(got.Error(), want) {
+			t.Errorf("diagnostic missing %q\nfull message:\n%s", want, got)
+		}
+	}
+}

--- a/modules/programs/prism/prism/cmd/mux_cutover_test.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover_test.go
@@ -9,6 +9,7 @@ package cmd
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -205,6 +206,117 @@ func TestNewMuxClient_Constructs(t *testing.T) {
 	defer mc.Close()
 	if mc.SocketPath() == "" {
 		t.Errorf("SocketPath is empty after newMuxClient")
+	}
+}
+
+// TestLiveSessionPredicate_RoutesByGate pins the cutover invariant
+// for the picker / nav liveness filter (PR #2175 round 2
+// review-context). Under the gate the predicate must consult the
+// mux daemon — NOT tmux — otherwise nav and the switch picker reduce
+// to silent no-ops because tmux.HasSession returns false for every
+// mux-hosted session, leaving the round-1 routing fix unreachable.
+func TestLiveSessionPredicate_RoutesByGate(t *testing.T) {
+	oldHasSession := tmuxHasSession
+	t.Cleanup(func() { tmuxHasSession = oldHasSession })
+
+	// Distinct tmux fake so we can prove the gate-off path goes
+	// through it and the gate-on path does NOT.
+	var tmuxCalls int
+	tmuxHasSession = func(name string) bool {
+		tmuxCalls++
+		return name == "tmux-only-session"
+	}
+
+	t.Run("gate-off-uses-tmux", func(t *testing.T) {
+		tmuxCalls = 0
+		t.Setenv(muxCutoverEnvVar, "")
+		live := liveSessionPredicate()
+		if !live("tmux-only-session") {
+			t.Errorf("gate-off: predicate did not see tmux-hosted session")
+		}
+		if live("mux-only-session") {
+			t.Errorf("gate-off: predicate spuriously matched a non-tmux session")
+		}
+		if tmuxCalls < 1 {
+			t.Errorf("gate-off: tmux.HasSession was not called")
+		}
+	})
+
+	t.Run("gate-on-uses-mux-not-tmux", func(t *testing.T) {
+		tmuxCalls = 0
+		dir := t.TempDir()
+		t.Setenv("XDG_STATE_HOME", dir)
+		t.Setenv(muxCutoverEnvVar, "1")
+
+		live := liveSessionPredicate()
+		// The mux daemon is not running (unbound socket), so the
+		// predicate must return an empty set — a tmux-hosted name
+		// must NOT slip through.
+		if live("tmux-only-session") {
+			t.Errorf("gate-on: predicate fell back to tmux for a tmux-only name — this is the load-bearing failure mode the cutover gate exists to prevent")
+		}
+		if tmuxCalls != 0 {
+			t.Errorf("gate-on: tmux.HasSession was called %d time(s); want 0 (the gate must route to the mux substrate)", tmuxCalls)
+		}
+	})
+}
+
+// TestCleanupSites_AllTeardownsAreGated is a structural assertion
+// over cmd/cleanup.go: every `tmux.KillSession` call must be
+// preceded by the cutover gate so the same call site does the
+// right thing under PRISM_USE_MUX=1. PR #2175 round 1 fixed the
+// headless paths; round 2 fixed the interactive doCleanup +
+// closeSession sites. The test pins the invariant by counting
+// gated vs. ungated KillSession references so a future change
+// that adds an ungated teardown trips the regression at PR-review
+// time, not at soak-time.
+func TestCleanupSites_AllTeardownsAreGated(t *testing.T) {
+	// Read the cleanup.go source. The path is relative to the
+	// test package's working directory; go test puts us in the
+	// package dir.
+	data, err := os.ReadFile("cleanup.go")
+	if err != nil {
+		t.Fatalf("read cleanup.go: %v", err)
+	}
+	src := string(data)
+
+	// Every tmux.KillSession in cleanup.go must be inside the
+	// `else` branch of a `muxCutoverEnabled()` guard. The minimal
+	// pattern this test enforces is that each line containing
+	// `tmux.KillSession(` is the body of an else-branch that
+	// immediately follows a `if muxCutoverEnabled() {` block.
+	//
+	// Implementation: scan lines, count `tmux.KillSession(`
+	// occurrences, and assert the line immediately above contains
+	// `} else {`. This is structural; the exact opcodes of the
+	// gate are not enumerated, but the shape is invariant.
+	lines := strings.Split(src, "\n")
+	killSites := 0
+	gated := 0
+	for i, ln := range lines {
+		if !strings.Contains(ln, "tmux.KillSession(") {
+			continue
+		}
+		killSites++
+		// Look back up to 3 lines for the `} else {` boundary.
+		// Allows for a comment line between the gate and the
+		// teardown call.
+		low := i - 3
+		if low < 0 {
+			low = 0
+		}
+		for j := i - 1; j >= low; j-- {
+			if strings.Contains(lines[j], "} else {") {
+				gated++
+				break
+			}
+		}
+	}
+	if killSites == 0 {
+		t.Fatal("no tmux.KillSession sites found in cleanup.go — test is vacuous")
+	}
+	if gated != killSites {
+		t.Errorf("cleanup.go: %d/%d tmux.KillSession sites are gated by muxCutoverEnabled() — the ungated ones leak the mux session under PRISM_USE_MUX=1 (PR #2175 review-code/review-context)", gated, killSites)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/mux_cutover_test.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover_test.go
@@ -77,6 +77,75 @@ func TestDaemonNotRunningError_MentionsRecoverySteps(t *testing.T) {
 	}
 }
 
+// TestPlatformSupervisorHint_LinuxAndDarwin pins both platform hint
+// strings so a refactor cannot silently regress either. The Darwin
+// path note (see platformSupervisorHintFor docstring) is
+// load-bearing: the plist filename must match the home-manager
+// `labelPrefix = "org.nix-community.home."` + service-name
+// composition, otherwise Darwin operators copy-paste a path that
+// does not exist on disk (PR #2175 review-context blocker).
+func TestPlatformSupervisorHint_LinuxAndDarwin(t *testing.T) {
+	t.Run("linux", func(t *testing.T) {
+		got := platformSupervisorHintFor("linux")
+		for _, want := range []string{
+			"systemctl --user start prismd-mux",
+			"# Linux",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("linux hint missing %q\nfull hint:\n%s", want, got)
+			}
+		}
+	})
+	t.Run("darwin", func(t *testing.T) {
+		// Pin a known UID so the test does not depend on the host's
+		// environment.
+		t.Setenv("UID", "501")
+		got := platformSupervisorHintFor("darwin")
+		for _, want := range []string{
+			"launchctl bootstrap user/501",
+			// The full path must include the `home.` segment that
+			// home-manager's launchd module hard-codes via its
+			// labelPrefix. Pinning the path verbatim catches
+			// regressions like PR #2175's original off-by-one
+			// filename (org.nix-community.prismd-mux.plist).
+			"~/Library/LaunchAgents/org.nix-community.home.prismd-mux.plist",
+			"# Darwin",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("darwin hint missing %q\nfull hint:\n%s", want, got)
+			}
+		}
+		// Defence-in-depth: assert the segment that the regression
+		// dropped is present. A negative assertion on the wrong
+		// filename catches the regression even if the broader
+		// substring assertion is loosened in the future.
+		if !strings.Contains(got, "org.nix-community.home.prismd-mux.plist") {
+			t.Errorf("darwin hint dropped the load-bearing `home.` segment")
+		}
+		if strings.Contains(got, "org.nix-community.prismd-mux.plist") &&
+			!strings.Contains(got, "org.nix-community.home.prismd-mux.plist") {
+			t.Errorf("darwin hint regressed to the pre-#2175 filename")
+		}
+	})
+	t.Run("darwin-uid-fallback", func(t *testing.T) {
+		// When $UID is unset the helper substitutes the literal
+		// "<uid>" placeholder so the operator can see they need to
+		// fill it in. Pin the fallback so the diagnostic stays
+		// informative.
+		t.Setenv("UID", "")
+		got := platformSupervisorHintFor("darwin")
+		if !strings.Contains(got, "user/<uid>") {
+			t.Errorf("darwin hint missing UID fallback placeholder: %s", got)
+		}
+	})
+	t.Run("unknown-goos", func(t *testing.T) {
+		got := platformSupervisorHintFor("plan9")
+		if !strings.Contains(got, "plan9") {
+			t.Errorf("unknown-GOOS hint = %q, want it to name the GOOS", got)
+		}
+	})
+}
+
 // TestSurfaceDaemonError_RewritesUnavailable confirms that the
 // canonical ErrServerUnavailable error is replaced by the structured
 // diagnostic, while other errors pass through unchanged.
@@ -137,4 +206,71 @@ func TestNewMuxClient_Constructs(t *testing.T) {
 	if mc.SocketPath() == "" {
 		t.Errorf("SocketPath is empty after newMuxClient")
 	}
+}
+
+// TestSwitchClientOrMuxSession_RoutesByGate pins the cutover
+// invariant for the picker-driven switch entry points (the
+// review-session attach in handleBareRepo and the agent pick in
+// handleReviewGroupPick — PR #2175 review-context). When the gate is
+// off the call lands on the tmux switch primitives; when the gate is
+// on it lands on the mux client. The test substitutes both halves so
+// it does not require a live tmux server or a live mux daemon.
+func TestSwitchClientOrMuxSession_RoutesByGate(t *testing.T) {
+	// Record which substrate fired so we can assert routing.
+	var tmuxFired bool
+	oldCurClient := tmuxCurrentClient
+	oldCallerClient := tmuxCallerClient
+	oldSwitch := tmuxSwitchClient
+	oldSwitchCurrent := tmuxSwitchClientCurrent
+	t.Cleanup(func() {
+		tmuxCurrentClient = oldCurClient
+		tmuxCallerClient = oldCallerClient
+		tmuxSwitchClient = oldSwitch
+		tmuxSwitchClientCurrent = oldSwitchCurrent
+	})
+	tmuxCurrentClient = func() (string, error) { return "fake-client", nil }
+	tmuxCallerClient = func() string { return "" }
+	tmuxSwitchClient = func(client, target string) error {
+		tmuxFired = true
+		if target != "repo@feat" {
+			t.Errorf("tmux switch target = %q, want %q", target, "repo@feat")
+		}
+		return nil
+	}
+	tmuxSwitchClientCurrent = func(target string) (string, error) {
+		tmuxFired = true
+		return target, nil
+	}
+
+	t.Run("gate-off-uses-tmux", func(t *testing.T) {
+		tmuxFired = false
+		t.Setenv(muxCutoverEnvVar, "")
+		if err := switchClientOrMuxSession("prism switch", "repo@feat"); err != nil {
+			t.Fatalf("switchClientOrMuxSession: %v", err)
+		}
+		if !tmuxFired {
+			t.Errorf("gate off did not route through tmux")
+		}
+	})
+
+	t.Run("gate-on-surfaces-daemon-not-running", func(t *testing.T) {
+		tmuxFired = false
+		// Point at an unbound socket so the call fails cleanly and
+		// the diagnostic surfaces. This proves the gate ROUTED to
+		// the mux client and DID NOT silently fall back to tmux.
+		dir := t.TempDir()
+		t.Setenv("XDG_STATE_HOME", dir)
+		t.Setenv(muxCutoverEnvVar, "1")
+
+		err := switchClientOrMuxSession("prism switch", "repo@feat")
+		if err == nil {
+			t.Fatalf("want error against unbound daemon, got nil")
+		}
+		if !strings.Contains(err.Error(), "prismd mux daemon is not running") {
+			t.Errorf("gate-on error did not surface daemon diagnostic: %v", err)
+		}
+		if tmuxFired {
+			t.Errorf("gate on silently fell back to tmux — this is the load-bearing failure mode the cutover gate exists to prevent")
+		}
+	})
 }

--- a/modules/programs/prism/prism/cmd/mux_cutover_test.go
+++ b/modules/programs/prism/prism/cmd/mux_cutover_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+// Tests for the PRISM_USE_MUX cutover plumbing (issue #2158).
+//
+// The gate is small and homeless-shelter clean — no DB, no tmux, no
+// network. The tests pin: (1) the env var must be exactly "1" to
+// enable; (2) the daemon-not-running diagnostic carries the expected
+// shape; (3) surfaceDaemonError preserves non-network errors.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/mux/client"
+)
+
+// TestMuxCutoverEnabled_StrictSentinel asserts the gate is on only
+// when the env var is exactly "1". Anything else (unset, "0", "true",
+// "yes", "1 ", or " 1") leaves the gate off so the operator does not
+// accidentally enable the new path with a typo.
+func TestMuxCutoverEnabled_StrictSentinel(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"1", true},
+		{"true", false},
+		{"yes", false},
+		{"on", false},
+		{" 1", false},
+		{"1 ", false},
+		{"01", false},
+	}
+	for _, tc := range cases {
+		t.Run("env="+tc.val, func(t *testing.T) {
+			t.Setenv(muxCutoverEnvVar, tc.val)
+			if got := muxCutoverEnabled(); got != tc.want {
+				t.Errorf("muxCutoverEnabled() with %s=%q = %v, want %v",
+					muxCutoverEnvVar, tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMuxCutoverEnabled_AbsentEnvIsDisabled covers the explicit
+// "no env var at all" path. t.Setenv only restores; it does not unset
+// across the whole process. Use os.Unsetenv via t.Setenv-then-empty
+// to make the absence explicit.
+func TestMuxCutoverEnabled_AbsentEnvIsDisabled(t *testing.T) {
+	t.Setenv(muxCutoverEnvVar, "")
+	if muxCutoverEnabled() {
+		t.Errorf("muxCutoverEnabled() with empty env = true, want false")
+	}
+}
+
+// TestDaemonNotRunningError_MentionsRecoverySteps confirms the
+// diagnostic carries the canonical recovery commands so the operator
+// can copy-paste from the error message. The exact wording is pinned
+// (subject to AC adjustments) so a future refactor does not silently
+// drop the recovery hint.
+func TestDaemonNotRunningError_MentionsRecoverySteps(t *testing.T) {
+	err := daemonNotRunningError("prism spawn")
+	if err == nil {
+		t.Fatal("daemonNotRunningError returned nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"prism spawn: prismd mux daemon is not running",
+		"prismd mux start",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\nfull message:\n%s", want, msg)
+		}
+	}
+}
+
+// TestSurfaceDaemonError_RewritesUnavailable confirms that the
+// canonical ErrServerUnavailable error is replaced by the structured
+// diagnostic, while other errors pass through unchanged.
+func TestSurfaceDaemonError_RewritesUnavailable(t *testing.T) {
+	// Nil → nil (defensive).
+	if got := surfaceDaemonError("prism spawn", nil); got != nil {
+		t.Errorf("surfaceDaemonError(nil) = %v, want nil", got)
+	}
+
+	// ErrServerUnavailable → rewritten.
+	got := surfaceDaemonError("prism spawn", client.ErrServerUnavailable)
+	if got == nil {
+		t.Fatal("surfaceDaemonError(ErrServerUnavailable) = nil, want diagnostic")
+	}
+	if !strings.Contains(got.Error(), "prismd mux daemon is not running") {
+		t.Errorf("surfaceDaemonError did not rewrite ErrServerUnavailable: %v", got)
+	}
+
+	// Wrapped ErrServerUnavailable → still rewritten (errors.Is matches
+	// through wrappers).
+	wrapped := errors.New("wrapper")
+	wrapped = &wrapErr{msg: "wrapper", inner: client.ErrServerUnavailable}
+	got = surfaceDaemonError("prism spawn", wrapped)
+	if got == nil || !strings.Contains(got.Error(), "prismd mux daemon is not running") {
+		t.Errorf("surfaceDaemonError(wrapped) = %v, want diagnostic", got)
+	}
+
+	// Non-network error → passes through unchanged.
+	other := errors.New("something else")
+	got = surfaceDaemonError("prism spawn", other)
+	if got != other {
+		t.Errorf("surfaceDaemonError(other) = %v, want pass-through %v", got, other)
+	}
+}
+
+// wrapErr is a tiny errors.Is-friendly wrapper for the test above.
+type wrapErr struct {
+	msg   string
+	inner error
+}
+
+func (w *wrapErr) Error() string { return w.msg }
+func (w *wrapErr) Unwrap() error { return w.inner }
+
+// TestNewMuxClient_Constructs constructs the default mux client and
+// asserts the canonical socket path is populated. The Close() is
+// expected to succeed on a no-op transport (DisableKeepAlives).
+func TestNewMuxClient_Constructs(t *testing.T) {
+	// Redirect $XDG_STATE_HOME to t.TempDir() so the canonical path
+	// resolution does not touch the developer's $HOME.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	mc, err := newMuxClient()
+	if err != nil {
+		t.Fatalf("newMuxClient: %v", err)
+	}
+	defer mc.Close()
+	if mc.SocketPath() == "" {
+		t.Errorf("SocketPath is empty after newMuxClient")
+	}
+}

--- a/modules/programs/prism/prism/cmd/nav.go
+++ b/modules/programs/prism/prism/cmd/nav.go
@@ -24,6 +24,7 @@ package cmd
 //   - Unknown direction arguments return a non-zero exit with a clear error.
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -56,6 +57,13 @@ func runNav(_ *cobra.Command, args []string) error {
 	// Require a tmux client. We treat $TMUX as the marker — `prism nav` is
 	// only ever invoked from a tmux key binding, and outside that context
 	// there is nothing to switch.
+	//
+	// PRISM_USE_MUX cutover (#2158): the $TMUX guard stays because the
+	// nav keybind is still wired to tmux's prefix table during phase 2/3.
+	// We resolve the target the same way; the difference is the
+	// switch-client side. Under PRISM_USE_MUX we tell the daemon to
+	// change its active-session pointer; the daemon's renderer (when
+	// later wired into a user-facing TUI) reacts to that.
 	if os.Getenv("TMUX") == "" {
 		return fmt.Errorf("prism nav: not running inside a tmux client ($TMUX is not set)")
 	}
@@ -77,6 +85,10 @@ func runNav(_ *cobra.Command, args []string) error {
 		return nil
 	}
 
+	if muxCutoverEnabled() {
+		return navMuxSwitch(target)
+	}
+
 	// Use the explicit -c <client> form whenever CurrentClient returns a name.
 	// This matches the pattern used by cmd/switch.go, cmd/switch_project.go,
 	// and cmd/cleanup.go and ensures that `prism nav` switches the client
@@ -91,6 +103,31 @@ func runNav(_ *cobra.Command, args []string) error {
 	}
 	if _, err := tmux.SwitchClientCurrent(target); err != nil {
 		return fmt.Errorf("prism nav: switch-client to %q failed: %w", target, err)
+	}
+	return nil
+}
+
+// navMuxSwitch is the PRISM_USE_MUX=1 dispatch target for the nav
+// command. It tells the daemon to change its active-session pointer;
+// the renderer (when later wired to a user-facing TUI) picks up the
+// change on its next paint.
+//
+// On daemon-not-running, surfaces the canonical diagnostic so the
+// operator knows to start prismd-mux. The session-not-found case
+// (target dropped between resolveTarget and the daemon call) is a
+// silent no-op to match the tmux path's behaviour.
+func navMuxSwitch(target string) error {
+	mc, err := newMuxClient()
+	if err != nil {
+		return surfaceDaemonError("prism nav", err)
+	}
+	defer mc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), muxClientTimeout)
+	defer cancel()
+
+	if _, err := mc.Sessions().Switch(ctx, target); err != nil {
+		return surfaceDaemonError("prism nav", err)
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/cmd/nav.go
+++ b/modules/programs/prism/prism/cmd/nav.go
@@ -134,8 +134,18 @@ func navMuxSwitch(target string) error {
 
 // resolveTarget computes the target session name for the requested direction,
 // or ("", false) when the navigation is a no-op.
+//
+// PRISM_USE_MUX cutover (#2158): the liveness predicate is sourced
+// from liveSessionPredicate, NOT tmux.HasSession directly. Under the
+// gate, sessions live in the mux daemon's tree, not in tmux — using
+// tmux.HasSession would reduce nav to a silent no-op for every
+// mux-hosted session (the round-1 fix at runNav routes the
+// switch-client call correctly, but if no candidate survives the
+// liveness filter, the routed call is never reached). The predicate
+// is captured once and reused across the per-target lookups so a
+// single CLI invocation pays one round-trip total.
 func resolveTarget(current string, dir nav.Direction, sessions []dashboard.AgentSession) (string, bool) {
-	live := tmux.HasSession
+	live := liveSessionPredicate()
 	switch dir {
 	case nav.DirUp, nav.DirDown:
 		targets := nav.VerticalTargets(sessions, live)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -753,6 +753,11 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		HarnessName:      harnessFlag,
 		ModelsByRole:     modelsByRole,
 		AllowEmptyPrompt: allowEmptyPrompt,
+		// PRISM_USE_MUX cutover (#2158): route layout creation through
+		// the prismd-mux daemon instead of tmux when the gate is on.
+		// Errors from the gate (e.g. daemon not running) surface from
+		// SpawnSession as a layoutErr just like a tmux failure would.
+		UseMux: muxCutoverEnabled(),
 		// CLI overrides (issue #2086) flow through to the tmux pane command
 		// so `prism agent-run` (bwrap / sandbox-exec) and direct pi (host)
 		// receive --model / --variant on the final argv.
@@ -1338,6 +1343,11 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		AgentPromptHash:      a.agentPromptHash,
 		AbtestPairID:         a.pairID,
 		// ────────────────────────────────────────────────────────
+		// PRISM_USE_MUX cutover (#2158): route layout creation through
+		// the prismd-mux daemon when the gate is on. Abtest legs honour
+		// the same env var as single spawns so a Ben-side soak that
+		// exports PRISM_USE_MUX=1 in a shell rc gets uniform behaviour.
+		UseMux: muxCutoverEnabled(),
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {
 		spawnOpts.AgentEnvVars = a.pf.AgentEnvVars

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -1211,7 +1211,16 @@ func runAbtestSpawn(cmd *cobra.Command, profileA, profileB string) error {
 		for _, r := range results {
 			if r.err == nil && r.sessionName != "" {
 				// Best-effort teardown of the session that did start.
-				_ = tmux.KillSession(r.sessionName)
+				// PRISM_USE_MUX cutover (#2158): spawnOneAbtest sets
+				// UseMux=muxCutoverEnabled() on its SpawnOpts, so the leg
+				// landed in the mux daemon's session tree, not tmux. Tear
+				// it down via the daemon's API so the surviving leg's mux
+				// session and PTYs do not orphan after a partial failure.
+				if muxCutoverEnabled() {
+					_ = session.TeardownMuxSession(r.sessionName)
+				} else {
+					_ = tmux.KillSession(r.sessionName)
+				}
 				session.KillSidecar(r.sessionName)
 				if killDBErr := d.SetEnded(r.sessionName); killDBErr != nil {
 					proglog.Warnf("[prism spawn] warning: cleanup DB for %q failed: %v\n", r.sessionName, killDBErr)

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -114,15 +114,21 @@ func injectContainerConfig(path string, pf *config.ProfilesFile, opts *session.O
 }
 
 // switchMuxOnly is the PRISM_USE_MUX=1 dispatch target for the switch
-// command. It tells the daemon to change its active-session pointer;
-// if the session is not registered in the daemon, surfaces a clear
-// error instead of attempting a tmux-style auto-create. Under the
-// mux model, session lifecycle is owned by `prism spawn` / `restore`,
-// not by switch.
+// command's create-or-attach path (ensureAndSwitch). It tells the
+// daemon to change its active-session pointer; if the session is not
+// registered in the daemon, surfaces a clear error instead of
+// attempting a tmux-style auto-create. Under the mux model, session
+// lifecycle is owned by `prism spawn` / `restore`, not by switch.
 //
 // sessionName is the canonical prism session name (e.g.
 // "nixos-config@main"). When sessionName is empty, the call is a
 // no-op — the caller has already validated the resolution path.
+//
+// Note: the create-or-attach path prints a "switched to <name>" line
+// because the caller expects the legacy session.Attach success
+// output. The picker-driven entry points (cmd/switch_project.go) use
+// switchClientOrMuxSession directly so they share the same gate
+// shape as nav and stay silent on success, matching the tmux path.
 func switchMuxOnly(sessionName string) error {
 	if sessionName == "" {
 		return nil

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -6,6 +6,7 @@ package cmd
 // (or $PRISM_CONFIG_FILE) via the internal/config package.
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -109,6 +110,36 @@ func injectContainerConfig(path string, pf *config.ProfilesFile, opts *session.O
 		return err
 	}
 	opts.ConfigContent = content
+	return nil
+}
+
+// switchMuxOnly is the PRISM_USE_MUX=1 dispatch target for the switch
+// command. It tells the daemon to change its active-session pointer;
+// if the session is not registered in the daemon, surfaces a clear
+// error instead of attempting a tmux-style auto-create. Under the
+// mux model, session lifecycle is owned by `prism spawn` / `restore`,
+// not by switch.
+//
+// sessionName is the canonical prism session name (e.g.
+// "nixos-config@main"). When sessionName is empty, the call is a
+// no-op — the caller has already validated the resolution path.
+func switchMuxOnly(sessionName string) error {
+	if sessionName == "" {
+		return nil
+	}
+	mc, err := newMuxClient()
+	if err != nil {
+		return surfaceDaemonError("prism switch", err)
+	}
+	defer mc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), muxClientTimeout)
+	defer cancel()
+
+	if _, err := mc.Sessions().Switch(ctx, sessionName); err != nil {
+		return surfaceDaemonError("prism switch", err)
+	}
+	fmt.Fprintf(stdoutW(), "switched to session %q (mux)\n", sessionName)
 	return nil
 }
 
@@ -243,6 +274,16 @@ func ensureAndSwitch(path string, projectRoot string, opts session.Opts) error {
 		} else {
 			opts.Port = port
 		}
+	}
+
+	// PRISM_USE_MUX cutover (#2158): under the mux gate, switch only
+	// changes the daemon's active-session pointer. Session lifecycle
+	// is owned by `prism spawn` / `restore`; we do not auto-create
+	// here because the runtime side (PTYs, sidecars, etc.) is owned
+	// by SpawnSession and reaching into it from switch would duplicate
+	// the spawn flow.
+	if muxCutoverEnabled() {
+		return switchMuxOnly(sessionName)
 	}
 
 	if err := session.Create(sessionName, directory, opts); err != nil {

--- a/modules/programs/prism/prism/cmd/switch_project.go
+++ b/modules/programs/prism/prism/cmd/switch_project.go
@@ -210,6 +210,13 @@ func activeReviewSessionEntries(projectPath string, worktrees []string) []entry 
 	groupSessions := map[string][]childInfo{}
 	groupOrder := []string{} // preserve insertion order for sorted output
 
+	// PRISM_USE_MUX cutover (#2158): use liveSessionPredicate so a
+	// mux-hosted session is visible in the picker. tmux.HasSession
+	// returns false for every mux session and would silently empty
+	// the picker, leaving the round-1 routing fix in handleBareRepo
+	// unreachable. Captured once for the whole loop — one round-trip
+	// per CLI invocation.
+	live := liveSessionPredicate()
 	for _, s := range all {
 		// Only per-agent review sessions: name must contain "~review-" and
 		// resolve to a non-empty ReviewRoundKey.
@@ -217,8 +224,9 @@ func activeReviewSessionEntries(projectPath string, worktrees []string) []entry 
 		if rk == "" {
 			continue
 		}
-		// The session must also exist in tmux.
-		if !tmux.HasSession(s.SessionName) {
+		// The session must also be alive in the active substrate (tmux
+		// when the gate is off, the mux daemon's session tree when on).
+		if !live(s.SessionName) {
 			continue
 		}
 		if _, exists := groupSessions[rk]; !exists {
@@ -292,13 +300,17 @@ func handleReviewGroupPick(groupKey string) error {
 		return fmt.Errorf("query sessions: %w", err)
 	}
 
+	// PRISM_USE_MUX cutover (#2158): same liveness predicate as
+	// reviewGroupEntries — see the comment there for why this cannot
+	// stay as tmux.HasSession.
+	live := liveSessionPredicate()
 	var items []entry
 	for _, s := range all {
 		rk := dashboard.ReviewRoundKey(s.SessionName)
 		if rk != groupKey {
 			continue
 		}
-		if !tmux.HasSession(s.SessionName) {
+		if !live(s.SessionName) {
 			continue
 		}
 		// Label: e.g. "~review-1-review-goal"

--- a/modules/programs/prism/prism/cmd/switch_project.go
+++ b/modules/programs/prism/prism/cmd/switch_project.go
@@ -124,17 +124,13 @@ func handleBareRepo(projectPath string, pf *config.ProfilesFile, opts session.Op
 		return handleReviewGroupPick(chosen.reviewGroup)
 	}
 
-	// Review session entry: attach directly to the named tmux session.
+	// Review session entry: attach directly to the named session.
+	// PRISM_USE_MUX cutover (#2158): switchClientOrMuxSession routes
+	// through the mux daemon when the gate is on and falls back to
+	// tmux's switch-client primitive otherwise. Mirrors the gate
+	// pattern used by ensureAndSwitch (cmd/switch.go) and runNav.
 	if chosen.sessionRef != "" {
-		client, _ := tmux.CurrentClient()
-		if client == "" {
-			client = tmux.CallerClient()
-		}
-		if client != "" {
-			return tmux.SwitchClient(client, chosen.sessionRef)
-		}
-		_, err := tmux.SwitchClientCurrent(chosen.sessionRef)
-		return err
+		return switchClientOrMuxSession("prism switch", chosen.sessionRef)
 	}
 
 	if chosen.special == "[+ create new worktree]" {
@@ -341,15 +337,9 @@ func handleReviewGroupPick(groupKey string) error {
 		return nil
 	}
 
-	client, _ := tmux.CurrentClient()
-	if client == "" {
-		client = tmux.CallerClient()
-	}
-	if client != "" {
-		return tmux.SwitchClient(client, chosen.sessionRef)
-	}
-	_, err = tmux.SwitchClientCurrent(chosen.sessionRef)
-	return err
+	// PRISM_USE_MUX cutover (#2158): same gate pattern as the
+	// review-session-entry path above.
+	return switchClientOrMuxSession("prism switch", chosen.sessionRef)
 }
 
 func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, isoCaps container.Capabilities, cfg config.Config) error {
@@ -404,8 +394,16 @@ func handleRegularRepo(path string, pf *config.ProfilesFile, opts session.Opts, 
 
 		// Conversion succeeded — clean up the pre-conversion session,
 		// mirroring the pattern used by cleanup.go for intentional teardowns.
-		// Kill the tmux session if it exists; ignore "no such session" errors.
-		_ = tmux.KillSession(oldSessionName)
+		// PRISM_USE_MUX cutover (#2158): under the gate the pre-conversion
+		// session is owned by the mux daemon, not tmux — destroy it via
+		// the daemon's API (cascades PTY teardown). Without this gate,
+		// `prism switch` after a bare-repo conversion under PRISM_USE_MUX=1
+		// leaves an orphan row in the daemon's session tree.
+		if muxCutoverEnabled() {
+			_ = session.TeardownMuxSession(oldSessionName)
+		} else {
+			_ = tmux.KillSession(oldSessionName)
+		}
 		// Kill any sidecar process associated with the old session (no-op if
 		// no PID file exists).
 		session.KillSidecar(oldSessionName)

--- a/modules/programs/prism/prism/internal/mux/client/client_pty_test.go
+++ b/modules/programs/prism/prism/internal/mux/client/client_pty_test.go
@@ -1,0 +1,222 @@
+package client
+
+// Tests for the PR #2158 additions to the client surface:
+//
+//   - Panes().Create now takes a PaneCreateOptions struct with Argv,
+//     Cwd, Env, Cols, Rows.
+//   - Panes().ReadOutput is a new GET-shape method that returns a
+//     PaneFrame snapshot of the rendered cell grid.
+//
+// The tests use a stub http.RoundTripper so they do not depend on a
+// live server, keeping them homeless-shelter clean (no XDG_STATE_HOME,
+// no PTY syscalls, no children).
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// fakeRoundTripper records the most recent request and serves a
+// scripted response. Distinct from any helper in client_test.go so
+// these tests stand on their own.
+type fakeRoundTripper struct {
+	lastReq    *http.Request
+	lastBody   []byte
+	respStatus int
+	respBody   []byte
+}
+
+func (f *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	f.lastReq = r
+	if r.Body != nil {
+		buf, _ := io.ReadAll(r.Body)
+		f.lastBody = buf
+	}
+	status := f.respStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+	body := f.respBody
+	if body == nil {
+		body = []byte("{}")
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// newFakeClient constructs a Client using the supplied round-tripper
+// in place of the default Unix-dialing transport. The socket path is
+// fixed because the round-tripper short-circuits the dial.
+func newFakeClient(t *testing.T, rt http.RoundTripper) *Client {
+	t.Helper()
+	c, err := New(WithSocketPath("/tmp/notused"), WithTransport(rt))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c
+}
+
+// TestPanesCreate_NoArgv_OmitsRuntimeFields asserts that a zero-value
+// PaneCreateOptions produces the legacy wire shape — no argv, cwd, or
+// env. The server interprets this as "model-only pane, no PTY".
+func TestPanesCreate_NoArgv_OmitsRuntimeFields(t *testing.T) {
+	rt := &fakeRoundTripper{respStatus: http.StatusOK, respBody: []byte("{}")}
+	c := newFakeClient(t, rt)
+
+	if err := c.Panes().Create(context.Background(), "r@b", "agent", PaneCreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if rt.lastReq.URL.Path != "/pane/create" {
+		t.Errorf("path = %q, want /pane/create", rt.lastReq.URL.Path)
+	}
+	if rt.lastReq.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", rt.lastReq.Method)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rt.lastBody, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for _, key := range []string{"argv", "cwd", "env", "cols", "rows"} {
+		if _, ok := body[key]; ok {
+			t.Errorf("body[%q] is present for zero-value opts: %v", key, body[key])
+		}
+	}
+}
+
+// TestPanesCreate_WithRuntimeFields_PopulatesWire confirms that the
+// runtime fields (argv, cwd, env, cols, rows) round-trip into the
+// JSON body the way the server expects.
+func TestPanesCreate_WithRuntimeFields_PopulatesWire(t *testing.T) {
+	rt := &fakeRoundTripper{respStatus: http.StatusOK, respBody: []byte("{}")}
+	c := newFakeClient(t, rt)
+
+	opts := PaneCreateOptions{
+		Argv: []string{"/bin/sh", "-c", "echo hi"},
+		Cwd:  "/var/tmp",
+		Env:  map[string]string{"FOO": "bar"},
+		Cols: 120,
+		Rows: 40,
+	}
+	if err := c.Panes().Create(context.Background(), "r@b", "agent", opts); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rt.lastBody, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	argv, ok := body["argv"].([]any)
+	if !ok || len(argv) != 3 || argv[0] != "/bin/sh" {
+		t.Errorf("argv = %v, want [/bin/sh -c echo hi]", body["argv"])
+	}
+	if body["cwd"] != "/var/tmp" {
+		t.Errorf("cwd = %v, want /var/tmp", body["cwd"])
+	}
+	if env, ok := body["env"].(map[string]any); !ok || env["FOO"] != "bar" {
+		t.Errorf("env = %v, want {FOO:bar}", body["env"])
+	}
+	if body["cols"] != float64(120) {
+		t.Errorf("cols = %v, want 120", body["cols"])
+	}
+	if body["rows"] != float64(40) {
+		t.Errorf("rows = %v, want 40", body["rows"])
+	}
+}
+
+// TestPanesReadOutput_HappyPath decodes a representative server
+// response into a PaneFrame. The wire shape is pinned here so a
+// rename / retype on the server side fails this test.
+func TestPanesReadOutput_HappyPath(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"cols":       80,
+		"rows":       24,
+		"cursor_x":   5,
+		"cursor_y":   3,
+		"alt_screen": true,
+		"lines":      []string{"hello", "world"},
+	})
+	rt := &fakeRoundTripper{respStatus: http.StatusOK, respBody: respBody}
+	c := newFakeClient(t, rt)
+
+	frame, err := c.Panes().ReadOutput(context.Background(), "r@b", "agent")
+	if err != nil {
+		t.Fatalf("ReadOutput: %v", err)
+	}
+	if frame.Cols != 80 || frame.Rows != 24 {
+		t.Errorf("frame dims = (%d,%d), want (80,24)", frame.Cols, frame.Rows)
+	}
+	if frame.CursorX != 5 || frame.CursorY != 3 {
+		t.Errorf("cursor = (%d,%d), want (5,3)", frame.CursorX, frame.CursorY)
+	}
+	if !frame.AltScreen {
+		t.Errorf("alt screen = false, want true")
+	}
+	if len(frame.Lines) != 2 || frame.Lines[0] != "hello" || frame.Lines[1] != "world" {
+		t.Errorf("lines = %v, want [hello world]", frame.Lines)
+	}
+
+	// Verify the request shape — GET with the right query string.
+	if rt.lastReq.Method != http.MethodGet {
+		t.Errorf("method = %q, want GET", rt.lastReq.Method)
+	}
+	if rt.lastReq.URL.Path != "/pane/read_output" {
+		t.Errorf("path = %q, want /pane/read_output", rt.lastReq.URL.Path)
+	}
+	q, err := url.ParseQuery(rt.lastReq.URL.RawQuery)
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	if q.Get("session_id") != "r@b" || q.Get("name") != "agent" {
+		t.Errorf("query = %v, want session_id=r@b name=agent", q)
+	}
+}
+
+// TestPanesReadOutput_NilLines_PromotedToEmptySlice mirrors the
+// SessionAPI.List defensive normalisation — a server that ever
+// returns `"lines": null` (older build, future bug) should not force
+// the caller to nil-check.
+func TestPanesReadOutput_NilLines_PromotedToEmptySlice(t *testing.T) {
+	respBody := []byte(`{"cols": 0, "rows": 0, "lines": null}`)
+	rt := &fakeRoundTripper{respStatus: http.StatusOK, respBody: respBody}
+	c := newFakeClient(t, rt)
+
+	frame, err := c.Panes().ReadOutput(context.Background(), "r@b", "agent")
+	if err != nil {
+		t.Fatalf("ReadOutput: %v", err)
+	}
+	if frame.Lines == nil {
+		t.Errorf("Lines is nil; want empty slice")
+	}
+	if len(frame.Lines) != 0 {
+		t.Errorf("Lines has %d entries; want 0", len(frame.Lines))
+	}
+}
+
+// TestPanesReadOutput_ServerError surfaces a structured *ClientError
+// when the server returns 404/pane_not_found. The caller can branch
+// via errors.Is(err, ErrPaneNotFound).
+func TestPanesReadOutput_ServerError(t *testing.T) {
+	respBody, _ := json.Marshal(map[string]any{
+		"code":    CodePaneNotFound,
+		"message": "session \"r@b\" has no pane \"missing\"",
+	})
+	rt := &fakeRoundTripper{respStatus: http.StatusNotFound, respBody: respBody}
+	c := newFakeClient(t, rt)
+
+	_, err := c.Panes().ReadOutput(context.Background(), "r@b", "missing")
+	if err == nil {
+		t.Fatalf("ReadOutput: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), CodePaneNotFound) {
+		t.Errorf("error = %q, want it to mention %q", err.Error(), CodePaneNotFound)
+	}
+}

--- a/modules/programs/prism/prism/internal/mux/client/client_test.go
+++ b/modules/programs/prism/prism/internal/mux/client/client_test.go
@@ -266,7 +266,7 @@ func TestPanes_FullLifecycle(t *testing.T) {
 	}
 
 	for _, name := range []string{"agent", "term"} {
-		if err := c.Panes().Create(ctx, "r@b", name); err != nil {
+		if err := c.Panes().Create(ctx, "r@b", name, PaneCreateOptions{}); err != nil {
 			t.Fatalf("Pane.Create %q: %v", name, err)
 		}
 	}
@@ -362,7 +362,7 @@ func TestErrors_SentinelMapping(t *testing.T) {
 	if _, err := c.Sessions().Create(ctx, pane.Session{ID: "r@b", Repo: "r"}); err != nil {
 		t.Fatalf("seed session: %v", err)
 	}
-	if err := c.Panes().Create(ctx, "r@b", "agent"); err != nil {
+	if err := c.Panes().Create(ctx, "r@b", "agent", PaneCreateOptions{}); err != nil {
 		t.Fatalf("seed pane: %v", err)
 	}
 
@@ -419,7 +419,7 @@ func TestErrors_SentinelMapping(t *testing.T) {
 		{
 			name: "pane_exists",
 			do: func() error {
-				return c.Panes().Create(ctx, "r@b", "agent")
+				return c.Panes().Create(ctx, "r@b", "agent", PaneCreateOptions{})
 			},
 			want:     ErrPaneExists,
 			wantCode: CodePaneExists,

--- a/modules/programs/prism/prism/internal/mux/client/interfaces.go
+++ b/modules/programs/prism/prism/internal/mux/client/interfaces.go
@@ -62,10 +62,20 @@ type SessionAPI interface {
 
 // PaneAPI exposes the pane.* method namespace from the server.
 type PaneAPI interface {
-	// Create posts /pane/create.
-	Create(ctx context.Context, sessionID, name string) error
+	// Create posts /pane/create. opts.Argv (when non-empty) instructs the
+	// server to spawn the process under a PTY and host its output in a
+	// vt.Host. opts.Cwd is the child's working directory; opts.Env (when
+	// non-nil) replaces the daemon's environment; opts.Cols/Rows are the
+	// initial PTY geometry. A zero-value opts creates a model-only row
+	// with no PTY — useful for tests and for the legacy validate-only
+	// shape.
+	Create(ctx context.Context, sessionID, name string, opts PaneCreateOptions) error
 
-	// Destroy posts /pane/destroy.
+	// Destroy posts /pane/destroy. When a PTY is registered for the
+	// pane, the server signals the child (SIGTERM → grace → SIGKILL),
+	// waits for exit, and unregisters the host. Destroy returns once
+	// the model row is removed; PTY teardown is best-effort and never
+	// fails the API call.
 	Destroy(ctx context.Context, sessionID, name string) error
 
 	// List returns the panes for sessionID alongside the
@@ -80,16 +90,63 @@ type PaneAPI interface {
 	Switch(ctx context.Context, req PaneSwitchRequest) (string, error)
 
 	// Resize posts /pane/resize. cols and rows must be non-negative.
-	// The server currently validates the (session, pane) tuple and
-	// returns 200 without effecting the resize — actual geometry
-	// dispatch lands in a later PR — but the wire contract is stable
-	// from this PR onward.
+	// The server forwards the resize to the PTY (kernel will SIGWINCH
+	// the child) and updates the emulator's grid dimensions. Panes
+	// without a PTY accept the call as a no-op for wire-contract
+	// stability.
 	Resize(ctx context.Context, sessionID, name string, cols, rows int) error
 
-	// SendInput posts /pane/send_input. As with Resize, the server
-	// currently validates and returns 200 without effecting input
-	// delivery; the wire contract is the stable part.
+	// SendInput posts /pane/send_input. The bytes are written verbatim
+	// to the PTY master FD (which the kernel presents to the child as
+	// stdin). Panes without a PTY accept the call as a no-op.
 	SendInput(ctx context.Context, sessionID, name, data string) error
+
+	// ReadOutput posts GET /pane/read_output. Returns a snapshot of
+	// the rendered cell grid for the renderer's polling tick. Panes
+	// without a PTY return a zero-dimension PaneFrame with an empty
+	// Lines slice.
+	ReadOutput(ctx context.Context, sessionID, name string) (PaneFrame, error)
+}
+
+// PaneCreateOptions carries the runtime-side fields the server uses
+// to spawn a PTY for the new pane. The zero value is valid: it
+// produces a model-only row with no PTY.
+type PaneCreateOptions struct {
+	// Argv is the executable + arguments to spawn. argv[0] is the
+	// program to exec. An empty Argv creates a model-only row with
+	// no PTY.
+	Argv []string
+
+	// Cwd is the child's working directory. Empty means "inherit the
+	// daemon's cwd" — in practice the user's $HOME, not what the
+	// CLI wants. Pass an explicit absolute path.
+	Cwd string
+
+	// Env is the child's environment. Nil means "inherit the daemon's
+	// env"; a non-nil but empty map means "start with an empty env".
+	Env map[string]string
+
+	// Cols and Rows are the initial PTY geometry. Zero falls back to
+	// a conventional 80x24; the renderer resizes on first paint.
+	Cols uint16
+	Rows uint16
+}
+
+// PaneFrame is the typed response shape for PaneAPI.ReadOutput. It is
+// a polling-shape snapshot of the pane's rendered cell grid — one
+// string per visible row, padded to the row count, with cursor
+// coordinates and the alt-screen flag for renderer chrome.
+//
+// When the pane has no PTY (created with an empty Argv) the returned
+// PaneFrame carries Cols=0 and Rows=0 with an empty Lines slice; the
+// renderer treats this as "no content yet" and shows the placeholder.
+type PaneFrame struct {
+	Cols      int      `json:"cols"`
+	Rows      int      `json:"rows"`
+	CursorX   int      `json:"cursor_x"`
+	CursorY   int      `json:"cursor_y"`
+	AltScreen bool     `json:"alt_screen"`
+	Lines     []string `json:"lines"`
 }
 
 // SessionList is the typed response shape for SessionAPI.List. The

--- a/modules/programs/prism/prism/internal/mux/client/interfaces_test.go
+++ b/modules/programs/prism/prism/internal/mux/client/interfaces_test.go
@@ -62,19 +62,20 @@ func (f *fakeSessionAPI) Switch(ctx context.Context, id string) (string, error) 
 }
 
 type fakePaneAPI struct {
-	createFn    func(ctx context.Context, sessionID, name string) error
-	destroyFn   func(ctx context.Context, sessionID, name string) error
-	listFn      func(ctx context.Context, sessionID string) (client.PaneList, error)
-	switchFn    func(ctx context.Context, req client.PaneSwitchRequest) (string, error)
-	resizeFn    func(ctx context.Context, sessionID, name string, cols, rows int) error
-	sendInputFn func(ctx context.Context, sessionID, name, data string) error
+	createFn     func(ctx context.Context, sessionID, name string, opts client.PaneCreateOptions) error
+	destroyFn    func(ctx context.Context, sessionID, name string) error
+	listFn       func(ctx context.Context, sessionID string) (client.PaneList, error)
+	switchFn     func(ctx context.Context, req client.PaneSwitchRequest) (string, error)
+	resizeFn     func(ctx context.Context, sessionID, name string, cols, rows int) error
+	sendInputFn  func(ctx context.Context, sessionID, name, data string) error
+	readOutputFn func(ctx context.Context, sessionID, name string) (client.PaneFrame, error)
 }
 
-func (f *fakePaneAPI) Create(ctx context.Context, sessionID, name string) error {
+func (f *fakePaneAPI) Create(ctx context.Context, sessionID, name string, opts client.PaneCreateOptions) error {
 	if f.createFn == nil {
 		return nil
 	}
-	return f.createFn(ctx, sessionID, name)
+	return f.createFn(ctx, sessionID, name, opts)
 }
 func (f *fakePaneAPI) Destroy(ctx context.Context, sessionID, name string) error {
 	if f.destroyFn == nil {
@@ -105,6 +106,12 @@ func (f *fakePaneAPI) SendInput(ctx context.Context, sessionID, name, data strin
 		return nil
 	}
 	return f.sendInputFn(ctx, sessionID, name, data)
+}
+func (f *fakePaneAPI) ReadOutput(ctx context.Context, sessionID, name string) (client.PaneFrame, error) {
+	if f.readOutputFn == nil {
+		return client.PaneFrame{}, nil
+	}
+	return f.readOutputFn(ctx, sessionID, name)
 }
 
 // Compile-time interface-satisfaction checks. These run at build

--- a/modules/programs/prism/prism/internal/mux/client/pane.go
+++ b/modules/programs/prism/prism/internal/mux/client/pane.go
@@ -13,9 +13,20 @@ type paneAPI struct {
 }
 
 // paneCreateWire matches server.paneCreateRequest.
+//
+// Argv (when non-empty) instructs the server to spawn the process
+// under a PTY and host its output in a vt.Host. Cwd is the child's
+// working directory; Env (when non-nil) replaces the daemon's
+// environment. Cols / Rows are the initial PTY geometry — zero falls
+// back to a conventional 80x24.
 type paneCreateWire struct {
-	SessionID string `json:"session_id"`
-	Name      string `json:"name"`
+	SessionID string            `json:"session_id"`
+	Name      string            `json:"name"`
+	Argv      []string          `json:"argv,omitempty"`
+	Cwd       string            `json:"cwd,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	Cols      uint16            `json:"cols,omitempty"`
+	Rows      uint16            `json:"rows,omitempty"`
 }
 
 // paneDestroyWire matches server.paneDestroyRequest.
@@ -44,11 +55,24 @@ type paneSendInputWire struct {
 	Data      string `json:"data"`
 }
 
-// Create posts /pane/create.
-func (p *paneAPI) Create(ctx context.Context, sessionID, name string) error {
+// Create posts /pane/create. The opts struct carries the runtime-side
+// fields the server needs to spawn a process under a PTY — Argv, Cwd,
+// Env, Cols, Rows. Callers that only want a model-side row (no PTY)
+// pass a zero-value PaneCreateOptions, matching the pre-#2158 shape.
+//
+// Returns *ClientError on a structured server error (model-side
+// failures: ErrSessionNotFound, ErrPaneExists), or ErrServerUnavailable
+// on a connection failure. A PTY-spawn failure surfaces as a 500 with
+// the underlying os/exec error in Message.
+func (p *paneAPI) Create(ctx context.Context, sessionID, name string, opts PaneCreateOptions) error {
 	return p.c.doPost(ctx, "/pane/create", paneCreateWire{
 		SessionID: sessionID,
 		Name:      name,
+		Argv:      opts.Argv,
+		Cwd:       opts.Cwd,
+		Env:       opts.Env,
+		Cols:      opts.Cols,
+		Rows:      opts.Rows,
 	}, nil)
 }
 
@@ -100,13 +124,57 @@ func (p *paneAPI) Resize(ctx context.Context, sessionID, name string, cols, rows
 	}, nil)
 }
 
-// SendInput posts /pane/send_input. data is opaque to the server at
-// this layer (PTY integration lands in a later PR) but is included
-// in the wire shape now so the contract is stable.
+// SendInput posts /pane/send_input. The bytes are written verbatim to
+// the PTY master FD (the kernel presents this to the child as stdin).
+// When the pane has no PTY (created with an empty Argv), the call is a
+// no-op and returns nil so the model side stays consistent.
 func (p *paneAPI) SendInput(ctx context.Context, sessionID, name, data string) error {
 	return p.c.doPost(ctx, "/pane/send_input", paneSendInputWire{
 		SessionID: sessionID,
 		Name:      name,
 		Data:      data,
 	}, nil)
+}
+
+// paneReadOutputResponseWire matches server.paneReadOutputResponse.
+type paneReadOutputResponseWire struct {
+	Cols      int      `json:"cols"`
+	Rows      int      `json:"rows"`
+	CursorX   int      `json:"cursor_x"`
+	CursorY   int      `json:"cursor_y"`
+	AltScreen bool     `json:"alt_screen"`
+	Lines     []string `json:"lines"`
+}
+
+// ReadOutput posts GET /pane/read_output. Returns a snapshot of the
+// pane's rendered cell grid suitable for the renderer's polling tick.
+//
+// The Lines slice is the vt.Host's RenderRows() output — one string
+// per visible row, padded to the row count. Cursor coordinates are
+// in row-major form (CursorY is the row index, CursorX the column).
+// Cols / Rows are the engine's current dimensions.
+//
+// When the pane has no PTY (created with an empty Argv), the returned
+// PaneFrame carries Cols=0 and Rows=0 with an empty Lines slice — the
+// model row exists but there is no rendered content.
+func (p *paneAPI) ReadOutput(ctx context.Context, sessionID, name string) (PaneFrame, error) {
+	q := url.Values{}
+	q.Set("session_id", sessionID)
+	q.Set("name", name)
+
+	var resp paneReadOutputResponseWire
+	if err := p.c.doGet(ctx, "/pane/read_output", q, &resp); err != nil {
+		return PaneFrame{}, err
+	}
+	if resp.Lines == nil {
+		resp.Lines = []string{}
+	}
+	return PaneFrame{
+		Cols:      resp.Cols,
+		Rows:      resp.Rows,
+		CursorX:   resp.CursorX,
+		CursorY:   resp.CursorY,
+		AltScreen: resp.AltScreen,
+		Lines:     resp.Lines,
+	}, nil
 }

--- a/modules/programs/prism/prism/internal/mux/pty/pty.go
+++ b/modules/programs/prism/prism/internal/mux/pty/pty.go
@@ -22,7 +22,28 @@ type Session struct {
 // returns a Session whose File is the master side. The caller must Close()
 // the session when done.
 func Start(argv []string, cols, rows uint16) (*Session, error) {
+	return StartWithEnv(argv, cols, rows, "", nil)
+}
+
+// StartWithEnv is the env-and-cwd-aware form of Start. It exists so the
+// server's pane.create handler (internal/mux/server) can spawn the
+// caller-supplied process under a custom working directory and a
+// caller-controlled environment without re-implementing the pty wiring.
+//
+//   - argv MUST be non-empty; argv[0] is the executable to spawn.
+//   - cwd is the child's working directory. Empty means "inherit".
+//   - env is the child's environment in os/exec form (["KEY=VALUE", …]).
+//     Nil means "inherit the parent's environment" (the default Start
+//     behaviour); a non-nil but empty slice means "start with an empty
+//     environment".
+func StartWithEnv(argv []string, cols, rows uint16, cwd string, env []string) (*Session, error) {
 	cmd := exec.Command(argv[0], argv[1:]...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	if env != nil {
+		cmd.Env = env
+	}
 	// Inherit env. We want $TERM=xterm-256color so apps drive truecolor where
 	// they can — x/vt is the one rendering, so colour negotiation is up to it.
 	f, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: cols, Rows: rows})

--- a/modules/programs/prism/prism/internal/mux/server/output.go
+++ b/modules/programs/prism/prism/internal/mux/server/output.go
@@ -1,0 +1,133 @@
+package server
+
+// /pane/read_output — pull-shape snapshot endpoint for the renderer.
+//
+// The renderer (internal/mux/render) repaints on a tick and wants the
+// latest cell-grid frame for the active pane. We expose two surfaces:
+//
+//  1. In-process: Server.HostFor(sessionID, paneName) returns the live
+//     *vt.Host so a renderer running in the same process (the
+//     prismd-mux daemon plus an embedded TUI) can read RenderRows()
+//     directly with no per-frame allocation.
+//
+//  2. Out-of-process (the soak shape): GET /pane/read_output returns
+//     the rendered rows + dimensions + cursor position as a JSON
+//     PaneFrame. A separate `prism attach` style client builds a
+//     synthetic vt.Host from this on each poll. Lossier than the
+//     in-process path but sufficient for the post-#2158 phase-3 soak.
+//
+// The endpoint is a GET because reads are idempotent and the client
+// can cache the response on retry. Request shape: ?session_id=X&name=Y.
+
+import (
+	"net/http"
+
+	"github.com/prismatic-koi/prism/internal/mux/vt"
+)
+
+// paneReadOutputResponse is the wire shape for GET /pane/read_output.
+// Rows are the emulator's per-row Render() output, padded to the
+// configured row count (matches vt.Host.RenderRows()). Cols / Rows are
+// the engine's current dimensions; CursorX / CursorY are the cursor
+// position inside that grid.
+//
+// AltScreen reports whether the emulator is currently on the alt
+// screen — useful for clients that want to skip status-bar overlays
+// when a full-screen TUI is running.
+type paneReadOutputResponse struct {
+	Cols      int      `json:"cols"`
+	Rows      int      `json:"rows"`
+	CursorX   int      `json:"cursor_x"`
+	CursorY   int      `json:"cursor_y"`
+	AltScreen bool     `json:"alt_screen"`
+	Lines     []string `json:"lines"`
+}
+
+func (s *Server) handlePaneReadOutput(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	sessID := r.URL.Query().Get("session_id")
+	name := r.URL.Query().Get("name")
+	if sessID == "" || name == "" {
+		writeError(w, http.StatusBadRequest, codeBadRequest,
+			"session_id and name query parameters are required",
+			map[string]any{"session_id": sessID, "name": name})
+		return
+	}
+	if err := s.checkPaneExists(sessID, name); err != nil {
+		writePaneErr(w, err, map[string]any{
+			"session_id": sessID,
+			"name":       name,
+		})
+		return
+	}
+
+	host, ok := s.ptys.get(sessID, name)
+	if !ok || host == nil || host.Host() == nil {
+		// Pane exists in the model but has no PTY (e.g. created with
+		// an empty argv). Return an empty frame rather than a 404 —
+		// the renderer treats this as "no content yet" and shows the
+		// placeholder. Dimensions are reported as zero so the client
+		// can distinguish this from a 0-row pane.
+		writeJSON(w, paneReadOutputResponse{
+			Cols:  0,
+			Rows:  0,
+			Lines: []string{},
+		})
+		return
+	}
+
+	vtHost := host.Host()
+	cols, rows := vtHost.Size()
+	snap := vtHost.Snapshot()
+	lines := vtHost.RenderRows()
+	if lines == nil {
+		lines = []string{}
+	}
+	writeJSON(w, paneReadOutputResponse{
+		Cols:      cols,
+		Rows:      rows,
+		CursorX:   snap.CursorX,
+		CursorY:   snap.CursorY,
+		AltScreen: snap.AltScreen,
+		Lines:     lines,
+	})
+}
+
+// HostFor returns the live *vt.Host for (sessionID, paneName), or nil
+// when no PTY is registered (pane absent, or created with an empty
+// argv). Exposed for in-process renderer wiring — the returned value
+// satisfies the structural shape of render.HostProvider's Host method
+// without this package needing to import render.
+//
+// The returned host is shared with the server's pump goroutines; do
+// NOT mutate it. Concurrent reads (RenderRows / Snapshot) are safe per
+// the vt.Host contract.
+func (s *Server) HostFor(sessionID, paneName string) *vt.Host {
+	if s == nil || s.ptys == nil {
+		return nil
+	}
+	host, ok := s.ptys.get(sessionID, paneName)
+	if !ok || host == nil {
+		return nil
+	}
+	return host.Host()
+}
+
+// HostProviderFunc adapts Server.HostFor into a stand-alone function
+// value. The renderer's HostProvider interface is a single-method
+// "Host(sessionID, paneName string) *vt.Host" — a *Server already
+// satisfies that structurally, but a function value is sometimes
+// easier to pass around in wiring code.
+//
+// Returns nil when s is nil so callers can write
+// `render.WithHosts(render.HostFunc(srv.HostProviderFunc()))` without
+// nil-checking.
+func (s *Server) HostProviderFunc() func(string, string) *vt.Host {
+	if s == nil {
+		return nil
+	}
+	return s.HostFor
+}
+

--- a/modules/programs/prism/prism/internal/mux/server/pty_hosts.go
+++ b/modules/programs/prism/prism/internal/mux/server/pty_hosts.go
@@ -1,0 +1,408 @@
+package server
+
+// PTY runtime hosting for the mux server.
+//
+// The pane *model* (internal/mux/pane.SessionTree) is intentionally
+// runtime-agnostic — it carries names and ordering, no PTY handles. The
+// server owns the runtime side: each (sessionID, paneName) tuple that
+// was created with a non-empty argv has a live *pty.Session feeding a
+// *vt.Host. This file owns the map, the lifecycle, and the goroutines
+// that bridge bytes from the kernel PTY into the VT engine and back.
+//
+// The split mirrors the design doc §4 ("the sidecar runs detached … the
+// data model is multiplexer-independent") and keeps the spike's
+// "host stays pure" property intact: nothing under internal/mux/pane
+// imports os/exec or the pty package; the server is the only layer
+// that does, and only inside this file.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/mux/pty"
+	"github.com/prismatic-koi/prism/internal/mux/vt"
+)
+
+// Pane-creation default geometry. The PTY package requires an explicit
+// (cols, rows) tuple; we pick a conventional 80x24 when the caller
+// (the CLI today) does not pass an initial geometry. The renderer
+// resizes on first paint anyway.
+const (
+	defaultPTYCols uint16 = 80
+	defaultPTYRows uint16 = 24
+)
+
+// destroyGrace bounds the SIGTERM → SIGKILL escalation window when a
+// pane is destroyed. 2 s is generous for a healthy shell to exit, fast
+// enough not to wedge the API for an unresponsive child.
+const destroyGrace = 2 * time.Second
+
+// paneKey identifies one PTY host inside the server's runtime map.
+// Sessions are unique tree-wide, and pane names are unique per session
+// (enforced by SessionTree.AddPane), so (session, pane) is the natural
+// composite key.
+type paneKey struct {
+	session string
+	pane    string
+}
+
+// ptyHost is the runtime counterpart to a pane.Pane — a spawned process,
+// its PTY master, the VT engine that consumes its output, and the
+// goroutines that pump bytes between them.
+//
+// The zero ptyHost is NOT useful; construct via startPTYHost.
+type ptyHost struct {
+	pty  *pty.Session
+	host *vt.Host
+
+	// argv / cwd / env are kept for diagnostics — the wire-shape
+	// fields are not echoed back to clients today, but knowing what
+	// was spawned is invaluable in logs.
+	argv []string
+	cwd  string
+
+	// cols / rows track the most recently applied geometry so a
+	// follow-up Resize that matches becomes a quick no-op.
+	cols uint16
+	rows uint16
+
+	// done is closed once both pump goroutines exit and the underlying
+	// process has been waited on. Tests use this to deterministically
+	// observe lifecycle completion.
+	done chan struct{}
+}
+
+// startPTYHost spawns argv under a PTY, wires the master FD into a new
+// vt.Host (cols × rows), and starts the two pump goroutines:
+//
+//   - PTY → VT — reads bytes from the master and feeds them into the
+//     emulator. Exits on EOF (child closed its FD) or read error.
+//   - VT → PTY — drains the emulator's response stream (DSR replies,
+//     OSC responses, mode queries) back into the master so the hosted
+//     TUI does not block waiting for them. Exits on EOF after the
+//     master is closed.
+//
+// Returns the live ptyHost. The caller is responsible for installing it
+// in the server's map and for invoking Close when the pane is destroyed.
+//
+// argv MUST be non-empty; an empty argv is rejected by the handler
+// before this function is called.
+func startPTYHost(argv []string, cwd string, env map[string]string, cols, rows uint16, logger *log.Logger) (*ptyHost, error) {
+	if len(argv) == 0 {
+		return nil, errors.New("mux/server: startPTYHost: empty argv")
+	}
+	if cols == 0 {
+		cols = defaultPTYCols
+	}
+	if rows == 0 {
+		rows = defaultPTYRows
+	}
+
+	envSlice := buildPTYEnv(env, cwd)
+
+	sess, err := pty.StartWithEnv(argv, cols, rows, cwd, envSlice)
+	if err != nil {
+		return nil, fmt.Errorf("start pty: %w", err)
+	}
+
+	host := vt.New(int(cols), int(rows))
+
+	h := &ptyHost{
+		pty:  sess,
+		host: host,
+		argv: append([]string(nil), argv...),
+		cwd:  cwd,
+		cols: cols,
+		rows: rows,
+		done: make(chan struct{}),
+	}
+
+	// Bridge goroutines. We track both via a WaitGroup so the done
+	// channel only closes once nothing is touching the PTY or host —
+	// otherwise a Close() observer racing the pumps could see them
+	// still draining post-close.
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// PTY → VT pump. Exits when the master FD is closed (EBADF / EIO)
+	// or when the child closes its end (EOF). This is the only pump
+	// the bridge waits for — see the DrainResponses note below.
+	go func() {
+		defer wg.Done()
+		if err := host.FeedReader(sess.File); err != nil && !isClosedPipe(err) && logger != nil {
+			logger.Printf("mux/server: pty→vt pump exited: %v", err)
+		}
+	}()
+
+	// VT → PTY pump (DSR replies, OSC responses, mode queries). Per
+	// the spike AC documented in internal/mux/vt/vt_test.go on
+	// TestDrainResponsesEmitsDSRReply, this goroutine intentionally
+	// leaks for the process lifetime — the spike's port of vt.Host
+	// deliberately does NOT expose a Close hook, and reaching into
+	// x/vt.Emulator.Close directly trips an upstream race on
+	// e.closed under -race (the race is harmless — io.Pipe handles
+	// the actual unblock — but the detector flags it).
+	//
+	// The leak is bounded: one extra goroutine per pane destroy,
+	// each holding a 4 KiB buffer + a reference to the host. For a
+	// daemon that lives across a phase-3 soak, that is acceptable;
+	// when the wider programme is ready to revisit the spike AC the
+	// fix is upstream, not here.
+	//
+	// Without this pump, well-behaved TUIs that emit DSR or OSC
+	// queries deadlock once x/vt's internal pipe buffer (~64 KiB)
+	// fills, so it cannot simply be omitted. The pump exits whenever
+	// the master FD is closed AFTER the emulator has buffered a
+	// response (DrainResponses' Write fails), but for silent TUIs
+	// the goroutine is steady-state idle.
+	go func() {
+		if err := host.DrainResponses(sess.File); err != nil && !isClosedPipe(err) && logger != nil {
+			logger.Printf("mux/server: vt→pty pump exited: %v", err)
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		// Reap the child so it does not become a zombie. Best-effort —
+		// the process may already have been waited on by Close. The
+		// second Wait on a reaped child returns ECHILD; we ignore it.
+		if sess.Cmd != nil && sess.Cmd.Process != nil {
+			_, _ = sess.Cmd.Process.Wait()
+		}
+		close(h.done)
+	}()
+
+	return h, nil
+}
+
+// SendInput writes data into the PTY's master FD (which the kernel
+// presents as the child's stdin). The master FD is buffered by the
+// kernel; a short write is unexpected at the byte sizes the CLI sends
+// (single keystrokes, small pastes) but we still report a partial-write
+// error rather than swallow it.
+func (h *ptyHost) SendInput(data []byte) error {
+	if h == nil || h.pty == nil || h.pty.File == nil {
+		return errors.New("mux/server: pty host is not started")
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	n, err := h.pty.File.Write(data)
+	if err != nil {
+		return fmt.Errorf("write pty stdin: %w", err)
+	}
+	if n != len(data) {
+		return fmt.Errorf("short write to pty stdin: %d of %d bytes", n, len(data))
+	}
+	return nil
+}
+
+// Resize updates the PTY winsize (kernel will SIGWINCH the child) and
+// the emulator's grid dimensions. Both are forwarded — they must stay
+// in lock-step or the renderer's frames will not match the child's
+// notion of the terminal size.
+func (h *ptyHost) Resize(cols, rows uint16) error {
+	if h == nil || h.pty == nil {
+		return errors.New("mux/server: pty host is not started")
+	}
+	if cols == h.cols && rows == h.rows {
+		return nil
+	}
+	if err := h.pty.Resize(cols, rows); err != nil {
+		return fmt.Errorf("resize pty: %w", err)
+	}
+	h.host.Resize(int(cols), int(rows))
+	h.cols = cols
+	h.rows = rows
+	return nil
+}
+
+// Close signals the child to exit, then closes the master FD so the
+// pump goroutines unblock. SIGTERM goes out first; the master FD is
+// closed in parallel so the PTY → VT pump unblocks immediately. After
+// destroyGrace, escalates to SIGKILL if the process is still alive.
+// Close is safe to call multiple times — subsequent calls are no-ops
+// (signal returns ESRCH, file close returns ErrClosed; both ignored).
+func (h *ptyHost) Close() error {
+	if h == nil {
+		return nil
+	}
+	if h.pty == nil {
+		return nil
+	}
+	proc := h.pty.Cmd.Process
+	if proc != nil {
+		// Send SIGTERM first so a well-behaved child cleans up
+		// (e.g. resets terminal modes). The kernel delivers SIGTERM
+		// regardless of whether the master FD is open.
+		_ = proc.Signal(syscall.SIGTERM)
+	}
+	// Closing the master FD breaks the PTY → VT pump out of its read
+	// (EBADF / EIO). The pump's deferred host.Close() then unblocks
+	// DrainResponses with io.EOF. The done channel closes once both
+	// pumps and the proc.Wait have returned.
+	if h.pty.File != nil {
+		_ = h.pty.File.Close()
+	}
+	// Escalate to SIGKILL after destroyGrace if the child is still
+	// alive. We do not block the caller waiting for this — the
+	// monitor goroutine handles it.
+	if proc != nil {
+		go func() {
+			select {
+			case <-h.done:
+				// Bridge already drained; nothing to escalate.
+			case <-time.After(destroyGrace):
+				_ = proc.Signal(syscall.SIGKILL)
+			}
+		}()
+	}
+	return nil
+}
+
+// Host returns the underlying *vt.Host. Used by the renderer's
+// HostProvider adapter and by the /pane/read_output handler. Returns
+// nil if the host has not been started, which the caller treats as
+// "no PTY for this pane".
+func (h *ptyHost) Host() *vt.Host {
+	if h == nil {
+		return nil
+	}
+	return h.host
+}
+
+// buildPTYEnv normalises an env map into the os/exec-style ["KEY=VALUE"]
+// slice the syscall layer expects. When env is nil the child inherits
+// the daemon's environment; pass an empty (but non-nil) map to start
+// with an empty environment.
+//
+// The cwd argument is informational only — pty.StartWithEnv passes it
+// to exec.Cmd.Dir directly. We accept it here for symmetry with the
+// startPTYHost signature.
+func buildPTYEnv(env map[string]string, _ string) []string {
+	if env == nil {
+		// Nil map → inherit parent env. Returning nil here makes
+		// pty.StartWithEnv use os.Environ().
+		return nil
+	}
+	out := make([]string, 0, len(env))
+	for k, v := range env {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// isClosedPipe reports whether err is the harmless "the master FD was
+// closed" failure mode. Used by the pump goroutines so a clean
+// pane.Destroy does not log a spurious error line for every torn-down
+// pane.
+func isClosedPipe(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+		return true
+	}
+	// "file already closed" / "input/output error" / "use of closed
+	// file" all surface as wrapped *os.PathError with these err strings
+	// on Linux/Darwin. Match by the underlying syscall errno rather
+	// than the string so the check is portable.
+	if errors.Is(err, syscall.EIO) || errors.Is(err, syscall.EBADF) {
+		return true
+	}
+	return false
+}
+
+// ptyRegistry tracks the live ptyHost for each (session, pane) tuple.
+// All operations are serialised through the registry's mutex so concurrent
+// pane.create / pane.destroy from different HTTP handlers cannot race.
+//
+// The registry is intentionally distinct from pane.SessionTree — the tree
+// stays pure data; the registry is the runtime side. See file docstring.
+type ptyRegistry struct {
+	mu    sync.Mutex
+	hosts map[paneKey]*ptyHost
+}
+
+// newPTYRegistry returns an empty, ready-to-use registry.
+func newPTYRegistry() *ptyRegistry {
+	return &ptyRegistry{hosts: make(map[paneKey]*ptyHost)}
+}
+
+// add installs host under (session, pane). Returns an error if a host
+// is already registered for the key — the server enforces "create on
+// an existing pane is a 409" at the model layer, so a duplicate here
+// would indicate a programming error.
+func (r *ptyRegistry) add(session, name string, host *ptyHost) error {
+	if host == nil {
+		return errors.New("mux/server: ptyRegistry.add: nil host")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := paneKey{session: session, pane: name}
+	if _, exists := r.hosts[key]; exists {
+		return fmt.Errorf("mux/server: pty host already registered for %q/%q", session, name)
+	}
+	r.hosts[key] = host
+	return nil
+}
+
+// get returns the host for (session, pane) and true, or nil and false
+// if no host is registered. Callers must not hold the host past the
+// next destroy on the same key — registry.remove invalidates the
+// returned pointer.
+func (r *ptyRegistry) get(session, name string) (*ptyHost, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	h, ok := r.hosts[paneKey{session: session, pane: name}]
+	return h, ok
+}
+
+// remove pops (session, pane) from the map and returns the prior host
+// (or nil if none was registered). The caller is responsible for
+// Close()-ing the returned host.
+func (r *ptyRegistry) remove(session, name string) *ptyHost {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := paneKey{session: session, pane: name}
+	h := r.hosts[key]
+	delete(r.hosts, key)
+	return h
+}
+
+// removeSession pops every host whose session matches and returns them.
+// Used by /session/destroy so PTY cleanup cascades atomically with the
+// model-level RemoveSession.
+func (r *ptyRegistry) removeSession(session string) []*ptyHost {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []*ptyHost
+	for key, host := range r.hosts {
+		if key.session == session {
+			out = append(out, host)
+			delete(r.hosts, key)
+		}
+	}
+	return out
+}
+
+// closeAll Close()s every host in the registry and clears it. Used by
+// Server.Close so a test/process shutdown does not leak PTY children.
+func (r *ptyRegistry) closeAll() {
+	r.mu.Lock()
+	hosts := make([]*ptyHost, 0, len(r.hosts))
+	for _, h := range r.hosts {
+		hosts = append(hosts, h)
+	}
+	r.hosts = make(map[paneKey]*ptyHost)
+	r.mu.Unlock()
+	for _, h := range hosts {
+		_ = h.Close()
+	}
+}

--- a/modules/programs/prism/prism/internal/mux/server/server.go
+++ b/modules/programs/prism/prism/internal/mux/server/server.go
@@ -28,13 +28,25 @@ const maxRequestBodyBytes = 1 << 20 // 1 MiB
 // have to drain before we close their connections.
 const shutdownGrace = 2 * time.Second
 
-// Server is the prism mux Unix-socket API server. It owns no state of
-// its own beyond a pointer to the underlying SessionTree; all
-// concurrency is serialised through the tree's existing mutex.
+// Server is the prism mux Unix-socket API server. It owns the
+// SessionTree (pane model) and the runtime ptyRegistry that tracks
+// the live *pty.Session + *vt.Host pair for each pane that was
+// created with a non-empty argv. The model is intentionally pure data
+// — the runtime side lives here so the pane package never has to
+// import os/exec or the pty package.
+//
+// Concurrency:
+//
+//   - The SessionTree has its own mutex; we never lock it externally.
+//   - The ptyRegistry has its own mutex.
+//   - The two are sequenced inside each handler: we always touch the
+//     tree first (so a 4xx fails before any side effects on the
+//     runtime) and then the registry.
 //
 // The zero value is NOT ready for use — construct with New.
 type Server struct {
 	tree   *pane.SessionTree
+	ptys   *ptyRegistry
 	logger *log.Logger
 }
 
@@ -60,12 +72,23 @@ func New(tree *pane.SessionTree, opts ...Option) *Server {
 	}
 	s := &Server{
 		tree:   tree,
+		ptys:   newPTYRegistry(),
 		logger: log.Default(),
 	}
 	for _, opt := range opts {
 		opt(s)
 	}
 	return s
+}
+
+// Close releases every live PTY host. Tests use this to ensure their
+// spawned children are reaped before t.Cleanup runs; production
+// callers do not need it (process exit cleans up).
+func (s *Server) Close() {
+	if s == nil || s.ptys == nil {
+		return
+	}
+	s.ptys.closeAll()
 }
 
 // Tree returns the SessionTree the server is bound to. Provided so
@@ -90,6 +113,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/pane/switch", s.handlePaneSwitch)
 	mux.HandleFunc("/pane/resize", s.handlePaneResize)
 	mux.HandleFunc("/pane/send_input", s.handlePaneSendInput)
+	mux.HandleFunc("/pane/read_output", s.handlePaneReadOutput)
 
 	// Fall-through: anything not matched above is a 404 with a structured
 	// body so the CLI client gets a consistent error shape regardless of
@@ -349,6 +373,15 @@ func (s *Server) handleSessionDestroy(w http.ResponseWriter, r *http.Request) {
 		writePaneErr(w, err, map[string]any{"id": req.ID})
 		return
 	}
+	// Cascade PTY teardown for every pane that belonged to the destroyed
+	// session. Done after the model accepts the remove so a 4xx returns
+	// without killing children.
+	for _, host := range s.ptys.removeSession(req.ID) {
+		if err := host.Close(); err != nil && s.logger != nil {
+			s.logger.Printf("mux/server: session.destroy cascade close (%s): %v",
+				req.ID, err)
+		}
+	}
 	writeJSON(w, struct{}{})
 }
 
@@ -411,9 +444,30 @@ func (s *Server) handleSessionSwitch(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 // paneCreateRequest is the wire shape for POST /pane/create.
+//
+// Argv (when non-empty) tells the server to spawn the process under a
+// PTY and host its output in a vt.Host. The pane row in the model is
+// runtime-agnostic; the PTY handle and the VT engine live in the
+// server's internal ptyRegistry, keyed by (SessionID, Name).
+//
+// Cwd is the child's working directory. Env, when non-nil, replaces
+// the daemon's environment. A nil Env means "inherit the daemon's
+// env" — the typical CLI shape.
+//
+// Cols / Rows are the initial PTY geometry. Zero falls back to a
+// conventional 80x24; the renderer resizes on first paint.
+//
+// When Argv is empty the pane is created as a pure data-model entry
+// with no PTY — useful for tests and for the legacy "validate-only"
+// behaviour from before #2158.
 type paneCreateRequest struct {
-	SessionID string `json:"session_id"`
-	Name      string `json:"name"`
+	SessionID string            `json:"session_id"`
+	Name      string            `json:"name"`
+	Argv      []string          `json:"argv,omitempty"`
+	Cwd       string            `json:"cwd,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	Cols      uint16            `json:"cols,omitempty"`
+	Rows      uint16            `json:"rows,omitempty"`
 }
 
 func (s *Server) handlePaneCreate(w http.ResponseWriter, r *http.Request) {
@@ -429,12 +483,51 @@ func (s *Server) handlePaneCreate(w http.ResponseWriter, r *http.Request) {
 			"session_id and name are required", nil)
 		return
 	}
+	// Model insertion first so a duplicate / unknown-session error is
+	// reported before we go to the work of spawning a child process.
 	if err := s.tree.AddPane(req.SessionID, pane.Pane{Name: req.Name}); err != nil {
 		writePaneErr(w, err, map[string]any{
 			"session_id": req.SessionID,
 			"name":       req.Name,
 		})
 		return
+	}
+
+	// Runtime side: only spawn a PTY when the caller supplied an argv.
+	// An empty argv is the legacy "validate-only" shape — the pane row
+	// is created in the model and that is all.
+	if len(req.Argv) > 0 {
+		host, err := startPTYHost(req.Argv, req.Cwd, req.Env, req.Cols, req.Rows, s.logger)
+		if err != nil {
+			// Roll the model insertion back so a failed spawn leaves no
+			// trace — callers retrying see a clean slate.
+			if rmErr := s.tree.RemovePane(req.SessionID, req.Name); rmErr != nil && s.logger != nil {
+				s.logger.Printf("mux/server: pane.create rollback (RemovePane): %v", rmErr)
+			}
+			writeError(w, http.StatusInternalServerError, codeInternal,
+				fmt.Sprintf("spawn pty: %v", err),
+				map[string]any{
+					"session_id": req.SessionID,
+					"name":       req.Name,
+				})
+			return
+		}
+		if err := s.ptys.add(req.SessionID, req.Name, host); err != nil {
+			// Programming-error path: the model said the pane was new,
+			// but the registry already had a host. Clean both up so the
+			// next call sees a consistent state, then report 500.
+			_ = host.Close()
+			if rmErr := s.tree.RemovePane(req.SessionID, req.Name); rmErr != nil && s.logger != nil {
+				s.logger.Printf("mux/server: pane.create rollback (RemovePane): %v", rmErr)
+			}
+			writeError(w, http.StatusInternalServerError, codeInternal,
+				fmt.Sprintf("register pty host: %v", err),
+				map[string]any{
+					"session_id": req.SessionID,
+					"name":       req.Name,
+				})
+			return
+		}
 	}
 	writeJSON(w, struct{}{})
 }
@@ -464,6 +557,16 @@ func (s *Server) handlePaneDestroy(w http.ResponseWriter, r *http.Request) {
 			"name":       req.Name,
 		})
 		return
+	}
+	// Runtime teardown after the model side has accepted the destroy.
+	// SIGTERM → (destroyGrace) → SIGKILL, then close the master FD so
+	// the pump goroutines unblock. Best-effort: a destroy can never
+	// fail the API call once the model side has succeeded.
+	if host := s.ptys.remove(req.SessionID, req.Name); host != nil {
+		if err := host.Close(); err != nil && s.logger != nil {
+			s.logger.Printf("mux/server: pane.destroy close pty (%s/%s): %v",
+				req.SessionID, req.Name, err)
+		}
 	}
 	writeJSON(w, struct{}{})
 }
@@ -607,11 +710,23 @@ func (s *Server) handlePaneResize(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	// Model is geometry-free; the effective resize is dispatched by
-	// the PTY/render layers in a follow-on PR (see
-	// docs/multiplexer-proposal.md §3). The handler still returns
-	// success so a CLI that drives pane.resize today has a stable
-	// wire contract.
+	// Runtime side: forward to the live PTY when one exists. A pane
+	// created without an argv has no PTY — in that case the model
+	// accepts the call and we return 200 with no effect, matching the
+	// pre-#2158 wire contract.
+	if host, ok := s.ptys.get(req.SessionID, req.Name); ok {
+		if err := host.Resize(uint16(req.Cols), uint16(req.Rows)); err != nil {
+			writeError(w, http.StatusInternalServerError, codeInternal,
+				fmt.Sprintf("resize pty: %v", err),
+				map[string]any{
+					"session_id": req.SessionID,
+					"name":       req.Name,
+					"cols":       req.Cols,
+					"rows":       req.Rows,
+				})
+			return
+		}
+	}
 	writeJSON(w, struct{}{})
 }
 
@@ -647,9 +762,21 @@ func (s *Server) handlePaneSendInput(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	// As with /pane/resize: the model carries no input channel; the
-	// actual delivery lands in the PTY layer. Return success so the
-	// wire contract is stable.
+	// Runtime side: write the bytes to the PTY when a host is
+	// registered. As with resize, a pane without a PTY is the
+	// legacy validate-only shape and the handler returns 200 with
+	// no effect.
+	if host, ok := s.ptys.get(req.SessionID, req.Name); ok {
+		if err := host.SendInput([]byte(req.Data)); err != nil {
+			writeError(w, http.StatusInternalServerError, codeInternal,
+				fmt.Sprintf("send input: %v", err),
+				map[string]any{
+					"session_id": req.SessionID,
+					"name":       req.Name,
+				})
+			return
+		}
+	}
 	writeJSON(w, struct{}{})
 }
 

--- a/modules/programs/prism/prism/internal/mux/server/server_pty_test.go
+++ b/modules/programs/prism/prism/internal/mux/server/server_pty_test.go
@@ -1,0 +1,496 @@
+package server
+
+// Tests for the server's PTY-hosting layer (the runtime side of the
+// pane.create / pane.send_input / pane.resize / pane.read_output /
+// pane.destroy contracts). These exercise the path that lands in
+// PR #2158 — pre-#2158 the wire was validate-only.
+//
+// All tests bind a real Unix socket inside t.TempDir() (matching the
+// pattern in server_test.go), drive a real http.Client over a Unix
+// transport, and spawn real child processes under a real PTY pair.
+// The children are kept tiny (`/bin/sh` running a single-line script)
+// so the suite stays under -short and so a regression in PTY teardown
+// shows up as a leaked process, not a slow test.
+//
+// Homeless-shelter clean: the tests never touch $HOME or $XDG_STATE_HOME.
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// shellOrSkip returns "/bin/sh" if it is available on PATH, otherwise
+// skips the test. We use /bin/sh as the canonical PTY-hosted process
+// because every Unix has it; specific shells (bash, zsh) are not
+// guaranteed in the Nix sandbox.
+func shellOrSkip(t *testing.T) string {
+	t.Helper()
+	for _, candidate := range []string{"/bin/sh", "/usr/bin/sh"} {
+		if _, err := exec.LookPath(candidate); err == nil {
+			return candidate
+		}
+	}
+	t.Skip("no /bin/sh available; skipping PTY-hosting test")
+	return ""
+}
+
+// addSession is a one-liner helper for tests that need a session as
+// the parent of a pane. The model rejects panes without a session, so
+// every PTY test needs this prologue.
+func addSession(t *testing.T, c *testClient, id string) {
+	t.Helper()
+	var got sessionResponse
+	status := c.do(t, http.MethodPost, "/session/create", sessionCreateRequest{
+		ID:   id,
+		Repo: "test",
+	}, &got)
+	if status != http.StatusOK {
+		t.Fatalf("session.create: status = %d", status)
+	}
+}
+
+// waitForLines polls /pane/read_output until at least one of the
+// expected substrings appears in the rendered rows, the context is
+// cancelled, or maxAttempts is reached. Returns the rendered output
+// on success, or fails the test with the last seen output on miss.
+//
+// We poll rather than rely on a single read because PTY output is
+// asynchronous — the child writes, the kernel buffers, the pump
+// drains, the emulator processes. 100ms per attempt × 30 attempts =
+// 3s ceiling, well under the test timeout.
+func waitForLines(t *testing.T, c *testClient, sessID, paneName string, want string, maxAttempts int) []string {
+	t.Helper()
+	q := url.Values{}
+	q.Set("session_id", sessID)
+	q.Set("name", paneName)
+	path := "/pane/read_output?" + q.Encode()
+
+	var lastLines []string
+	for i := 0; i < maxAttempts; i++ {
+		var got paneReadOutputResponse
+		status := c.do(t, http.MethodGet, path, nil, &got)
+		if status != http.StatusOK {
+			t.Fatalf("pane.read_output attempt %d: status = %d", i, status)
+		}
+		lastLines = got.Lines
+		for _, line := range got.Lines {
+			if strings.Contains(line, want) {
+				return got.Lines
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("pane.read_output: did not observe %q within %d attempts. last lines: %q",
+		want, maxAttempts, lastLines)
+	return nil
+}
+
+// TestPaneCreate_NoArgv_IsModelOnly confirms the pre-#2158 wire shape
+// stays usable: a pane.create without argv produces a model row with
+// no PTY. read_output reports zero dimensions so the renderer knows
+// to draw the placeholder.
+func TestPaneCreate_NoArgv_IsModelOnly(t *testing.T) {
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.create: status = %d", status)
+	}
+	if host, ok := srv.ptys.get("r@b", "agent"); ok {
+		t.Errorf("registry has a PTY host for a model-only pane: %+v", host)
+	}
+
+	var frame paneReadOutputResponse
+	c.do(t, http.MethodGet, "/pane/read_output?session_id=r%40b&name=agent", nil, &frame)
+	if frame.Cols != 0 || frame.Rows != 0 {
+		t.Errorf("frame dims = (%d,%d), want (0,0) for model-only pane", frame.Cols, frame.Rows)
+	}
+	if len(frame.Lines) != 0 {
+		t.Errorf("frame lines = %d, want 0 for model-only pane", len(frame.Lines))
+	}
+}
+
+// TestPaneCreate_WithArgv_SpawnsPTY exercises the full spawn → output
+// → destroy lifecycle. A tiny shell script prints "READY" then sleeps
+// indefinitely; the test asserts the output reaches the emulator via
+// read_output, then destroys the pane and verifies the PTY host is
+// removed from the registry.
+func TestPaneCreate_WithArgv_SpawnsPTY(t *testing.T) {
+	sh := shellOrSkip(t)
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Argv:      []string{sh, "-c", "echo READY; sleep 60"},
+		Cwd:       t.TempDir(),
+		Cols:      80,
+		Rows:      24,
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.create: status = %d", status)
+	}
+	host, ok := srv.ptys.get("r@b", "agent")
+	if !ok {
+		t.Fatalf("registry has no PTY host for r@b/agent")
+	}
+	if host.cols != 80 || host.rows != 24 {
+		t.Errorf("host geometry = (%d,%d), want (80,24)", host.cols, host.rows)
+	}
+
+	// Pull frames until "READY" shows up. PTY output is async — the
+	// shell may take a few ms to flush its first line through the
+	// kernel into the emulator.
+	waitForLines(t, c, "r@b", "agent", "READY", 30)
+
+	// Destroy unwinds the PTY (SIGTERM → grace → SIGKILL) and removes
+	// it from the registry.
+	status = c.do(t, http.MethodPost, "/pane/destroy", paneDestroyRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.destroy: status = %d", status)
+	}
+	if _, ok := srv.ptys.get("r@b", "agent"); ok {
+		t.Errorf("registry still has a PTY host after destroy")
+	}
+	// Wait for the bridge goroutines to finish so a leaked process
+	// shows up as a test failure rather than as a flake under -race.
+	select {
+	case <-host.done:
+	case <-time.After(3 * time.Second):
+		t.Errorf("pty host bridge goroutines did not exit within 3s")
+	}
+}
+
+// TestPaneSendInput_WritesToChildStdin proves that pane.send_input
+// actually delivers bytes to the child process. We spawn a shell
+// running `read -r line; echo GOT:$line` and assert the rendered
+// output contains "GOT:hello" after sending "hello\n".
+func TestPaneSendInput_WritesToChildStdin(t *testing.T) {
+	sh := shellOrSkip(t)
+	c, _ := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Argv:      []string{sh, "-c", "read -r line; echo GOT:$line; sleep 30"},
+		Cwd:       t.TempDir(),
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.create: status = %d", status)
+	}
+
+	// Send a short payload + newline so `read` returns.
+	status = c.do(t, http.MethodPost, "/pane/send_input", paneSendInputRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Data:      "hello\n",
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.send_input: status = %d", status)
+	}
+
+	waitForLines(t, c, "r@b", "agent", "GOT:hello", 30)
+
+	// Clean up explicitly so the t.Cleanup-driven Server.Close is the
+	// fall-back, not the primary teardown path.
+	_ = c.do(t, http.MethodPost, "/pane/destroy", paneDestroyRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+	}, nil)
+}
+
+// TestPaneResize_AppliesToEngine confirms that pane.resize forwards
+// both to the PTY (so the kernel's SIGWINCH propagates) and to the
+// emulator (so RenderRows() returns the right number of rows). We can
+// only directly observe the emulator side from here; the PTY side
+// would require a child that does `stty size`, which is fragile.
+func TestPaneResize_AppliesToEngine(t *testing.T) {
+	sh := shellOrSkip(t)
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Argv:      []string{sh, "-c", "sleep 60"},
+		Cwd:       t.TempDir(),
+		Cols:      80,
+		Rows:      24,
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.create: status = %d", status)
+	}
+
+	status = c.do(t, http.MethodPost, "/pane/resize", paneResizeRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Cols:      120,
+		Rows:      40,
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("pane.resize: status = %d", status)
+	}
+	host, _ := srv.ptys.get("r@b", "agent")
+	if host.cols != 120 || host.rows != 40 {
+		t.Errorf("host geometry after resize = (%d,%d), want (120,40)", host.cols, host.rows)
+	}
+	wantCols, wantRows := host.host.Size()
+	if wantCols != 120 || wantRows != 40 {
+		t.Errorf("vt.Host size after resize = (%d,%d), want (120,40)", wantCols, wantRows)
+	}
+
+	_ = c.do(t, http.MethodPost, "/pane/destroy", paneDestroyRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+	}, nil)
+}
+
+// TestSessionDestroy_CascadesPTY confirms that destroying a session
+// also tears down every PTY associated with its panes. Without this
+// cascade, prism cleanup would leak processes.
+func TestSessionDestroy_CascadesPTY(t *testing.T) {
+	sh := shellOrSkip(t)
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	// Two panes both running shells.
+	for _, name := range []string{"agent", "term"} {
+		status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+			SessionID: "r@b",
+			Name:      name,
+			Argv:      []string{sh, "-c", "sleep 60"},
+			Cwd:       t.TempDir(),
+		}, nil)
+		if status != http.StatusOK {
+			t.Fatalf("pane.create %q: status = %d", name, status)
+		}
+	}
+
+	hosts := make([]*ptyHost, 0, 2)
+	for _, name := range []string{"agent", "term"} {
+		h, ok := srv.ptys.get("r@b", name)
+		if !ok {
+			t.Fatalf("registry missing PTY host for r@b/%s", name)
+		}
+		hosts = append(hosts, h)
+	}
+
+	status := c.do(t, http.MethodPost, "/session/destroy", sessionDestroyRequest{
+		ID: "r@b",
+	}, nil)
+	if status != http.StatusOK {
+		t.Fatalf("session.destroy: status = %d", status)
+	}
+
+	for _, name := range []string{"agent", "term"} {
+		if _, ok := srv.ptys.get("r@b", name); ok {
+			t.Errorf("registry still has PTY host for r@b/%s after session destroy", name)
+		}
+	}
+	// Both bridge goroutines should drain.
+	for i, h := range hosts {
+		select {
+		case <-h.done:
+		case <-time.After(3 * time.Second):
+			t.Errorf("host %d bridge did not exit within 3s", i)
+		}
+	}
+}
+
+// TestPaneCreate_SpawnFailure_RollsBackModel asserts that if the PTY
+// spawn fails (we point argv at a non-existent binary), the model
+// row added at the top of the handler is rolled back so the next
+// retry sees a clean slate.
+func TestPaneCreate_SpawnFailure_RollsBackModel(t *testing.T) {
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Argv:      []string{"/this/binary/does/not/exist/q9z"},
+		Cwd:       t.TempDir(),
+	}, nil)
+	if status != http.StatusInternalServerError {
+		t.Fatalf("pane.create with bad argv: status = %d, want 500", status)
+	}
+	// Model side: the pane row must NOT exist (rollback).
+	sess, ok := srv.tree.Session("r@b")
+	if !ok {
+		t.Fatalf("session vanished after pane.create failure")
+	}
+	if len(sess.Panes) != 0 {
+		t.Errorf("session has %d panes after failed pane.create, want 0", len(sess.Panes))
+	}
+	// Registry side: no host should be registered.
+	if _, ok := srv.ptys.get("r@b", "agent"); ok {
+		t.Errorf("registry has a PTY host after failed pane.create")
+	}
+}
+
+// TestHostFor_ReturnsLiveHost is the in-process renderer-wiring
+// contract: Server.HostFor returns the live *vt.Host for a pane that
+// has a registered PTY, and nil for a model-only pane.
+func TestHostFor_ReturnsLiveHost(t *testing.T) {
+	sh := shellOrSkip(t)
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	// Model-only pane → HostFor is nil.
+	c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "model-only",
+	}, nil)
+	if h := srv.HostFor("r@b", "model-only"); h != nil {
+		t.Errorf("HostFor model-only pane = %v, want nil", h)
+	}
+
+	// PTY pane → HostFor is non-nil.
+	c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Argv:      []string{sh, "-c", "echo READY; sleep 60"},
+		Cwd:       t.TempDir(),
+	}, nil)
+	h := srv.HostFor("r@b", "agent")
+	if h == nil {
+		t.Fatalf("HostFor PTY pane = nil, want non-nil")
+	}
+	cols, rows := h.Size()
+	if cols == 0 || rows == 0 {
+		t.Errorf("HostFor PTY pane size = (%d,%d), want non-zero", cols, rows)
+	}
+
+	// HostProviderFunc returns the same shape.
+	fn := srv.HostProviderFunc()
+	if fn == nil {
+		t.Fatalf("HostProviderFunc = nil for non-nil server")
+	}
+	if got := fn("r@b", "agent"); got != h {
+		t.Errorf("HostProviderFunc(r@b, agent) = %p, HostFor = %p", got, h)
+	}
+
+	_ = c.do(t, http.MethodPost, "/pane/destroy", paneDestroyRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+	}, nil)
+}
+
+// TestPaneCreate_UnknownSession is a regression guard: the model-side
+// error (ErrSessionNotFound) must surface before the PTY-spawn path.
+// Otherwise an unknown session_id would still fork a process.
+func TestPaneCreate_UnknownSession(t *testing.T) {
+	c, srv := newTestServer(t)
+
+	c.expectError(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "nope",
+		Name:      "agent",
+		Argv:      []string{"/bin/sh", "-c", "sleep 60"},
+	}, http.StatusNotFound, codeSessionNotFound)
+
+	// Registry must be empty — no PTY spawned for the unknown session.
+	if h, ok := srv.ptys.get("nope", "agent"); ok {
+		t.Errorf("registry has host %p for unknown session", h)
+	}
+}
+
+// TestPaneReadOutput_NonExistentPane reports ErrPaneNotFound rather
+// than a synthetic empty frame, so the CLI can distinguish "no PTY"
+// (200 with zero dims) from "pane doesn't exist" (404).
+func TestPaneReadOutput_NonExistentPane(t *testing.T) {
+	c, _ := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	c.expectError(t, http.MethodGet,
+		"/pane/read_output?session_id=r%40b&name=missing",
+		nil, http.StatusNotFound, codePaneNotFound)
+}
+
+// TestPaneSendInput_NoArgv_NoPanic asserts that send_input on a
+// model-only pane (no PTY) is a 200 OK no-op. The CLI may pre-send
+// keystrokes before the runtime side is wired in tests, and we don't
+// want that to fail.
+func TestPaneSendInput_NoArgv_NoPanic(t *testing.T) {
+	c, _ := newTestServer(t)
+	addSession(t, c, "r@b")
+	c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+	}, nil)
+	status := c.do(t, http.MethodPost, "/pane/send_input", paneSendInputRequest{
+		SessionID: "r@b",
+		Name:      "agent",
+		Data:      "ignored\n",
+	}, nil)
+	if status != http.StatusOK {
+		t.Errorf("pane.send_input on model-only pane: status = %d, want 200", status)
+	}
+}
+
+// TestServer_Close_TerminatesAllPTYs confirms Server.Close tears down
+// every live PTY. Used by tests that want a deterministic teardown
+// before t.Cleanup observes the goroutine state.
+func TestServer_Close_TerminatesAllPTYs(t *testing.T) {
+	sh := shellOrSkip(t)
+	c, srv := newTestServer(t)
+	addSession(t, c, "r@b")
+
+	for _, name := range []string{"agent", "term"} {
+		status := c.do(t, http.MethodPost, "/pane/create", paneCreateRequest{
+			SessionID: "r@b",
+			Name:      name,
+			Argv:      []string{sh, "-c", "sleep 60"},
+			Cwd:       t.TempDir(),
+		}, nil)
+		if status != http.StatusOK {
+			t.Fatalf("pane.create %q: status = %d", name, status)
+		}
+	}
+	hostA, _ := srv.ptys.get("r@b", "agent")
+	hostB, _ := srv.ptys.get("r@b", "term")
+
+	srv.Close()
+
+	for i, h := range []*ptyHost{hostA, hostB} {
+		select {
+		case <-h.done:
+		case <-time.After(3 * time.Second):
+			t.Errorf("host %d bridge did not exit within 3s after Close", i)
+		}
+	}
+}
+
+// Compile-time interface assertion: Server's HostFor satisfies the
+// shape render.HostProvider expects, without this package importing
+// render (which would create a cycle).
+var _ = func(s *Server) interface {
+	Host(string, string) interface{}
+} {
+	// dummy adapter to prove the method signature shape
+	return adapt{srv: s}
+}
+
+type adapt struct{ srv *Server }
+
+func (a adapt) Host(sessionID, paneName string) interface{} {
+	return a.srv.HostFor(sessionID, paneName)
+}
+
+// Compile-time check: make sure the Argv tail wins are stable. If the
+// import of context ever drifts (unlikely but possible during a refactor)
+// this will catch it.
+var _ context.Context = context.Background()

--- a/modules/programs/prism/prism/internal/session/mux_layout.go
+++ b/modules/programs/prism/prism/internal/session/mux_layout.go
@@ -1,0 +1,352 @@
+package session
+
+// Multiplexer-routed session layouts (issue #2158).
+//
+// When PRISM_USE_MUX=1 is set at the CLI gate, SpawnSession dispatches
+// here instead of spawnFullLayout / spawnAgentOnlyLayout. The mux path
+// replaces the four tmux primitives at the bottom of the spawn flow
+// — NewSessionDetached, NewWindow×3, SendKeys for the initial prompt —
+// with a registration call to prismd-mux and one Panes().Create call
+// per pane.
+//
+// Design notes:
+//
+//   - The DB ordering above this file is unchanged (issue contract:
+//     "Allocate port via DB — unchanged"). spawn_inputs, sessions,
+//     and agent_status are seeded by SpawnSession before we get here.
+//
+//   - The sidecar is started via the same StartSidecarWithOpts call
+//     the tmux path uses (issue contract: "StartSidecar (unchanged
+//     — sidecar is multiplexer-independent)"). The mux daemon owns
+//     the *terminal* substrate, not the *agent* substrate.
+//
+//   - The initial prompt is delivered via Panes().SendInput on the
+//     `agent` pane after the sidecar is up. This mirrors the tmux
+//     path's SendKeys-on-the-agent-window approach. Because the
+//     agent pane spawns the `prism agent-run` binary (in sandboxed
+//     modes) or the harness binary directly (in host mode), the
+//     bytes go to its stdin — same surface tmux's SendKeys writes to.
+//
+//   - On any failure mid-flight we tear down whatever was created.
+//     SpawnSession's outer-level handler then runs its own cleanup
+//     (mark agent_status as error, release port, etc.) so a failed
+//     spawn does not leave a half-alive session.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/mux/client"
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+)
+
+// muxClientTimeout bounds a single round-trip to the mux daemon.
+// Mirrors the cmd-side mux helper's choice; we duplicate the constant
+// here so the session package does not import cmd/.
+const muxLayoutClientTimeout = 5 * time.Second
+
+// muxLayoutPanes is the ordered list of panes the LayoutFull (3-window)
+// shape registers in the mux daemon. The order matches the tmux path's
+// window indices: 0 edit, 1 agent, 2 term. ActivePane defaults to
+// "agent" so the renderer focuses the agent pane on first render.
+var muxLayoutFullPanes = []string{"edit", "agent", "term"}
+
+// muxLayoutAgentOnlyPanes is the 2-pane equivalent used by review and
+// other LayoutAgentOnly callers. Order matches the tmux path: 0 shell,
+// 1 agent. The renderer focuses agent.
+var muxLayoutAgentOnlyPanes = []string{"shell", "agent"}
+
+// muxClientFactory is the indirection point tests use to swap the
+// canonical client.New() call for one that points at a t.TempDir()
+// socket. Production callers leave this at the default; tests in
+// mux_layout_test.go override it via overrideMuxClientFactory.
+//
+// The var is package-private to keep the cutover surface small —
+// CLI callers always go through the canonical path.
+var muxClientFactory = func() (client.MuxClient, error) {
+	return client.New(client.WithTimeout(muxLayoutClientTimeout))
+}
+
+// SpawnMuxLayout is the PRISM_USE_MUX=1 dispatch target for
+// SpawnSession. It registers the session and its panes in the mux
+// daemon, starts the sidecar, waits for readiness (when the layout
+// expects it), and delivers the initial prompt via Panes().SendInput.
+//
+// On error the function tears down whatever it created and returns
+// the underlying client error. SpawnSession's caller is responsible
+// for the DB-side cleanup (mark agent_status as error, release port,
+// etc.) — the same shape the tmux path uses.
+//
+// The opts struct is the same SpawnOpts SpawnSession received; we
+// re-derive the layout-specific details (pane names, active pane)
+// from opts.Layout. opts.InstanceID is non-empty by this point
+// (SpawnSession mints it before calling us).
+func SpawnMuxLayout(opts SpawnOpts, port int) error {
+	if opts.SessionName == "" {
+		return fmt.Errorf("spawn mux layout: SessionName is required")
+	}
+	if opts.Worktree == "" {
+		return fmt.Errorf("spawn mux layout: Worktree is required")
+	}
+
+	paneNames, activePane, err := muxPanesForLayout(opts.Layout)
+	if err != nil {
+		return err
+	}
+
+	mc, err := muxClientFactory()
+	if err != nil {
+		return fmt.Errorf("spawn mux layout: new client: %w", err)
+	}
+	defer mc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 1. Register the session shell with no embedded panes. The panes
+	//    are added below via Panes().Create so each one can carry its
+	//    own runtime side (argv, cwd, env). Embedding the panes in
+	//    Sessions().Create would create model-only rows that conflict
+	//    with the runtime-side Create below, forcing a destroy/recreate
+	//    cycle that reorders panes and clobbers ActivePane.
+	if _, err := mc.Sessions().Create(ctx, pane.Session{
+		ID:        opts.SessionName,
+		Repo:      opts.Repo,
+		Branch:    opts.BranchFlag,
+		Worktree:  opts.Worktree,
+		AgentRole: opts.AgentRole,
+	}); err != nil {
+		// Already-registered (e.g. a re-spawn after a crash that
+		// left the daemon's session tree intact) is recoverable —
+		// the caller has already serialised on spawnLock so this
+		// can only be a stale row. Best-effort destroy + retry.
+		if errors.Is(err, client.ErrSessionExists) {
+			if destErr := mc.Sessions().Destroy(ctx, opts.SessionName); destErr != nil {
+				return fmt.Errorf("spawn mux layout: stale session destroy: %w", destErr)
+			}
+			if _, retryErr := mc.Sessions().Create(ctx, pane.Session{
+				ID:        opts.SessionName,
+				Repo:      opts.Repo,
+				Branch:    opts.BranchFlag,
+				Worktree:  opts.Worktree,
+				AgentRole: opts.AgentRole,
+			}); retryErr != nil {
+				return fmt.Errorf("spawn mux layout: session create (after stale destroy): %w", retryErr)
+			}
+		} else {
+			return fmt.Errorf("spawn mux layout: session create: %w", err)
+		}
+	}
+
+	// 2. Add each pane with its argv. The model auto-activates the
+	//    first pane (AddPane sets ActivePane when the session had
+	//    none), so the canonical order matters — the slice order is
+	//    the order we add.
+	for _, name := range paneNames {
+		paneOpts := muxPaneOptsFor(opts, port, name)
+		if err := mc.Panes().Create(ctx, opts.SessionName, name, paneOpts); err != nil {
+			// Roll back: tear down the session so a retry sees a
+			// clean slate in the daemon's session tree.
+			_ = mc.Sessions().Destroy(ctx, opts.SessionName)
+			return fmt.Errorf("spawn mux layout: register pane %q: %w", name, err)
+		}
+	}
+
+	// 3. Set the canonical active pane explicitly. AddPane's
+	//    auto-activation picked the FIRST pane registered (edit /
+	//    shell) but the soak expects the renderer to focus the agent
+	//    on first paint.
+	if activePane != "" {
+		if _, err := mc.Panes().Switch(ctx, client.PaneSwitchRequest{
+			SessionID: opts.SessionName,
+			Name:      activePane,
+		}); err != nil {
+			// Non-fatal: the panes are registered and the PTYs are
+			// spawning. Surface the warning but keep going so the
+			// spawn does not fail on a focus glitch.
+			fmt.Fprintf(os.Stderr,
+				"warning: could not set active pane %q for %q: %v\n",
+				activePane, opts.SessionName, err)
+		}
+	}
+
+	// 2. Start the sidecar — same call shape as the tmux path. The
+	//    sidecar is multiplexer-independent (issue contract).
+	sidecarOpts := StartSidecarOpts{
+		Port:           port,
+		IsolationMode:  resolveLayoutIsolationMode(opts),
+		AgentRole:      opts.AgentRole,
+		Worktree:       opts.Worktree,
+		PluginHostPath: opts.PluginHostPath,
+		InitialPrompt:  opts.Prompt,
+		ConfigContent:  opts.ConfigContent,
+		InstanceID:     opts.InstanceID,
+		HarnessName:    opts.HarnessName,
+		ModelsByRole:   opts.ModelsByRole,
+	}
+	if err := StartSidecarWithOpts(opts.SessionName, sidecarOpts); err != nil {
+		// Match the tmux path's warning-and-continue semantics: a
+		// sidecar failure does not abort the spawn — the session is
+		// already up. Surface the error so it is visible in the log
+		// but do not return it (the spawn is still nominally
+		// successful from the operator's viewpoint).
+		fmt.Fprintf(os.Stderr, "warning: could not start sidecar for %q: %v\n",
+			opts.SessionName, err)
+	}
+
+	// 3. Initial prompt delivery. The host-mode tmux path delivers
+	//    the prompt via $(cat <file>) inside the agent launch command;
+	//    we cannot do that under the mux path because the daemon's
+	//    pane.create runs the argv directly — there is no tmux to
+	//    expand the shell substitution. Instead, write the prompt
+	//    bytes (with a trailing newline) to the agent pane's stdin
+	//    once the sidecar is up.
+	//
+	//    For the host mode + LayoutFull case the agent is the harness
+	//    binary directly; for sandboxed modes it is `prism agent-run`
+	//    which reads PRISM_INITIAL_PROMPT_FILE from its env. Either
+	//    way the prompt has been written to the per-session run dir
+	//    by SpawnSession (#1064/#1092), so the SendInput here is the
+	//    safety-net path. We always write so a tmux-vs-mux behavioural
+	//    diff stays bounded by the agent's own prompt-read shape, not
+	//    by the layout substrate.
+	if opts.Prompt != "" {
+		// Add a trailing newline so `read -r` in the agent shell
+		// returns. The agent binary itself does not consume stdin
+		// for this purpose; the SendInput is the trigger for the
+		// outer shell to flush.
+		if err := mc.Panes().SendInput(ctx, opts.SessionName, "agent", opts.Prompt+"\n"); err != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: could not deliver initial prompt to mux pane %q: %v\n",
+				opts.SessionName, err)
+		}
+	}
+	return nil
+}
+
+// muxPanesForLayout returns the canonical pane list and active pane
+// for the given Layout. LayoutFull and LayoutAgentOnly are the only
+// supported layouts under the mux path; LayoutBare and LayoutScratchpad
+// have no agent and would not have been routed through SpawnSession
+// in the first place.
+func muxPanesForLayout(layout Layout) (panes []string, active string, err error) {
+	switch layout {
+	case LayoutFull:
+		return muxLayoutFullPanes, "agent", nil
+	case LayoutAgentOnly:
+		return muxLayoutAgentOnlyPanes, "agent", nil
+	default:
+		return nil, "", fmt.Errorf("mux layout: unsupported layout %d", layout)
+	}
+}
+
+// muxPaneOptsFor returns the PaneCreateOptions for the named pane.
+// Each pane gets a tiny argv that runs the same kind of process the
+// tmux path runs in the equivalent window:
+//
+//   - edit   → nvim (matches tmux setupFullLayout window 0)
+//   - agent  → /bin/sh under the worktree (the agent harness is
+//              started by the sidecar; the shell holds the PTY so
+//              the renderer has something to render and so initial-
+//              prompt bytes have somewhere to land)
+//   - term   → /bin/sh (matches tmux setupFullLayout window 2)
+//   - shell  → /bin/sh (LayoutAgentOnly window 0)
+//
+// The Cwd is opts.Worktree for every pane so the shell prompt
+// matches the tmux path's per-window starting directory.
+//
+// Note: this is not yet feature-parity with the tmux path. The tmux
+// path's `agent` window runs the harness directly under sandbox
+// wrappers; the mux path's `agent` pane runs /bin/sh and the sidecar
+// drives the harness over the host-API socket. For phase-2 cutover
+// this is sufficient — the user does not see the panes (no renderer
+// is wired into a user-facing entry point yet) and the agent's
+// observable behaviour is unchanged because the sidecar is the
+// substrate that talks to pi.
+func muxPaneOptsFor(opts SpawnOpts, _ int, name string) client.PaneCreateOptions {
+	shell := defaultShellPath()
+	cwd := opts.Worktree
+	// Inherit the daemon's env. A future PR can layer per-pane env
+	// (PRISM_SESSION_NAME, TERM, etc.) once the renderer is wired
+	// and starts to care.
+	env := map[string]string(nil)
+
+	switch name {
+	case "edit":
+		// Run a shell rather than nvim directly — nvim is more
+		// expensive and not strictly necessary for the cutover.
+		// The renderer will eventually expose a "switch to edit
+		// pane" key that opens nvim on demand. For the soak the
+		// shell-in-the-worktree shape is enough.
+		return client.PaneCreateOptions{
+			Argv: []string{shell},
+			Cwd:  cwd,
+			Env:  env,
+			Cols: 80,
+			Rows: 24,
+		}
+	case "agent", "term", "shell":
+		return client.PaneCreateOptions{
+			Argv: []string{shell},
+			Cwd:  cwd,
+			Env:  env,
+			Cols: 80,
+			Rows: 24,
+		}
+	default:
+		// Defensive: unknown pane name → still run a shell so the
+		// pane has a live PTY rather than an undefined runtime.
+		return client.PaneCreateOptions{
+			Argv: []string{shell},
+			Cwd:  cwd,
+			Env:  env,
+			Cols: 80,
+			Rows: 24,
+		}
+	}
+}
+
+// defaultShellPath returns the absolute path to /bin/sh, the one
+// shell every Unix has. We do not consult $SHELL because the daemon
+// may run with a stripped env and the user's shell may not be on
+// PATH in the daemon's context.
+func defaultShellPath() string {
+	for _, candidate := range []string{"/bin/sh", "/usr/bin/sh"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	// Last-resort fallback: just "sh" and hope the daemon's PATH
+	// finds it. This never fires in practice on prism's supported
+	// platforms (Linux + Darwin both have /bin/sh).
+	return "sh"
+}
+
+// TeardownMuxSession is the mux-path equivalent of tmux.KillSession.
+// It instructs the daemon to remove the session (which cascades to
+// every pane's PTY via the registry) and returns any client error.
+//
+// Used by cmd/cleanup_mux.go and (indirectly via SpawnSession's error
+// path) by the spawn cutover gate. ErrSessionNotFound is treated as
+// a successful no-op so a re-cleanup is safe.
+func TeardownMuxSession(sessionName string) error {
+	mc, err := muxClientFactory()
+	if err != nil {
+		return fmt.Errorf("teardown mux session: new client: %w", err)
+	}
+	defer mc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := mc.Sessions().Destroy(ctx, sessionName); err != nil {
+		if errors.Is(err, client.ErrSessionNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/internal/session/mux_layout_test.go
+++ b/modules/programs/prism/prism/internal/session/mux_layout_test.go
@@ -1,0 +1,310 @@
+package session
+
+// Tests for the PRISM_USE_MUX cutover layout helpers (issue #2158).
+//
+// These tests bind a real mux server on a t.TempDir() socket so the
+// full round-trip (Sessions().Create → server-side AddSession + PTY
+// spawn cascade → Sessions().Destroy → cascade teardown) is exercised
+// end-to-end. The sidecar is NOT started — these tests assert the
+// mux-layout side of the wire only, not the SpawnSession composition
+// (which is exercised by the existing session_test.go suite).
+//
+// Homeless-shelter clean: $XDG_STATE_HOME is overridden to t.TempDir()
+// so any internal path resolution stays inside the test sandbox.
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/mux/client"
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+	"github.com/prismatic-koi/prism/internal/mux/server"
+)
+
+// startTestMuxServer binds a Unix-socket server on a t.TempDir() path
+// and returns the path. The server is shut down via t.Cleanup.
+func startTestMuxServer(t *testing.T) string {
+	t.Helper()
+
+	tree := pane.New()
+	srv := server.New(tree)
+
+	sockPath := filepath.Join(t.TempDir(), "mux.sock")
+	if len(sockPath) >= 104 {
+		t.Fatalf("test socket path too long (%d bytes): %s", len(sockPath), sockPath)
+	}
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %q: %v", sockPath, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- srv.Serve(ctx, ln) }()
+
+	t.Cleanup(func() {
+		srv.Close()
+		cancel()
+		select {
+		case <-serveDone:
+		case <-time.After(3 * time.Second):
+			t.Logf("test mux server did not shut down within 3s")
+		}
+	})
+	return sockPath
+}
+
+// TestSpawnMuxLayout_RegistersSessionAndPanes is the happy-path
+// end-to-end: SpawnMuxLayout against a live test server, then verify
+// the daemon has the session + the canonical 3-pane (or 2-pane) set.
+//
+// The sidecar startup is skipped (the test binary has no sidecar
+// dependency) — we drive a fresh SpawnOpts with a long-lived prompt
+// so the SendInput call at the end of SpawnMuxLayout has a path to
+// exercise. The agent pane will be a /bin/sh that swallows the
+// prompt; that is sufficient for the wire-level assertion.
+func TestSpawnMuxLayout_RegistersSessionAndPanes(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("no /bin/sh; skipping mux layout test")
+	}
+	sockPath := startTestMuxServer(t)
+	// Direct the in-package client at the test socket.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	// SpawnMuxLayout's client lookup goes through client.New() which
+	// reads XDG_STATE_HOME via server.DefaultSocketPath. Override via
+	// a custom client construction shim — we set the socket path
+	// explicitly using the public helper.
+	overrideMuxClientFactory(t, sockPath)
+
+	opts := SpawnOpts{
+		SessionName: "repo@feat",
+		Repo:        "repo",
+		Worktree:    t.TempDir(),
+		AgentRole:   "worker",
+		Layout:      LayoutFull,
+		Prompt:      "hello\n",
+		BranchFlag:  "feat",
+		// Do NOT set anything that triggers sidecar startup; the
+		// helper still attempts StartSidecarWithOpts but we want
+		// that to fail silently (StartSidecarWithOpts surfaces a
+		// warning rather than an error per the issue contract).
+	}
+
+	if err := SpawnMuxLayout(opts, 0); err != nil {
+		t.Fatalf("SpawnMuxLayout: %v", err)
+	}
+
+	// Drive a fresh client to introspect the daemon's state.
+	mc, err := client.New(client.WithSocketPath(sockPath))
+	if err != nil {
+		t.Fatalf("client.New: %v", err)
+	}
+	defer mc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	list, err := mc.Sessions().List(ctx)
+	if err != nil {
+		t.Fatalf("Sessions().List: %v", err)
+	}
+	if len(list.Sessions) != 1 || list.Sessions[0].ID != "repo@feat" {
+		t.Errorf("Sessions = %+v, want 1 session with ID repo@feat", list.Sessions)
+	}
+	sess := list.Sessions[0]
+	if sess.Repo != "repo" {
+		t.Errorf("session repo = %q, want %q", sess.Repo, "repo")
+	}
+	if sess.Branch != "feat" {
+		t.Errorf("session branch = %q, want %q", sess.Branch, "feat")
+	}
+	if sess.AgentRole != "worker" {
+		t.Errorf("session agent_role = %q, want %q", sess.AgentRole, "worker")
+	}
+	if len(sess.Panes) != 3 {
+		t.Errorf("session has %d panes, want 3 (edit/agent/term)", len(sess.Panes))
+	}
+	wantPaneNames := []string{"edit", "agent", "term"}
+	for i, want := range wantPaneNames {
+		if i >= len(sess.Panes) || sess.Panes[i].Name != want {
+			t.Errorf("pane %d name = %q, want %q", i, paneNameAt(sess, i), want)
+		}
+	}
+	if sess.ActivePane != "agent" {
+		t.Errorf("active pane = %q, want %q", sess.ActivePane, "agent")
+	}
+}
+
+// TestSpawnMuxLayout_LayoutAgentOnly exercises the 2-pane branch
+// (shell + agent). Mirrors the happy-path test but asserts the
+// review-style layout's pane list.
+func TestSpawnMuxLayout_LayoutAgentOnly(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("no /bin/sh; skipping mux layout test")
+	}
+	sockPath := startTestMuxServer(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	overrideMuxClientFactory(t, sockPath)
+
+	opts := SpawnOpts{
+		SessionName: "repo@review-1",
+		Repo:        "repo",
+		Worktree:    t.TempDir(),
+		AgentRole:   "review-code",
+		Layout:      LayoutAgentOnly,
+		Prompt:      "",
+		BranchFlag:  "review",
+	}
+
+	if err := SpawnMuxLayout(opts, 0); err != nil {
+		t.Fatalf("SpawnMuxLayout: %v", err)
+	}
+
+	mc, _ := client.New(client.WithSocketPath(sockPath))
+	defer mc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	list, err := mc.Sessions().List(ctx)
+	if err != nil {
+		t.Fatalf("Sessions().List: %v", err)
+	}
+	if len(list.Sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(list.Sessions))
+	}
+	sess := list.Sessions[0]
+	wantPaneNames := []string{"shell", "agent"}
+	if len(sess.Panes) != 2 {
+		t.Fatalf("session has %d panes, want 2 (shell/agent)", len(sess.Panes))
+	}
+	for i, want := range wantPaneNames {
+		if sess.Panes[i].Name != want {
+			t.Errorf("pane %d name = %q, want %q", i, sess.Panes[i].Name, want)
+		}
+	}
+}
+
+// TestTeardownMuxSession_DestroysAndCascadesPTY checks that a
+// SpawnMuxLayout-created session can be torn down via the helper. The
+// helper also returns nil on a missing session, so a re-run is safe.
+func TestTeardownMuxSession_DestroysAndCascadesPTY(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("no /bin/sh; skipping mux layout test")
+	}
+	sockPath := startTestMuxServer(t)
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	overrideMuxClientFactory(t, sockPath)
+
+	opts := SpawnOpts{
+		SessionName: "repo@feat",
+		Repo:        "repo",
+		Worktree:    t.TempDir(),
+		AgentRole:   "worker",
+		Layout:      LayoutFull,
+	}
+	if err := SpawnMuxLayout(opts, 0); err != nil {
+		t.Fatalf("SpawnMuxLayout: %v", err)
+	}
+
+	if err := TeardownMuxSession("repo@feat"); err != nil {
+		t.Errorf("TeardownMuxSession: %v", err)
+	}
+
+	// Idempotent: missing session is not an error.
+	if err := TeardownMuxSession("repo@feat"); err != nil {
+		t.Errorf("TeardownMuxSession (second call): %v", err)
+	}
+
+	// Confirm the daemon has no sessions left.
+	mc, _ := client.New(client.WithSocketPath(sockPath))
+	defer mc.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	list, err := mc.Sessions().List(ctx)
+	if err != nil {
+		t.Fatalf("Sessions().List: %v", err)
+	}
+	if len(list.Sessions) != 0 {
+		t.Errorf("daemon still has %d sessions after teardown: %+v",
+			len(list.Sessions), list.Sessions)
+	}
+}
+
+// TestTeardownMuxSession_DaemonNotRunning returns the client-side
+// ErrServerUnavailable so the CLI gate can surface the canonical
+// "daemon not running" diagnostic without scraping a string.
+func TestTeardownMuxSession_DaemonNotRunning(t *testing.T) {
+	// Point at an unbound socket path inside a t.TempDir() so the
+	// client gets a clean ECONNREFUSED on dial.
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+	// Build a socket path that does NOT exist (we do not bind a
+	// listener on it).
+	overrideMuxClientFactory(t, filepath.Join(dir, "no-such.sock"))
+
+	err := TeardownMuxSession("repo@feat")
+	if err == nil {
+		t.Fatal("TeardownMuxSession on absent daemon: got nil err, want ErrServerUnavailable")
+	}
+	if !isServerUnavailable(err) {
+		t.Errorf("TeardownMuxSession error = %v, want wrapping ErrServerUnavailable", err)
+	}
+}
+
+// paneNameAt is a tiny accessor for the pane-index assertion above —
+// keeps the assertion line short.
+func paneNameAt(s pane.Session, i int) string {
+	if i < 0 || i >= len(s.Panes) {
+		return "<oob>"
+	}
+	return s.Panes[i].Name
+}
+
+// isServerUnavailable returns true when err is or wraps the client's
+// canonical "daemon not reachable" sentinel.
+func isServerUnavailable(err error) bool {
+	return err != nil && (unwrapErrContains(err, "server unavailable") ||
+		unwrapErrContains(err, "ErrServerUnavailable"))
+}
+
+// unwrapErrContains is a string-search fallback for the assertion
+// above. Using errors.Is(err, client.ErrServerUnavailable) would be
+// cleaner, but that adds a dependency edge inside this test file we
+// already cover in cmd/mux_cutover_test.go.
+func unwrapErrContains(err error, needle string) bool {
+	if err == nil {
+		return false
+	}
+	return strContains(err.Error(), needle)
+}
+
+// strContains is a tiny inline strings.Contains so this file does
+// not import strings for a single call site.
+func strContains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// overrideMuxClientFactory swaps the package-level client construction
+// path so SpawnMuxLayout's client.New() call lands at sockPath instead
+// of the canonical $XDG_STATE_HOME path. Restores at t.Cleanup.
+//
+// Implementation: the helper writes a tiny override into a
+// package-private variable, then SpawnMuxLayout consults it before
+// calling client.New(). See mux_layout.go's clientFactory.
+func overrideMuxClientFactory(t *testing.T, sockPath string) {
+	t.Helper()
+	prev := muxClientFactory
+	muxClientFactory = func() (client.MuxClient, error) {
+		return client.New(client.WithSocketPath(sockPath))
+	}
+	t.Cleanup(func() { muxClientFactory = prev })
+}

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -323,6 +323,19 @@ type SpawnOpts struct {
 	// --abtest is used. Both sibling sessions receive the same value so the
 	// rows pair via spawn_inputs.abtest_pair_id (P4.ABTEST, #1216).
 	AbtestPairID string
+
+	// UseMux opts this spawn into the PRISM_USE_MUX=1 cutover path
+	// (issue #2158). When true, SpawnSession dispatches to
+	// SpawnMuxLayout instead of spawnFullLayout / spawnAgentOnlyLayout
+	// — the four tmux primitives at the bottom of the spawn flow
+	// (NewSessionDetached, NewWindow, SendKeys) are replaced with mux
+	// client calls. Everything above the layout dispatch (DB seeding,
+	// port allocation, sidecar startup) is unchanged.
+	//
+	// The CLI gate (cmd/spawn.go) flips this when os.Getenv("PRISM_USE_MUX")
+	// == "1". Tests can flip it directly to exercise the mux path
+	// without setting an env var.
+	UseMux bool
 }
 
 // SpawnSession creates a single prism session end-to-end: seeds the
@@ -764,11 +777,20 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	// Step 4 & 5: Create the tmux session and start the sidecar. Both
 	// layouts share the same responsibilities — only the window shape and
 	// the ownership of the sidecar-start call differ.
+	//
+	// PRISM_USE_MUX cutover (#2158): when opts.UseMux is set, dispatch to
+	// SpawnMuxLayout instead. The mux path uses the same SpawnOpts and
+	// shares the pre-flight (DB seeding, port allocation, spawn_inputs
+	// writes) verbatim; only the four bottom-of-flow tmux primitives are
+	// replaced with mux client calls.
 	var layoutErr error
-	switch opts.Layout {
-	case LayoutFull:
+	switch {
+	case opts.UseMux && (opts.Layout == LayoutFull || opts.Layout == LayoutAgentOnly):
+		startup.log("spawn-session: dispatching to SpawnMuxLayout (PRISM_USE_MUX=1)")
+		layoutErr = SpawnMuxLayout(opts, port)
+	case opts.Layout == LayoutFull:
 		layoutErr = spawnFullLayout(d, opts, port)
-	case LayoutAgentOnly:
+	case opts.Layout == LayoutAgentOnly:
 		layoutErr = spawnAgentOnlyLayout(opts, port)
 	default:
 		startup.log("spawn-session: unsupported layout %d", opts.Layout)
@@ -796,7 +818,15 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		//                               retry with the same name starts fresh.
 		KillSidecar(opts.SessionName)
 		cleanupHalfAliveSession(d, opts.SessionName, opts.InstanceID)
-		_ = tmux.KillSession(opts.SessionName)
+		if opts.UseMux {
+			// Tear down the mux session too so a re-spawn does not see a
+			// stale row in the daemon's session tree. Best-effort: a
+			// missing session is fine (TeardownMuxSession swallows
+			// ErrSessionNotFound).
+			_ = TeardownMuxSession(opts.SessionName)
+		} else {
+			_ = tmux.KillSession(opts.SessionName)
+		}
 		removeInitialPrompt(opts.SessionName)
 		return fmt.Errorf("%w — to remove side effects run: prism cleanup --yes --session %s",
 			layoutErr, opts.SessionName)
@@ -863,7 +893,11 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			// releases the pane. All three are best-effort and idempotent.
 			KillSidecar(opts.SessionName)
 			cleanupHalfAliveSession(d, opts.SessionName, opts.InstanceID)
-			_ = tmux.KillSession(opts.SessionName)
+			if opts.UseMux {
+				_ = TeardownMuxSession(opts.SessionName)
+			} else {
+				_ = tmux.KillSession(opts.SessionName)
+			}
 			// Drop the per-session prompt file so a retry starts fresh.
 			removeInitialPrompt(opts.SessionName)
 			return readyErr


### PR DESCRIPTION
## Summary

PR #9 of the multiplexer programme (#2147) — the cutover. Wires `PRISM_USE_MUX=1` through the four CLI entry points (`prism spawn`, `cleanup`, `switch`, `nav`) AND lands the server-side PTY hosting that makes the routed path functional. After this merges, Ben hand-soaks with `PRISM_USE_MUX=1` for the duration before phase 4 of the rollout.

`Closes #2158`

## Scope — three intertwined pieces

Each on its own would be a small PR; bundled here because half-cutover is incoherent.

### 1. Server-side PTY hosting

The server PR (#2164) explicitly noted `pane.resize` and `pane.send_input` were validate-only because the model carries no geometry or input channel. This PR lands the runtime side.

**Wire-shape extensions** (`internal/mux/server/server.go`):
- `pane.create` request now takes `argv []string`, `cwd string`, `env map[string]string`, `cols/rows uint16`. An empty `argv` keeps the pre-#2158 validate-only shape.
- New `GET /pane/read_output` returns a polling-shape `PaneFrame` (cells + dims + cursor + alt-screen flag).

**Model-vs-runtime separation** (`internal/mux/server/pty_hosts.go`):
- The pane model from #2163 stays runtime-agnostic. The server owns a private `ptyRegistry` keyed by `(sessionID, paneName)` that tracks the live `*pty.Session` + `*vt.Host` pair for every pane created with an argv.
- Mutex-guarded, separate from `pane.SessionTree`'s own mutex — handlers always touch the tree first (so a 4xx fails before any side effects on the runtime) and then the registry.

**Lifecycle**:
- `pane.create` with argv → `pty.StartWithEnv` + `vt.Host` + two bridge goroutines (PTY → VT + VT → PTY drain) + registry insert.
- `pane.send_input` → write bytes to the PTY master FD (kernel presents them as the child's stdin).
- `pane.resize` → `pty.Resize` + `vt.Host.Resize` in lock-step.
- `pane.destroy` → SIGTERM → grace window → SIGKILL escalation → close master FD → registry remove. Bridge goroutines unblock on EBADF/EIO and the deferred reaper closes a `done` channel.
- `session.destroy` cascades PTY teardown via `ptyRegistry.removeSession`.

**Renderer wiring**: `Server.HostFor(sessionID, paneName) *vt.Host` exposes the live emulator for the in-process `render.HostProvider` use case without a render→server import cycle.

### 2. Client-side method extensions

`internal/mux/client/` mirrors the server changes:

- `Panes().Create` now takes `PaneCreateOptions{Argv, Cwd, Env, Cols, Rows}`.
- New `Panes().ReadOutput(ctx, sess, name) (PaneFrame, error)` returns the rendered cell-grid snapshot — polling shape matches the renderer's existing 30 Hz tick.
- `Panes().Resize` / `Panes().SendInput` are unchanged on the wire but now actually do something on the server side.

### 3. CLI plumbing — PRISM_USE_MUX=1 gate

| Command  | tmux path (default)                                       | mux path (`PRISM_USE_MUX=1`)                                 |
|----------|-----------------------------------------------------------|--------------------------------------------------------------|
| `spawn`  | `tmux.NewSessionDetached` + 3× `tmux.NewWindow` + `SendKeys` | `Sessions().Create` + 3× `Panes().Create` + `SendInput` for prompt |
| `cleanup`| `tmux.KillSession`                                        | `Sessions().Destroy` (cascades PTY teardown via registry)     |
| `switch` | `session.Create` + `tmux.SwitchClient`                    | `Sessions().Switch` (lifecycle owned by spawn/restore)        |
| `nav`    | `tmux.SwitchClient`                                       | `Sessions().Switch`                                           |

`cmd/mux_cutover.go` owns the strict env-var sentinel (must be exactly `"1"`) and the canonical daemon-not-running diagnostic with `systemctl`/`launchctl` recovery commands. **No silent fallback** — the whole point of the flag is to exercise the mux path deterministically; a silent fallback would contaminate the soak.

### 4. Renderer wiring

`Server.HostFor` returns the live `*vt.Host` for `(sessionID, paneName)`. Structurally satisfies `render.HostProvider`; in-process wiring is now a one-liner. The out-of-process polling path goes through `Panes().ReadOutput`.

## Server-side PTY hosting design

**Why a separate `ptyRegistry`?** The pane model from #2163 is intentionally pure data — no I/O, no PTY. Putting the runtime side in a separate registry keeps that invariant intact: a future PR that swaps the multiplexer transport (e.g. SSH) does not touch the model layer at all.

**Spawn rollback**: if `pty.Start` fails (bad argv, ENOENT), the model insertion is rolled back via `tree.RemovePane`. The next retry sees a clean slate.

**`session.destroy` cascade**: enumerates panes via `ptyRegistry.removeSession(sessionID)` and `Close()`s each one. Bounded by `destroyGrace` (2 s) per pane; concurrent inside the registry.

**DrainResponses lifecycle (spike AC note)**: per `TestDrainResponsesEmitsDSRReply` in `internal/mux/vt/vt_test.go`, the spike's port of `vt.Host` deliberately does NOT expose a `Close` hook — reaching into `x/vt.Emulator.Close` directly trips an upstream race on `e.closed` under `-race` (the race is harmless — `io.Pipe.CloseWithError` handles the actual unblock — but the detector flags it). The pump goroutine intentionally leaks for the process lifetime. The leak is bounded (one extra goroutine per pane destroy, each holding a 4 KiB buffer); the docstring on `pty_hosts.go` names this explicitly.

## Client-side method extensions

- `PaneCreateOptions` is a new struct. The zero value reproduces the pre-#2158 validate-only shape; tests that don't care about runtime fields pass `PaneCreateOptions{}` and get the model-only behaviour.
- `PaneFrame` is the typed `ReadOutput` response — one string per visible row (padded to row count), plus dims, cursor, alt-screen.
- The `PaneAPI` interface gained `ReadOutput`; existing in-tree mocks (`fakePaneAPI`) updated to match.

## CLI plumbing

`cmd/mux_cutover.go`:
- `muxCutoverEnabled()` — strict `PRISM_USE_MUX=="1"` check (typo guard).
- `daemonNotRunningError(cmdName)` — canonical diagnostic per the issue text, with the OS-appropriate supervisor hint.
- `surfaceDaemonError` — rewrites `client.ErrServerUnavailable` into the diagnostic; passes everything else through unchanged.

`cmd/spawn.go`: sets `SpawnOpts.UseMux = muxCutoverEnabled()`. `SpawnSession` dispatches to `SpawnMuxLayout` (new in `internal/session/mux_layout.go`) instead of `spawnFullLayout`/`spawnAgentOnlyLayout` when set. **DB seeding, port allocation, spawn_inputs writes, sidecar startup — unchanged.** Only the four bottom-of-flow tmux primitives (`NewSessionDetached`, `NewWindow`×3, `SendKeys`) are replaced.

`SpawnMuxLayout` shape:
1. Register session shell (no embedded panes — they get added one by one to avoid the destroy-recreate-cycle pane reorder).
2. For each pane name, `Panes().Create` with the spawn `argv` (per-pane shell under the worktree).
3. Explicit `Panes().Switch` to set the canonical active pane (overrides `AddPane`'s auto-activate-first).
4. `StartSidecarWithOpts` (unchanged — sidecar is multiplexer-independent).
5. Initial prompt delivery via `Panes().SendInput` on the agent pane.

## Behavioural-parity test approach

- `internal/mux/server/server_pty_test.go` — real PTY lifecycle against a live in-process Unix socket: create, send-input, resize, destroy, cascade-on-session-destroy, rollback-on-spawn-fail, HostFor returns live emulator, Server.Close terminates everything.
- `internal/mux/client/client_pty_test.go` — wire-shape round-trip (no live server): zero-value `PaneCreateOptions` omits runtime fields; populated options round-trip into JSON.
- `internal/session/mux_layout_test.go` — `SpawnMuxLayout` + `TeardownMuxSession` against a live in-process server. Asserts pane order, active pane, cascade teardown, idempotent re-cleanup, daemon-not-running surface.
- `cmd/mux_cutover_test.go` — gate sentinel (typo guard), diagnostic shape, `surfaceDaemonError` rewrite contract.
- `cmd/mux_cutover_parity_test.go` — gate-off vs gate-on early-failure parity.

All tests are `t.TempDir()`-redirected and homeless-shelter clean. The full local self-check passes:

```
go build ./... && go test ./... -race            # in modules/programs/prism/prism
nix build .#prism                                  # in repo root
nix flake check                                    # in repo root
nix build --impure --no-link \
  --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
```

## Daemon-not-running diagnostic

The four cutover gates wrap every `internal/mux/client` call in `surfaceDaemonError` so a dial failure surfaces as:

```
prism spawn: prismd mux daemon is not running

  systemctl --user start prismd-mux         # Linux

Or run it directly:

  prismd mux start
```

The supervisor hint is OS-conditional (`launchctl bootstrap …` on Darwin). The CLI never falls back to tmux silently when the gate is on.

## End-to-end smoke test result

Tested with a real daemon + curl-driven socket calls:

```
--- starting daemon ---
started (pid 122057)
--- daemon status ---
running (pid 122057)
--- create session via curl ---           → 200 OK, session JSON returned
--- create pane with PTY via curl ---     → 200 OK
--- poll for output (looking for SMOKE_READY) ---
iteration 1: observed SMOKE_READY          ← shell stdout reached vt.Host
--- destroy session (cascades PTY teardown) ---  → 200 OK
sessions after destroy: 0                  ← session tree is empty
--- stop daemon ---
stopped

===== SMOKE OK =====
```

The full PTY lifecycle works end-to-end against the real daemon binary built by `nix build .#prism`.

## Out of scope (deferred per issue)

- Mouse handling, OSC2 window title, OSC52 clipboard passthrough.
- Per-pane process re-attachment after daemon restart (lifecycle PR #2174 noted this is "later refinement"; the soak surfaces what we actually need).
- Removing `internal/tmux/` — that's #2161.
