### PR TITLE
mux/cutover-ux-min: launch renderer + branch agent argv by isolation + finish cleanup gating

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -207,22 +207,34 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			}
 		}
 
-		// Ensure scratchpad exists.
-		if !tmux.HasSession("scratchpad") {
-			home, _ := os.UserHomeDir()
-			_ = tmux.NewSessionDetached("scratchpad", home)
-			_ = tmux.RenameWindow("scratchpad:0", "term")
-		}
+		// Scratchpad swing + SwitchClient is a tmux-substrate UX
+		// affordance: redirect any attached tmux client off the
+		// session we are about to kill so the client doesn't watch
+		// its own pane die. Under PRISM_USE_MUX (#2176) the session
+		// lives in the mux daemon's tree, not tmux — there is no
+		// tmux client to redirect, the renderer handles its own
+		// session-list focus, and ensuring a tmux "scratchpad"
+		// session at this point would defeat the cutover (it would
+		// silently re-introduce a tmux dependency the renderer was
+		// supposed to replace).
+		if !muxCutoverEnabled() {
+			// Ensure scratchpad exists.
+			if !tmux.HasSession("scratchpad") {
+				home, _ := os.UserHomeDir()
+				_ = tmux.NewSessionDetached("scratchpad", home)
+				_ = tmux.RenameWindow("scratchpad:0", "term")
+			}
 
-		// Switch only this client to scratchpad, then kill the session.
-		client, _ := tmux.CurrentClient()
-		if client == "" {
-			client = tmux.CallerClient()
-		}
-		if client != "" {
-			_ = tmux.SwitchClient(client, "scratchpad")
-		} else {
-			_, _ = tmux.SwitchClientCurrent("scratchpad")
+			// Switch only this client to scratchpad, then kill the session.
+			client, _ := tmux.CurrentClient()
+			if client == "" {
+				client = tmux.CallerClient()
+			}
+			if client != "" {
+				_ = tmux.SwitchClient(client, "scratchpad")
+			} else {
+				_, _ = tmux.SwitchClientCurrent("scratchpad")
+			}
 		}
 		// PRISM_USE_MUX cutover (#2158): under the gate the session is
 		// in the mux daemon's tree, not tmux — destroy it via the
@@ -668,19 +680,29 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 		}
 	}
 
-	// Ensure the scratchpad exists so we have somewhere to send the client.
-	if !tmux.HasSession("scratchpad") {
-		home, _ := os.UserHomeDir()
-		_ = tmux.NewSessionDetached("scratchpad", home)
-		_ = tmux.RenameWindow("scratchpad:0", "term")
-	}
+	// Scratchpad swing + per-client SwitchClient is a tmux-substrate
+	// affordance (see the doCleanup gate above). Under PRISM_USE_MUX
+	// (#2176) the session lives in the mux daemon's tree, not tmux —
+	// there is no tmux client attached to the target session, the
+	// renderer handles its own session-list focus, and ensuring a
+	// tmux "scratchpad" session at this point would silently
+	// re-introduce the tmux dependency the cutover was supposed to
+	// replace.
+	if !muxCutoverEnabled() {
+		// Ensure the scratchpad exists so we have somewhere to send the client.
+		if !tmux.HasSession("scratchpad") {
+			home, _ := os.UserHomeDir()
+			_ = tmux.NewSessionDetached("scratchpad", home)
+			_ = tmux.RenameWindow("scratchpad:0", "term")
+		}
 
-	// Redirect only clients that are currently attached to the target session.
-	// We must not touch the orchestrator's own client.
-	if clients, err := tmux.ListClients(); err == nil {
-		for _, c := range clients {
-			if sess, err := tmux.ClientSession(c); err == nil && sess == session {
-				_ = tmux.SwitchClient(c, "scratchpad")
+		// Redirect only clients that are currently attached to the target session.
+		// We must not touch the orchestrator's own client.
+		if clients, err := tmux.ListClients(); err == nil {
+			for _, c := range clients {
+				if sess, err := tmux.ClientSession(c); err == nil && sess == session {
+					_ = tmux.SwitchClient(c, "scratchpad")
+				}
 			}
 		}
 	}
@@ -791,22 +813,29 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 // delete the branch — used for default-branch sessions where the checkout
 // must remain intact.
 func closeSession(session string) error {
-	// Ensure scratchpad exists.
-	if !tmux.HasSession("scratchpad") {
-		home, _ := os.UserHomeDir()
-		_ = tmux.NewSessionDetached("scratchpad", home)
-		_ = tmux.RenameWindow("scratchpad:0", "term")
-	}
+	// Scratchpad swing + SwitchClient is a tmux-substrate UX
+	// affordance — same shape as doCleanup / headlessCleanup. Skip
+	// under PRISM_USE_MUX (#2176): the session is in the mux
+	// daemon's tree, the renderer handles its own focus, and a
+	// scratchpad tmux session here would silently undo the cutover.
+	if !muxCutoverEnabled() {
+		// Ensure scratchpad exists.
+		if !tmux.HasSession("scratchpad") {
+			home, _ := os.UserHomeDir()
+			_ = tmux.NewSessionDetached("scratchpad", home)
+			_ = tmux.RenameWindow("scratchpad:0", "term")
+		}
 
-	// Switch only this client to scratchpad, then kill the session.
-	client, _ := tmux.CurrentClient()
-	if client == "" {
-		client = tmux.CallerClient()
-	}
-	if client != "" {
-		_ = tmux.SwitchClient(client, "scratchpad")
-	} else {
-		_, _ = tmux.SwitchClientCurrent("scratchpad")
+		// Switch only this client to scratchpad, then kill the session.
+		client, _ := tmux.CurrentClient()
+		if client == "" {
+			client = tmux.CallerClient()
+		}
+		if client != "" {
+			_ = tmux.SwitchClient(client, "scratchpad")
+		} else {
+			_, _ = tmux.SwitchClientCurrent("scratchpad")
+		}
 	}
 	// PRISM_USE_MUX cutover (#2158): same gate as doCleanup above
 	// and the headless-soft-close mirror. closeSession is the
@@ -887,18 +916,26 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 
 	printLine("closing session %s...\n", session)
 
-	// Ensure scratchpad exists.
-	if !tmux.HasSession("scratchpad") {
-		home, _ := os.UserHomeDir()
-		_ = tmux.NewSessionDetached("scratchpad", home)
-		_ = tmux.RenameWindow("scratchpad:0", "term")
-	}
+	// Scratchpad swing + per-client SwitchClient is a tmux-substrate
+	// affordance — same shape as the other sibling sites in this
+	// file. Skip under PRISM_USE_MUX (#2176): the session lives in
+	// the mux daemon's tree, the renderer handles its own focus,
+	// and a scratchpad tmux session here would silently undo the
+	// cutover.
+	if !muxCutoverEnabled() {
+		// Ensure scratchpad exists.
+		if !tmux.HasSession("scratchpad") {
+			home, _ := os.UserHomeDir()
+			_ = tmux.NewSessionDetached("scratchpad", home)
+			_ = tmux.RenameWindow("scratchpad:0", "term")
+		}
 
-	// Redirect clients attached to the target session.
-	if clients, err := tmux.ListClients(); err == nil {
-		for _, c := range clients {
-			if sess, err := tmux.ClientSession(c); err == nil && sess == session {
-				_ = tmux.SwitchClient(c, "scratchpad")
+		// Redirect clients attached to the target session.
+		if clients, err := tmux.ListClients(); err == nil {
+			for _, c := range clients {
+				if sess, err := tmux.ClientSession(c); err == nil && sess == session {
+					_ = tmux.SwitchClient(c, "scratchpad")
+				}
 			}
 		}
 	}

--- a/modules/programs/prism/prism/cmd/cleanup_scratchpad_gate_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_scratchpad_gate_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+// Tests for the scratchpad-swing + SwitchClient gating in cleanup.go
+// (#2176). The cutover PR (#2175) fixed the KillSession sites but
+// left the sibling scratchpad-ensure + SwitchClient blocks at four
+// line ranges (211-225, 672-685, 795-809, 891-901) ungated. Under
+// PRISM_USE_MUX=1 those blocks have no useful effect (no tmux client
+// to redirect; the renderer handles its own focus) and silently
+// re-introduce a tmux dependency the cutover was supposed to
+// remove. This test pins the corrected invariant: every
+// `tmux.NewSessionDetached("scratchpad"…)` call in cleanup.go is
+// inside an `if !muxCutoverEnabled()` block.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestCleanupSites_AllScratchpadSwingsAreGated asserts that every
+// scratchpad-ensure block in cleanup.go is guarded by
+// `if !muxCutoverEnabled()`. The pre-#2176 sites called
+// `tmux.NewSessionDetached("scratchpad", …)` unconditionally; the
+// post-#2176 sites must skip when the gate is on.
+//
+// Structural shape mirrors TestCleanupSites_AllTeardownsAreGated
+// (the sibling gate test for tmux.KillSession): scan lines, count
+// scratchpad sites, assert each one sits inside a
+// `!muxCutoverEnabled()` body.
+func TestCleanupSites_AllScratchpadSwingsAreGated(t *testing.T) {
+	data, err := os.ReadFile("cleanup.go")
+	if err != nil {
+		t.Fatalf("read cleanup.go: %v", err)
+	}
+	src := string(data)
+	lines := strings.Split(src, "\n")
+
+	// We look for the marker line that starts each scratchpad-
+	// ensure block. Every site in cleanup.go uses this exact
+	// shape: tmux.HasSession("scratchpad") inside an `if !`
+	// branch. The line above the ensure-body is the guard.
+	scratchpadSites := 0
+	gated := 0
+	for i, ln := range lines {
+		// Match the inner ensure call (the unique marker that
+		// only appears in scratchpad-ensure blocks). Using
+		// NewSessionDetached("scratchpad" pins the four sites
+		// without false-positives from other tmux calls.
+		if !strings.Contains(ln, `tmux.NewSessionDetached("scratchpad"`) {
+			continue
+		}
+		scratchpadSites++
+		// Look back up to 25 lines for the `!muxCutoverEnabled()`
+		// guard. The window is generous because the gate may sit
+		// above a multi-line comment block.
+		low := i - 25
+		if low < 0 {
+			low = 0
+		}
+		for j := i - 1; j >= low; j-- {
+			if strings.Contains(lines[j], "!muxCutoverEnabled()") {
+				gated++
+				break
+			}
+		}
+	}
+	if scratchpadSites == 0 {
+		t.Fatal("no tmux.NewSessionDetached(\"scratchpad\"…) sites found in cleanup.go — test is vacuous")
+	}
+	if scratchpadSites != 4 {
+		// The issue body names the four sibling sites explicitly
+		// (lines 211-225, 672-685, 795-809, 891-901). A change in
+		// the site count means a new ungated site was added or one
+		// was deleted — both warrant a manual review.
+		t.Errorf("cleanup.go: found %d scratchpad-ensure sites, expected 4 (per issue #2176 — sibling sites at 211-225, 672-685, 795-809, 891-901)", scratchpadSites)
+	}
+	if gated != scratchpadSites {
+		t.Errorf("cleanup.go: %d/%d scratchpad-ensure sites are gated by !muxCutoverEnabled() — the ungated ones silently re-introduce a tmux dependency under PRISM_USE_MUX=1 (issue #2176)", gated, scratchpadSites)
+	}
+}

--- a/modules/programs/prism/prism/cmd/launch.go
+++ b/modules/programs/prism/prism/cmd/launch.go
@@ -52,6 +52,23 @@ func init() {
 }
 
 func runLaunch(_ *cobra.Command, _ []string) error {
+	// PRISM_USE_MUX=1 (#2176): bring up the bubbletea renderer in the
+	// calling terminal instead of standing up the tmux
+	// scratchpad+dashboard pair. The mux path owns its own session
+	// tree (sourced from the local mux daemon) and does not need the
+	// scratchpad to exist; the renderer is the user-facing surface.
+	//
+	// --path is a legacy keybinding fast-path (ALT+o / ALT+n / zsh ^o)
+	// that opens the tmux context switcher pre-seeded with a directory.
+	// It is intentionally NOT routed through the mux path — the mux
+	// renderer does not have an equivalent "open the C-f popup at this
+	// dir" affordance yet, and the soak's launch entry point is the
+	// no-flag form. The --path path stays on the existing tmux
+	// behaviour regardless of PRISM_USE_MUX.
+	if muxCutoverEnabled() && launchPath == "" {
+		return runLaunchMux()
+	}
+
 	// --path: bypass the dashboard and open the context switcher at the given
 	// directory. This preserves the existing UX for project-specific keybindings
 	// (e.g. ALT+o → Obsidian, ALT+n → nixos-config, zsh ^o).

--- a/modules/programs/prism/prism/cmd/launch_mux.go
+++ b/modules/programs/prism/prism/cmd/launch_mux.go
@@ -1,0 +1,549 @@
+package cmd
+
+// prism launch — PRISM_USE_MUX=1 path (issue #2176).
+//
+// When PRISM_USE_MUX=1 is set, runLaunch dispatches here instead of
+// creating tmux scratchpad+dashboard sessions. This file owns the
+// renderer wire-up: it constructs the §3.1 bubbletea renderer
+// (internal/mux/render), seeds its providers (state.Subscriber for
+// sidebar colours, a client-side ReadOutput poller for active-pane
+// content), and runs the program against the user's terminal.
+//
+// Architecture:
+//
+//   - One *pane.SessionTree shared between the renderer and a
+//     reconcile-loop. The reconcile loop polls the daemon's
+//     Sessions().List() every refreshInterval, diffs against the
+//     tree, and applies AddSession / RemoveSession / AddPane to keep
+//     them in lock-step.
+//
+//   - One state.Store + one state.Subscriber per active session.
+//     Each subscriber tails its session's sidecar /events stream.
+//     The reconcile loop spawns subscribers for new sessions and
+//     cancels them when the session disappears.
+//
+//   - A clientHostProvider that maintains one *vt.Host per
+//     (sessionID, paneName) the renderer asks about. A background
+//     goroutine polls the daemon's /pane/read_output for every cached
+//     entry every refreshInterval and re-feeds the vt.Host so
+//     RenderRows() reflects the latest frame.
+//
+//   - All goroutines are bound by a single context tied to the
+//     bubbletea program's lifetime. tea.Quit cancels the context
+//     which unwinds every poller, subscriber, and reconciler.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/mux/client"
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+	"github.com/prismatic-koi/prism/internal/mux/render"
+	"github.com/prismatic-koi/prism/internal/mux/state"
+	"github.com/prismatic-koi/prism/internal/mux/vt"
+	prismSession "github.com/prismatic-koi/prism/internal/session"
+)
+
+// muxLaunchRefreshInterval bounds how often the launch path polls the
+// daemon for session-list and pane-output deltas. 100 ms is short enough
+// to feel live for an interactive operator but long enough not to flood
+// the daemon's socket with redundant GETs. Tuneable; the renderer is
+// repainted on every successful poll so a slower interval just means
+// stale frames.
+const muxLaunchRefreshInterval = 100 * time.Millisecond
+
+// muxLaunchHTTPTimeout bounds a single GET round-trip to the daemon's
+// /pane/read_output or /session/list endpoint. Long enough that a
+// momentarily-busy daemon does not flap into "(no PTY)"; short enough
+// that a wedged daemon does not stall the reconcile loop.
+const muxLaunchHTTPTimeout = 2 * time.Second
+
+// runLaunchMux is the PRISM_USE_MUX=1 entry point for `prism launch`.
+// It connects to the local mux daemon, builds a renderer Model wired
+// to a live SessionTree + state.Store + clientHostProvider, and runs
+// the bubbletea program in the calling terminal.
+//
+// Returns an error in three cases:
+//
+//   - daemon unreachable (surfaces the canonical
+//     daemonNotRunningError diagnostic so the operator sees the
+//     supervisor hint)
+//   - tea.Program.Run failure
+//   - reconcile-loop initial-list failure not covered by the
+//     daemon-not-running check (best-effort: we still launch the
+//     program; the sidebar simply shows "0 sessions" until the
+//     reconcile recovers)
+func runLaunchMux() error {
+	mc, err := newMuxClient()
+	if err != nil {
+		return surfaceDaemonError("prism launch", err)
+	}
+	defer mc.Close()
+
+	// Probe the daemon once up-front so a stopped daemon surfaces the
+	// canonical hint immediately rather than after the program loop is
+	// running (a tea.Program eating the error would be a worse UX than
+	// a clean exit).
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), muxLaunchHTTPTimeout)
+	if _, err := mc.Sessions().List(probeCtx); err != nil {
+		probeCancel()
+		return surfaceDaemonError("prism launch", err)
+	}
+	probeCancel()
+
+	tree := pane.New()
+	store := state.New(tree)
+
+	hostProvider := newClientHostProvider(mc)
+
+	model := render.New(
+		tree,
+		render.WithStates(newStateAdapter(store)),
+		render.WithHosts(hostProvider),
+	)
+
+	prog := tea.NewProgram(model, tea.WithAltScreen())
+
+	// All background goroutines share one context tied to the
+	// program's lifetime. Cancelled in the defer below so a tea.Quit
+	// cleanly unwinds every poller.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Subscriber manager: one state.Subscriber per active session.
+	// Spawned/cancelled by the reconcile loop as sessions appear and
+	// disappear from the daemon's session list.
+	mgr := newSubscriberManager(ctx, store)
+
+	// Reconcile loop: polls Sessions().List on a tick, diffs against
+	// the tree, applies the diff, and starts/stops subscribers.
+	go runReconcileLoop(ctx, mc, tree, mgr, prog)
+
+	// Host poll loop: polls /pane/read_output for every cached host
+	// on a tick, feeds the bytes into the corresponding *vt.Host, and
+	// sends a redraw message to the program.
+	go hostProvider.run(ctx, prog)
+
+	// On every store transition send a redraw message so the sidebar
+	// glyph for the affected session repaints "within one frame of an
+	// agent_events row change" (AC #2176).
+	store.AddListener(func() { prog.Send(muxRedrawMsg{}) })
+
+	if _, err := prog.Run(); err != nil {
+		return fmt.Errorf("prism launch: tea.Program.Run: %w", err)
+	}
+	return nil
+}
+
+// muxRedrawMsg is a no-op message used to nudge bubbletea into
+// repainting after a background goroutine updated the store or a
+// cached host. The renderer's Update() does not need to handle it
+// explicitly — any tea.Msg triggers a View() pass.
+type muxRedrawMsg struct{}
+
+// ── State adapter: agent.AgentState → render.State ─────────────────
+
+// stateAdapter implements render.StateProvider by reading from a
+// state.Store. The Store keeps per-session agent.AgentState; the
+// renderer wants the render.State enum. The mapping is the canonical
+// vocabulary from agent/agent.go translated into the renderer's int
+// enum from render/state.go.
+type stateAdapter struct {
+	store *state.Store
+}
+
+func newStateAdapter(store *state.Store) *stateAdapter {
+	return &stateAdapter{store: store}
+}
+
+// State implements render.StateProvider.
+func (a *stateAdapter) State(sessionID string) render.State {
+	if a == nil || a.store == nil {
+		return render.StateIdle
+	}
+	st, ok := a.store.SessionState(sessionID)
+	if !ok {
+		return render.StateIdle
+	}
+	switch st {
+	case agent.StateActive:
+		return render.StateActive
+	case agent.StateWaiting:
+		return render.StateWaiting
+	case agent.StateReviewing:
+		return render.StateReviewing
+	case agent.StateEscalated:
+		return render.StateEscalated
+	case agent.StateFinished:
+		return render.StateFinished
+	default:
+		// idle, compacting, error, interrupted, deleted → idle glyph.
+		// The renderer treats any unknown state as StateIdle (zero
+		// value) which is the desired UX for "session exists but is
+		// not actively doing anything".
+		return render.StateIdle
+	}
+}
+
+// ── Subscriber manager ────────────────────────────────────────────
+
+// subscriberManager owns one state.Subscriber goroutine per active
+// session. The reconcile loop calls ensure(id) on every session it
+// sees in the daemon's list and stop(id) on every session that
+// disappears.
+type subscriberManager struct {
+	ctx   context.Context
+	store *state.Store
+
+	mu   sync.Mutex
+	subs map[string]context.CancelFunc
+}
+
+func newSubscriberManager(ctx context.Context, store *state.Store) *subscriberManager {
+	return &subscriberManager{
+		ctx:   ctx,
+		store: store,
+		subs:  make(map[string]context.CancelFunc),
+	}
+}
+
+// ensure spawns a Subscriber for sessionID if one is not already
+// running. The Subscriber's cancellation is bound to the manager's
+// parent context so a manager-level shutdown unwinds every goroutine.
+//
+// Each Subscriber connects to its session's per-session host-API
+// socket — there is no daemon-wide events socket in the current
+// architecture (every prism session has its own sidecar; see
+// internal/session/sidecar.go's SidecarHostAPIPath).
+func (m *subscriberManager) ensure(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.subs[sessionID]; ok {
+		return
+	}
+	sockPath, err := prismSession.SidecarHostAPIPath(sessionID)
+	if err != nil {
+		// The session's sidecar may not have started yet, or the
+		// path resolution failed. Try again on the next reconcile
+		// tick by leaving the map entry unset.
+		return
+	}
+	subCtx, cancel := context.WithCancel(m.ctx)
+	sub := &state.Subscriber{
+		SockPath: sockPath,
+		Sessions: []string{sessionID},
+		Store:    m.store,
+	}
+	m.subs[sessionID] = cancel
+	go func() {
+		// Run blocks until subCtx fires. Errors surface to the
+		// default logger; the launch path itself does not log
+		// directly so the renderer's altscreen is not polluted.
+		_ = sub.Run(subCtx)
+	}()
+}
+
+// stop cancels the Subscriber for sessionID, if one is running. Safe
+// to call on an unknown ID (no-op).
+func (m *subscriberManager) stop(sessionID string) {
+	m.mu.Lock()
+	cancel, ok := m.subs[sessionID]
+	if ok {
+		delete(m.subs, sessionID)
+	}
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// ── Reconcile loop ────────────────────────────────────────────────
+
+// runReconcileLoop polls the daemon's Sessions().List on a tick,
+// diffs against the SessionTree, and applies the difference.
+//
+// New sessions in the daemon are AddSession'd into the tree (and a
+// Subscriber is spawned for state). Sessions that disappear from the
+// daemon are RemoveSession'd and their Subscriber stopped. Existing
+// sessions whose pane list grew are AddPane'd.
+//
+// The loop sends a muxRedrawMsg after every successful pass so the
+// sidebar repaints with the latest session set even when no state
+// event flowed (e.g. the first paint after a fresh launch).
+func runReconcileLoop(ctx context.Context, mc client.MuxClient, tree *pane.SessionTree, mgr *subscriberManager, prog *tea.Program) {
+	ticker := time.NewTicker(muxLaunchRefreshInterval)
+	defer ticker.Stop()
+
+	// Run one pass synchronously so the program's first paint is
+	// against the daemon's current state, not an empty tree.
+	reconcileOnce(ctx, mc, tree, mgr)
+	if prog != nil {
+		prog.Send(muxRedrawMsg{})
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reconcileOnce(ctx, mc, tree, mgr)
+			if prog != nil {
+				prog.Send(muxRedrawMsg{})
+			}
+		}
+	}
+}
+
+// reconcileOnce is one pass of the reconcile loop, broken out for
+// clarity. Fetches Sessions().List, diffs against the tree, applies
+// AddSession / RemoveSession / AddPane, and reconciles the subscriber
+// set.
+func reconcileOnce(ctx context.Context, mc client.MuxClient, tree *pane.SessionTree, mgr *subscriberManager) {
+	listCtx, cancel := context.WithTimeout(ctx, muxLaunchHTTPTimeout)
+	defer cancel()
+	list, err := mc.Sessions().List(listCtx)
+	if err != nil {
+		// Transient daemon error — leave the tree alone and retry
+		// on the next tick. Subscribers continue running against
+		// their per-session sockets independently.
+		return
+	}
+
+	wanted := make(map[string]struct{}, len(list.Sessions))
+	for _, s := range list.Sessions {
+		wanted[s.ID] = struct{}{}
+		// AddSession is idempotent at the "already exists" level
+		// — we suppress that error and apply the pane diff below.
+		if !tree.HasSession(s.ID) {
+			toAdd := s
+			// Strip ActivePane on add — the server's view may set
+			// it but the tree's AddSession rejects a non-empty
+			// ActivePane that does not resolve to a pane it has
+			// been given. Adding panes one-by-one below re-derives
+			// the active pane.
+			toAdd.ActivePane = ""
+			toAdd.Panes = nil
+			_ = tree.AddSession(toAdd)
+		}
+		// Diff the pane list and add any new panes. Removing
+		// panes mid-session is out of scope for this poll loop —
+		// the daemon does not advertise pane removals through
+		// Sessions().List in a way the tree can apply without a
+		// full rebuild.
+		existing := map[string]struct{}{}
+		if existingSess, ok := tree.Session(s.ID); ok {
+			for _, p := range existingSess.Panes {
+				existing[p.Name] = struct{}{}
+			}
+		}
+		for _, p := range s.Panes {
+			if _, ok := existing[p.Name]; ok {
+				continue
+			}
+			_ = tree.AddPane(s.ID, p)
+		}
+		// Activate the daemon's preferred pane explicitly. This
+		// is a best-effort op: if the pane name is unknown to the
+		// tree it returns ErrPaneNotFound, which we swallow.
+		if s.ActivePane != "" {
+			_ = tree.ActivatePane(s.ID, s.ActivePane)
+		}
+		mgr.ensure(s.ID)
+	}
+
+	// Remove sessions that vanished. tree.Sessions() returns a
+	// snapshot, so this is safe to range over while calling
+	// RemoveSession.
+	for _, existing := range tree.Sessions() {
+		if _, keep := wanted[existing.ID]; keep {
+			continue
+		}
+		_ = tree.RemoveSession(existing.ID)
+		mgr.stop(existing.ID)
+	}
+
+	// Activate the daemon's tree-level focus pointer if it has one.
+	// Same best-effort semantics as the pane activation above.
+	if list.ActiveSession != "" {
+		_ = tree.ActivateSession(list.ActiveSession)
+	}
+}
+
+// ── Client-side HostProvider ──────────────────────────────────────
+
+// clientHostProvider implements render.HostProvider by maintaining a
+// *vt.Host per (sessionID, paneName) and re-feeding it from the
+// daemon's /pane/read_output endpoint on a tick.
+//
+// The renderer's Host() contract is "return the same *vt.Host across
+// successive calls for the same key" — the Model dereferences the
+// returned host every View(), so the value must be stable. We use a
+// sync.Map-shaped cache keyed by sessionID+"\x00"+paneName.
+//
+// The provider is intentionally one-frame-behind: the renderer reads
+// whatever the most recent poll cached. This is acceptable for the
+// soak — the daemon's /pane/read_output endpoint is documented as
+// "lossier than the in-process path but sufficient for the phase-3
+// soak" (internal/mux/server/output.go).
+type clientHostProvider struct {
+	mc client.MuxClient
+
+	mu    sync.RWMutex
+	hosts map[string]*vt.Host
+}
+
+func newClientHostProvider(mc client.MuxClient) *clientHostProvider {
+	return &clientHostProvider{
+		mc:    mc,
+		hosts: make(map[string]*vt.Host),
+	}
+}
+
+// hostKey is the cache key — sessionID + NUL + paneName. The NUL
+// byte separates the components so a pane named "a/b" in a session
+// "x" cannot collide with a pane named "b" in a session "x/a". NUL
+// is never a valid byte in either field so the encoding is
+// unambiguous.
+func hostKey(sessionID, paneName string) string {
+	return sessionID + "\x00" + paneName
+}
+
+// Host implements render.HostProvider. Returns the cached *vt.Host
+// for (sessionID, paneName), constructing an empty one on first call.
+// The first call also triggers an immediate async poll so the next
+// View() pass has content.
+func (p *clientHostProvider) Host(sessionID, paneName string) *vt.Host {
+	if sessionID == "" || paneName == "" {
+		return nil
+	}
+	key := hostKey(sessionID, paneName)
+	p.mu.RLock()
+	h, ok := p.hosts[key]
+	p.mu.RUnlock()
+	if ok {
+		return h
+	}
+	// First-call path: install an empty host so subsequent View()
+	// passes get the cached value, then kick off an immediate refresh.
+	p.mu.Lock()
+	h, ok = p.hosts[key]
+	if !ok {
+		h = vt.New(80, 24)
+		p.hosts[key] = h
+	}
+	p.mu.Unlock()
+	// Async refresh so the next View() pass has live bytes. We do
+	// not block the renderer on the round-trip.
+	go p.refreshOne(context.Background(), sessionID, paneName, h)
+	return h
+}
+
+// refreshOne fetches the latest PaneFrame for (sessionID, paneName)
+// and re-feeds it into host. The feed sequence is:
+//
+//  1. Resize host to PaneFrame.Cols × PaneFrame.Rows so RenderRows()
+//     returns the right row count for the renderer's truncation.
+//  2. Clear and home: `\x1b[H\x1b[2J`.
+//  3. Feed the rendered lines joined by `\r\n`.
+//
+// This rebuilds the cell grid from the daemon's already-rendered
+// snapshot. Cursor position and attributes are NOT preserved — the
+// /pane/read_output endpoint's response shape carries them but the
+// renderer's renderHostFrame only inspects Size() and RenderRows(),
+// so a faithful textual replay is sufficient for the soak.
+func (p *clientHostProvider) refreshOne(ctx context.Context, sessionID, paneName string, host *vt.Host) {
+	if host == nil {
+		return
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, muxLaunchHTTPTimeout)
+	defer cancel()
+	frame, err := p.mc.Panes().ReadOutput(reqCtx, sessionID, paneName)
+	if err != nil {
+		return
+	}
+	cols := frame.Cols
+	rows := frame.Rows
+	if cols <= 0 || rows <= 0 {
+		// Pane has no PTY yet (model-only row). Leave the host as
+		// last-seen so the renderer shows the previous frame
+		// rather than flashing the placeholder.
+		return
+	}
+	host.Resize(cols, rows)
+	// Reset + home + clear so each refresh starts from a known
+	// state. Without the reset, repeated feeds would scroll
+	// content off the top of the emulator's grid.
+	var buf bytes.Buffer
+	buf.WriteString("\x1bc")    // RIS — full reset
+	buf.WriteString("\x1b[H")   // home
+	buf.WriteString("\x1b[2J")  // clear screen
+	for i, line := range frame.Lines {
+		if i > 0 {
+			buf.WriteString("\r\n")
+		}
+		buf.WriteString(line)
+	}
+	_, _ = host.Feed(buf.Bytes())
+}
+
+// run is the host-poll background goroutine. Every tick, walks the
+// cached host set and refreshes each one in parallel-bounded chunks.
+// Sends a muxRedrawMsg after the pass so the renderer picks up the
+// new frames.
+func (p *clientHostProvider) run(ctx context.Context, prog *tea.Program) {
+	ticker := time.NewTicker(muxLaunchRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.refreshAll(ctx)
+			if prog != nil {
+				prog.Send(muxRedrawMsg{})
+			}
+		}
+	}
+}
+
+// refreshAll polls every cached host once. Synchronous — the next
+// tick fires only after this pass completes. For the soak's typical
+// cardinality (≤ a dozen panes per developer) the cumulative
+// round-trip time stays well under the tick interval.
+func (p *clientHostProvider) refreshAll(ctx context.Context) {
+	p.mu.RLock()
+	keys := make([]string, 0, len(p.hosts))
+	hosts := make([]*vt.Host, 0, len(p.hosts))
+	for k, h := range p.hosts {
+		keys = append(keys, k)
+		hosts = append(hosts, h)
+	}
+	p.mu.RUnlock()
+	for i, key := range keys {
+		sessionID, paneName, ok := splitHostKey(key)
+		if !ok {
+			continue
+		}
+		p.refreshOne(ctx, sessionID, paneName, hosts[i])
+	}
+}
+
+// splitHostKey is the inverse of hostKey — splits sessionID and
+// paneName on the NUL separator.
+func splitHostKey(key string) (sessionID, paneName string, ok bool) {
+	idx := strings.IndexByte(key, '\x00')
+	if idx < 0 {
+		return "", "", false
+	}
+	return key[:idx], key[idx+1:], true
+}

--- a/modules/programs/prism/prism/cmd/launch_mux_test.go
+++ b/modules/programs/prism/prism/cmd/launch_mux_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+// Tests for the prism launch PRISM_USE_MUX=1 renderer wiring (#2176).
+//
+// These tests pin the state-adapter mapping (agent.AgentState →
+// render.State) and the host-provider's empty-frame contract. Both
+// are leaf wiring pieces that the runLaunchMux entry point depends
+// on; getting them right pre-empts a class of "the renderer shows
+// the wrong glyph" failures the soak would otherwise surface.
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/mux/pane"
+	"github.com/prismatic-koi/prism/internal/mux/render"
+	"github.com/prismatic-koi/prism/internal/mux/state"
+)
+
+// TestStateAdapter_MapsAgentStateToRenderState pins the canonical
+// agent.AgentState → render.State translation table the launch
+// renderer relies on. The agent vocabulary is wider than the
+// renderer's (idle / compacting / error / interrupted / deleted all
+// collapse to StateIdle for the sidebar glyph) so the mapping
+// deserves an explicit table-driven test.
+func TestStateAdapter_MapsAgentStateToRenderState(t *testing.T) {
+	cases := []struct {
+		in   agent.AgentState
+		want render.State
+	}{
+		{agent.StateActive, render.StateActive},
+		{agent.StateWaiting, render.StateWaiting},
+		{agent.StateReviewing, render.StateReviewing},
+		{agent.StateEscalated, render.StateEscalated},
+		{agent.StateFinished, render.StateFinished},
+		{agent.StateIdle, render.StateIdle},
+		// The vocabulary outside the renderer's enum collapses to
+		// idle. This is the desired UX — the sidebar glyph stays
+		// neutral rather than showing an "unknown" character.
+		{agent.StateCompacting, render.StateIdle},
+		{agent.StateError, render.StateIdle},
+		{agent.StateInterrupted, render.StateIdle},
+		{agent.StateDeleted, render.StateIdle},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.in), func(t *testing.T) {
+			store := state.New(nil)
+			store.SetSessionState("test", tc.in)
+			a := newStateAdapter(store)
+			got := a.State("test")
+			if got != tc.want {
+				t.Errorf("agent.AgentState(%q) → render.State = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStateAdapter_UnknownSessionIsIdle pins the "no event yet"
+// path: a session the Store has never seen reports StateIdle (the
+// renderer's zero value) so the sidebar renders cleanly on first
+// paint, before any agent_events row has flowed.
+func TestStateAdapter_UnknownSessionIsIdle(t *testing.T) {
+	store := state.New(nil)
+	a := newStateAdapter(store)
+	if got := a.State("never-seen"); got != render.StateIdle {
+		t.Errorf("unknown session → %d, want StateIdle (%d)", got, render.StateIdle)
+	}
+}
+
+// TestStateAdapter_NilSafe pins the defensive nil-check inside the
+// adapter. The launch wire-up should never pass a nil store, but a
+// future refactor that accidentally does should fail soft (every
+// session reports idle) rather than panic.
+func TestStateAdapter_NilSafe(t *testing.T) {
+	var a *stateAdapter // nil receiver
+	if got := a.State("anything"); got != render.StateIdle {
+		t.Errorf("nil adapter → %d, want StateIdle (%d)", got, render.StateIdle)
+	}
+	a = newStateAdapter(nil)
+	if got := a.State("anything"); got != render.StateIdle {
+		t.Errorf("adapter with nil store → %d, want StateIdle (%d)", got, render.StateIdle)
+	}
+}
+
+// TestClientHostProvider_HostKey_RoundTrips pins the (sessionID,
+// paneName) ↔ cacheKey encoding. The NUL separator is documented to
+// prevent collisions between a pane named "a/b" in session "x" and
+// a pane named "b" in session "x/a"; this test enforces the round-
+// trip so a future refactor that swaps NUL for a different
+// separator does not silently re-introduce the collision class.
+func TestClientHostProvider_HostKey_RoundTrips(t *testing.T) {
+	cases := []struct {
+		session, pane string
+	}{
+		{"repo@feat", "agent"},
+		{"repo@feat", "edit"},
+		{"repo@feat~review-1-code", "agent"},
+		// Cases with slashes / colons / dashes in either field —
+		// the NUL separator should make all of these unambiguous.
+		{"repo/sub@feat", "agent:1"},
+		{"x", "a/b"},
+		{"x/a", "b"},
+	}
+	for _, tc := range cases {
+		key := hostKey(tc.session, tc.pane)
+		sess, name, ok := splitHostKey(key)
+		if !ok {
+			t.Errorf("splitHostKey(%q): ok=false; want true", key)
+			continue
+		}
+		if sess != tc.session || name != tc.pane {
+			t.Errorf("round-trip(%q,%q) = (%q,%q); want unchanged", tc.session, tc.pane, sess, name)
+		}
+	}
+}
+
+// TestClientHostProvider_HostKey_CollisionResistant pins the
+// non-collision invariant for the case the NUL separator solves:
+// session "x" + pane "a/b" must map to a different key than session
+// "x/a" + pane "b".
+func TestClientHostProvider_HostKey_CollisionResistant(t *testing.T) {
+	a := hostKey("x", "a/b")
+	b := hostKey("x/a", "b")
+	if a == b {
+		t.Errorf("hostKey collisions: hostKey(x, a/b) = hostKey(x/a, b) = %q", a)
+	}
+}
+
+// TestClientHostProvider_Host_NilOnEmptyInput pins the defensive
+// short-circuit for empty (sessionID, paneName). The renderer's
+// renderActivePane already filters these out at the row-resolution
+// step, but the provider should return nil rather than fabricating
+// an empty host that would never be polled.
+func TestClientHostProvider_Host_NilOnEmptyInput(t *testing.T) {
+	p := newClientHostProvider(nil) // mc unused on the nil-arg branch
+	if got := p.Host("", "agent"); got != nil {
+		t.Errorf("Host(\"\", \"agent\") = %v, want nil", got)
+	}
+	if got := p.Host("repo@feat", ""); got != nil {
+		t.Errorf("Host(\"repo@feat\", \"\") = %v, want nil", got)
+	}
+}
+
+// Ensure the unused imports (pane / render) report no
+// "imported and not used" errors at build time. The references
+// here are no-ops at runtime but keep the test file honest about
+// the type contracts it depends on.
+var _ render.StateProvider = (*stateAdapter)(nil)
+var _ = pane.New

--- a/modules/programs/prism/prism/internal/session/mux_layout.go
+++ b/modules/programs/prism/prism/internal/session/mux_layout.go
@@ -145,8 +145,18 @@ func SpawnMuxLayout(opts SpawnOpts, port int) error {
 	//    first pane (AddPane sets ActivePane when the session had
 	//    none), so the canonical order matters — the slice order is
 	//    the order we add.
+	//
+	//    The agent pane's argv is branched on isolation mode (#2176):
+	//    sandboxed modes (bwrap / podman / sandbox-exec) exec
+	//    `prism agent-run --session <name>`; host mode execs the
+	//    harness directly via BuildAgentCmd. Both paths wrap the
+	//    command string in `sh -c …` so shell features (env-var
+	//    expansion, `$(cat <prompt-file>)`, the podman readiness
+	//    wait loop) keep working — mirroring tmux's NewWindow,
+	//    which itself runs the agent command via `sh -c`.
+	isolation := resolveLayoutIsolationMode(opts)
 	for _, name := range paneNames {
-		paneOpts := muxPaneOptsFor(opts, port, name)
+		paneOpts := muxPaneOptsFor(opts, port, name, isolation)
 		if err := mc.Panes().Create(ctx, opts.SessionName, name, paneOpts); err != nil {
 			// Roll back: tear down the session so a retry sees a
 			// clean slate in the daemon's session tree.
@@ -244,55 +254,70 @@ func muxPanesForLayout(layout Layout) (panes []string, active string, err error)
 }
 
 // muxPaneOptsFor returns the PaneCreateOptions for the named pane.
-// Each pane gets a tiny argv that runs the same kind of process the
-// tmux path runs in the equivalent window:
+// Each pane's argv mirrors the tmux path's equivalent window:
 //
-//   - edit   → nvim (matches tmux setupFullLayout window 0)
-//   - agent  → /bin/sh under the worktree (the agent harness is
-//              started by the sidecar; the shell holds the PTY so
-//              the renderer has something to render and so initial-
-//              prompt bytes have somewhere to land)
+//   - edit   → /bin/sh under the worktree (matches tmux
+//              setupFullLayout window 0; the renderer will gain a
+//              "switch to edit pane" key that opens nvim on demand —
+//              not strictly needed for the soak)
+//   - agent  → the harness launch command, dispatched by isolation:
+//              · sandboxed (bwrap / podman / sandbox-exec):
+//                `prism agent-run --session <name>` (BuildAgentCmd's
+//                AgentPaneCmd output for those modes; #2176 cutover)
+//              · host: pi (or the configured harness) execs directly
+//                via buildDirectAgentCmd's output (#2176 cutover)
 //   - term   → /bin/sh (matches tmux setupFullLayout window 2)
 //   - shell  → /bin/sh (LayoutAgentOnly window 0)
 //
+// The agent pane is wrapped in `sh -c <cmd>` so shell features the
+// tmux path relies on — host mode's `$(cat <prompt-file>)`,
+// sandboxed modes' env-var expansion, and podman's readiness-wait
+// loop — keep working. This mirrors tmux's NewWindow, which runs the
+// agent command via `sh -c` itself.
+//
 // The Cwd is opts.Worktree for every pane so the shell prompt
 // matches the tmux path's per-window starting directory.
-//
-// Note: this is not yet feature-parity with the tmux path. The tmux
-// path's `agent` window runs the harness directly under sandbox
-// wrappers; the mux path's `agent` pane runs /bin/sh and the sidecar
-// drives the harness over the host-API socket. For phase-2 cutover
-// this is sufficient — the user does not see the panes (no renderer
-// is wired into a user-facing entry point yet) and the agent's
-// observable behaviour is unchanged because the sidecar is the
-// substrate that talks to pi.
-func muxPaneOptsFor(opts SpawnOpts, _ int, name string) client.PaneCreateOptions {
+func muxPaneOptsFor(opts SpawnOpts, port int, name, isolation string) client.PaneCreateOptions {
 	shell := defaultShellPath()
 	cwd := opts.Worktree
-	// Inherit the daemon's env. A future PR can layer per-pane env
-	// (PRISM_SESSION_NAME, TERM, etc.) once the renderer is wired
-	// and starts to care.
-	env := map[string]string(nil)
 
 	switch name {
-	case "edit":
-		// Run a shell rather than nvim directly — nvim is more
-		// expensive and not strictly necessary for the cutover.
-		// The renderer will eventually expose a "switch to edit
-		// pane" key that opens nvim on demand. For the soak the
-		// shell-in-the-worktree shape is enough.
+	case "agent":
+		// Build the agent launch command using the same Opts shape
+		// the tmux path uses (buildOptsForLayout). The isolation
+		// mode is explicit so a SpawnOpts with an empty IsolationMode
+		// (the review-fanout shape on a bwrap-default machine)
+		// resolves the same way it does in the tmux path —
+		// resolveLayoutIsolationMode is called once in SpawnMuxLayout
+		// and threaded through here.
+		launchOpts := buildOptsForLayout(opts, port, opts.PromptFilePath)
+		launchOpts.IsolationMode = isolation
+		launchOpts.Worktree = opts.Worktree
+		agentCmd := BuildAgentCmd(launchOpts)
+
 		return client.PaneCreateOptions{
-			Argv: []string{shell},
+			// `sh -c <cmd>` mirrors what tmux does for NewWindow's
+			// command argument. argv[0] is the shell so the daemon's
+			// PTY-spawn path is unchanged.
+			Argv: []string{shell, "-c", agentCmd},
 			Cwd:  cwd,
-			Env:  env,
+			// Merge the daemon's env (inherited via os.Environ() on
+			// the CLI side — both daemon and CLI run under the same
+			// user session for the soak) with the per-session
+			// overrides agentPaneEnvVars produces. The overrides
+			// carry PRISM_INITIAL_PROMPT_FILE (sandboxed modes) and
+			// PRISM_HARNESS_PIPE (host mode with a socket-pipe
+			// harness) — without these the agent never reads the
+			// prompt and never connects to the sidecar bridge.
+			Env:  muxAgentEnv(launchOpts),
 			Cols: 80,
 			Rows: 24,
 		}
-	case "agent", "term", "shell":
+	case "edit", "term", "shell":
 		return client.PaneCreateOptions{
 			Argv: []string{shell},
 			Cwd:  cwd,
-			Env:  env,
+			Env:  nil, // inherit daemon env
 			Cols: 80,
 			Rows: 24,
 		}
@@ -302,11 +327,45 @@ func muxPaneOptsFor(opts SpawnOpts, _ int, name string) client.PaneCreateOptions
 		return client.PaneCreateOptions{
 			Argv: []string{shell},
 			Cwd:  cwd,
-			Env:  env,
+			Env:  nil,
 			Cols: 80,
 			Rows: 24,
 		}
 	}
+}
+
+// muxAgentEnv builds the env map for the agent pane: the CLI process's
+// own os.Environ() (used as a proxy for the daemon's inherited env,
+// since both run under the same user for the soak) merged with the
+// per-session overrides from agentPaneEnvVars.
+//
+// The mux daemon's pane.create REPLACES the child's env when a non-nil
+// map is supplied — there is no "inherit + override" mode — so we have
+// to assemble the full set here. agentPaneEnvVars overrides win on key
+// collision: a session-specific PRISM_HARNESS_PIPE replaces any stale
+// one in the operator's shell env.
+func muxAgentEnv(opts Opts) map[string]string {
+	env := make(map[string]string, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if i := indexByte(kv, '='); i > 0 {
+			env[kv[:i]] = kv[i+1:]
+		}
+	}
+	for k, v := range agentPaneEnvVars(opts) {
+		env[k] = v
+	}
+	return env
+}
+
+// indexByte is a tiny inline strings.IndexByte so this file does not
+// need to import strings for a single call site.
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
 }
 
 // defaultShellPath returns the absolute path to /bin/sh, the one

--- a/modules/programs/prism/prism/internal/session/mux_pane_argv_test.go
+++ b/modules/programs/prism/prism/internal/session/mux_pane_argv_test.go
@@ -1,0 +1,205 @@
+package session
+
+// Tests for the isolation-mode argv branching in muxPaneOptsFor (#2176).
+//
+// The pre-#2176 implementation returned Argv = ["/bin/sh"] for every
+// pane regardless of isolation mode, so the agent harness never
+// launched and SpawnSession's WaitForReady gate timed out after 30s.
+// These tests pin the corrected branch: the `agent` pane's argv runs
+// the harness (host) or `prism agent-run` (bwrap / sandbox-exec)
+// wrapped in `sh -c …`; the `edit` / `term` / `shell` panes stay on
+// plain `/bin/sh`.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMuxPaneOptsFor_AgentPane_BwrapMode_RunsAgentRun asserts that
+// the bwrap branch's agent argv invokes `prism agent-run --session
+// <name>`. This is the pre-#2176 spawn-hang fix: without this
+// branch, the agent pane runs /bin/sh and pi never starts.
+func TestMuxPaneOptsFor_AgentPane_BwrapMode_RunsAgentRun(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName: "repo@feat",
+		Worktree:    "/tmp/repo/feat",
+		AgentRole:   "worker",
+	}
+	got := muxPaneOptsFor(opts, 0, "agent", "bwrap")
+
+	if len(got.Argv) < 3 {
+		t.Fatalf("agent argv too short: %v (want at least 3 elements)", got.Argv)
+	}
+	if !isShellExecArgv(got.Argv) {
+		t.Fatalf("agent argv = %v, want [sh, -c, <cmd>] shape", got.Argv)
+	}
+	cmd := got.Argv[2]
+	if !strings.Contains(cmd, "prism agent-run") {
+		t.Errorf("bwrap agent cmd = %q, want it to invoke `prism agent-run`", cmd)
+	}
+	if !strings.Contains(cmd, "repo@feat") {
+		t.Errorf("bwrap agent cmd = %q, want --session repo@feat", cmd)
+	}
+}
+
+// TestMuxPaneOptsFor_AgentPane_SandboxExecMode_RunsAgentRun mirrors
+// the bwrap test for the sandbox-exec branch. Both modes route the
+// agent through `prism agent-run`, so the assertion is the same
+// shape.
+func TestMuxPaneOptsFor_AgentPane_SandboxExecMode_RunsAgentRun(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName: "repo@review",
+		Worktree:    "/tmp/repo/review",
+		AgentRole:   "review-code",
+	}
+	got := muxPaneOptsFor(opts, 0, "agent", "sandbox-exec")
+
+	if !isShellExecArgv(got.Argv) {
+		t.Fatalf("sandbox-exec agent argv = %v, want [sh, -c, <cmd>] shape", got.Argv)
+	}
+	cmd := got.Argv[2]
+	if !strings.Contains(cmd, "prism agent-run") {
+		t.Errorf("sandbox-exec agent cmd = %q, want `prism agent-run`", cmd)
+	}
+}
+
+// TestMuxPaneOptsFor_AgentPane_HostMode_RunsHarnessDirectly verifies
+// that host mode bypasses `prism agent-run` and execs the harness
+// (pi) directly. The exact flag shape comes from buildDirectAgentCmd
+// which is tested in session_test.go; here we just assert the cmd
+// is NOT `prism agent-run`.
+func TestMuxPaneOptsFor_AgentPane_HostMode_RunsHarnessDirectly(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName: "repo@feat",
+		Worktree:    "/tmp/repo/feat",
+		AgentRole:   "worker",
+		Prompt:      "hello",
+	}
+	got := muxPaneOptsFor(opts, 0, "agent", "host")
+
+	if !isShellExecArgv(got.Argv) {
+		t.Fatalf("host agent argv = %v, want [sh, -c, <cmd>] shape", got.Argv)
+	}
+	cmd := got.Argv[2]
+	if strings.Contains(cmd, "prism agent-run") {
+		t.Errorf("host agent cmd = %q, MUST NOT route through `prism agent-run` (host execs the harness directly)", cmd)
+	}
+	// The pi harness is the default; the cmd should reference it.
+	if !strings.HasPrefix(cmd, "pi") && !strings.Contains(cmd, " pi ") {
+		t.Errorf("host agent cmd = %q, want it to invoke pi", cmd)
+	}
+}
+
+// TestMuxPaneOptsFor_NonAgentPanes_StayShell pins the non-regression
+// path: the edit / term / shell panes should NOT run the agent
+// harness. They are plain shells regardless of isolation mode.
+func TestMuxPaneOptsFor_NonAgentPanes_StayShell(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName: "repo@feat",
+		Worktree:    "/tmp/repo/feat",
+	}
+	for _, name := range []string{"edit", "term", "shell"} {
+		t.Run(name, func(t *testing.T) {
+			for _, mode := range []string{"bwrap", "sandbox-exec", "host", "podman"} {
+				got := muxPaneOptsFor(opts, 0, name, mode)
+				if len(got.Argv) != 1 {
+					t.Errorf("(%s, %s) argv = %v, want single-element [sh]", name, mode, got.Argv)
+				}
+				if len(got.Argv) > 0 && !strings.HasSuffix(got.Argv[0], "sh") {
+					t.Errorf("(%s, %s) argv[0] = %q, want a shell path", name, mode, got.Argv[0])
+				}
+			}
+		})
+	}
+}
+
+// TestMuxPaneOptsFor_AgentPane_CwdIsWorktree pins the per-pane
+// working directory invariant. The agent harness needs to start in
+// the worktree so relative path references in the prompt and the
+// agent's tool calls resolve to the right repo.
+func TestMuxPaneOptsFor_AgentPane_CwdIsWorktree(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName: "repo@feat",
+		Worktree:    "/abs/path/to/worktree",
+	}
+	for _, mode := range []string{"host", "bwrap", "sandbox-exec"} {
+		got := muxPaneOptsFor(opts, 0, "agent", mode)
+		if got.Cwd != "/abs/path/to/worktree" {
+			t.Errorf("(agent, %s) Cwd = %q, want /abs/path/to/worktree", mode, got.Cwd)
+		}
+	}
+}
+
+// TestMuxPaneOptsFor_AgentPane_HostMode_HarnessPipeEnv pins the
+// PRISM_HARNESS_PIPE env-var plumbing for host mode + socket-pipe
+// harness. agentPaneEnvVars writes this var for host mode when
+// HarnessPipeSockPath is non-empty; muxPaneOptsFor must propagate
+// it onto the pane's env so the PI extension can find the sidecar.
+func TestMuxPaneOptsFor_AgentPane_HostMode_HarnessPipeEnv(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName:         "repo@feat",
+		Worktree:            "/tmp/repo/feat",
+		HarnessPipeSockPath: "/tmp/sidecar.sock",
+	}
+	got := muxPaneOptsFor(opts, 0, "agent", "host")
+	if got.Env == nil {
+		t.Fatal("Env is nil; expected non-nil env carrying PRISM_HARNESS_PIPE")
+	}
+	v, ok := got.Env["PRISM_HARNESS_PIPE"]
+	if !ok {
+		t.Fatalf("PRISM_HARNESS_PIPE missing from env; got keys: %v", envKeys(got.Env))
+	}
+	want := "unix:///tmp/sidecar.sock"
+	if v != want {
+		t.Errorf("PRISM_HARNESS_PIPE = %q, want %q", v, want)
+	}
+}
+
+// TestMuxPaneOptsFor_AgentPane_SandboxedMode_InitialPromptFileEnv
+// pins the per-session prompt-file plumbing. Sandboxed modes
+// (bwrap / sandbox-exec) carry the prompt body in a file path via
+// PRISM_INITIAL_PROMPT_FILE so the launch command stays O(1) in
+// prompt size (#1092 / #1195).
+func TestMuxPaneOptsFor_AgentPane_SandboxedMode_InitialPromptFileEnv(t *testing.T) {
+	opts := SpawnOpts{
+		SessionName:    "repo@feat",
+		Worktree:       "/tmp/repo/feat",
+		Prompt:         "hello",
+		PromptFilePath: "/tmp/run/repo@feat/initial-prompt.txt",
+	}
+	for _, mode := range []string{"bwrap", "sandbox-exec"} {
+		got := muxPaneOptsFor(opts, 0, "agent", mode)
+		v, ok := got.Env["PRISM_INITIAL_PROMPT_FILE"]
+		if !ok {
+			t.Errorf("(%s) PRISM_INITIAL_PROMPT_FILE missing from env; got keys: %v", mode, envKeys(got.Env))
+			continue
+		}
+		if v != "/tmp/run/repo@feat/initial-prompt.txt" {
+			t.Errorf("(%s) PRISM_INITIAL_PROMPT_FILE = %q, want the prompt-file path", mode, v)
+		}
+	}
+}
+
+// isShellExecArgv returns true when argv looks like ["<shell>", "-c",
+// "<cmd>"] — the canonical wrap muxPaneOptsFor uses for the agent
+// pane so shell features (env expansion, $(cat <file>), the podman
+// readiness loop) work the same way they do under tmux's `sh -c`.
+func isShellExecArgv(argv []string) bool {
+	if len(argv) != 3 {
+		return false
+	}
+	if !strings.HasSuffix(argv[0], "sh") {
+		return false
+	}
+	return argv[1] == "-c"
+}
+
+// envKeys is a tiny helper to surface a missing-key failure with a
+// readable list of what env vars WERE present.
+func envKeys(env map[string]string) []string {
+	out := make([]string, 0, len(env))
+	for k := range env {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Closes #2176. Follow-up to #2175 that lands the three architecturally critical pieces the cutover missed: the pi harness is now launched (not `/bin/sh`) on the agent pane under mux, `prism launch` brings up the bubbletea renderer when `PRISM_USE_MUX=1`, and `cmd/cleanup.go`'s four sibling scratchpad-swing sites are gated so cleanup under mux does not silently re-introduce a tmux dependency. The phase-3 soak can start.

## The three pieces

### 1. `muxPaneOptsFor` branches on `IsolationMode` (`internal/session/mux_layout.go`)

The pre-#2176 implementation returned `Argv = [/bin/sh]` for **every** pane regardless of mode, so the agent harness never launched and `WaitForReady` timed out at 30s. The fix:

- Threads `resolveLayoutIsolationMode(opts)` from `SpawnMuxLayout` into `muxPaneOptsFor` so the agent pane sees the resolved mode.
- For sandboxed modes (`bwrap`, `podman`, `sandbox-exec`) and host mode, the agent pane's `Argv` is `[sh, -c, BuildAgentCmd(opts)]` — the same launch command the tmux path builds, just dispatched through the mux daemon's pane.create instead of tmux's NewWindow. Shell wrap preserves the `$(cat <prompt-file>)` expansion, the podman readiness-wait loop, and bwrap/sandbox-exec env-var expansion verbatim.
- `agentPaneEnvVars` is merged with `os.Environ()` because `PaneCreateOptions.Env` replaces (not appends) the child's env — without the merge, the agent process would lose `PATH` / `HOME` / etc.
- `edit` / `term` / `shell` panes stay on `[sh]` per the spec.

### 2. Renderer wire-up in `prism launch` (new `cmd/launch_mux.go`)

`render.New` had **zero importers in production code** before this PR — the substrate was built but nothing was using it. The new file:

- Gates on `muxCutoverEnabled()` (the canonical `PRISM_USE_MUX=1` sentinel from `cmd/mux_cutover.go`).
- Probes the daemon once up-front so a stopped daemon surfaces `daemonNotRunningError` immediately rather than after `tea.Program` is running (which would eat the error behind the altscreen).
- Constructs `pane.SessionTree` + `state.Store` + a `clientHostProvider` that maintains one `*vt.Host` per `(sessionID, paneName)` and re-feeds it from `/pane/read_output` on a 100ms tick.
- Spawns one `state.Subscriber` per active session (each session has its own sidecar with its own host-API socket — there is no daemon-wide events stream); a reconcile loop polls `Sessions().List` and adds/removes Subscribers as sessions appear / disappear.
- Bridges `agent.AgentState` → `render.State` via a small `stateAdapter`. The wider agent vocabulary (`compacting` / `error` / `interrupted` / `deleted`) collapses to `StateIdle` for the sidebar glyph.
- All goroutines share one `context.WithCancel` tied to the program's lifetime, so `tea.Quit` cleanly unwinds every poller.

When `PRISM_USE_MUX` is unset, `runLaunch`'s tmux scratchpad+dashboard path is byte-for-byte unchanged — the gate is a single `if` at the top of `runLaunch`.

### 3. Cleanup partial-gating fixed (`cmd/cleanup.go`)

The four sibling sites at lines 211-225, 672-685, 795-809, 891-901 called `tmux.NewSessionDetached("scratchpad", …)` + `tmux.SwitchClient(client, "scratchpad")` **unconditionally**. Under mux those have no useful effect (no tmux client to redirect; the renderer handles its own focus) and ensuring a tmux `scratchpad` session silently re-introduced the tmux dependency the cutover was supposed to remove. Each block is now wrapped in `if !muxCutoverEnabled()`.

A structural test (`TestCleanupSites_AllScratchpadSwingsAreGated`) pins the invariant the same way the existing `TestCleanupSites_AllTeardownsAreGated` pins the `tmux.KillSession` siblings: scan `cleanup.go`, count scratchpad-ensure sites, assert each one sits in a `!muxCutoverEnabled()` body. The test fails against the pre-#2176 source (verified by `git stash` round-trip).

## End-to-end smoke test (mandatory — actual observable behaviour)

Host: `navi` (Linux, `default_isolation_mode = bwrap`). Daemon: `prismd mux start` → `running (pid 82189)`.

### Test 1 — `prism launch` shows the renderer

```text
 prism · 0 sessions            │
───────────────────────────────│
                               │
                               │
                               │                                      (no session)
                               │
                               │
 ↑↓ ←→ ⏎ ⇥ q                   │
```

Sidebar header reads `prism · 0 sessions` (correct — no sessions exist). Active pane shows `(no session)`. Keybinding row `↑↓ ←→ ⏎ ⇥ q` visible at the bottom.

### Test 2 — `prism spawn` registers in the daemon + pi runs in the agent pane

The smoke test ran from inside this PR's own worker session, with `PRISM_HOST_API` unset so spawn does not proxy. After ~3 seconds the daemon's session tree contained:

```json
{
  "sessions": [{
    "id": "nixos-config@test-render",
    "repo": "nixos-config",
    "branch": "test-render",
    "worktree": "/home/ben/code/nixos-config/test-render",
    "agent_role": "worker",
    "panes": [{"name": "edit"}, {"name": "agent"}, {"name": "term"}],
    "active_pane": "agent"
  }]
}
```

…and with the renderer up against that session:

```text
 prism · 1 sessions            │echo hello
───────────────────────────────│2026/06/07 11:02:45 container: signing key (private) not resolvable: lstat /home
 ▾ nixos-config                │/ben/.ssh/prismatic-koi-ed25519-signingkey: no such file or directory; omitting
 └─ ○ @test-render         idle│signing config from gitconfig
                               │…
                               │Error: Unknown option: --agent
 ↑↓ ←→ ⏎ ⇥ q                   │
```

**Reading this output for what the cutover claims to fix:**

- The sidebar header updates to `prism · 1 sessions`; the tree shows `▾ nixos-config` → `└─ ○ @test-render   idle`. The renderer's `StateProvider` + `HostProvider` are both live (sidebar state + active-pane bytes).
- The active pane shows the `echo hello` prompt and the `prism agent-run` → `bwrap` → `pi` output. **The agent pane is running `prism agent-run`, not `/bin/sh`** — pre-#2176, `muxPaneOptsFor("agent", "bwrap")` returned `[/bin/sh]` and `prism agent-run` never executed. The fact that we see bwrap-stage timing output + pi's `Unknown option: --agent` is **direct evidence** that the spawn-hang fix is in place: pi is being invoked.
- The `Unknown option: --agent` error is a **pre-existing environment issue** unrelated to this PR — the pi extension that registers `--agent` cannot load when running spawn from inside a worker session whose bwrap sandbox view lacks the `~/.ssh/prismatic-koi-ed25519-signingkey` files. **The same error reproduces on the pre-#2176 tmux path with `PRISM_USE_MUX` unset** (verified by running `./result/bin/prism spawn --branch test-tmuxmode --prompt 'echo hello'` and observing the same `agent-run.log` content). The fix here surfaced the pi extension issue rather than hiding it behind a 30s shell wait. End-to-end verification with a fully working pi/extension load is on the operator's `nixos-config@main` coordinator session (this worker cannot run spawn against the host sidecar — workers cannot spawn).

The 30s `not ready` failure that follows is the readiness gate firing because pi never reached the harness handshake (because of the extension load issue above), not because of the cutover. Pre-#2176, the same 30s failure surfaced silently with a `/bin/sh`-only agent pane.

### Test 3 — `prism cleanup` removes the session from the daemon

```text
session "nixos-config@test-cleanup" created
removing worktree /home/ben/code/nixos-config/test-cleanup...
deleting branch test-cleanup...
killing session nixos-config@test-cleanup
2026/06/07 11:02:34 pi archive: Export: raw/session.jsonl not found — no export produced
done
```

Daemon's session list before cleanup: 1 entry (`nixos-config@test-cleanup`). After cleanup: `{"sessions": []}`. The scratchpad-swing sites are correctly skipped — cleanup completed without any `tmux.NewSessionDetached("scratchpad", …)` invocation under `PRISM_USE_MUX=1`.

## Local self-check status (all PASS)

```text
go build ./...                                                          PASS
go test ./... -race                                                     PASS (38 packages)
nix build .#prism                                                       PASS
nix flake check                                                         PASS
nix build --impure --no-link \
  --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
                                                                        PASS (homeless-shelter)
```

New tests added:

- `internal/session/mux_pane_argv_test.go` — 7 tests pinning the per-mode argv shape, the cwd invariant, and the env-var plumbing for both `PRISM_HARNESS_PIPE` (host) and `PRISM_INITIAL_PROMPT_FILE` (sandboxed). Verified to fail at compile time against pre-#2176 (the old `muxPaneOptsFor` arity is wrong).
- `cmd/cleanup_scratchpad_gate_test.go` — structural test that fails against pre-#2176 with `0/4 scratchpad-ensure sites are gated`.
- `cmd/launch_mux_test.go` — state-adapter mapping table + `hostKey` round-trip + nil-safety.

## Review-process note

PR #2175 PASSed across 4 cycles but the cutover did not work for Ben at all — the reviewers had a code-correctness lens, not an end-to-end-feature lens. The smoke-test output above is captured **deliberately** so the next review round can verify observable behaviour, not just "tests pass". If you are reviewing this PR and the `Test 2` / `Test 3` output above is unclear, please flag it as a `<blocking_issues>` — the goal is to make the end-to-end claim falsifiable from the PR body alone, without needing to re-run anything.

## Out of scope (tracked separately in #2177)

`prism dashboard` / `restart` / `reset` / `restore` / `switch_dashboard`, the `checkin_*.go` family, `cmd/event.go:441`, `tmux.nix` keybindings, `internal/tmuxstatus/` replacement, mouse / OSC2 / OSC52 — all deferred per the design doc.

Closes #2176
