### PR TITLE
AGENTS.md + pi deny list: forbid env-override workarounds for nix build (#2180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,33 @@ This is not a hypothetical: PR #1455 (`TestDeliverToSession_PiPath_DeliverAsForw
 
 **Scope — this gate applies only to prism-touching PRs.** PRs that touch only non-prism files (other modules, dotfiles, docs) do **not** trigger the `go-tests` or `nix-build-prism-checked` jobs. The relaxation introduced in #1441 stands for those paths.
 
+### When `nix build` fails inside a sandbox
+
+The local `nix build .#prism` is a *pre-PR* check, not the authoritative
+gate — CI runs the homeless-shelter build (`nix-build-prism-checked`) on
+every prism-touching PR and that is the build that must be green for merge.
+A worker MAY push without a green local build provided the PR description
+says so.
+
+**If `nix build .#prism` fails inside a worker sandbox, escalate via
+`prism escalate`. Do not attempt environment workarounds.**
+
+Specifically, do NOT override any of `XDG_DATA_HOME`, `NIX_STORE_DIR`,
+`NIX_DATA_DIR`, or `HOME` to try to "isolate" or "reset" nix between
+retries. Pointing nix's local profile / trust DB / daemon-socket linkage at
+an empty tempdir forces nix to bootstrap a fresh single-user store, and
+inside sandbox-exec (no host nix-daemon access) the parallel evaluation
+leaks file descriptors that the next retry inherits. On Darwin this
+exhausts the system-wide `kern.maxfiles` cap; once hit, *every* process on
+the host that calls `open()` fails (Karabiner, Chrome, Finder, the agent's
+own harness), and recovery requires a reboot. This actually happened — see
+issue #2180 for the post-incident writeup.
+
+The pi extension's pre-tool-call deny list (`BLOCKED_BASH_PATTERNS` in
+`modules/programs/prism/pi/extensions/prism.ts`) also blocks this command
+shape as defence in depth; if you see that block fire, the correct response
+is still `prism escalate`, not a different workaround.
+
 ### sandbox-exec testing convention
 
 Any change to `internal/container/sandbox_exec.go::generateProfile`,

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -33,9 +33,10 @@ import {
   processDoomLoop,
   isGitPush,
   EXCLUDED_BASH_BASES,
-  // Pre-tool-call bash deny list (#1528)
+  // Pre-tool-call bash deny list (#1528, #2180)
   BLOCKED_BASH_PATTERNS,
   checkBlockedBash,
+  stripCommandSubstitutions,
   newDoomLoopState,
   snapshotGuardState,
   restoreGuardState,
@@ -1605,8 +1606,8 @@ describe("isGitPush", () => {
 // ---------------------------------------------------------------------------
 
 describe("BLOCKED_BASH_PATTERNS", () => {
-  it("contains exactly two entries", () => {
-    assert.equal(BLOCKED_BASH_PATTERNS.length, 2)
+  it("contains exactly three entries", () => {
+    assert.equal(BLOCKED_BASH_PATTERNS.length, 3)
   })
 
   it("has the git-worktree-prune entry", () => {
@@ -1619,6 +1620,11 @@ describe("BLOCKED_BASH_PATTERNS", () => {
     assert.ok(ids.includes("git-worktree-remove"))
   })
 
+  it("has the nix-build-with-env-override entry (#2180)", () => {
+    const ids = BLOCKED_BASH_PATTERNS.map((p) => p.id)
+    assert.ok(ids.includes("nix-build-with-env-override"))
+  })
+
   it("every entry has id, match, and reason fields", () => {
     for (const p of BLOCKED_BASH_PATTERNS) {
       assert.equal(typeof p.id, "string")
@@ -1629,8 +1635,9 @@ describe("BLOCKED_BASH_PATTERNS", () => {
     }
   })
 
-  it("every entry's reason names the recommended alternative (prism cleanup --yes --session)", () => {
+  it("git-worktree-* entries' reasons name the recommended alternative (prism cleanup --yes --session)", () => {
     for (const p of BLOCKED_BASH_PATTERNS) {
+      if (!p.id.startsWith("git-worktree-")) continue
       assert.ok(
         p.reason.includes("prism cleanup --yes --session"),
         `pattern ${p.id} reason should mention 'prism cleanup --yes --session'`,
@@ -1766,6 +1773,213 @@ describe("checkBlockedBash — negative cases (quoted / heredoc / grep)", () => 
 
   it("does NOT match when there is no command", () => {
     assert.equal(checkBlockedBash(""), null)
+  })
+})
+
+describe("checkBlockedBash — nix-build-with-env-override (positive cases, #2180)", () => {
+  it("blocks 'XDG_DATA_HOME=$(mktemp -d) nix build .#prism' (the killshot from the incident)", () => {
+    const hit = checkBlockedBash("XDG_DATA_HOME=$(mktemp -d) nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks 'NIX_STORE_DIR=/tmp/x nix build .#prism'", () => {
+    const hit = checkBlockedBash("NIX_STORE_DIR=/tmp/x nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks 'env XDG_DATA_HOME=/tmp/x nix build'", () => {
+    const hit = checkBlockedBash("env XDG_DATA_HOME=/tmp/x nix build")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks 'cd /repo && XDG_DATA_HOME=/tmp/x nix build .#prism' (segment after &&)", () => {
+    const hit = checkBlockedBash(
+      "cd /repo && XDG_DATA_HOME=/tmp/x nix build .#prism",
+    )
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks 'HOME=/tmp/h nix build .#prism'", () => {
+    const hit = checkBlockedBash("HOME=/tmp/h nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks 'NIX_DATA_DIR=/tmp/d nix build .#prism'", () => {
+    const hit = checkBlockedBash("NIX_DATA_DIR=/tmp/d nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks multiple inline assignments 'XDG_DATA_HOME=/tmp/x HOME=/tmp/h nix build .#prism'", () => {
+    const hit = checkBlockedBash(
+      "XDG_DATA_HOME=/tmp/x HOME=/tmp/h nix build .#prism",
+    )
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks 'XDG_DATA_HOME=/tmp/xdg-data-$$ nix build .#prism' (the second incident retry, with $$)", () => {
+    const hit = checkBlockedBash(
+      "XDG_DATA_HOME=/tmp/xdg-data-$$ nix build .#prism",
+    )
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+
+  it("blocks backtick command substitution 'XDG_DATA_HOME=`mktemp -d` nix build .#prism'", () => {
+    const hit = checkBlockedBash(
+      "XDG_DATA_HOME=`mktemp -d` nix build .#prism",
+    )
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "nix-build-with-env-override")
+  })
+})
+
+describe("checkBlockedBash — nix-build-with-env-override (negative cases, #2180)", () => {
+  it("does NOT block plain 'nix build .#prism' (no env override)", () => {
+    assert.equal(checkBlockedBash("nix build .#prism"), null)
+  })
+
+  it("does NOT block 'nix build .#prism --no-link' (still no env override)", () => {
+    assert.equal(checkBlockedBash("nix build .#prism --no-link"), null)
+  })
+
+  it("does NOT block double-quoted 'XDG_DATA_HOME=/tmp/x nix build' inside echo (AC: quoted regions stripped)", () => {
+    assert.equal(
+      checkBlockedBash('echo "XDG_DATA_HOME=/tmp/x nix build"'),
+      null,
+    )
+  })
+
+  it("does NOT block single-quoted 'XDG_DATA_HOME=/tmp/x nix build' inside echo", () => {
+    assert.equal(
+      checkBlockedBash("echo 'XDG_DATA_HOME=/tmp/x nix build'"),
+      null,
+    )
+  })
+
+  it("does NOT block 'XDG_DATA_HOME=/tmp/x go test' (env override without nix build is fine)", () => {
+    assert.equal(checkBlockedBash("XDG_DATA_HOME=/tmp/x go test"), null)
+  })
+
+  it("does NOT block 'HOME=/tmp/h go test ./...' (Go suite under an env override is fine)", () => {
+    assert.equal(checkBlockedBash("HOME=/tmp/h go test ./..."), null)
+  })
+
+  it("does NOT block bare 'XDG_DATA_HOME=/tmp/x' (no command after)", () => {
+    assert.equal(checkBlockedBash("XDG_DATA_HOME=/tmp/x"), null)
+  })
+
+  it("does NOT block unrelated env vars 'FOO=bar nix build .#prism'", () => {
+    assert.equal(checkBlockedBash("FOO=bar nix build .#prism"), null)
+  })
+
+  it("does NOT block 'nix flake check' even with an env override", () => {
+    assert.equal(
+      checkBlockedBash("XDG_DATA_HOME=/tmp/x nix flake check"),
+      null,
+    )
+  })
+})
+
+describe("checkBlockedBash — nix-build-with-env-override reason string (#2180)", () => {
+  it("names the FD-exhaustion failure mode", () => {
+    const hit = checkBlockedBash("XDG_DATA_HOME=/tmp/x nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.ok(
+      hit!.reason.toLowerCase().includes("fd") ||
+        hit!.reason.toLowerCase().includes("file descriptor"),
+      `reason should mention FD exhaustion: ${hit!.reason}`,
+    )
+    assert.ok(
+      hit!.reason.includes("kern.maxfiles") ||
+        hit!.reason.toLowerCase().includes("reboot"),
+      `reason should mention kern.maxfiles or reboot: ${hit!.reason}`,
+    )
+  })
+
+  it("points the agent at the AGENTS.md subsection", () => {
+    const hit = checkBlockedBash("XDG_DATA_HOME=/tmp/x nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.ok(
+      hit!.reason.includes("AGENTS.md"),
+      `reason should reference AGENTS.md: ${hit!.reason}`,
+    )
+  })
+
+  it("recommends `prism escalate` as the correct path forward", () => {
+    const hit = checkBlockedBash("XDG_DATA_HOME=/tmp/x nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.ok(
+      hit!.reason.includes("prism escalate"),
+      `reason should recommend prism escalate: ${hit!.reason}`,
+    )
+  })
+
+  it("is prefixed with 'blocked by prism extension'", () => {
+    const hit = checkBlockedBash("XDG_DATA_HOME=/tmp/x nix build .#prism")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.startsWith("blocked by prism extension:"))
+  })
+})
+
+describe("stripCommandSubstitutions (#2180)", () => {
+  it("replaces `$(...)` with a single space", () => {
+    assert.equal(
+      stripCommandSubstitutions("XDG_DATA_HOME=$(mktemp -d) nix build"),
+      "XDG_DATA_HOME=  nix build",
+    )
+  })
+
+  it("handles nested `$(...)` via depth tracking", () => {
+    assert.equal(
+      stripCommandSubstitutions("a$(b $(c) d)e"),
+      "a e",
+    )
+  })
+
+  it("replaces backtick regions with a single space", () => {
+    assert.equal(
+      stripCommandSubstitutions("XDG_DATA_HOME=`mktemp -d` nix build"),
+      "XDG_DATA_HOME=  nix build",
+    )
+  })
+
+  it("leaves bare `$` and `$VAR` alone", () => {
+    assert.equal(
+      stripCommandSubstitutions("XDG_DATA_HOME=/tmp/x-$$ nix build"),
+      "XDG_DATA_HOME=/tmp/x-$$ nix build",
+    )
+    assert.equal(
+      stripCommandSubstitutions("echo $HOME"),
+      "echo $HOME",
+    )
+  })
+
+  it("is a no-op when no substitutions are present", () => {
+    assert.equal(
+      stripCommandSubstitutions("nix build .#prism"),
+      "nix build .#prism",
+    )
+  })
+
+  it("handles an unterminated `$(...)` by consuming to end-of-string", () => {
+    assert.equal(
+      stripCommandSubstitutions("nix build $(mktemp -d"),
+      "nix build  ",
+    )
+  })
+
+  it("handles an unterminated backtick by consuming to end-of-string", () => {
+    assert.equal(
+      stripCommandSubstitutions("nix build `mktemp -d"),
+      "nix build  ",
+    )
   })
 })
 

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -585,6 +585,65 @@ export function splitShellSegments(command: string): string[] {
 }
 
 /**
+ * Strip `$(...)` command-substitution and `` `...` `` backtick regions
+ * from a (quote-stripped) command, replacing each region with a single
+ * space so token boundaries are preserved but the substitution body is
+ * gone. `$(...)` nesting is tracked with a depth counter; backticks do
+ * not nest.
+ *
+ * Unlike `splitShellSegments` — which promotes substitution bodies to
+ * their own segments so e.g. a nested `git push` is still considered a
+ * real invocation — this helper is for patterns that need to match a
+ * shape *spanning* a substitution. Example: `XDG_DATA_HOME=$(mktemp -d)
+ * nix build` would otherwise be split into three disjoint segments
+ * (`XDG_DATA_HOME=`, `mktemp -d`, `nix build .#prism`), none of which
+ * matches the deny-list regex alone. After stripping, the outer command
+ * collapses to a single segment `XDG_DATA_HOME=  nix build .#prism` that
+ * a regex like `VAR=\S*\s+nix build` can detect.
+ *
+ * `checkBlockedBash` runs both the original-stripped and the
+ * substitution-stripped command through `splitShellSegments` and dedupes
+ * the results, so existing patterns that rely on the substitution body
+ * being its own segment continue to fire.
+ *
+ * Exported for unit testing.
+ */
+export function stripCommandSubstitutions(command: string): string {
+  let result = ""
+  let i = 0
+  while (i < command.length) {
+    const c = command[i]
+    const next = command[i + 1]
+    if (c === "$" && next === "(") {
+      // Skip past `$(` and the matching `)`, tracking nesting depth.
+      i += 2
+      let depth = 1
+      while (i < command.length && depth > 0) {
+        if (command[i] === "(") depth++
+        else if (command[i] === ")") depth--
+        if (depth > 0) i++
+      }
+      // Skip the closing `)` itself (if we found one).
+      if (i < command.length) i++
+      result += " "
+      continue
+    }
+    if (c === "`") {
+      // Backticks do not nest; consume to the next backtick.
+      i++
+      while (i < command.length && command[i] !== "`") i++
+      // Skip the closing backtick (if we found one).
+      if (i < command.length) i++
+      result += " "
+      continue
+    }
+    result += c
+    i++
+  }
+  return result
+}
+
+/**
  * Decide whether a single tokenised command segment is a `git push`
  * invocation. Accepts the leading-flag forms the prior regex accepted:
  *   git push ...
@@ -676,6 +735,35 @@ export const BLOCKED_BASH_PATTERNS: readonly BlockedBashPattern[] = [
       "(they are not bind-mounted into your view). Use " +
       "`prism cleanup --yes --session <name>` instead.",
   },
+  {
+    // #2180 — `nix build` with an inline override of any of XDG_DATA_HOME,
+    // NIX_STORE_DIR, NIX_DATA_DIR, or HOME repoints nix's local profile /
+    // trust DB / daemon-socket linkage at an empty tempdir, forcing it to
+    // bootstrap a fresh single-user store. Inside sandbox-exec the
+    // parallel evaluation leaks FDs that the next retry inherits; on
+    // Darwin this exhausts `kern.maxfiles` and renders every process on
+    // the host unable to call open() until a reboot. See AGENTS.md
+    // § "When `nix build` fails inside a sandbox".
+    //
+    // The `\S*` (zero-or-more) in the value group is intentional — after
+    // checkBlockedBash's substitution-stripping pass, the command
+    // `XDG_DATA_HOME=$(mktemp -d) nix build` collapses to
+    // `XDG_DATA_HOME=  nix build` (empty value) and must still match.
+    id: "nix-build-with-env-override",
+    match: (segment: string) =>
+      /^\s*(?:env\s+)?(?:(?:XDG_DATA_HOME|NIX_STORE_DIR|NIX_DATA_DIR|HOME)=\S*\s+)+(?:env\s+)?nix\s+build\b/.test(
+        segment,
+      ),
+    reason:
+      "blocked by prism extension: `nix build` with an inline override " +
+      "of XDG_DATA_HOME, NIX_STORE_DIR, NIX_DATA_DIR, or HOME has caused " +
+      "system-wide FD exhaustion on Darwin (kern.maxfiles), requiring a " +
+      "reboot to recover \u2014 see AGENTS.md § 'When `nix build` fails " +
+      "inside a sandbox' for the incident writeup. If `nix build .#prism` " +
+      "fails inside your sandbox, escalate via `prism escalate` rather " +
+      "than attempting environment workarounds; CI runs the authoritative " +
+      "build so a local failure is not a merge blocker.",
+  },
 ]
 
 /**
@@ -693,7 +781,22 @@ export function checkBlockedBash(
   command: string,
 ): { id: string; reason: string } | null {
   const stripped = stripQuotedAndHeredocRegions(command)
-  for (const segment of splitShellSegments(stripped)) {
+  // Two passes:
+  //   1. The plain quote-stripped command — preserves the existing
+  //      behaviour where substitution bodies (e.g. `$(git worktree prune)`)
+  //      become their own segments and can still trigger a block.
+  //   2. The substitution-stripped command — collapses `$(...)` and
+  //      backtick regions to a placeholder space so patterns that need to
+  //      match a shape *spanning* a substitution (e.g. the
+  //      `nix-build-with-env-override` entry on `XDG_DATA_HOME=$(mktemp -d)
+  //      nix build`) fire on the resulting single segment.
+  // The Set dedupes segments that survive unchanged in both passes so the
+  // common case pays no extra cost.
+  const segments = new Set<string>([
+    ...splitShellSegments(stripped),
+    ...splitShellSegments(stripCommandSubstitutions(stripped)),
+  ])
+  for (const segment of segments) {
     for (const pattern of BLOCKED_BASH_PATTERNS) {
       if (pattern.match(segment)) {
         return { id: pattern.id, reason: pattern.reason }


### PR DESCRIPTION
Closes #2180

## Background

A worker session hit a `nix build .#prism` failure inside a sandbox-exec sandbox and tried to "reset nix" by overriding `XDG_DATA_HOME`. Each retry leaked FDs against the host nix-daemon; Darwin's `kern.maxfiles=122880` cap was hit; every process on the host (Karabiner, Chrome, Finder, the agent's own harness) lost the ability to call `open()`. Recovery required a reboot.

## Changes

### `AGENTS.md`

A new subsection under the existing `Prism Go-source and .nix changes` block:

- States the rule plainly: escalate via `prism escalate` when `nix build .#prism` fails inside a sandbox.
- Explicitly forbids overriding `XDG_DATA_HOME`, `NIX_STORE_DIR`, `NIX_DATA_DIR`, or `HOME` as a workaround.
- Explains the failure mode (system-wide FD exhaustion → reboot) in one paragraph so the rule reads as documented engineering, not arbitrary policy.
- Clarifies that local `nix build` is a *pre-PR* check, CI is the authoritative gate, and a worker may push without a green local build provided the PR description says so.
- Cross-references the new `BLOCKED_BASH_PATTERNS` entry as defence in depth.

### `modules/programs/prism/pi/extensions/prism.ts`

A third `BLOCKED_BASH_PATTERNS` entry, `nix-build-with-env-override`, that blocks any shell segment combining `nix build` with an inline assignment of one of those four variables (with or without a leading `env` keyword). The `reason` string names the FD-exhaustion failure mode, points at the AGENTS.md subsection, and recommends `prism escalate`.

To make the matcher work on the killshot command shape `XDG_DATA_HOME=$(mktemp -d) nix build .#prism` — where the existing `splitShellSegments` helper splits the substitution body off and leaves the outer command in disjoint pieces, none of which matches on its own — a new `stripCommandSubstitutions` helper collapses `$(...)` and backtick regions to a placeholder space. `checkBlockedBash` runs both the original quote-stripped command and the substitution-stripped command through `splitShellSegments`, dedupes via a `Set`, and matches every pattern against the union. This preserves the existing behaviour where substitution bodies (e.g. inside `$(git worktree prune)`) can still trigger a block while letting the new pattern fire on substitution-spanning shapes.

## Tests

`modules/programs/prism/pi/extensions/prism.test.ts` covers:

- **Positive cases** (all four ACs): the killshot form, the `NIX_STORE_DIR=` form, the `env XDG_DATA_HOME=` prefix form, and the `cd /repo && XDG_DATA_HOME=... nix build` segment-after-`&&` form. Plus `HOME=`, `NIX_DATA_DIR=`, multiple inline assignments, the `$$` PID-tempdir form, and the backtick substitution form.
- **Negative cases** (all three ACs): plain `nix build .#prism`, the quoted-inside-echo form (must remain non-blocked because quoted regions are stripped before matching), the env-override-without-nix-build form. Plus `HOME=/tmp/h go test ./...`, bare env assignment with no command, unrelated env vars on `nix build`, and the env-override-on-different-nix-subcommand form (`nix flake check`).
- **`reason` string content**: names the FD-exhaustion failure mode (`kern.maxfiles` / reboot), references `AGENTS.md`, recommends `prism escalate`, and starts with the `blocked by prism extension:` prefix used by the existing entries.
- **`stripCommandSubstitutions` helper**: `$(...)` replacement, nested `$( $(...) )`, backticks, bare `$VAR` left alone, no-op when no substitutions present, unterminated `$(...)` and backtick regions consumed to end-of-string.
- **`BLOCKED_BASH_PATTERNS.length`** assertion bumped from `2` to `3`.

Worker reported `334/334 passing` (was `304`; +30 new tests + count bump).

**Vacuous-pass check (per worker report):** reverting only `prism.ts` while keeping the new tests surfaces 22 failures, proving the new tests are not no-ops.

## Provenance note

This PR was opened by the @main coordinator on behalf of the worker session `nixos-config@deny-nix-env-overrides`. The worker successfully committed and pushed the change but hit a fatal shell-injection accident when constructing its own `gh pr create --body "$(cat <<EOF ... EOF)"` invocation — the heredoc-in-substitution failed to parse and bash interpreted the PR-body markdown content (including code-block examples of `XDG_DATA_HOME=$(mktemp -d) nix build .#prism`) as live shell commands. Those commands re-triggered the exact FD-exhaustion failure mode this change is supposed to prevent.

The worker's commit is intact on `origin/deny-nix-env-overrides` at `e841a50720894cecb22802994e4b7d762028372a`. The coordinator is opening the PR using the safe `gh pr create --body-file` pattern, then spawning a review session on the open PR per the standard review flow.

The shell-injection failure mode in `gh pr create --body "$(...)"` is being addressed as a follow-up worker-rule update (use `--body-file` for any long-string arg), and the architectural FD-isolation gap is being addressed as a separate issue covering per-process `RLIMIT_NOFILE` caps on agent exec paths plus a `kern.maxfiles` bump.

## Files touched

- `AGENTS.md` — new subsection
- `modules/programs/prism/pi/extensions/prism.ts` — `stripCommandSubstitutions` helper, new `BLOCKED_BASH_PATTERNS` entry, two-pass `checkBlockedBash`
- `modules/programs/prism/pi/extensions/prism.test.ts` — positive/negative/reason/helper tests, count bump

## Out of scope

- The Go test-suite leakage that also contributed to incident 1 (`go test ./cmd/` leaking tmux servers under `-race`). Separate bug, separate issue.
- Reworking sandbox-exec so `nix build` works cleanly inside a worker sandbox. Larger architectural change.
- Role-scoping the new deny-list entry. The current `BLOCKED_BASH_PATTERNS` surface is universal; coordinators and investigators have no legitimate reason to override these env vars for `nix build` either.
