### PR TITLE
prism close: smart-decide soft/hard cleanup based on PR state

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -344,6 +345,7 @@ var cleanupCmd = &cobra.Command{
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 		sessionFlag, _ := cmd.Flags().GetString("session")
 		jsonFlag, _ := cmd.Flags().GetBool("json")
+		keepWorktreeFlag, _ := cmd.Flags().GetBool("keep-worktree")
 
 		// --json implies --yes: emitting a single structured object is
 		// incompatible with an interactive TUI.
@@ -361,7 +363,7 @@ var cleanupCmd = &cobra.Command{
 			if target == "" {
 				return fmt.Errorf("--session is required when running inside a container")
 			}
-			return proxyCleanupToHostAPI(apiURL, target, yesFlag, jsonFlag)
+			return proxyCleanupToHostAPI(apiURL, target, yesFlag, jsonFlag, keepWorktreeFlag)
 		}
 
 		// Only require tmux when we need to auto-detect the current session.
@@ -401,6 +403,7 @@ var cleanupCmd = &cobra.Command{
 			if yesFlag {
 				return headlessCloseSessionWithJSON(session, jsonFlag)
 			}
+			_ = keepWorktreeFlag // soft close is already implied for non-worktree sessions
 			// Interactive path: simplified confirmation (no worktree/branch prompts).
 			if os.Getenv("TMUX") == "" {
 				return fmt.Errorf("interactive cleanup requires tmux — use --yes for non-interactive use outside tmux")
@@ -466,6 +469,7 @@ var cleanupCmd = &cobra.Command{
 			if yesFlag {
 				return headlessCloseSessionWithJSON(session, jsonFlag)
 			}
+			_ = keepWorktreeFlag // soft close is already implied for coordinator sessions
 			// Interactive path: simplified confirmation (no worktree/branch prompts).
 			if os.Getenv("TMUX") == "" {
 				return fmt.Errorf("interactive cleanup requires tmux — use --yes for non-interactive use outside tmux")
@@ -482,6 +486,13 @@ var cleanupCmd = &cobra.Command{
 
 		// Non-interactive path: --yes skips all prompts and runs headlessly.
 		if yesFlag {
+			// --keep-worktree forces a soft close on this worker session
+			// (issue #2179): preserve the worktree and branch instead of
+			// removing them. Coordinator and non-worktree sessions already
+			// soft-close above, so this branch only affects worker sessions.
+			if keepWorktreeFlag {
+				return headlessCloseSessionWithJSON(session, jsonFlag)
+			}
 			return headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot, jsonFlag)
 		}
 
@@ -587,6 +598,15 @@ func markDBLifecycleSkipped(result *cleanupResult, reason string) {
 // to os.Stdout. Used by the --json path; mutually exclusive with the textual
 // per-step lines.
 func emitCleanupJSON(r cleanupResult) {
+	emitCleanupJSONTo(os.Stdout, r)
+}
+
+// emitCleanupJSONTo writes the cleanup result as a single JSON object on a
+// line to the supplied writer. Used by callers (e.g. `prism close --yes`)
+// that need to redirect the JSON envelope to io.Discard for popup-safe
+// silent-on-success behaviour while preserving the structured-output
+// contract when --json is also set.
+func emitCleanupJSONTo(w io.Writer, r cleanupResult) {
 	data, err := json.Marshal(r)
 	if err != nil {
 		// Marshal of a small fixed-shape struct should never fail; surface
@@ -595,7 +615,7 @@ func emitCleanupJSON(r cleanupResult) {
 		proglog.Warnf("[prism] warning: cleanup --json: marshal: %v\n", err)
 		return
 	}
-	fmt.Println(string(data))
+	fmt.Fprintln(w, string(data))
 }
 
 // headlessCleanup removes the worktree and session without any TUI interaction.
@@ -618,15 +638,26 @@ func headlessCleanup(session, worktreeName, worktreePath, bareRoot string) error
 // single JSON object is emitted on success. Stderr warnings (e.g. branch
 // delete failure, archive collision) are preserved in both modes per AC.
 func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot string, jsonMode bool) error {
+	return headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot, jsonMode, os.Stdout)
+}
+
+// headlessCleanupWithJSONTo is the writer-aware form of
+// headlessCleanupWithJSON. The `stdout` writer receives the per-step textual
+// progress lines, the "done" line, and the JSON envelope. Callers that want
+// popup-safe silent-on-success behaviour (e.g. `prism close --yes` from a
+// tmux keybind) pass io.Discard; the standard CLI path passes os.Stdout.
+// proglog warnings continue to fire to os.Stderr regardless — they only
+// trigger on partial failures, not on a clean happy-path success.
+func headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot string, jsonMode bool, stdout io.Writer) error {
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyCleanupToHostAPI(apiURL, session, true, jsonMode)
+		return proxyCleanupToHostAPI(apiURL, session, true, jsonMode, false)
 	}
 
 	result := cleanupResult{Session: session}
 
 	printLine := func(format string, a ...any) {
 		if !jsonMode {
-			fmt.Printf(format, a...)
+			fmt.Fprintf(stdout, format, a...)
 		}
 	}
 
@@ -756,9 +787,9 @@ func headlessCleanupWithJSON(session, worktreeName, worktreePath, bareRoot strin
 		proglog.Warnf("[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
 	}
 	if jsonMode {
-		emitCleanupJSON(result)
+		emitCleanupJSONTo(stdout, result)
 	} else {
-		fmt.Println("done")
+		fmt.Fprintln(stdout, "done")
 	}
 	return nil
 }
@@ -843,14 +874,27 @@ func headlessCloseSession(session string) error {
 // single JSON object is emitted on success (worktree_removed=null,
 // branch_deleted=null since this path never touches them).
 func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
+	return headlessCloseSessionWithJSONTo(session, jsonMode, os.Stdout)
+}
+
+// headlessCloseSessionWithJSONTo is the writer-aware form of
+// headlessCloseSessionWithJSON. See headlessCleanupWithJSONTo for the
+// silent-on-success rationale; identical contract on stdout.
+func headlessCloseSessionWithJSONTo(session string, jsonMode bool, stdout io.Writer) error {
 	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
-		return proxyCleanupToHostAPI(apiURL, session, true, jsonMode)
+		// The host-side `prism cleanup` already implements the soft-close
+		// path for coordinator and non-@ sessions. We don't need
+		// keep-worktree here because the host's session-routing logic in
+		// cleanupCmd.RunE already chooses the soft path on its own. For
+		// container-mode `prism close --keep-worktree` on a worker session,
+		// see proxyCloseToHostAPI in close.go, which goes through /close.
+		return proxyCleanupToHostAPI(apiURL, session, true, jsonMode, false)
 	}
 
 	result := cleanupResult{Session: session}
 	printLine := func(format string, a ...any) {
 		if !jsonMode {
-			fmt.Printf(format, a...)
+			fmt.Fprintf(stdout, format, a...)
 		}
 	}
 
@@ -931,9 +975,9 @@ func headlessCloseSessionWithJSON(session string, jsonMode bool) error {
 		proglog.Warnf("[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
 	}
 	if jsonMode {
-		emitCleanupJSON(result)
+		emitCleanupJSONTo(stdout, result)
 	} else {
-		fmt.Println("done")
+		fmt.Fprintln(stdout, "done")
 	}
 	return nil
 }
@@ -1209,6 +1253,7 @@ func init() {
 	cleanupCmd.Flags().Bool("yes", false, "Non-interactive: skip all prompts and clean up immediately")
 	cleanupCmd.Flags().String("session", "", "Target session name (default: current session)")
 	cleanupCmd.Flags().Bool("json", false, "Emit a single JSON object describing per-resource outcomes (requires --yes)")
+	cleanupCmd.Flags().Bool("keep-worktree", false, "Soft-close: preserve the worktree and branch (matches coordinator / non-@ session behaviour)")
 	rootCmd.AddCommand(cleanupCmd)
 }
 

--- a/modules/programs/prism/prism/cmd/cleanup_proxy_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_proxy_test.go
@@ -44,7 +44,7 @@ func TestProxyCleanupToHostAPI_ForwardsStdoutAndStderr(t *testing.T) {
 	})
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	if err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@some-branch", true, false, &stdoutBuf, &stderrBuf); err != nil {
+	if err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@some-branch", true, false, false, &stdoutBuf, &stderrBuf); err != nil {
 		t.Fatalf("proxyCleanupToHostAPI: %v", err)
 	}
 	if stdoutBuf.String() != wantStdout {
@@ -90,7 +90,7 @@ func TestProxyCleanupToHostAPI_ForwardsErrorWithStdoutStderr(t *testing.T) {
 	})
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@some-branch", true, false, &stdoutBuf, &stderrBuf)
+	err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@some-branch", true, false, false, &stdoutBuf, &stderrBuf)
 	if err == nil {
 		t.Fatal("expected error from proxyCleanupToHostAPI on 500 response")
 	}
@@ -124,7 +124,7 @@ func TestProxyCleanupToHostAPI_PassesJSONFlag(t *testing.T) {
 	})
 
 	var stdoutBuf, stderrBuf bytes.Buffer
-	if err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@b", true, true, &stdoutBuf, &stderrBuf); err != nil {
+	if err := proxyCleanupToHostAPIWithWriters(srv.apiURL(), "myrepo@b", true, true, false, &stdoutBuf, &stderrBuf); err != nil {
 		t.Fatalf("proxyCleanupToHostAPI: %v", err)
 	}
 	select {

--- a/modules/programs/prism/prism/cmd/cleanup_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/prismatic-koi/prism/internal/db"
 )
 
@@ -1343,5 +1345,137 @@ func TestHeadlessCleanup_InvestigatorSessionPreservesMainWorktree(t *testing.T) 
 	}
 	if status.EndedAt == nil {
 		t.Errorf("ended_at is nil — investigator session was not marked as ended")
+	}
+}
+
+// TestCleanupCmd_KeepWorktreeFlag_SoftClosesWorker verifies the issue #2179
+// parity AC: `prism cleanup --yes --keep-worktree --session <worker>` runs
+// the soft-close path (preserves worktree + branch, marks DB ended) instead
+// of the default destructive cleanup.
+//
+// Without the flag, the same invocation removes the worktree. The flag is
+// the load-bearing difference — see the AC "`prism cleanup --keep-worktree`
+// exists as a flag on the existing `prism cleanup` command and produces a
+// soft close even for a non-coordinator worker session".
+func TestCleanupCmd_KeepWorktreeFlag_SoftClosesWorker(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH — skipping integration test")
+	}
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	withNoopTmux(t)
+
+	bareRoot, worktreePath, branchName := setupMinimalBareRepo(t)
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	session := "myrepo@" + branchName
+	if err := d.UpsertStatus(session, "myrepo", worktreePath, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Drive cleanupCmd.RunE directly with --keep-worktree set.
+	cmd := &cobra.Command{Use: "cleanup", RunE: cleanupCmd.RunE}
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("session", "", "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().Bool("keep-worktree", false, "")
+	_ = cmd.Flags().Set("session", session)
+	_ = cmd.Flags().Set("yes", "true")
+	_ = cmd.Flags().Set("keep-worktree", "true")
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("cleanupCmd.RunE with --keep-worktree: %v", err)
+	}
+
+	// The worktree must still exist on disk (soft close preserves it).
+	if _, statErr := os.Stat(worktreePath); statErr != nil {
+		t.Errorf("worktree %q removed despite --keep-worktree: %v", worktreePath, statErr)
+	}
+
+	// The branch must still exist in the bare repo.
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if err := exec.Command("git", "--git-dir", bareDir, "rev-parse", "--verify",
+		"refs/heads/"+branchName).Run(); err != nil {
+		t.Errorf("branch %q deleted despite --keep-worktree: %v", branchName, err)
+	}
+
+	// The DB row must be marked ended (soft close still stamps ended_at).
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("CurrentStatus returned nil — row missing")
+	}
+	if status.EndedAt == nil {
+		t.Errorf("ended_at is nil — soft close did not mark the row as ended")
+	}
+}
+
+// TestCleanupCmd_NoKeepWorktreeFlag_HardCleansWorker is the negative-control
+// pair to TestCleanupCmd_KeepWorktreeFlag_SoftClosesWorker. Without the flag,
+// the same invocation removes the worktree and force-deletes the branch —
+// the AC "`prism cleanup` (without `--keep-worktree`) continues to behave
+// identically to its current implementation".
+func TestCleanupCmd_NoKeepWorktreeFlag_HardCleansWorker(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found in PATH — skipping integration test")
+	}
+	t.Setenv("PRISM_HOST_API", "")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	withNoopTmux(t)
+
+	bareRoot, worktreePath, branchName := setupMinimalBareRepo(t)
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	session := "myrepo@" + branchName
+	if err := d.UpsertStatus(session, "myrepo", worktreePath, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	cmd := &cobra.Command{Use: "cleanup", RunE: cleanupCmd.RunE}
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("session", "", "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().Bool("keep-worktree", false, "")
+	_ = cmd.Flags().Set("session", session)
+	_ = cmd.Flags().Set("yes", "true")
+	// --keep-worktree NOT set.
+
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("cleanupCmd.RunE without --keep-worktree: %v", err)
+	}
+
+	// The worktree must be gone.
+	if _, statErr := os.Stat(worktreePath); statErr == nil {
+		t.Errorf("worktree %q still present after default cleanup — expected removal", worktreePath)
+	}
+
+	// The branch must be gone.
+	bareDir := filepath.Join(bareRoot, ".bare")
+	if err := exec.Command("git", "--git-dir", bareDir, "rev-parse", "--verify",
+		"refs/heads/"+branchName).Run(); err == nil {
+		t.Errorf("branch %q still exists after default cleanup — expected force-delete", branchName)
 	}
 }

--- a/modules/programs/prism/prism/cmd/close.go
+++ b/modules/programs/prism/prism/cmd/close.go
@@ -1,0 +1,328 @@
+package cmd
+
+// prism close — smart-decide session close based on PR state (issue #2179).
+//
+// The decision tree:
+//
+//	1. Force flags win:
+//	   --keep-worktree   → soft close (preserve worktree + branch)
+//	   --remove-worktree → hard cleanup (remove worktree, force-delete branch)
+//	2. Coordinator session (root_agent_name == "coordinator" or @main heuristic)
+//	   → soft close
+//	3. Non-worktree session (no "@" in name, e.g. "obsidian") → soft close
+//	4. Worker worktree session: probe `gh pr list --head <branch>`:
+//	   - any PR is OPEN                              → soft close
+//	   - all PRs are MERGED/CLOSED                   → hard cleanup
+//	   - no PR found                                 → hard cleanup
+//	   - probe error / timeout / unauthenticated     → soft close (fail-safe)
+//
+// The asymmetric-risk argument: a spurious soft close costs one
+// `prism close --remove-worktree` later; a spurious hard cleanup destroys
+// uncommitted work. Every error path on the gh probe therefore routes to
+// soft close.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/git"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// ghProbeTimeout caps the `gh pr list` probe so a hung GitHub API never
+// wedges the tmux popup (issue #2179, AC: performance ≤ 5s). On timeout the
+// command fails safe to a soft close.
+const ghProbeTimeout = 5 * time.Second
+
+// prProbe is the indirection used by decideClose to query PR state for a
+// branch. Replaced in tests with a fake that returns canned responses.
+var prProbe = probePRStateExec
+
+// closeCmd is the public `prism close` cobra command.
+var closeCmd = &cobra.Command{
+	Use:   "close",
+	Short: "Smart-decide session close: soft-close on an open PR; hard-cleanup otherwise",
+	Long: `Close a prism session, deciding between soft close (preserve the worktree
+and branch) and hard cleanup (remove worktree, force-delete branch) based on
+whether an open pull request exists for the branch.
+
+Decision tree:
+
+  - Coordinator session or non-worktree session → soft close
+  - Worker session:
+      * branch has an OPEN pull request          → soft close
+      * branch has a MERGED or CLOSED PR         → hard cleanup
+      * branch has no pull request               → hard cleanup
+      * gh probe errors out / times out          → soft close (fail-safe)
+
+The fail-safe to soft close is deliberate: a spurious soft close costs one
+extra ` + "`prism close --remove-worktree`" + ` later, while a spurious hard cleanup
+destroys uncommitted work.
+
+Force flags override the decision:
+  --keep-worktree    preserve the worktree regardless of PR state
+  --remove-worktree  remove the worktree regardless of PR state`,
+	RunE: runCloseCmd,
+}
+
+func init() {
+	closeCmd.Flags().Bool("yes", false, "Non-interactive: skip all prompts and close immediately")
+	closeCmd.Flags().String("session", "", "Target session name (default: current session)")
+	closeCmd.Flags().Bool("json", false, "Emit a single JSON object describing per-resource outcomes (requires --yes)")
+	closeCmd.Flags().Bool("keep-worktree", false, "Force soft close: preserve the worktree and branch regardless of PR state")
+	closeCmd.Flags().Bool("remove-worktree", false, "Force hard cleanup: remove the worktree and branch regardless of PR state")
+	rootCmd.AddCommand(closeCmd)
+}
+
+func runCloseCmd(cmd *cobra.Command, args []string) error {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	sessionFlag, _ := cmd.Flags().GetString("session")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+	keepFlag, _ := cmd.Flags().GetBool("keep-worktree")
+	removeFlag, _ := cmd.Flags().GetBool("remove-worktree")
+
+	if keepFlag && removeFlag {
+		return fmt.Errorf("--keep-worktree and --remove-worktree are mutually exclusive")
+	}
+	// --json implies --yes: emitting a single structured object is incompatible
+	// with an interactive TUI. Match `prism cleanup`'s wording exactly so
+	// scripts that pattern-match on the error see no difference.
+	if jsonFlag && !yesFlag {
+		return fmt.Errorf("--json requires --yes (interactive close is incompatible with structured output)")
+	}
+
+	// Inside a container: proxy to the host sidecar. The host runs the same
+	// `prism close` binary so the decision tree is identical there; the
+	// container side just forwards stdout/stderr verbatim.
+	if apiURL := os.Getenv("PRISM_HOST_API"); apiURL != "" {
+		target := sessionFlag
+		if target == "" {
+			return fmt.Errorf("--session is required when running inside a container")
+		}
+		return proxyCloseToHostAPI(apiURL, target, yesFlag, jsonFlag, keepFlag, removeFlag)
+	}
+
+	// Only require tmux when we need to auto-detect the current session.
+	if sessionFlag == "" && os.Getenv("TMUX") == "" {
+		return fmt.Errorf("interactive close requires tmux — use --yes for non-interactive use outside tmux")
+	}
+
+	var session string
+	if sessionFlag != "" {
+		session = sessionFlag
+		// Validate the session name early against the DB so a typo produces a
+		// helpful enumerated error rather than a later "worktree not found".
+		// Match `prism cleanup`'s error shape exactly (AC: edge-case parity).
+		if d, dbErr := openDB(); dbErr == nil {
+			st, stErr := d.CurrentStatus(session)
+			if stErr == nil && st == nil {
+				names, _ := activeSessionNamesForError(d, 10)
+				d.Close()
+				if len(names) == 0 {
+					return fmt.Errorf("--session %q not found — no active sessions in DB", session)
+				}
+				return fmt.Errorf("--session must be one of: %s (got: %q)", strings.Join(names, ", "), session)
+			}
+			d.Close()
+		}
+	} else {
+		s, err := tmux.CurrentSession()
+		if err != nil || s == "" {
+			return fmt.Errorf("could not determine current tmux session")
+		}
+		session = s
+	}
+
+	soft, hard := decideClose(session, keepFlag, removeFlag)
+
+	// quiet = silent on stdout (popup-safe). --json keeps emitting the JSON
+	// envelope; only the "$yes && !$json" combination is fully silent on
+	// success.
+	quiet := yesFlag && !jsonFlag
+	stdout := io.Writer(os.Stdout)
+	if quiet {
+		stdout = io.Discard
+	}
+
+	switch {
+	case soft:
+		if yesFlag {
+			return headlessCloseSessionWithJSONTo(session, jsonFlag, stdout)
+		}
+		// Interactive path: prompt the user, then run the same headless flow
+		// with os.Stdout so progress is visible.
+		if os.Getenv("TMUX") == "" {
+			return fmt.Errorf("interactive close requires tmux — use --yes for non-interactive use outside tmux")
+		}
+		if !confirm(fmt.Sprintf("Close session %s? (worktree will be kept)", session)) {
+			return nil
+		}
+		return closeSession(session)
+
+	case hard:
+		// Resolve worktree path & bareRoot for hard cleanup. Mirrors the
+		// resolution in cleanupCmd.RunE.
+		worktreeName := ""
+		if i := strings.Index(session, "@"); i >= 0 {
+			worktreeName = session[i+1:]
+		}
+		worktreePath := worktreePathFromSession(session)
+		bareRoot := ""
+		if worktreePath != "" {
+			bareRoot = git.BareRoot(worktreePath)
+		} else {
+			probed, probedBareRoot := probeConventionalWorktreePath(session, worktreeName)
+			if probed != "" {
+				worktreePath = probed
+				bareRoot = git.BareRoot(worktreePath)
+			} else if probedBareRoot != "" {
+				bareRoot = probedBareRoot
+			}
+		}
+
+		if yesFlag {
+			return headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot, jsonFlag, stdout)
+		}
+		// Interactive path: drive the same TUI cleanup model as `prism cleanup`.
+		// The popup keybind always passes --yes so this path is only reached
+		// when a user types `prism close` at a shell prompt without --yes; we
+		// keep behaviour parity with `prism cleanup` so the surface is
+		// predictable.
+		if os.Getenv("TMUX") == "" {
+			return fmt.Errorf("interactive close requires tmux — use --yes for non-interactive use outside tmux")
+		}
+		defaultBr := ""
+		if bareRoot != "" {
+			defaultBr = git.DefaultBranchFromBareRoot(bareRoot)
+		}
+		m := newCleanupModel(session, worktreeName, worktreePath, bareRoot, defaultBr)
+		prog := tea.NewProgram(cleanupWrapper{m}, tea.WithAltScreen())
+		_, runErr := prog.Run()
+		return runErr
+	}
+	return nil
+}
+
+// decideClose returns (soft, hard) — exactly one is true. Implements the
+// decision tree documented at the top of this file.
+//
+// keepFlag and removeFlag are caller-provided force-overrides; the function
+// rejects mutual specification upstream (in runCloseCmd) so this helper can
+// assume at most one is set.
+func decideClose(session string, keepFlag, removeFlag bool) (soft, hard bool) {
+	// Force flags win.
+	switch {
+	case keepFlag:
+		return true, false
+	case removeFlag:
+		return false, true
+	}
+
+	// Non-worktree session (no "@"): soft close (matches `prism cleanup`).
+	if !strings.Contains(session, "@") {
+		return true, false
+	}
+
+	branch := session[strings.Index(session, "@")+1:]
+
+	// Coordinator detection: resolve default branch via the worktree path,
+	// then fall back to the DB-backed coordinator check.
+	isDefaultBranch := false
+	worktreePath := worktreePathFromSession(session)
+	if worktreePath != "" {
+		if bareRoot := git.BareRoot(worktreePath); bareRoot != "" {
+			if defaultBr := git.DefaultBranchFromBareRoot(bareRoot); defaultBr != "" && branch == defaultBr {
+				isDefaultBranch = true
+			}
+		}
+	}
+	if isCoordinatorFromDB(session, isDefaultBranch) {
+		return true, false
+	}
+
+	// Worker session: probe PR state.
+	state, err := prProbe(worktreePath, branch)
+	if err != nil {
+		// Fail-safe: any probe failure routes to soft close so an unreachable
+		// gh, missing PATH entry, or auth failure cannot destroy a worktree.
+		return true, false
+	}
+	switch strings.ToUpper(state) {
+	case "OPEN":
+		return true, false
+	case "MERGED", "CLOSED":
+		return false, true
+	case "":
+		// No PR found for this branch → hard cleanup.
+		return false, true
+	default:
+		// Unknown state (e.g. future gh output) → fail-safe to soft close.
+		return true, false
+	}
+}
+
+// prProbeResult is the gh JSON shape we care about.
+type prProbeResult struct {
+	Number int    `json:"number"`
+	State  string `json:"state"`
+}
+
+// probePRStateExec is the production gh probe. It runs
+// `gh pr list --head <branch> --state all --json state,number --limit 10`
+// in the supplied working directory with a bounded context timeout.
+//
+// Why `gh pr list` and not `gh pr view`: the AC requires that when multiple
+// PRs exist for the same head branch and any of them is OPEN, the probe
+// returns OPEN. `gh pr view` returns a single PR; `gh pr list --head` returns
+// the full set, which is necessary to honour the multi-PR AC.
+//
+// Returns:
+//   - ("OPEN", nil) when any PR for the branch is OPEN.
+//   - ("MERGED"|"CLOSED", nil) when no PR is OPEN; the state of the first
+//     non-open PR is returned (caller treats both identically: hard cleanup).
+//   - ("", nil) when no PR exists for the branch.
+//   - ("", err) on any failure — caller fails safe to soft close.
+func probePRStateExec(workdir, branch string) (string, error) {
+	if branch == "" {
+		return "", fmt.Errorf("probePRState: empty branch")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), ghProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--head", branch,
+		"--state", "all",
+		"--json", "state,number",
+		"--limit", "10")
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	var prs []prProbeResult
+	if uerr := json.Unmarshal(out, &prs); uerr != nil {
+		return "", uerr
+	}
+	if len(prs) == 0 {
+		return "", nil
+	}
+	// Multi-PR case: if any PR is OPEN, treat as OPEN (AC: edge-case).
+	for _, pr := range prs {
+		if strings.EqualFold(pr.State, "OPEN") {
+			return "OPEN", nil
+		}
+	}
+	// No open PR — return the state of the first non-open PR; the caller
+	// treats MERGED and CLOSED identically (both → hard cleanup).
+	return strings.ToUpper(prs[0].State), nil
+}

--- a/modules/programs/prism/prism/cmd/close_test.go
+++ b/modules/programs/prism/prism/cmd/close_test.go
@@ -1,0 +1,834 @@
+// Unit tests for `prism close` (issue #2179).
+//
+// The tests fall into three groups:
+//
+//  1. decideClose — pure decision-tree tests that swap prProbe for a stub.
+//  2. probePRStateExec — exercises the production gh shell-out via a PATH-
+//     injected `gh` stub, so we test the JSON-parse branches without depending
+//     on a real network call.
+//  3. runCloseCmd — flag validation (mutually-exclusive force flags, --json
+//     requires --yes, unknown --session) and the integration with the
+//     existing cleanup-soft / cleanup-hard paths.
+//
+// Integration tests that drive tmux clients (the popup-style end-to-end) live
+// alongside the cleanup integration tests further down; this file covers the
+// command-internal logic without spinning up a tmux server.
+
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// withPRProbeStub swaps prProbe for the duration of the test.
+func withPRProbeStub(t *testing.T, fn func(workdir, branch string) (string, error)) {
+	t.Helper()
+	orig := prProbe
+	prProbe = fn
+	t.Cleanup(func() { prProbe = orig })
+}
+
+// TestDecideClose_ForceFlagsWin confirms --keep-worktree and --remove-worktree
+// short-circuit before the gh probe is ever consulted.
+func TestDecideClose_ForceFlagsWin(t *testing.T) {
+	// Probe should never run when a force flag is set — fail loudly if it does.
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		t.Errorf("prProbe should not be called when a force flag is set; got branch=%q", branch)
+		return "", fmt.Errorf("unreachable")
+	})
+
+	t.Run("--keep-worktree forces soft close", func(t *testing.T) {
+		soft, hard := decideClose("myrepo@feature", true, false)
+		if !soft || hard {
+			t.Errorf("decideClose(--keep-worktree) = (soft=%v, hard=%v), want (true, false)", soft, hard)
+		}
+	})
+
+	t.Run("--remove-worktree forces hard cleanup", func(t *testing.T) {
+		soft, hard := decideClose("myrepo@feature", false, true)
+		if soft || !hard {
+			t.Errorf("decideClose(--remove-worktree) = (soft=%v, hard=%v), want (false, true)", soft, hard)
+		}
+	})
+}
+
+// TestDecideClose_NonWorktreeSession verifies the non-"@" path soft-closes
+// without consulting gh or the DB.
+func TestDecideClose_NonWorktreeSession(t *testing.T) {
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		t.Errorf("prProbe should not be called for a non-worktree session")
+		return "", fmt.Errorf("unreachable")
+	})
+	soft, hard := decideClose("obsidian", false, false)
+	if !soft || hard {
+		t.Errorf("decideClose(non-worktree) = (soft=%v, hard=%v), want (true, false)", soft, hard)
+	}
+}
+
+// TestDecideClose_CoordinatorSession verifies a coordinator session
+// (root_agent_name == "coordinator") soft-closes without consulting gh. This
+// is the key behaviour for the @main coordinator carve-out.
+func TestDecideClose_CoordinatorSession(t *testing.T) {
+	// Set up DB with a coordinator row.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Coordinator on a non-@main branch — root_agent_name must be the
+	// deciding factor, not the branch heuristic.
+	if err := d.UpsertStatusSeedRootAgentName(
+		"myrepo@some-coord-branch", "myrepo", "/code/myrepo", "active",
+		nil, nil, "coordinator", "", "",
+	); err != nil {
+		t.Fatalf("seed coordinator: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		t.Errorf("prProbe should not be called for a coordinator session; got branch=%q", branch)
+		return "", fmt.Errorf("unreachable")
+	})
+
+	soft, hard := decideClose("myrepo@some-coord-branch", false, false)
+	if !soft || hard {
+		t.Errorf("decideClose(coordinator) = (soft=%v, hard=%v), want (true, false)", soft, hard)
+	}
+}
+
+// TestDecideClose_WorkerWithOpenPR verifies an OPEN PR routes to soft close.
+func TestDecideClose_WorkerWithOpenPR(t *testing.T) {
+	// Empty DB — no coordinator rows; decideClose must consult gh.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, _ := db.Open(dbFile)
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		if branch != "feature-foo" {
+			t.Errorf("probe called with branch %q, want feature-foo", branch)
+		}
+		return "OPEN", nil
+	})
+
+	soft, hard := decideClose("myrepo@feature-foo", false, false)
+	if !soft || hard {
+		t.Errorf("decideClose(open PR) = (soft=%v, hard=%v), want (true, false)", soft, hard)
+	}
+}
+
+// TestDecideClose_WorkerWithMergedOrClosedPR verifies MERGED and CLOSED both
+// route to hard cleanup.
+func TestDecideClose_WorkerWithMergedOrClosedPR(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, _ := db.Open(dbFile)
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	for _, state := range []string{"MERGED", "CLOSED", "merged", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			withPRProbeStub(t, func(workdir, branch string) (string, error) {
+				return state, nil
+			})
+			soft, hard := decideClose("myrepo@some-merged-branch", false, false)
+			if soft || !hard {
+				t.Errorf("decideClose(state=%s) = (soft=%v, hard=%v), want (false, true)", state, soft, hard)
+			}
+		})
+	}
+}
+
+// TestDecideClose_WorkerWithNoPR verifies "no PR found" routes to hard cleanup.
+func TestDecideClose_WorkerWithNoPR(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, _ := db.Open(dbFile)
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		return "", nil // no PR
+	})
+
+	soft, hard := decideClose("myrepo@orphan-branch", false, false)
+	if soft || !hard {
+		t.Errorf("decideClose(no PR) = (soft=%v, hard=%v), want (false, true)", soft, hard)
+	}
+}
+
+// TestDecideClose_WorkerProbeError verifies any probe error fails safe to
+// soft close. This is the load-bearing AC: "fail safe to soft close" means
+// destructive paths never fire when gh is unavailable.
+func TestDecideClose_WorkerProbeError(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, _ := db.Open(dbFile)
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"gh missing", fmt.Errorf("exec: \"gh\": executable file not found in $PATH")},
+		{"network failure", fmt.Errorf("dial: connection refused")},
+		{"unauthenticated", fmt.Errorf("HTTP 401")},
+		{"timeout", fmt.Errorf("context deadline exceeded")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withPRProbeStub(t, func(workdir, branch string) (string, error) {
+				return "", tc.err
+			})
+			soft, hard := decideClose("myrepo@some-branch", false, false)
+			if !soft || hard {
+				t.Errorf("decideClose(probe err=%v) = (soft=%v, hard=%v), want (true, false)",
+					tc.err, soft, hard)
+			}
+		})
+	}
+}
+
+// TestDecideClose_WorkerUnknownState verifies an unknown gh state value
+// (e.g. a future state name) fails safe to soft close.
+func TestDecideClose_WorkerUnknownState(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, _ := db.Open(dbFile)
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		return "DRAFT_NEW_STATE", nil
+	})
+
+	soft, hard := decideClose("myrepo@some-branch", false, false)
+	if !soft || hard {
+		t.Errorf("decideClose(unknown state) = (soft=%v, hard=%v), want (true, false)", soft, hard)
+	}
+}
+
+// ── probePRStateExec ─────────────────────────────────────────────────────────
+
+// withFakeGhInPath writes a fake `gh` to a tempdir, prepends it to $PATH, and
+// returns the tempdir so the test can also inspect what gh was invoked with.
+//
+// The fake gh writes the contents of $FAKE_GH_STDOUT to stdout, the contents
+// of $FAKE_GH_STDERR to stderr, and exits with $FAKE_GH_EXIT (default 0). It
+// also records its argv to $FAKE_GH_ARGV_FILE if that env var is set.
+func withFakeGhInPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+if [ -n "$FAKE_GH_ARGV_FILE" ]; then
+  echo "$@" >> "$FAKE_GH_ARGV_FILE"
+fi
+if [ -n "$FAKE_GH_STDOUT" ]; then
+  printf '%s' "$FAKE_GH_STDOUT"
+fi
+if [ -n "$FAKE_GH_STDERR" ]; then
+  printf '%s' "$FAKE_GH_STDERR" >&2
+fi
+exit "${FAKE_GH_EXIT:-0}"
+`
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+	return dir
+}
+
+// TestProbePRStateExec_OpenPR verifies the happy path: a single OPEN PR.
+func TestProbePRStateExec_OpenPR(t *testing.T) {
+	withFakeGhInPath(t)
+	t.Setenv("FAKE_GH_STDOUT", `[{"number":42,"state":"OPEN"}]`)
+
+	state, err := probePRStateExec("", "feature-foo")
+	if err != nil {
+		t.Fatalf("probePRStateExec: %v", err)
+	}
+	if state != "OPEN" {
+		t.Errorf("state = %q, want OPEN", state)
+	}
+}
+
+// TestProbePRStateExec_MergedPR verifies a single MERGED PR returns MERGED.
+func TestProbePRStateExec_MergedPR(t *testing.T) {
+	withFakeGhInPath(t)
+	t.Setenv("FAKE_GH_STDOUT", `[{"number":42,"state":"MERGED"}]`)
+
+	state, err := probePRStateExec("", "feature-merged")
+	if err != nil {
+		t.Fatalf("probePRStateExec: %v", err)
+	}
+	if state != "MERGED" {
+		t.Errorf("state = %q, want MERGED", state)
+	}
+}
+
+// TestProbePRStateExec_NoPR verifies an empty result returns ("", nil), which
+// the caller treats as "no PR found → hard cleanup".
+func TestProbePRStateExec_NoPR(t *testing.T) {
+	withFakeGhInPath(t)
+	t.Setenv("FAKE_GH_STDOUT", `[]`)
+
+	state, err := probePRStateExec("", "orphan-branch")
+	if err != nil {
+		t.Fatalf("probePRStateExec: %v", err)
+	}
+	if state != "" {
+		t.Errorf("state = %q, want \"\" (no PR)", state)
+	}
+}
+
+// TestProbePRStateExec_MultiPROpenWins verifies the AC: when multiple PRs
+// exist for the same head branch and any is OPEN, the probe returns OPEN.
+func TestProbePRStateExec_MultiPROpenWins(t *testing.T) {
+	withFakeGhInPath(t)
+	// Two PRs: one MERGED, one OPEN. OPEN must win regardless of order.
+	t.Setenv("FAKE_GH_STDOUT", `[{"number":1,"state":"MERGED"},{"number":2,"state":"OPEN"}]`)
+
+	state, err := probePRStateExec("", "branch-with-multiple-prs")
+	if err != nil {
+		t.Fatalf("probePRStateExec: %v", err)
+	}
+	if state != "OPEN" {
+		t.Errorf("state = %q, want OPEN (any-OPEN-wins multi-PR contract)", state)
+	}
+}
+
+// TestProbePRStateExec_GhExitsNonZero verifies an error exit propagates,
+// so decideClose can fail-safe to soft close.
+func TestProbePRStateExec_GhExitsNonZero(t *testing.T) {
+	withFakeGhInPath(t)
+	t.Setenv("FAKE_GH_EXIT", "1")
+	t.Setenv("FAKE_GH_STDERR", "gh: not authenticated\n")
+
+	state, err := probePRStateExec("", "some-branch")
+	if err == nil {
+		t.Errorf("expected non-nil error from non-zero gh exit; got state=%q", state)
+	}
+}
+
+// TestProbePRStateExec_GhMissing verifies the probe returns an error when gh
+// is not on $PATH. PATH is set to an empty tempdir to guarantee no gh on
+// PATH for this test, decoupled from the test runner's environment.
+func TestProbePRStateExec_GhMissing(t *testing.T) {
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	state, err := probePRStateExec("", "some-branch")
+	if err == nil {
+		t.Errorf("expected non-nil error when gh missing; got state=%q", state)
+	}
+}
+
+// TestProbePRStateExec_EmptyBranch verifies the early-return on an empty
+// branch (defensive guard).
+func TestProbePRStateExec_EmptyBranch(t *testing.T) {
+	withFakeGhInPath(t)
+	if state, err := probePRStateExec("", ""); err == nil {
+		t.Errorf("expected error for empty branch; got state=%q", state)
+	}
+}
+
+// TestProbePRStateExec_PassesArgv verifies the exact argv shape sent to gh:
+// `gh pr list --head <branch> --state all --json state,number --limit 10`.
+// This is a regression guard on the AC: multi-PR support requires
+// `gh pr list --head`, not `gh pr view`.
+func TestProbePRStateExec_PassesArgv(t *testing.T) {
+	dir := withFakeGhInPath(t)
+	argvFile := filepath.Join(dir, "argv.log")
+	t.Setenv("FAKE_GH_STDOUT", `[]`)
+	t.Setenv("FAKE_GH_ARGV_FILE", argvFile)
+
+	if _, err := probePRStateExec("", "my-branch"); err != nil {
+		t.Fatalf("probePRStateExec: %v", err)
+	}
+
+	data, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read argv: %v", err)
+	}
+	argv := strings.TrimSpace(string(data))
+	wantSubstrings := []string{
+		"pr list",
+		"--head my-branch",
+		"--state all",
+		"--json state,number",
+		"--limit 10",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(argv, want) {
+			t.Errorf("argv %q missing %q", argv, want)
+		}
+	}
+}
+
+// TestProbePRStateExec_HangingProbeRespectsTimeout verifies the 5s context
+// timeout. The fake gh execs sleep so SIGKILL on context cancellation tears
+// down the actual sleep process (a wrapping shell would leave the sleep
+// child holding the stdout pipe open, hanging cmd.Output past the deadline).
+func TestProbePRStateExec_HangingProbeRespectsTimeout(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "gh")
+	// `exec sleep` replaces the shell with sleep so SIGKILL hits sleep
+	// directly, closing the stdout pipe and unblocking probePRStateExec.
+	script := "#!/bin/sh\nexec sleep 30\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write hanging gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	start := time.Now()
+	_, err := probePRStateExec("", "stuck-branch")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Errorf("expected error from hanging gh probe; got nil after %v", elapsed)
+	}
+	if elapsed > ghProbeTimeout+2*time.Second {
+		t.Errorf("probe took %v, want < %v (timeout not enforced)", elapsed, ghProbeTimeout+2*time.Second)
+	}
+}
+
+// ── runCloseCmd flag validation ──────────────────────────────────────────────
+
+// freshCloseCmd returns a copy of closeCmd with a clean flag set so each
+// test invocation runs in isolation. We can't reuse closeCmd directly
+// because parsed flag values persist between RunE invocations.
+func freshCloseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "close",
+		RunE: runCloseCmd,
+	}
+	cmd.Flags().Bool("yes", false, "")
+	cmd.Flags().String("session", "", "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().Bool("keep-worktree", false, "")
+	cmd.Flags().Bool("remove-worktree", false, "")
+	return cmd
+}
+
+// TestCloseCmd_MutuallyExclusiveFlags verifies --keep-worktree and
+// --remove-worktree cannot be combined.
+func TestCloseCmd_MutuallyExclusiveFlags(t *testing.T) {
+	cmd := freshCloseCmd()
+	_ = cmd.Flags().Set("keep-worktree", "true")
+	_ = cmd.Flags().Set("remove-worktree", "true")
+	_ = cmd.Flags().Set("yes", "true")
+
+	err := runCloseCmd(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for --keep-worktree + --remove-worktree, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error %q does not mention 'mutually exclusive'", err.Error())
+	}
+}
+
+// TestCloseCmd_JSONRequiresYes verifies the --json without --yes error message
+// matches `prism cleanup` for parity.
+func TestCloseCmd_JSONRequiresYes(t *testing.T) {
+	cmd := freshCloseCmd()
+	_ = cmd.Flags().Set("json", "true")
+
+	err := runCloseCmd(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for --json without --yes, got nil")
+	}
+	if !strings.Contains(err.Error(), "--json requires --yes") {
+		t.Errorf("error %q does not contain '--json requires --yes'", err.Error())
+	}
+}
+
+// TestCloseCmd_UnknownSessionEnumerates verifies the "must be one of" error
+// shape matches `prism cleanup` exactly (AC: edge-case parity).
+func TestCloseCmd_UnknownSessionEnumerates(t *testing.T) {
+	// Seed DB with one active session so the error lists it.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := d.UpsertStatus("myrepo@known-session", "myrepo", "/tmp/wt", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+	t.Setenv("PRISM_HOST_API", "") // run host-side path
+
+	cmd := freshCloseCmd()
+	_ = cmd.Flags().Set("session", "myrepo@does-not-exist")
+	_ = cmd.Flags().Set("yes", "true")
+
+	err = runCloseCmd(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for unknown --session, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be one of") {
+		t.Errorf("error %q does not contain 'must be one of'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "myrepo@known-session") {
+		t.Errorf("error %q does not enumerate known session", err.Error())
+	}
+	if !strings.Contains(err.Error(), "myrepo@does-not-exist") {
+		t.Errorf("error %q does not name the bad input", err.Error())
+	}
+}
+
+// TestCloseCmd_NoTmuxWithoutSessionFails verifies the tmux-required error
+// matches `prism cleanup` for parity (AC: edge-case).
+func TestCloseCmd_NoTmuxWithoutSessionFails(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("PRISM_HOST_API", "")
+
+	cmd := freshCloseCmd()
+	// No --session, no --yes — runCloseCmd's early guard fires.
+
+	err := runCloseCmd(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when TMUX unset and --session absent, got nil")
+	}
+	if !strings.Contains(err.Error(), "tmux") {
+		t.Errorf("error %q does not mention tmux", err.Error())
+	}
+}
+
+// TestCloseCmd_ContainerProxyRequiresSession verifies that running inside a
+// container (PRISM_HOST_API set) without --session is rejected client-side,
+// matching `prism cleanup` (AC: edge-case parity).
+func TestCloseCmd_ContainerProxyRequiresSession(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "unix:///tmp/never-reached.sock")
+	cmd := freshCloseCmd()
+	_ = cmd.Flags().Set("yes", "true")
+
+	err := runCloseCmd(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when PRISM_HOST_API set without --session, got nil")
+	}
+	if !strings.Contains(err.Error(), "--session is required") {
+		t.Errorf("error %q does not mention '--session is required'", err.Error())
+	}
+}
+
+// TestCloseCmd_ContainerProxyForwardsFlags verifies that when PRISM_HOST_API is
+// set, runCloseCmd forwards --session/--yes/--json/--keep-worktree/
+// --remove-worktree to the /close endpoint as a JSON request body.
+func TestCloseCmd_ContainerProxyForwardsFlags(t *testing.T) {
+	type closeReq struct {
+		Session        string `json:"session"`
+		Yes            bool   `json:"yes"`
+		JSON           bool   `json:"json"`
+		KeepWorktree   bool   `json:"keep_worktree"`
+		RemoveWorktree bool   `json:"remove_worktree"`
+	}
+	reqCh := make(chan closeReq, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/close" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req closeReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":"","stderr":""}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	cmd := freshCloseCmd()
+	_ = cmd.Flags().Set("session", "myrepo@feature")
+	_ = cmd.Flags().Set("yes", "true")
+	_ = cmd.Flags().Set("json", "true")
+	_ = cmd.Flags().Set("keep-worktree", "true")
+
+	if err := runCloseCmd(cmd, nil); err != nil {
+		t.Fatalf("runCloseCmd: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Session != "myrepo@feature" {
+			t.Errorf("session = %q, want myrepo@feature", req.Session)
+		}
+		if !req.Yes {
+			t.Error("yes = false, want true")
+		}
+		if !req.JSON {
+			t.Error("json = false, want true")
+		}
+		if !req.KeepWorktree {
+			t.Error("keep_worktree = false, want true")
+		}
+		if req.RemoveWorktree {
+			t.Error("remove_worktree = true, want false (not set)")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// ── close-cmd integration: smart-decide on a real session row ────────────────
+
+// TestCloseCmd_SoftCloseOnOpenPR verifies the end-to-end soft-close path for
+// a worker session with an OPEN PR: the DB row is marked ended, the worktree
+// path is preserved (we just check it's still there on disk), and stdout is
+// silent.
+func TestCloseCmd_SoftCloseOnOpenPR(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		return "OPEN", nil
+	})
+
+	worktreePath := t.TempDir()
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sessionName := "myrepo@open-feature"
+	if err := d.UpsertStatus(sessionName, "myrepo", worktreePath, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	// Capture stdout via os.Pipe so the test can assert silence.
+	stdout := captureStdout(t, func() {
+		cmd := freshCloseCmd()
+		_ = cmd.Flags().Set("session", sessionName)
+		_ = cmd.Flags().Set("yes", "true")
+		if err := runCloseCmd(cmd, nil); err != nil {
+			t.Fatalf("runCloseCmd: %v", err)
+		}
+	})
+
+	if stdout != "" {
+		t.Errorf("expected silent stdout on success, got %q", stdout)
+	}
+
+	// Worktree directory still exists (soft close did not remove it).
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree directory was removed; soft close should preserve it: %v", err)
+	}
+
+	// DB row is marked ended.
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	status, err := d2.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil {
+		t.Fatal("CurrentStatus returned nil — row missing")
+	}
+	if status.EndedAt == nil {
+		t.Errorf("ended_at is nil — soft close did not mark the session as ended")
+	}
+}
+
+// TestCloseCmd_JSONOnSoftCloseEmitsEnvelope verifies --json + --yes still emits
+// the JSON envelope (the quiet rule only applies to the non-json case).
+func TestCloseCmd_JSONOnSoftCloseEmitsEnvelope(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		return "OPEN", nil
+	})
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sessionName := "myrepo@json-feature"
+	if err := d.UpsertStatus(sessionName, "myrepo", t.TempDir(), "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	stdout := captureStdout(t, func() {
+		cmd := freshCloseCmd()
+		_ = cmd.Flags().Set("session", sessionName)
+		_ = cmd.Flags().Set("yes", "true")
+		_ = cmd.Flags().Set("json", "true")
+		if err := runCloseCmd(cmd, nil); err != nil {
+			t.Fatalf("runCloseCmd: %v", err)
+		}
+	})
+
+	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		t.Fatal("expected JSON envelope on stdout, got empty")
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v (stdout=%q)", err, stdout)
+	}
+	if envelope["session"] != sessionName {
+		t.Errorf("envelope.session = %v, want %q", envelope["session"], sessionName)
+	}
+	if envelope["session_killed"] != true {
+		t.Errorf("envelope.session_killed = %v, want true", envelope["session_killed"])
+	}
+	// Soft-close paths do not touch the worktree or branch.
+	if envelope["worktree_removed"] != nil {
+		t.Errorf("envelope.worktree_removed = %v, want null (soft close)", envelope["worktree_removed"])
+	}
+	if envelope["branch_deleted"] != nil {
+		t.Errorf("envelope.branch_deleted = %v, want null (soft close)", envelope["branch_deleted"])
+	}
+}
+
+// TestCloseCmd_ForcedKeepWorktreeNeverProbesGh verifies that --keep-worktree
+// short-circuits the gh probe entirely. This is an end-to-end check on the
+// AC's "force soft regardless of PR state".
+func TestCloseCmd_ForcedKeepWorktreeNeverProbesGh(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+
+	probeCalled := false
+	withPRProbeStub(t, func(workdir, branch string) (string, error) {
+		probeCalled = true
+		return "MERGED", nil // would route to hard cleanup, but probe must not run
+	})
+
+	worktreePath := t.TempDir()
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	sessionName := "myrepo@forced-soft"
+	if err := d.UpsertStatus(sessionName, "myrepo", worktreePath, "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	cmd := freshCloseCmd()
+	_ = cmd.Flags().Set("session", sessionName)
+	_ = cmd.Flags().Set("yes", "true")
+	_ = cmd.Flags().Set("keep-worktree", "true")
+	if err := runCloseCmd(cmd, nil); err != nil {
+		t.Fatalf("runCloseCmd: %v", err)
+	}
+
+	if probeCalled {
+		t.Error("gh probe was called despite --keep-worktree")
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree was removed despite --keep-worktree: %v", err)
+	}
+}
+
+// ── proxy helper unit tests ──────────────────────────────────────────────────
+
+// TestProxyCloseToHostAPI_ForwardsAllFlags verifies the proxy sends all flags
+// through the JSON body and that absent flags are omitted (rather than sent
+// as `false`). The omitted-when-absent contract matches the cleanup proxy
+// shape so the sidecar's struct-decoder default of `false` does the right
+// thing on both sides.
+func TestProxyCloseToHostAPI_ForwardsAllFlags(t *testing.T) {
+	gotBody := make(chan map[string]any, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		select {
+		case gotBody <- body:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stdout":"","stderr":""}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if err := proxyCloseToHostAPIWithWriters(srv.apiURL(), "myrepo@b", true, true, true, false, &stdoutBuf, &stderrBuf); err != nil {
+		t.Fatalf("proxyCloseToHostAPI: %v", err)
+	}
+
+	select {
+	case body := <-gotBody:
+		if body["session"] != "myrepo@b" {
+			t.Errorf("session = %v, want myrepo@b", body["session"])
+		}
+		if body["yes"] != true {
+			t.Errorf("yes = %v, want true", body["yes"])
+		}
+		if body["json"] != true {
+			t.Errorf("json = %v, want true", body["json"])
+		}
+		if body["keep_worktree"] != true {
+			t.Errorf("keep_worktree = %v, want true", body["keep_worktree"])
+		}
+		if _, present := body["remove_worktree"]; present {
+			t.Errorf("remove_worktree should be omitted when false; got %v", body["remove_worktree"])
+		}
+	default:
+		t.Fatal("no request body received")
+	}
+}
+
+// TestProxyCloseToHostAPI_ForwardsErrorWithStdoutStderr verifies that on a
+// non-2xx response the proxy forwards stdout/stderr to the caller's writers
+// and returns an error containing the underlying message (parity with
+// proxyCleanupToHostAPI; issue #1527 contract carried over).
+func TestProxyCloseToHostAPI_ForwardsErrorWithStdoutStderr(t *testing.T) {
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{` +
+			`"error":"close failed: exit status 1",` +
+			`"stdout":"closing session myrepo@b...\n",` +
+			`"stderr":"[prism] warning: archive: exists\n"` +
+			`}`))
+	})
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	err := proxyCloseToHostAPIWithWriters(srv.apiURL(), "myrepo@b", true, false, false, false, &stdoutBuf, &stderrBuf)
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+	if !strings.Contains(err.Error(), "close failed: exit status 1") {
+		t.Errorf("error %q should contain underlying cause", err.Error())
+	}
+	if stdoutBuf.String() != "closing session myrepo@b...\n" {
+		t.Errorf("forwarded stdout: %q", stdoutBuf.String())
+	}
+	if stderrBuf.String() != "[prism] warning: archive: exists\n" {
+		t.Errorf("forwarded stderr: %q", stderrBuf.String())
+	}
+}

--- a/modules/programs/prism/prism/cmd/hostapi.go
+++ b/modules/programs/prism/prism/cmd/hostapi.go
@@ -310,18 +310,25 @@ type cleanupResponse struct {
 // the host-path output (modulo trailing whitespace), per issue #1527 AC #1.
 // Without this forwarding, the container path was silent on success because
 // the previous handler discarded the captured CombinedOutput.
-func proxyCleanupToHostAPI(apiURL, session string, yes, jsonMode bool) error {
-	return proxyCleanupToHostAPIWithWriters(apiURL, session, yes, jsonMode, os.Stdout, os.Stderr)
+//
+// `keepWorktree`, when true, forwards `keep_worktree:true` to the host so the
+// host-side `prism cleanup` runs with --keep-worktree (issue #2179). Passing
+// false preserves the pre-#2179 destructive default.
+func proxyCleanupToHostAPI(apiURL, session string, yes, jsonMode, keepWorktree bool) error {
+	return proxyCleanupToHostAPIWithWriters(apiURL, session, yes, jsonMode, keepWorktree, os.Stdout, os.Stderr)
 }
 
 // proxyCleanupToHostAPIWithWriters is the testable form of
 // proxyCleanupToHostAPI: stdout/stderr destinations are injectable so unit
 // tests can capture forwarded output without redirecting os.Stdout.
-func proxyCleanupToHostAPIWithWriters(apiURL, session string, yes, jsonMode bool, stdout, stderr io.Writer) error {
+func proxyCleanupToHostAPIWithWriters(apiURL, session string, yes, jsonMode, keepWorktree bool, stdout, stderr io.Writer) error {
 	body := map[string]any{
 		"session": session,
 		"yes":     yes,
 		"json":    jsonMode,
+	}
+	if keepWorktree {
+		body["keep_worktree"] = true
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -383,6 +390,89 @@ func proxyCleanupToHostAPIWithWriters(apiURL, session string, yes, jsonMode bool
 			return fmt.Errorf("host-API /cleanup: %s", parsed.Error)
 		}
 		return fmt.Errorf("host-API /cleanup: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// proxyCloseToHostAPI sends a `prism close` request to the host-API sidecar
+// and forwards the host-side stdout and stderr to the caller's stdout/stderr
+// (issue #2179). Mirrors proxyCleanupToHostAPI but targets the /close endpoint
+// so the host runs `prism close` (with its smart-decide logic) rather than
+// `prism cleanup` (always destructive).
+func proxyCloseToHostAPI(apiURL, session string, yes, jsonMode, keepWorktree, removeWorktree bool) error {
+	return proxyCloseToHostAPIWithWriters(apiURL, session, yes, jsonMode, keepWorktree, removeWorktree, os.Stdout, os.Stderr)
+}
+
+// proxyCloseToHostAPIWithWriters is the testable form of
+// proxyCloseToHostAPI: stdout/stderr destinations are injectable so unit
+// tests can capture forwarded output without redirecting os.Stdout.
+func proxyCloseToHostAPIWithWriters(apiURL, session string, yes, jsonMode, keepWorktree, removeWorktree bool, stdout, stderr io.Writer) error {
+	body := map[string]any{
+		"session": session,
+		"yes":     yes,
+		"json":    jsonMode,
+	}
+	if keepWorktree {
+		body["keep_worktree"] = true
+	}
+	if removeWorktree {
+		body["remove_worktree"] = true
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("proxyCloseToHostAPI: marshal request body: %w", err)
+	}
+
+	var client *http.Client
+	var reqURL string
+	if strings.HasPrefix(apiURL, "http://") {
+		client = newTCPHostAPIClient()
+		reqURL = apiURL + "/close"
+	} else {
+		sockPath, parseErr := parseUnixSocketURL(apiURL)
+		if parseErr != nil {
+			return fmt.Errorf("PRISM_HOST_API %q: %w", apiURL, parseErr)
+		}
+		client = newHostAPIClient(sockPath)
+		reqURL = "http://prism-hostapi/close"
+	}
+
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("proxyCloseToHostAPI: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("host-API /close: read response: %w", readErr)
+	}
+
+	var parsed cleanupResponse
+	if len(respBody) > 0 {
+		if unmarshalErr := json.Unmarshal(respBody, &parsed); unmarshalErr != nil {
+			return fmt.Errorf("host-API /close: unmarshal response: %w (body=%s)", unmarshalErr, strings.TrimSpace(string(respBody)))
+		}
+	}
+
+	// Forward unconditionally on success and error (parity with /cleanup).
+	if parsed.Stdout != "" {
+		_, _ = io.WriteString(stdout, parsed.Stdout)
+	}
+	if parsed.Stderr != "" {
+		_, _ = io.WriteString(stderr, parsed.Stderr)
+	}
+
+	if resp.StatusCode >= 400 {
+		if parsed.Error != "" {
+			return fmt.Errorf("host-API /close: %s", parsed.Error)
+		}
+		return fmt.Errorf("host-API /close: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 	return nil
 }

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -198,6 +198,7 @@ func hostAPIServeLogsFollow(w http.ResponseWriter, r *http.Request, targetSessio
 //	POST /spawn         — spawn a new worktree session (coordinator only)
 //	POST /review        — run review agents against a PR (workers and coordinators)
 //	POST /cleanup       — clean up an existing session (coordinator only)
+//	POST /close         — smart-decide close (soft if open PR; hard otherwise) (coordinator only)
 //	POST /switch        — switch the tmux client to a session
 //	GET  /list-sessions — list active sessions (role-scoped)
 //	GET  /checkin       — return conversation history for a session (coordinator only)
@@ -1721,9 +1722,10 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			return
 		}
 		var req struct {
-			Session string `json:"session"`
-			Yes     bool   `json:"yes"`
-			JSON    bool   `json:"json"`
+			Session      string `json:"session"`
+			Yes          bool   `json:"yes"`
+			JSON         bool   `json:"json"`
+			KeepWorktree bool   `json:"keep_worktree"`
 		}
 		// /cleanup body cap: default 1 MiB (issue #1848).
 		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
@@ -1760,6 +1762,12 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		if req.JSON {
 			args = append(args, "--json")
 		}
+		if req.KeepWorktree {
+			// issue #2179: forward --keep-worktree so the host-side cleanup
+			// performs a soft close (preserves worktree + branch) even for
+			// a worker session.
+			args = append(args, "--keep-worktree")
+		}
 
 		s.logger().Printf("sidecar: host-API /cleanup: prism %s", strings.Join(args, " "))
 
@@ -1793,6 +1801,109 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			// just the outer transport's exit shape.
 			writeJSON(w, http.StatusInternalServerError, map[string]any{
 				"error":  fmt.Sprintf("cleanup failed: %v", err),
+				"stdout": stdoutStr,
+				"stderr": stderrStr,
+			})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"stdout": stdoutStr,
+			"stderr": stderrStr,
+		})
+	})
+
+	// POST /close (issue #2179)
+	// Request:  {"session":"nixos-config@my-feature","yes":true,"json":false,
+	//            "keep_worktree":false,"remove_worktree":false}
+	// Response: {"stdout":"...","stderr":"..."} | {"error":"...","stdout":"...","stderr":"..."}
+	//
+	// Mirrors /cleanup but invokes `prism close`, which auto-decides between
+	// soft close (preserve worktree) and hard cleanup (remove worktree) based
+	// on whether an open PR exists for the branch. The container-side proxy
+	// (proxyCloseToHostAPI) writes stdout/stderr verbatim to its own streams,
+	// matching the /cleanup contract.
+	mux.HandleFunc("/close", func(w http.ResponseWriter, r *http.Request) {
+		if !requirePost(w, r) {
+			return
+		}
+		if !requireCoordinator(w, "close") {
+			return
+		}
+		var req struct {
+			Session        string `json:"session"`
+			Yes            bool   `json:"yes"`
+			JSON           bool   `json:"json"`
+			KeepWorktree   bool   `json:"keep_worktree"`
+			RemoveWorktree bool   `json:"remove_worktree"`
+		}
+		// /close body cap: default 1 MiB (matches /cleanup).
+		if status, err := decodeRequestJSON(w, r, &req, defaultMaxBodyBytes, false); err != nil {
+			writeError(w, status, "invalid JSON: "+err.Error())
+			return
+		}
+		if req.Session == "" {
+			writeError(w, http.StatusBadRequest, "session is required")
+			return
+		}
+
+		// Own-repo restriction: coordinators may only close sessions in their own repo.
+		ownRepo, repoErr := repoFromSession(s.cfg.SessionName, s.cfg.DB)
+		if repoErr != nil {
+			writeError(w, http.StatusInternalServerError, "cannot derive repo from session name: "+repoErr.Error())
+			return
+		}
+		targetRepo, targetRepoErr := repoFromSession(req.Session, s.cfg.DB)
+		if targetRepoErr != nil {
+			writeError(w, http.StatusNotFound, "target "+targetRepoErr.Error())
+			return
+		}
+		if targetRepo != ownRepo {
+			writeError(w, http.StatusForbidden,
+				fmt.Sprintf("coordinators can only close sessions in their own repo (%s), got %q", ownRepo, req.Session))
+			return
+		}
+
+		args := []string{"close", "--session", req.Session}
+		if req.Yes {
+			args = append(args, "--yes")
+		}
+		if req.JSON {
+			args = append(args, "--json")
+		}
+		if req.KeepWorktree {
+			args = append(args, "--keep-worktree")
+		}
+		if req.RemoveWorktree {
+			args = append(args, "--remove-worktree")
+		}
+
+		s.logger().Printf("sidecar: host-API /close: prism %s", strings.Join(args, " "))
+
+		// 5-min budget matches /cleanup (the soft path is fast; the hard path
+		// can take as long as cleanup).
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, prismBinary(), args...)
+		var stdoutBuf, stderrBuf bytes.Buffer
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+		err := cmd.Run()
+		stdoutStr := stdoutBuf.String()
+		stderrStr := stderrBuf.String()
+		if err != nil {
+			if status, ok := contextErrStatus(ctx); ok {
+				s.logger().Printf("sidecar: host-API /close: context fired (%v): killed child after %v", ctx.Err(), 5*time.Minute)
+				writeJSON(w, status, map[string]any{
+					"error":  fmt.Sprintf("close aborted: %v", ctx.Err()),
+					"stdout": stdoutStr,
+					"stderr": stderrStr,
+				})
+				return
+			}
+			s.logger().Printf("sidecar: host-API /close: %v: stdout=%q stderr=%q", err, stdoutStr, stderrStr)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"error":  fmt.Sprintf("close failed: %v", err),
 				"stdout": stdoutStr,
 				"stderr": stderrStr,
 			})

--- a/modules/programs/prism/prism/internal/sidecar/host_api_close_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_close_test.go
@@ -1,0 +1,204 @@
+// Tests for the /close host-API endpoint (issue #2179). The endpoint mirrors
+// /cleanup: a coordinator-only POST that shells out to a host-side prism
+// binary and forwards stdout/stderr verbatim. These tests use a shell-script
+// stub bound to PrismBinaryPath in place of the real `prism close` so we can
+// assert the argv-forwarding contract without exercising the full close flow.
+
+package sidecar
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestHostAPI_Close_ForwardsAllFlags verifies that --yes, --json,
+// --keep-worktree, and --remove-worktree are all forwarded to the spawned
+// `prism close` subprocess when their request-body counterparts are set.
+func TestHostAPI_Close_ForwardsAllFlags(t *testing.T) {
+	// Stub echoes its argv (one per line) so we can match against it.
+	script := `printf '%s\n' "$@"
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close",
+		`{"session":"myrepo@some-branch","yes":true,"json":true,"keep_worktree":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+		Stderr string `json:"stderr"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	want := "close\n--session\nmyrepo@some-branch\n--yes\n--json\n--keep-worktree\n"
+	if resp.Stdout != want {
+		t.Errorf("forwarded argv mismatch:\n  got:  %q\n  want: %q", resp.Stdout, want)
+	}
+}
+
+// TestHostAPI_Close_ForwardsRemoveWorktreeFlag verifies the symmetric
+// --remove-worktree case.
+func TestHostAPI_Close_ForwardsRemoveWorktreeFlag(t *testing.T) {
+	script := `printf '%s\n' "$@"
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close",
+		`{"session":"myrepo@some-branch","yes":true,"remove_worktree":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	want := "close\n--session\nmyrepo@some-branch\n--yes\n--remove-worktree\n"
+	if resp.Stdout != want {
+		t.Errorf("forwarded argv mismatch:\n  got:  %q\n  want: %q", resp.Stdout, want)
+	}
+}
+
+// TestHostAPI_Close_DefaultOmitsForceFlags verifies that when neither force
+// flag is set, the host-side argv carries only --yes/--json (matching the
+// proxy's "omit when false" body shape).
+func TestHostAPI_Close_DefaultOmitsForceFlags(t *testing.T) {
+	script := `printf '%s\n' "$@"
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close",
+		`{"session":"myrepo@some-branch","yes":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	want := "close\n--session\nmyrepo@some-branch\n--yes\n"
+	if resp.Stdout != want {
+		t.Errorf("forwarded argv mismatch:\n  got:  %q\n  want: %q", resp.Stdout, want)
+	}
+}
+
+// TestHostAPI_Close_ForwardsStdoutAndStderrOnSuccess verifies the success
+// path of the /close handler: the spawned subprocess's stdout and stderr are
+// captured separately and surfaced in the JSON response, matching /cleanup.
+func TestHostAPI_Close_ForwardsStdoutAndStderrOnSuccess(t *testing.T) {
+	script := `printf 'closing session myrepo@some-branch...\n'
+printf '[prism] info: keeping worktree (open PR detected)\n' 1>&2
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close",
+		`{"session":"myrepo@some-branch","yes":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+		Stderr string `json:"stderr"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Stdout != "closing session myrepo@some-branch...\n" {
+		t.Errorf("stdout mismatch: got %q", resp.Stdout)
+	}
+	if resp.Stderr != "[prism] info: keeping worktree (open PR detected)\n" {
+		t.Errorf("stderr mismatch: got %q", resp.Stderr)
+	}
+}
+
+// TestHostAPI_Close_ForwardsStdoutAndStderrOnFailure verifies the failure
+// path: a non-zero exit still produces stdout/stderr in the JSON response
+// alongside the error field. Mirrors /cleanup's contract.
+func TestHostAPI_Close_ForwardsStdoutAndStderrOnFailure(t *testing.T) {
+	script := `printf 'closing session myrepo@some-branch...\n'
+printf '[prism] error: tmux session not found\n' 1>&2
+exit 1`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close",
+		`{"session":"myrepo@some-branch","yes":true}`)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Error  string `json:"error"`
+		Stdout string `json:"stdout"`
+		Stderr string `json:"stderr"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	if resp.Error == "" {
+		t.Errorf("expected non-empty error field on 500; got empty")
+	}
+	if resp.Stdout != "closing session myrepo@some-branch...\n" {
+		t.Errorf("stdout mismatch on failure: got %q", resp.Stdout)
+	}
+	if resp.Stderr != "[prism] error: tmux session not found\n" {
+		t.Errorf("stderr mismatch on failure: got %q", resp.Stderr)
+	}
+}
+
+// TestHostAPI_Close_RejectsMissingSession verifies the request-validation
+// guard: an empty "session" field is a 400, matching /cleanup.
+func TestHostAPI_Close_RejectsMissingSession(t *testing.T) {
+	script := `exit 0`
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close", `{"session":"","yes":true}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Close_RequiresPost verifies that GET /close is rejected with
+// 405 Method Not Allowed (matches the requirePost guard on /cleanup).
+func TestHostAPI_Close_RequiresPost(t *testing.T) {
+	script := `exit 0`
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodGet, "/close", "")
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Close_RequiresCoordinator verifies that worker-role sidecars
+// cannot invoke /close (parity with /cleanup).
+func TestHostAPI_Close_RequiresCoordinator(t *testing.T) {
+	script := `exit 0`
+	sc := newSidecarWithCleanupStub(t, "myrepo@feature", "myrepo", "worker", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/close",
+		`{"session":"myrepo@feature","yes":true}`)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHostAPI_Close_ForwardsKeepWorktreeToCleanup verifies the /cleanup
+// endpoint also accepts and forwards keep_worktree (the parity surface added
+// by issue #2179 for coordinators that want to soft-close via /cleanup
+// without going through /close's decision tree).
+func TestHostAPI_Close_ForwardsKeepWorktreeToCleanup(t *testing.T) {
+	script := `printf '%s\n' "$@"
+exit 0`
+
+	sc := newSidecarWithCleanupStub(t, "myrepo@main", "myrepo", "coordinator", script)
+	rr := doHostAPI(t, sc, http.MethodPost, "/cleanup",
+		`{"session":"myrepo@some-branch","yes":true,"keep_worktree":true}`)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Stdout string `json:"stdout"`
+	}
+	decodeJSONBody(t, rr, &resp)
+	want := "cleanup\n--session\nmyrepo@some-branch\n--yes\n--keep-worktree\n"
+	if resp.Stdout != want {
+		t.Errorf("forwarded argv mismatch:\n  got:  %q\n  want: %q", resp.Stdout, want)
+	}
+}

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -537,7 +537,39 @@ When you spawn a session and later merge its PR yourself, you are responsible fo
 session "nixos-config@update-plex" created
 ```
 
-Note down the session name from that output. Once you have merged the PR, clean up:
+Note down the session name from that output. Two commands tear down a session, with different defaults:
+
+| Command | Default behaviour | When to use |
+|---|---|---|
+| `prism close --yes --session <name>` | Smart-decide: soft-close if an open PR exists for the branch, otherwise hard-cleanup. | Default. Safe for parked WIP branches and merged work alike. Bound to `prefix+q`. |
+| `prism cleanup --yes --session <name>` | Always destructive (remove worktree + force-delete branch). | Scripted coordinator workflows that know the work is finished and want a guaranteed hard cleanup. |
+
+### `prism close` — smart-decide
+
+```bash
+prism close --yes --session "nixos-config@update-plex"
+```
+
+Decision tree (issue #2179):
+
+1. Coordinator session (`root_agent_name == "coordinator"` or `@main`) → soft close.
+2. Non-worktree session (no `@`) → soft close.
+3. Worker worktree session: probe `gh pr list --head <branch>`:
+   - any PR is OPEN → soft close (preserve worktree + branch)
+   - all PRs MERGED/CLOSED → hard cleanup
+   - no PR found → hard cleanup
+   - probe error / timeout / `gh` missing / unauthenticated → soft close (fail-safe)
+
+The fail-safe is deliberate: a spurious soft close costs one extra `prism close --remove-worktree` later; a spurious hard cleanup destroys uncommitted work. The probe is bounded by a 5-second context timeout so a hung GitHub API cannot wedge the tmux popup.
+
+Force flags override the decision (mutually exclusive):
+
+- `--keep-worktree` — always soft close (paranoid mode for long-lived WIP branches).
+- `--remove-worktree` — always hard cleanup ("I'm done with this branch").
+
+`prism close --yes` writes nothing to stdout/stderr on the happy path, making it safe to bind to a tmux popup. The `--json` envelope is identical to `prism cleanup`'s and is still emitted when `--json` is passed.
+
+### `prism cleanup` — always destructive
 
 ```bash
 prism cleanup --yes --session "nixos-config@update-plex"
@@ -548,6 +580,8 @@ prism cleanup --yes --session "nixos-config@update-plex"
 - Force-delete the local branch (relies on the orchestrator-trust contract: call this only after confirming the PR is merged)
 - Kill the tmux session, redirecting any attached client to `scratchpad`
 - Mark the `agent_status` row as ended (stamps `ended_at`, releases the harness port, and clears the pi `harness_session_id` so the next spawn starts a fresh conversation)
+
+For parity with `prism close`, `prism cleanup` also accepts `--keep-worktree`, which downgrades it to a soft close even on a worker session. Without that flag the command keeps its pre-#2179 always-destructive default, so scripted coordinator workflows that call `prism cleanup --yes --session <X>` after a merge are unaffected.
 
 The `agent_status` row itself is preserved — it is not deleted. Re-spawning on the same branch name reuses the row: `tmux-session-start` re-seeds it to `idle`, which the state machine accepts from any non-`deleted` terminal state (`error`, `finished`, `interrupted`). Long-term retention is handled by the 90-day `Prune` job.
 

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -214,8 +214,12 @@ in
               bind-key X kill-window
               # close pane without confirmation
               bind-key x kill-pane
-              # worktree cleanup: remove worktree + kill session (project@worktree sessions only)
-              bind-key q display-popup -E -w 60% -h 40% -b single "${prism} cleanup"
+              # smart-decide session close (project@worktree sessions only):
+              # - open PR        → soft close (preserve worktree + branch)
+              # - merged/no PR   → hard cleanup (remove worktree + branch)
+              # - probe failure  → fail-safe to soft close
+              # See `prism close --help` for the full decision tree (issue #2179).
+              bind-key q display-popup -E -w 60% -h 40% -b single "${prism} close --yes"
               # restart prism (prefix+R)
               bind-key R run-shell '${prism} restart'
               # toggle session mute (prefix+m). Operator escape hatch (see #2013):


### PR DESCRIPTION
Adds a new top-level `prism close` command that auto-decides between soft close (preserve worktree + branch) and hard cleanup (remove worktree, force-delete branch) based on whether an open pull request exists for the branch. Bound to `prefix+q` in tmux so the smart-decide path is the default keybind.

Closes #2179

## Decision tree

```
1. Coordinator session (repo@main / root_agent_name=coordinator) → soft close
2. Non-worktree session (no @)                                   → soft close
3. Worker worktree session:
   ├─ gh pr list → any OPEN PR                                   → soft close
   ├─ gh pr list → all MERGED/CLOSED                              → hard cleanup
   ├─ gh pr list → no PR                                          → hard cleanup
   └─ gh pr list → error / timeout / unauthenticated              → soft close (fail-safe)
```

Force flags (mutually exclusive):
- `--keep-worktree`   force soft close (paranoid mode)
- `--remove-worktree` force hard cleanup (I decided to abandon)

For parity, `prism cleanup --keep-worktree` is also added so scripted coordinator workflows can opt in to soft-close without switching commands.

## Why fail-safe to soft close

The asymmetric risk is destructive: a spurious soft close costs one extra `prism close --remove-worktree` later; a spurious hard cleanup loses uncommitted work. Any error path on the PR probe (gh missing, unauthenticated, network failure, branch not pushed, repo not on GitHub, timeout) routes to soft close.

The gh probe runs with a bounded 5s context timeout — the popup keybind cannot wedge on a hung GitHub API.

## Output discipline

`prism close --yes` writes nothing to stdout/stderr on the happy path, making it safe to bind to a tmux popup. proglog warnings only fire on partial failures (archive collision, DB unavailable), preserving the silence on clean success. `--json` still emits the cleanup envelope when set.

## Reuse, not duplicate

The soft-close (`closeSession` / `headlessCloseSessionWithJSON`) and hard-cleanup (`headlessCleanupWithJSON`) paths are unchanged in behaviour — `close.go` just routes between them per the decision tree. The two headless functions gained `*WithJSONTo` writer-aware variants so the close command can pass `io.Discard` for the popup-safe silent-on-success contract.

## Container proxy

A new `/close` host-API endpoint mirrors `/cleanup` so container-mode `prism close` proxies to the host's binary. The host runs the smart-decide flow there, identical to a host-side invocation. `/cleanup` also accepts the new `keep_worktree` field so `prism cleanup --keep-worktree` works from inside a container too.

## Test coverage

- `cmd/close_test.go`: full decideClose decision-tree coverage (force flags, non-worktree, coordinator, worker with OPEN/MERGED/CLOSED/no-PR/error/unknown-state); probePRStateExec via PATH-injected fake gh including the 5s-timeout enforcement check; flag validation (mutually-exclusive force, --json requires --yes, unknown session, no-tmux); container proxy forwards all flags; end-to-end soft-close via headless invocation asserts silence + DB state; JSON envelope on soft-close; --keep-worktree never invokes gh; proxyCloseToHostAPI body shape + error forwarding.
- `cmd/cleanup_test.go`: `cleanup --keep-worktree` soft-closes a worker, and the negative-control without the flag still hard-cleans (regression guard for the AC "`prism cleanup` (without `--keep-worktree`) continues to behave identically").
- `internal/sidecar/host_api_close_test.go`: /close argv forwarding (all flags, default-omit, --remove-worktree variant), stdout/stderr forwarding on success and failure, request validation (POST required, session required), coordinator-only enforcement, and /cleanup's new keep_worktree parameter.

## Self-checks

- `go build ./...` clean.
- `go test ./... -count=1` all green (including `-race` on the touched packages).
- `nix build .#prism` builds.
- `prism agent-context | jq '.commands.close'` resolves with the new command's full metadata.
- Manual smoke: `prism close --keep-worktree --remove-worktree --yes`, `prism close --json`, `prism close --session does-not-exist --yes` all produce the expected error shapes; `prism --help` lists `close` alongside `cleanup`.