### PR TITLE
openscad: switch tui and navi to openscad-unstable

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -150,7 +150,7 @@
     gphoto2
     inkscape
     ntfs3g
-    openscad
+    openscad-unstable
     parted
     protontricks
     protonup-ng

--- a/machines/tui/configuration.nix
+++ b/machines/tui/configuration.nix
@@ -133,7 +133,7 @@
     inkscape
     lm_sensors
     ntfs3g
-    openscad
+    openscad-unstable
     parted
     protontricks
     protonup-ng


### PR DESCRIPTION
The 2026-06-09 \`update-flakes\` cron ([run 27186502764](https://github.com/prismatic-koi/nixos-config/actions/runs/27186502764)) failed building \`tui\` after a nixpkgs \`glew\` bump dropped the \`__GLXEW_SGIX_pbuffer\` / \`__GLXEW_SGIX_fbconfig\` symbols. The pinned \`nixpkgs#openscad\` attribute is still \`openscad-2021.01\` — upstream has not cut a release since January 2021 — and its \`GLView.cc\` still references those symbols, so linking dies with \`collect2: error: ld returned 1 exit status\`.

\`nixpkgs#openscad-unstable\` is a periodic snapshot of upstream master (currently \`2021.01-unstable-2026-02-25\`) which absorbs the build-system fixes for newer GLEW. That's the package we actually want for daily use anyway.

## Change

Two single-line swaps:

- \`machines/tui/configuration.nix\` — \`openscad\` → \`openscad-unstable\`
- \`machines/navi/configuration.nix\` — \`openscad\` → \`openscad-unstable\`

\`rg openscad\` confirms these were the only two references in the repo.

## Verification

Both system toplevels build clean against the current \`flake.lock\`:

\`\`\`
nix build --no-link .#nixosConfigurations.tui.config.system.build.toplevel   # OK
nix build --no-link .#nixosConfigurations.navi.config.system.build.toplevel  # OK
\`\`\`

\`nix path-info -r\` on each closure shows only \`openscad-unstable-2021.01-unstable-2026-02-25\` — no stray transitive pull of the broken \`openscad\`.

\`nixfmt .\` is a no-op (neither edit touches whitespace).

## Effect

Unblocks the \`update-flakes\` cron so it can resume cutting flake-lock bump PRs.