### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1780795403,
+        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "6a771120d607dcccb279a27d227650e324815c35",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780290312,
-        "narHash": "sha256-eTAlX0CwgB84Ts3GaBd944A3DRXVMzgA0EqroZBISUo=",
+        "lastModified": 1780894562,
+        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "115e5211780054d8a890b41f0b7734cafad54dfe",
+        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1780943742,
+        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780700792,
-        "narHash": "sha256-sGCauddYNF1Nymtdjnl3xx2fkJl8yZ4HgW/ucuEnSb8=",
+        "lastModified": 1780997039,
+        "narHash": "sha256-8pPXOCZkrySE3zwtix2MYxm9NzzHT/XQr0mHJsf3lis=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0381b3037a2256efc2b54b9c5f16b71d48e7d9a0",
+        "rev": "872eb0174d0d5a1bc37388ff84eea2bca44b1065",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/27197802468

## Closure diff: navi

```
aquamarine: 0.11.0 → 0.12.0, 8.6 KiB
boringssl: 0.20260508.0 → 0.20260526.0, 38.9 KiB
btrfs-progs: 6.19.1 → 7.0, 26.0 KiB
chromium: 148.0.7778.215 → 149.0.7827.53
chromium-unwrapped: 148.0.7778.215 → 149.0.7827.53, 4.3 MiB
dhcpcd: 10.3.1 → 10.3.2
discord: 1.0.138 → 1.0.141, 984.9 KiB
fc: 186.0 KiB
gegl: 0.4.68 → 0.4.70, 282.0 KiB
gmic: 3.6.3 → 3.7.6, 102.6 KiB
google-cloud-sdk: -311.5 KiB
initrd-linux: 7.0.10 → 7.0.11, 485.8 KiB
kubelogin: 1.36.1 → 1.36.2
libXNVCtrl: 595.71.05 → 595.80
libblockdev: 3.4.0 → 3.5.0, 46.8 KiB
libcdr: 0.1.8 → 0.1.9
libgit2: 1.9.3 → 1.9.4
libgphoto2: 2.5.33 → 2.5.34, 453.2 KiB
libinput: 1.31.1 → 1.31.3
libwacom: 2.18.0 → 2.19.0, 27.0 KiB
linux: 7.0.10 → 7.0.11, 27.2 KiB
manifold: 3.5.0 → 3.5.1, 30.8 KiB
mesa: 26.1.1 → 26.1.2, 29.1 KiB
nixfmt: 1.2.0 → 1.3.1, 83.8 KiB
nixos-manual: 40.5 KiB
nixos-rebuild-ng: 51.4 KiB
nixos-system-navi: 26.11.20260531.331800d → 26.11.20260606.a799d3e
noto-fonts: 2026.05.01 → 2026.06.01
noto-fonts-cjk-sans: ∅ → 2.004, 61.6 MiB
noto-fonts-cjk-serif: ∅ → 2.003, 54.8 MiB
openrazer: 3.12.3-7.0.10 → 3.12.3-7.0.11
python3.14-zeroconf: 0.148.0 → 0.149.16, 99.1 KiB
rust-analyzer: 2026-04-27 → 2026-06-01
rust-analyzer-unwrapped: 2026-04-27 → 2026-06-01, 141.9 KiB
shotcut: 26.2.26 → 26.4.30, 348.0 KiB
signal-desktop: 8.9.1 → 8.13.0, -1.3 MiB
source: 468.6 KiB
vimplugin-luajit2.1-lualine.nvim-scm: 4-unstable-scm-4 → 5-unstable-scm-5
vimplugin-nvim-colorizer.lua: 0-unstable-2026-04-07 → 0-unstable-2026-05-30
vimplugin-obsidian.nvim: 3.16.3 → 3.16.4, 46.0 KiB
xwayland: 24.1.11 → 24.1.12
zsh: 5.9 → 5.9.1, 437.0 KiB
```

## Closure diff: tui

```
aquamarine: 0.11.0 → 0.12.0, 8.6 KiB
boringssl: 0.20260508.0 → 0.20260526.0, 38.9 KiB
btrfs-progs: 6.19.1 → 7.0, 26.0 KiB
chromium: 148.0.7778.215 → 149.0.7827.53
chromium-unwrapped: 148.0.7778.215 → 149.0.7827.53, 4.3 MiB
dhcpcd: 10.3.1 → 10.3.2
discord: 1.0.138 → 1.0.141, 984.9 KiB
fc: 186.0 KiB
gegl: 0.4.68 → 0.4.70, 282.0 KiB
gmic: 3.6.3 → 3.7.6, 102.6 KiB
google-cloud-sdk: -311.5 KiB
initrd-linux: 7.0.10 → 7.0.11, 13.3 KiB
kubelogin: 1.36.1 → 1.36.2
libXNVCtrl: 595.71.05 → 595.80
libblockdev: 3.4.0 → 3.5.0, 46.8 KiB
libcdr: 0.1.8 → 0.1.9
libgit2: 1.9.3 → 1.9.4
libgphoto2: 2.5.33 → 2.5.34, 453.2 KiB
libinput: 1.31.1 → 1.31.3
libwacom: 2.18.0 → 2.19.0, 27.0 KiB
linux: 7.0.10 → 7.0.11, 27.2 KiB
manifold: 3.5.0 → 3.5.1, 30.8 KiB
mesa: 26.1.1 → 26.1.2, 29.1 KiB
ngtcp2: ∅ → 1.23.0, 31.1 KiB
nixfmt: 1.2.0 → 1.3.1, 83.8 KiB
nixos-manual: 40.5 KiB
nixos-rebuild-ng: 51.4 KiB
nixos-system-tui: 26.11.20260531.331800d → 26.11.20260606.a799d3e
noto-fonts: 2026.05.01 → 2026.06.01
noto-fonts-cjk-sans: ∅ → 2.004, 61.6 MiB
noto-fonts-cjk-serif: ∅ → 2.003, 54.8 MiB
openrazer: 3.12.3-7.0.10 → 3.12.3-7.0.11
python3.14-zeroconf: 0.148.0 → 0.149.16, 99.1 KiB
rust-analyzer: 2026-04-27 → 2026-06-01
rust-analyzer-unwrapped: 2026-04-27 → 2026-06-01, 141.9 KiB
shotcut: 26.2.26 → 26.4.30, 348.0 KiB
signal-desktop: 8.9.1 → 8.13.0, -1.3 MiB
source: 468.6 KiB
vimplugin-luajit2.1-lualine.nvim-scm: 4-unstable-scm-4 → 5-unstable-scm-5
vimplugin-nvim-colorizer.lua: 0-unstable-2026-04-07 → 0-unstable-2026-05-30
vimplugin-obsidian.nvim: 3.16.3 → 3.16.4, 46.0 KiB
xwayland: 24.1.11 → 24.1.12
zsh: 5.9 → 5.9.1, 437.0 KiB
```