### PR TITLE
Add anthropic-fable profile and switch navi to it

### DIFF
--- a/machines/navi/configuration.nix
+++ b/machines/navi/configuration.nix
@@ -23,7 +23,7 @@
     };
     programs = {
       prism = {
-        profile.default = "anthropic-opus-max";
+        profile.default = "anthropic-fable";
         agent.isolation.default = "bwrap";
       };
       anki.enable = false; # build broken as of 2025-08-30

--- a/modules/programs/prism/profiles.nix
+++ b/modules/programs/prism/profiles.nix
@@ -133,6 +133,19 @@
               };
             };
 
+            anthropic-fable = profileFromSlots {
+              _default = slot "worker" {
+                provider = "anthropic";
+                model = "anthropic/claude-fable-5";
+                thinking = "xhigh";
+              };
+              coordinator = slot "coordinator" {
+                provider = "anthropic";
+                model = "anthropic/claude-fable-5";
+                thinking = "xhigh";
+              };
+            };
+
             anthropic-opus-max-4-8 = profileFromSlots {
               _default = slot "worker" {
                 provider = "anthropic";


### PR DESCRIPTION
Adds a new `anthropic-fable` profile pointing both worker and coordinator slots at `anthropic/claude-fable-5` with `xhigh` thinking, then sets it as the default on navi.