### PR TITLE
prism: remove stale podman-isolation references from code, tests, and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ Prism is a tmux-based AI development environment that is developed and configure
 - **Custom agents**: `modules/programs/prism/agents/`
 - **Skills**: `modules/programs/prism/skills/`
 
+**Isolation modes.** The valid prism isolation modes are `bwrap` (Linux), `sandbox-exec` (Darwin), and `host` — the source of truth is `config.ValidIsolationModes` in `modules/programs/prism/prism/internal/config/config.go`. Podman is **not** a prism isolation mode; it was removed some time ago (issue #2189 cleaned up the stale references). The only remaining `podman` strings in prism source are legacy DB-row fallbacks (and the schema migrations that backfill them) which convert old `isolation_mode='podman'` rows to bwrap at read time — do not reintroduce podman as a mode, and do not "fix" those fallbacks without a dedicated audit. (Podman the container runtime is still used on these machines — `modules/programs/podman.nix` — that is unrelated to prism isolation.)
+
 When making changes to prism Go source, always build and test before committing:
 
 ```bash

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -55,7 +55,7 @@ let
     color_bg0 = bg0;
     kitty_bin = "${pkgs.kitty}/bin/kitty";
     default_isolation_mode = isolationDefault;
-    # sidecar_plugin_path: unused since podman removal; kept for forward compat.
+    # sidecar_plugin_path: unused since container isolation removal; kept for forward compat.
     sidecar_plugin_path = "";
     worktree_exclude = config.nx.programs.prism.worktreeExclude;
     project_locations = config.nx.programs.prism.projects.locations;
@@ -111,7 +111,7 @@ in
       default = 0;
       description = ''
         Delay in milliseconds inserted between successive session creates in
-        `prism restore`, to flatten the podman startup burst on machines with
+        `prism restore`, to flatten the sidecar startup burst on machines with
         many sessions. 0 means use the compiled-in default (500ms). Set to a
         negative value to disable the stagger entirely.
       '';

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -4,8 +4,8 @@ package cmd
 //
 // This command is invoked by the tmux agent window when the resolved isolation
 // mode is "bwrap" or "sandbox-exec". It reconstructs the container.Manager
-// from the session's DB row and config, writes the same temp files that
-// Manager.Create() writes for podman sessions (SSH config, gitconfig,
+// from the session's DB row and config, writes the per-session temp files
+// (SSH config, gitconfig,
 // opencode.json), and then runs:
 //
 //	bwrap <args...>        (bwrap mode — supervised child with PTY, Linux-only)
@@ -126,10 +126,10 @@ func init() {
 
 func runAgentRun(cmd *cobra.Command, args []string) error {
 	// Capture wall-clock entry time so that the bwrap and sandbox-exec
-	// dispatch paths can emit `[timing]` markers symmetric to the podman
-	// path's sidecar-side instrumentation (see internal/sidecar/sidecar.go
+	// dispatch paths can emit `[timing]` markers symmetric to the
+	// sidecar-side instrumentation (see internal/sidecar/sidecar.go
 	// "from start" lines). All `[timing]` durations from agent-run are
-	// relative to this point, which is the closest analogue to the podman
+	// relative to this point, which is the closest analogue to the sidecar's
 	// `sessionStart` marker (taken when sidecar Run() begins).
 	agentRunStart := time.Now()
 
@@ -164,8 +164,8 @@ func runAgentRun(cmd *cobra.Command, args []string) error {
 	// Dispatch based on the session's isolation mode.
 	//
 	// Post A1.L6 (issue #1140): the per-mode switch collapses to a single
-	// container.For(mode).AgentRun(ctx, opts) call. host and podman are not
-	// valid modes for `prism agent-run`; the registered isolator returns
+	// container.For(mode).AgentRun(ctx, opts) call. host is not a
+	// valid mode for `prism agent-run`; the registered isolator returns
 	// the original "this command is only for bwrap and sandbox-exec
 	// sessions" error verbatim, replacing the manual `else` arm.
 	isoMode := config.IsolationMode(status.IsolationMode)
@@ -344,7 +344,7 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 
 	// `[timing] pre-exec`: covers everything between agent-run entry and the
 	// start of bwrap-args assembly — DB lookup, config load, profile load,
-	// Manager construction. Symmetric to the podman path's `[timing] pre-Create`
+	// Manager construction. Symmetric to the sidecar's `[timing] pre-Create`
 	// in internal/sidecar/sidecar.go.
 	logTimingTo(logFile, "pre-exec", time.Since(agentRunStart))
 
@@ -355,9 +355,8 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 	}
 	// `[timing] bwrap-args build`: time spent assembling the bwrap argv plus
 	// writing the per-session SSH config / gitconfig / opencode.json temp files
-	// (PrepareBwrap does both). Analogous to `[timing] buildRunArgs` on the
-	// podman side. Emitted before the binary lookup and exec so that an
-	// exec-stage failure still leaves this marker in the agent-run log.
+	// (PrepareBwrap does both). Emitted before the binary lookup and exec so
+	// that an exec-stage failure still leaves this marker in the agent-run log.
 	logTimingTo(logFile, "bwrap-args build", time.Since(argsBuildStart))
 
 	// Locate the bwrap binary.
@@ -657,7 +656,7 @@ func openAgentRunLog(sessionName string) *os.File {
 
 // logTimingTo writes a single `[timing] <phase>: <duration>` line to both the
 // per-session agent-run log file (when non-nil) and stderr. The format matches
-// the podman side's `[timing]` markers (see internal/sidecar/sidecar.go and
+// the sidecar-side `[timing]` markers (see internal/sidecar/sidecar.go and
 // internal/container/container.go) so the two timelines grep coherently:
 //
 //	grep '\[timing\]' ~/.local/state/prism/run/<session>/agent-run.log

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -297,8 +297,8 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	// sandbox-exec runs directly on the host — there is no VM, no gvproxy,
 	// and no synthetic hostname resolution. The sidecar listener and the
 	// sandboxed extension are both on the host loopback, so 127.0.0.1 is the
-	// correct address. host.containers.internal is a podman/gvproxy convention
-	// that does NOT resolve on bare macOS.
+	// correct address. host.containers.internal is a gvproxy container-VM
+	// convention that does NOT resolve on bare macOS.
 	if ctrCfg.HarnessPipeTCPPort != 0 {
 		env = append(env, fmt.Sprintf("PRISM_HARNESS_PIPE=tcp://127.0.0.1:%d", ctrCfg.HarnessPipeTCPPort))
 	}

--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -575,8 +575,8 @@ func TestLogTimingTo_NilLogFile(t *testing.T) {
 
 // TestLogTimingTo_RoundsToMillisecond verifies that sub-millisecond durations
 // are rounded up/down to the nearest millisecond, mirroring the format used
-// by the podman-side `[timing]` markers (`time.Since(...).Round(time.Millisecond)`).
-// This keeps the bwrap and podman log lines visually aligned for grep.
+// by the sidecar-side `[timing]` markers (`time.Since(...).Round(time.Millisecond)`).
+// This keeps the agent-run and sidecar log lines visually aligned for grep.
 func TestLogTimingTo_RoundsToMillisecond(t *testing.T) {
 	tmp := t.TempDir()
 	logPath := filepath.Join(tmp, "agent-run.log")

--- a/modules/programs/prism/prism/cmd/investigate_harness_pipe_test.go
+++ b/modules/programs/prism/prism/cmd/investigate_harness_pipe_test.go
@@ -20,7 +20,7 @@ package cmd
 //   - TestSpawnInvestigateSession_BwrapMode_LeavesHarnessPipeSockPathEmpty
 //     proves the gate does real work — for container-mode invokers
 //     HarnessPipeSockPath stays empty, so the existing container-mode
-//     injection paths (bwrap --setenv, sandbox-exec profile, podman --env)
+//     injection paths (bwrap --setenv, sandbox-exec profile)
 //     remain responsible for PRISM_HARNESS_PIPE.
 //
 // Test-suite isolation contract (AGENTS.md, issue #1608):
@@ -117,7 +117,7 @@ func TestSpawnInvestigateSession_HostMode_PopulatesHarnessPipeSockPath(t *testin
 // verifies the gate does real work: when the invoker's resolved isolation
 // mode is not "host" (here bwrap), SpawnOpts.HarnessPipeSockPath stays empty
 // so the existing container-mode injection paths (bwrap --setenv, sandbox-exec
-// profile, podman --env) remain responsible for PRISM_HARNESS_PIPE.
+// profile) remain responsible for PRISM_HARNESS_PIPE.
 //
 // Without this assertion a buggy fix that unconditionally set
 // HarnessPipeSockPath for all isolation modes would pass the host-mode test
@@ -151,7 +151,7 @@ func TestSpawnInvestigateSession_BwrapMode_LeavesHarnessPipeSockPathEmpty(t *tes
 	}
 
 	if captured.HarnessPipeSockPath != "" {
-		t.Errorf("SpawnOpts.HarnessPipeSockPath = %q, want \"\" for bwrap invokers — container-mode injection paths (bwrap --setenv, sandbox-exec profile, podman --env) own PRISM_HARNESS_PIPE for container sessions; pre-computing the sock path here would double-inject (issue #2111 AC).",
+		t.Errorf("SpawnOpts.HarnessPipeSockPath = %q, want \"\" for bwrap invokers — container-mode injection paths (bwrap --setenv, sandbox-exec profile) own PRISM_HARNESS_PIPE for container sessions; pre-computing the sock path here would double-inject (issue #2111 AC).",
 			captured.HarnessPipeSockPath)
 	}
 }

--- a/modules/programs/prism/prism/cmd/isolation_test.go
+++ b/modules/programs/prism/prism/cmd/isolation_test.go
@@ -193,9 +193,9 @@ func TestSidecarCmd_IsolationModeFlag(t *testing.T) {
 	if flag == nil {
 		t.Fatal("--isolation-mode flag not found on sidecarCmd")
 	}
-	// Default should be empty (sidecar falls back to --container for back-compat).
+	// Default should be empty (sidecar falls back to host mode).
 	if flag.DefValue != "" {
-		t.Errorf("--isolation-mode default = %q, want %q (empty, falls back to --container flag)", flag.DefValue, "")
+		t.Errorf("--isolation-mode default = %q, want %q (empty, falls back to host mode)", flag.DefValue, "")
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/pr.go
+++ b/modules/programs/prism/prism/cmd/pr.go
@@ -17,7 +17,7 @@ package cmd
 //	--variant <name>                model variant override (overrides all agents' variant)
 //	--model-override role=model     per-role model override (repeatable)
 //	--harness <name>                agent harness to use (default: from profile slot, or "pi")
-//	--isolation <mode>              isolation mode: podman, bwrap, sandbox-exec, or host
+//	--isolation <mode>              isolation mode: bwrap, sandbox-exec, or host
 
 import (
 	"encoding/json"
@@ -181,8 +181,7 @@ var prCmd = &cobra.Command{
 		// temp path. The bwrap.go mount-emission block checks file existence
 		// (os.Stat) rather than cfg.ConfigContent, so it picks this up correctly.
 		//
-		// Podman mode does NOT need this write — the sidecar's Create() path
-		// already writes the file before the container starts. Host mode does
+		// Host mode does
 		// NOT need this write — it uses the host harness config
 		// directly via xdg.configFile. sandbox-exec mode does NOT yet use this
 		// path — config delivery for sandbox-exec is deferred to #1016 (no
@@ -414,6 +413,6 @@ func init() {
 	prCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
 	prCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
 	prCmd.Flags().String("harness", "", "Agent harness to use (default: from profile slot, or 'pi')")
-	prCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
+	prCmd.Flags().String("isolation", "", "Isolation mode: bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	rootCmd.AddCommand(prCmd)
 }

--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -5,7 +5,7 @@ package cmd
 // Steps (each attempted independently — a failure in one does not abort others):
 //
 //  1. Kill the tmux server (equivalent to `tmux kill-server`).
-//  2. Stop and remove all podman containers whose names match the "prism-" prefix.
+//  2. Run each registered isolator's Reset sweep (all no-op stubs today).
 //  3. Mark all non-ended rows in agent_status as ended (sets ended_at = now;
 //     state is intentionally left at its last known value — ended_at IS NULL
 //     is the canonical "active session" filter throughout the codebase) AND
@@ -49,7 +49,7 @@ var resetCmd = &cobra.Command{
 
 Steps (each attempted independently):
   1. Kill the tmux server (all sessions and panes).
-  2. Stop and remove all podman containers with the "prism-" name prefix.
+  2. Run each registered isolator's Reset sweep.
   3. Mark all non-ended rows in agent_status as ended and clear the pi
      conversation resume pointer (harness_session_id) on every row.
   4. Terminate all sidecar processes (reads PID files from
@@ -100,10 +100,9 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	// ── Step 2: Reset every registered isolator ──────────────────────────────
 	// Post A1.L3 (issue #1140): the per-mode reset logic moved into each
 	// Isolator's Reset method. `prism reset` iterates over the registered
-	// modes and dispatches to each. Today only podman has a non-stub Reset
-	// body (the prism-* container sweep); bwrap, sandbox-exec, and host
-	// return nil — orphan-agent-run reaping is a future implementation.
-	fmt.Println("Removing prism- podman containers...")
+	// modes and dispatches to each. Today every isolator's Reset is a no-op
+	// stub — orphan-agent-run reaping is a future implementation.
+	fmt.Println("Running per-isolator reset sweeps...")
 	if err := resetIsolators(); err != nil {
 		proglog.Warnf("[prism reset] isolator cleanup: %v (continuing)\n", err)
 	}
@@ -151,15 +150,13 @@ func runReset(cmd *cobra.Command, _ []string) error {
 
 // resetIsolators iterates over every registered isolation mode and calls
 // Reset on each one. Returns the first non-nil error encountered (other
-// modes still get a chance to run). Today only podmanIsolator.Reset has a
-// non-stub body — the prism-* container sweep (was: resetRemovePodmanContainers).
+// modes still get a chance to run). Today every Reset body is a no-op stub.
 //
 // Failures are logged at the call site (Step 2 in runReset); this function
 // returns the error verbatim so the caller can decide whether to continue.
 func resetIsolators() error {
-	// Use a generous per-mode timeout so a slow `podman ps` does not starve
-	// the rm step. The podman implementation issues two podman calls
-	// (`ps -a` then `rm -f <ids...>`); 60 s covers both with margin.
+	// Use a generous per-mode timeout so a slow sweep in one isolator does
+	// not starve the others.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/modules/programs/prism/prism/cmd/restore.go
+++ b/modules/programs/prism/prism/cmd/restore.go
@@ -7,7 +7,7 @@ package cmd
 // exist are skipped silently — safe to call more than once.
 //
 // Stagger: a configurable delay (default 500ms) is inserted between successive
-// session creates to flatten the podman startup burst on machines with many
+// session creates to flatten the sidecar startup burst on machines with many
 // sessions. The delay only applies to sessions that are actually being created;
 // it is skipped for already-running sessions and for sessions being marked
 // ended due to missing worktrees. It is also fully skipped in dry-run mode.
@@ -128,7 +128,7 @@ func Restore(dryRun bool) error {
 	// pendingStagger is set to true after each successful session.Create. It is
 	// consumed (a sleep is applied) immediately before the NEXT actual create,
 	// not before skipped sessions or circuit-breaker-tripped sessions. This
-	// ensures the delay only fires between real podman/sidecar starts.
+	// ensures the delay only fires between real sidecar starts.
 	//
 	// Using a pointer so that restoreProjectSession can consume it without an
 	// extra return value: the function sleeps before session.Create if
@@ -380,8 +380,9 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		}
 	}
 
-	// In sandboxed mode (podman or bwrap), inject the role-specific config
-	// blob as the harness config env var. This mirrors the pattern in spawn.go.
+	// In sandboxed mode (bwrap or sandbox-exec), inject the role-specific
+	// config blob as the harness config env var. This mirrors the pattern in
+	// spawn.go.
 	// Profile load errors are non-fatal for restore: log and skip config
 	// injection so the session is still recreated without it, rather than
 	// aborting the entire restore run.
@@ -419,9 +420,6 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 		// file existence (os.Stat) rather than cfg.ConfigContent, so it picks
 		// this up correctly.
 		//
-		// Podman mode does NOT need this write — the sidecar's Create() path
-		// already writes the file before the container starts.
-		//
 		// IMPORTANT: the path key used here must match the one used by Manager
 		// internally. Manager.name = container.NameForSession(s.SessionName),
 		// and Manager.harnessConfigFilePath() calls HarnessConfigFilePath(m.name).
@@ -457,9 +455,9 @@ func restoreProjectSession(d *db.DB, s db.Status, threshold int, pendingStagger 
 	// fresh one below.
 	session.KillSidecar(s.SessionName)
 
-	// For container-mode sessions, also remove any stale container left over
-	// from the previous lifecycle. Without this, `podman create` inside the
-	// new sidecar would fail with "container name already in use".
+	// For container-mode sessions (none in current code — isoCaps.IsContainer
+	// is always false), also remove any stale container left over
+	// from the previous lifecycle.
 	// removeContainerIfExists is idempotent and logs non-fatal errors
 	// internally, so it is safe to call even when no container exists.
 	// Host-mode sessions never have a container, so this step is skipped.

--- a/modules/programs/prism/prism/cmd/reviews.go
+++ b/modules/programs/prism/prism/cmd/reviews.go
@@ -87,7 +87,7 @@ func runReviewsList(cmd *cobra.Command, _ []string) error {
 	jsonMode, _ := cmd.Flags().GetBool("json")
 	limit, _ := cmd.Flags().GetInt("limit")
 
-	// Inside a bwrap / podman / sandbox-exec sandbox: proxy the list to
+	// Inside a bwrap / sandbox-exec sandbox: proxy the list to
 	// the host sidecar (#1043 pattern). The host's prism.db is invisible
 	// to direct reads from inside the sandbox — falling through to the DB
 	// path would silently return an empty list (the shadow tmpfs DB has

--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -1,43 +1,35 @@
 package cmd
 
-// prism sidecar — long-running SSE consumer and (optionally) container manager
-// that drives agent state transitions.
+// prism sidecar — long-running SSE consumer that drives agent state
+// transitions.
 //
 // Flags:
 //
 //	--session <name>           prism session name (e.g. "nixos-config@main")
 //	--harness-url <url>        base URL of the harness HTTP endpoint
 //	                           (e.g. "http://localhost:14000")
-//	--isolation-mode <mode>    isolation mode: "podman", "bwrap", or "host"
-//	                           (default: "host" for back-compat when absent)
-//	--container                enable container mode: create and manage a podman
-//	                           container before connecting.
-//	                           Deprecated: use --isolation-mode=podman instead.
-//	--agent-role <role>        "worker" or "coordinator" (used in container mode
-//	                           to select the correct GitHub token; when empty,
-//	                           the role is inferred from events at runtime)
-//	--port <n>                 allocated host port (required in container/bwrap mode)
-//	--plugin-path <path>       host path to the prism-hooks plugin; mounted
-//	                           read-only into the container (container mode only)
-//	--config-content <json>    JSON blob for the container harness config;
-//	                           written to a temp file and mounted into the
-//	                           container (container mode only)
+//	--isolation-mode <mode>    isolation mode: "bwrap", "sandbox-exec", or
+//	                           "host" (default: "host" when absent); see
+//	                           config.ValidIsolationModes
+//	--agent-role <role>        "worker" or "coordinator" (used to select the
+//	                           correct GitHub token; when empty, the role is
+//	                           inferred from events at runtime)
+//	--port <n>                 allocated host port (required in bwrap/
+//	                           sandbox-exec mode)
 //
 // The sidecar connects to <harness-url>/event and maps harness events to
 // agent state transitions, writing them to prism.db. It handles idle debounce,
 // permission tracking, and dashboard sentinel updates.
 //
-// In bwrap mode (--isolation-mode=bwrap), the sidecar does NOT create a
-// container. The bwrap sandbox is launched and owned by the tmux pane via
-// "prism agent-run". The sidecar still sets up the host-API Unix socket,
-// selects the NewContainerMode harness adapter, and runs the full SSE loop.
+// In bwrap and sandbox-exec mode, the sandbox is launched and owned by the
+// tmux pane via "prism agent-run". The sidecar sets up the host-API Unix
+// socket, selects the container-mode harness adapter, and runs the full SSE
+// loop.
 //
-// In host mode (--isolation-mode=host or no --container flag), the sidecar
-// connects to an already-running agent process. No container or sandbox
-// management is performed.
+// In host mode (--isolation-mode=host or no flag), the sidecar connects to an
+// already-running agent process. No sandbox management is performed.
 //
-// Clean shutdown: SIGINT and SIGTERM write "interrupted" state and (in container
-// mode) stop/remove the container before exiting.
+// Clean shutdown: SIGINT and SIGTERM write "interrupted" state before exiting.
 
 import (
 	"context"
@@ -69,28 +61,23 @@ by prism spawn.
 The sidecar handles: state machine transitions, idle debounce (2s),
 permission tracking, event logging, and dashboard sentinel updates.
 
-In podman mode (--isolation-mode=podman or legacy --container), the sidecar
-also creates and manages the podman container running the harness in combined
-TUI + HTTP mode, health-checks it until ready, then writes a readiness signal
-so the tmux pane can run podman attach to bridge the container PTY (RFC #691).
-
-In bwrap mode (--isolation-mode=bwrap), the sidecar sets up the host-API Unix
-socket and runs the full SSE loop, but does NOT create a container or write a
-readiness signal. The bwrap sandbox is owned by the tmux pane.`,
+In bwrap and sandbox-exec mode, the sidecar sets up the host-API Unix socket
+and runs the full SSE loop. The sandbox itself is owned by the tmux pane via
+"prism agent-run". In host mode the sidecar connects to an already-running
+agent process.`,
 	RunE: runSidecar,
 }
 
 func init() {
 	sidecarCmd.Flags().String("session", "", "Prism session name (e.g. nixos-config@main)")
 	sidecarCmd.Flags().String("harness-url", "", "Base URL of the harness HTTP server (used by HTTP-transport harnesses)")
-	sidecarCmd.Flags().String("isolation-mode", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: derived from --container flag)")
-	sidecarCmd.Flags().Bool("container", false, "Enable container mode (create/manage podman container) — deprecated, use --isolation-mode=podman")
-	sidecarCmd.Flags().String("agent-role", "", "Agent role: worker or coordinator (used in container mode; inferred from SSE events when empty)")
-	sidecarCmd.Flags().Int("port", 0, "Allocated host port (required in container/bwrap mode)")
-	sidecarCmd.Flags().String("plugin-path", "", "Host path to prism-hooks.ts plugin (container mode only)")
-	sidecarCmd.Flags().String("initial-prompt", "", "Initial prompt to deliver to the agent after container readiness (container mode only)")
-	sidecarCmd.Flags().String("config-content", "", "JSON blob for container harness config; written to temp file and mounted (container mode only)")
-	sidecarCmd.Flags().String("instance-id", "", "UUID instance identifier for this session incarnation (for container labels and bus message scoping)")
+	sidecarCmd.Flags().String("isolation-mode", "", "Isolation mode: bwrap, sandbox-exec, or host (default: host)")
+	sidecarCmd.Flags().String("agent-role", "", "Agent role: worker or coordinator (inferred from SSE events when empty)")
+	sidecarCmd.Flags().Int("port", 0, "Allocated host port (required in bwrap/sandbox-exec mode)")
+	sidecarCmd.Flags().String("plugin-path", "", "Host path to prism-hooks.ts plugin (unused; retained for back-compat)")
+	sidecarCmd.Flags().String("initial-prompt", "", "Initial prompt to deliver to the agent after readiness")
+	sidecarCmd.Flags().String("config-content", "", "JSON blob for the harness config (unused; retained for back-compat)")
+	sidecarCmd.Flags().String("instance-id", "", "UUID instance identifier for this session incarnation (for bus message scoping)")
 	sidecarCmd.Flags().Bool("worktree-readonly", false, "Mount the worktree read-only inside the container (used for review agents)")
 	sidecarCmd.Flags().String("harness", "pi", "Agent harness to use")
 	sidecarCmd.Flags().String("harness-binary", "", "Path to the harness binary (required for stdio-pipe harnesses; ignored for http-port harnesses)")
@@ -105,11 +92,10 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	sessionName, _ := cmd.Flags().GetString("session")
 	harnessURL, _ := cmd.Flags().GetString("harness-url")
 	isolationModeFlag, _ := cmd.Flags().GetString("isolation-mode")
-	containerFlag, _ := cmd.Flags().GetBool("container")
 	agentRole, _ := cmd.Flags().GetString("agent-role")
 	port, _ := cmd.Flags().GetInt("port")
 	pluginPath, _ := cmd.Flags().GetString("plugin-path")
-	_ = pluginPath // was used for podman container config, now removed
+	_ = pluginPath // retained for back-compat; no longer consumed
 	initialPrompt, _ := cmd.Flags().GetString("initial-prompt")
 	configContent, _ := cmd.Flags().GetString("config-content")
 	_ = configContent
@@ -143,14 +129,11 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		modelsByRole = nil
 	}
 
-	// Resolve the effective isolation mode. When --isolation-mode is set it
-	// takes precedence. The --container flag is retained for back-compat but
-	// now maps to bwrap (podman isolation has been removed).
+	// Resolve the effective isolation mode. Valid values are defined by
+	// config.ValidIsolationModes; anything else falls back to host.
 	var isolationMode config.IsolationMode
 	if isolationModeFlag != "" && config.IsValidIsolationMode(isolationModeFlag) {
 		isolationMode = config.IsolationMode(isolationModeFlag)
-	} else if containerFlag {
-		isolationMode = config.IsolationBwrap
 	} else {
 		isolationMode = config.IsolationHost
 	}
@@ -160,12 +143,12 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	isoCaps := container.CapabilitiesFor(isolationMode)
 
 	// needsHostAPI is true for any mode where the agent runs in a sandbox
-	// without direct access to host tmux — podman (IsContainer), bwrap, and
-	// sandbox-exec (NeedsHostAPISocket) all require the host-API Unix socket.
+	// without direct access to host tmux — bwrap and sandbox-exec
+	// (NeedsHostAPISocket) both require the host-API Unix socket.
 	needsHostAPI := isoCaps.NeedsHostAPISocket || isoCaps.IsContainer
 
 	// useContainerHarness is true for modes where the agent is pre-created with
-	// --prompt at launch (podman, bwrap, sandbox-exec), so the harness uses
+	// --prompt at launch (bwrap, sandbox-exec), so the harness uses
 	// GET /session to retrieve the existing session ID rather than POST /session.
 	useContainerHarness := isoCaps.NeedsHostAPISocket || isoCaps.IsContainer
 
@@ -218,13 +201,14 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		agentModel = modelProbe.EffectiveModel(agentRole)
 	}
 
-	// ctrCfg is always nil now that podman isolation has been removed.
-	// The downstream nil checks gate all container-specific code paths.
+	// ctrCfg is always nil — no current isolation mode runs the agent in a
+	// sidecar-managed container. The downstream nil checks gate all
+	// container-specific code paths.
 	var ctrCfg *container.Config
 
-	// Build the host-API socket path for podman, bwrap, and sandbox-exec modes.
-	// The agent runs in a sandbox without direct access to host tmux in all
-	// three cases, so the host-API Unix socket is required for proxying prism
+	// Build the host-API socket path for bwrap and sandbox-exec modes.
+	// The agent runs in a sandbox without direct access to host tmux in both
+	// cases, so the host-API Unix socket is required for proxying prism
 	// CLI calls.
 	var hostAPISockPath string
 	if needsHostAPI {
@@ -282,7 +266,8 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Build the OnReady callback — only for podman mode (AC-18, AC-19).
+	// Build the OnReady callback — only for container-owning modes (AC-18,
+	// AC-19). No current isolation mode sets IsContainer, so onReady stays nil.
 	// In bwrap and sandbox-exec modes the sidecar does NOT write the readiness
 	// signal: "prism agent-run" in the tmux pane starts immediately without
 	// waiting. In host mode there is no readiness file at all.
@@ -314,7 +299,7 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// event mapping. The sidecar calls through the harness.Harness interface
 	// and has no direct dependency on the adapter package (#710).
 	//
-	// In podman and bwrap mode, use NewContainer so that:
+	// In bwrap and sandbox-exec mode, use NewContainer so that:
 	//   - CreateSession uses GET /session to retrieve the existing session ID
 	//     (the agent already created a session when the TUI started)
 	//   - DeliverInitialPrompt is a no-op (prompt was sent via --prompt CLI flag)
@@ -399,8 +384,8 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 	// This implements the TTL sweep that prevents ~/.cache/prism/clipboard/ from
 	// growing unboundedly across multiple paste operations. The sweep is
 	// fire-and-forget; errors are non-fatal (logged by runClipboardClean itself).
-	// Runs for podman and bwrap modes (both run the agent in a sandbox where
-	// the clipboard staging dir is mounted).
+	// Runs for bwrap and sandbox-exec modes (both run the agent in a sandbox
+	// where the clipboard staging dir is mounted).
 	if needsHostAPI {
 		go func() {
 			_ = runClipboardClean(nil, nil)

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -15,7 +15,7 @@ package cmd
 //	--model <name>               model identifier override (overrides profile's primary model)
 //	--variant <name>             model variant override (overrides all agents' variant)
 //	--model-override role=model  per-role model override (repeatable); overrides --model for that role
-//	--isolation <mode>           isolation mode: podman, bwrap, sandbox-exec, or host (default: from config.json)
+//	--isolation <mode>           isolation mode: bwrap, sandbox-exec, or host (default: from config.json)
 //	--harness <name>             agent harness to use (default: "pi")
 
 import (
@@ -295,7 +295,7 @@ func init() {
 	spawnCmd.Flags().String("model", "", "Model identifier override (e.g. anthropic/claude-sonnet-4-6); overrides profile's primary model")
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
 	spawnCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
-	spawnCmd.Flags().String("isolation", "", "Isolation mode: podman, bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
+	spawnCmd.Flags().String("isolation", "", "Isolation mode: bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
 	spawnCmd.Flags().String("harness", "pi", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	spawnCmd.Flags().Bool("wait", false, "Block until the spawned agent finishes its initial prompt. Without --wait, returns immediately.")
@@ -322,9 +322,9 @@ func init() {
 //
 // D1 (issue #1133): platform availability is checked via the registered
 // Isolator's Available() method — but only for non-container modes. The
-// podman binary/socket/image checks live in the runSpawn caller (gated by
-// isoCaps.IsContainer) so resolveIsolationMode keeps its pre-refactor
-// surface (no podman daemon required to resolve the mode under test).
+// container availability checks live in the runSpawn caller (gated by
+// isoCaps.IsContainer, always false today) so resolveIsolationMode keeps its
+// pre-refactor surface.
 func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.IsolationMode, error) {
 	isolationFlag, _ := cmd.Flags().GetString("isolation")
 
@@ -336,10 +336,9 @@ func resolveIsolationMode(cmd *cobra.Command, cfg config.Config) (config.Isolati
 	if err != nil {
 		return "", err
 	}
-	// Skip Available() for container modes — the container availability
-	// check (podman binary, socket, image) runs later in runSpawn so it
-	// happens after the worktree-irrelevant pre-flight is complete and so
-	// resolveIsolationMode itself stays usable on hosts without podman.
+	// Skip Available() for container modes (none in current code) — the
+	// container availability check runs later in runSpawn so it
+	// happens after the worktree-irrelevant pre-flight is complete.
 	if container.CapabilitiesFor(mode).IsContainer {
 		return mode, nil
 	}
@@ -453,11 +452,12 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// below reads from isoCaps rather than comparing against raw mode constants.
 	isoCaps := container.CapabilitiesFor(isolationMode)
 
-	// Container availability check: when container mode is active verify
-	// podman is available before touching anything. resolveIsolationMode
+	// Container availability check: when container mode is active (never, in
+	// current code) verify the runtime is available before touching anything.
+	// resolveIsolationMode
 	// has already validated platform availability for bwrap / sandbox-exec
-	// (D1: iso.Available()); the podman binary/socket/image checks remain
-	// here because they fire only when isoCaps.IsContainer.
+	// (D1: iso.Available()); this branch remains
+	// because it fires only when isoCaps.IsContainer.
 	if isoCaps.IsContainer {
 		iso, isoErr := container.For(isolationMode, container.ConstructorOpts{})
 		if isoErr != nil {
@@ -468,9 +468,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Concurrency cap checks: BEFORE any container-creation side effects
+	// Concurrency cap checks: BEFORE any session-creation side effects
 	// (no worktree, no tmux session, no DB row on refusal).
-	// The podman cap guards host memory against container overhead.
 	// The bwrap cap guards against process-count exhaustion from uncapped
 	// bwrap sessions (each is a host process with no per-session memory ceil).
 	// The sandbox-exec cap mirrors the bwrap cap for Darwin sessions.
@@ -659,8 +658,6 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// path. The bwrap.go mount-emission block checks file existence (os.Stat)
 	// rather than cfg.ConfigContent, so it picks this up correctly.
 	//
-	// Podman mode does NOT need this write — the sidecar's Create() path at
-	// container.go:580 already writes the file before the container starts.
 	// Host mode does NOT need this write — it uses ~/.config/opencode/opencode.json
 	// directly via xdg.configFile.
 	//
@@ -804,8 +801,8 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			proglog.Warnf("[prism spawn] warning: could not resolve harness pipe path for %q: %v\n", sessionName, pipeErr)
 		}
 	}
-	// AgentEnvVars only applies to host-mode sessions; container sessions
-	// receive env vars via podman --env flags in the sidecar.
+	// AgentEnvVars only applies to host-mode sessions; sandboxed sessions
+	// receive env vars via their own injection paths.
 	if pf != nil && !isoCaps.IsContainer {
 		spawnOpts.AgentEnvVars = pf.AgentEnvVars
 	}

--- a/modules/programs/prism/prism/cmd/switch.go
+++ b/modules/programs/prism/prism/cmd/switch.go
@@ -330,9 +330,9 @@ var switchCmd = &cobra.Command{
 		// below reads from isoCaps rather than comparing against raw mode constants.
 		isoCaps := container.CapabilitiesFor(isoMode)
 
-		// Load profiles.json for container/bwrap/sandbox-exec config injection and
+		// Load profiles.json for bwrap/sandbox-exec config injection and
 		// agent env var injection (host mode). Always attempt to load; treat missing
-		// file as fatal when sandboxed (podman, bwrap, or sandbox-exec), since those
+		// file as fatal when sandboxed (bwrap or sandbox-exec), since those
 		// paths require the role config blob.
 		var pf *config.ProfilesFile
 		{
@@ -376,8 +376,8 @@ var switchCmd = &cobra.Command{
 			PIExtensionDir: cfg.PIExtensionDir,
 		}
 		// AgentEnvVars only applies to host-mode sessions; sandboxed sessions
-		// receive env vars via podman --env flags in the sidecar (podman) or
-		// via the bwrap environment pass-through.
+		// receive env vars via their own injection paths (bwrap --setenv,
+		// sandbox-exec profile).
 		if pf != nil && !isoCaps.NeedsConfigBlob {
 			opts.AgentEnvVars = pf.AgentEnvVars
 		}

--- a/modules/programs/prism/prism/docs/pi-wire-protocol.md
+++ b/modules/programs/prism/prism/docs/pi-wire-protocol.md
@@ -82,16 +82,17 @@ subsystems.
 ### 2.2 Darwin: localhost TCP listener
 
 - TCP listener on `127.0.0.1:0` (OS-allocated port). The listener binds on
-  `127.0.0.1` (loopback only). Unlike the podman/gvproxy path — where the
-  listener binds `0.0.0.0` so gvproxy's bridge interface (`192.168.127.254`)
-  can reach it from the container VM — `sandbox-exec` runs **directly on the
-  host**. Both the sidecar and the sandboxed extension share the host
+  `127.0.0.1` (loopback only). Unlike the legacy container/gvproxy path —
+  where the
+  listener bound `0.0.0.0` so gvproxy's bridge interface (`192.168.127.254`)
+  could reach it from the container VM — `sandbox-exec` runs **directly on
+  the host**. Both the sidecar and the sandboxed extension share the host
   loopback, so binding only `127.0.0.1` is both sufficient and more secure
   (the port is not reachable from external network interfaces).
 - The allocated port is captured at sidecar startup — *before* the
   extension is launched — and exposed as `tcp://127.0.0.1:<port>` via
-  the env var (§2.4). **Note:** `host.containers.internal` is a
-  podman/gvproxy convention (resolved by gvproxy inside the container VM)
+  the env var (§2.4). **Note:** `host.containers.internal` is a gvproxy
+  container-VM convention (resolved by gvproxy inside the container VM)
   and does **not** resolve on bare macOS; using it for sandbox-exec causes
   `ENOTFOUND` on every dial.
 - Rationale: macOS `sandbox-exec` does not support reliable Unix-socket
@@ -136,7 +137,8 @@ or on Darwin (sandbox-exec, where both sidecar and extension run on the host loo
 PRISM_HARNESS_PIPE=tcp://127.0.0.1:54321
 ```
 
-> **Note:** `host.containers.internal` is a podman/gvproxy convention and
+> **Note:** `host.containers.internal` is a gvproxy container-VM convention
+> and
 > resolves only inside a container VM where gvproxy injects the hostname. It
 > does **not** resolve on bare macOS. The sandbox-exec path always uses
 > `127.0.0.1` instead.
@@ -861,8 +863,8 @@ The order is:
 5. The extension's `hello` frame arrives at the sidecar.
 6. The sidecar replies `hello_ack` and **calls `OnReady`** (writes
    `~/.local/state/prism/run/<session>-sidecar.ready`). The agent pane,
-   which is polling for this file, unblocks and runs `podman attach` /
-   the equivalent for non-podman modes.
+   which is polling for this file, unblocks and launches the agent
+   command for the session's isolation mode.
 7. Domain frames flow.
 
 The first frame **is** the readiness signal. There is no separate health

--- a/modules/programs/prism/prism/docs/sandbox-exec-testing.md
+++ b/modules/programs/prism/prism/docs/sandbox-exec-testing.md
@@ -174,7 +174,7 @@ the load-bearing check.
 ## Out of scope
 
 - Migrating the profile to `(version 3)` — separate spike in #1190.
-- Test convention work for other isolation modes (bwrap, podman). If
+- Test convention work for other isolation modes (bwrap). If
   symmetric work is warranted there, file a separate issue.
 
 ## References

--- a/modules/programs/prism/prism/internal/archive/archive.go
+++ b/modules/programs/prism/prism/internal/archive/archive.go
@@ -93,7 +93,8 @@ type Params struct {
 	GroupID string
 	// PrismVersion is the git SHA or version of the prism binary. May be empty.
 	PrismVersion string
-	// IsolationMode is "podman", "bwrap", "sandbox-exec", or "host".
+	// IsolationMode is "bwrap", "sandbox-exec", or "host" (see
+	// config.ValidIsolationModes).
 	IsolationMode string
 	// AgentRunLogPath is the absolute path to the harness log file
 	// (~/.local/state/prism/run/<session>/agent-run.log). When non-empty and the

--- a/modules/programs/prism/prism/internal/config/profiles.go
+++ b/modules/programs/prism/prism/internal/config/profiles.go
@@ -66,27 +66,27 @@ type ProfilesFile struct {
 	// pi processes. Values are fully expanded absolute paths (no $HOME).
 	// Written by Nix under agent_env_vars.
 	AgentEnvVars map[string]string `json:"agent_env_vars,omitempty"`
-	// ContainerResources holds per-container resource cap values to be passed
-	// to podman run as --memory, --memory-swap, and --pids-limit.
-	// Written by Nix under container_resources.
+	// ContainerResources holds per-container resource cap values that the
+	// removed container isolation mode passed to the container runtime.
+	// Unused by current isolation modes; retained for config-shape
+	// compatibility. Written by Nix under container_resources.
 	ContainerResources ContainerResources `json:"container_resources,omitempty"`
 	// QuickProfiles holds lightweight model configs for prism quick subcommands.
 	// Written by Nix under quick_profiles.
 	QuickProfiles map[string]QuickProfile `json:"quick_profiles,omitempty"`
 }
 
-// ContainerResources holds the per-container resource cap values that are
-// passed to podman run via buildRunArgs. Zero values / empty strings mean
-// "no flag emitted".
+// ContainerResources holds the per-container resource cap values that the
+// removed container isolation mode consumed. Unused by current isolation
+// modes; retained for config-shape compatibility. Zero values / empty
+// strings mean "no flag emitted".
 type ContainerResources struct {
-	// MemoryMax is the value for podman run --memory (e.g. "8g").
-	// Empty string means no --memory flag.
+	// MemoryMax is the memory cap (e.g. "8g"). Empty string means no cap.
 	MemoryMax string `json:"memoryMax,omitempty"`
-	// MemorySwapMax is the value for podman run --memory-swap (e.g. "8g").
-	// Empty string means no --memory-swap flag.
+	// MemorySwapMax is the memory+swap cap (e.g. "8g"). Empty string means
+	// no cap.
 	MemorySwapMax string `json:"memorySwapMax,omitempty"`
-	// PidsLimit is the value for podman run --pids-limit.
-	// Zero means no --pids-limit flag.
+	// PidsLimit is the process-count cap. Zero means no cap.
 	PidsLimit int `json:"pidsLimit,omitempty"`
 }
 

--- a/modules/programs/prism/prism/internal/container/agent_pane_overrides_test.go
+++ b/modules/programs/prism/prism/internal/container/agent_pane_overrides_test.go
@@ -118,7 +118,7 @@ func TestBwrapAgentPaneCmd_PartialOverride_ModelOnly(t *testing.T) {
 }
 
 // TestBwrapAgentPaneCmd_ShellQuoting_SingleQuotedValues ensures values pass
-// through shellQuotePodman so weird characters in a model name (or in the
+// through shellQuoteContainer so weird characters in a model name (or in the
 // session name) cannot break out of the shell context. Cobra parses argv
 // regardless, but the tmux pane wraps the command in `sh -c "<cmd>"` so
 // unquoted values are a real injection risk.
@@ -127,7 +127,7 @@ func TestBwrapAgentPaneCmd_ShellQuoting_SingleQuotedValues(t *testing.T) {
 	got := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@bwrap",
 		// A value containing a single quote exercises the escape path in
-		// shellQuotePodman.
+		// shellQuoteContainer.
 		Model: "danger'name",
 	})
 	want := `--model 'danger'\''name'`

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -1,4 +1,5 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines bwrapIsolator, a bubblewrap-based implementation of the
 // Isolator interface. It is a pure addition — nothing constructs bwrapIsolator
 // at runtime yet. The wiring (CLI flag / config field) is intentionally deferred
@@ -152,13 +153,9 @@ func standardSandboxEnvArgs() []string {
 	return args
 }
 
-// BuildArgs constructs the bwrap argument list that is equivalent to the
-// podman run arguments built by Manager.buildRunArgs(), translating podman
-// syntax into bubblewrap equivalents:
-//
-//   - --volume SRC:DST:ro → --ro-bind SRC DST
-//   - --volume SRC:DST[:Z] → --bind SRC DST
-//   - --env K=V → --setenv K V
+// BuildArgs constructs the bwrap argument list for the session sandbox:
+// bind-mounts (--ro-bind / --bind), environment injection (--setenv), and
+// namespace flags.
 //   - --workdir X → --chdir X
 //
 // Key design decision: Dst == Src for all mounts (no /workspace remap).
@@ -191,9 +188,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// standardSandboxEnvArgs and credentialEnvVars). Without --clearenv, bwrap
 	// forwards the full host environment — which on a prism coordinator
 	// includes role-specific GitHub tokens (PRISM_GITHUB_TOKEN_*) and other
-	// credentials that must never reach a sandboxed agent. Podman does not
-	// have this problem because its default is to pass nothing from the host;
-	// --clearenv gives bwrap the same baseline.
+	// credentials that must never reach a sandboxed agent. --clearenv gives
+	// bwrap a pass-nothing-from-the-host baseline.
 	//
 	// --unshare-ipc is intentionally omitted: SQLite WAL mode uses a -shm
 	// shared memory file that relies on mmap() coherency across processes.
@@ -293,8 +289,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 
 	// ── Bare repo and worktree private git state (read-write) ──────────────
 	// Dst == Src: both directories mount at their host paths inside the
-	// sandbox, not at the /prism-git canonical container path used by the
-	// podman path. This is correct bwrap behaviour — the git commondir pointer
+	// sandbox (no canonical-path remapping). This is correct bwrap behaviour
+	// — the git commondir pointer
 	// inside WorktreeGitDir/commondir already points at the absolute host path
 	// for the bare dir, so no remapping is needed. PRISM_BARE_ROOT is updated
 	// below to point at the actual host path rather than /prism-git.
@@ -338,8 +334,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// to follow in a PR.
 
 	// ── Nix daemon socket dir (read-write) ──────────────────────────────────
-	// Mount the parent directory, not the socket file directly (same pattern
-	// as the podman path — avoids statfs ENOTSUP on certain filesystems).
+	// Mount the parent directory, not the socket file directly
+	// (avoids statfs ENOTSUP on certain filesystems).
 	// Kept inline because the absolute system path (not HOME-relative) is
 	// outside the StandardSandboxMounts shape.
 	nixDaemonSocketDir := "/nix/var/nix/daemon-socket"
@@ -347,10 +343,10 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 
 	// ── SSH keys (read-only, conditional) ───────────────────────────────────
 	// All SSH artefacts are remapped to canonical generic paths under
-	// $HOME/.ssh/ inside the sandbox. Agents inside both bwrap and podman
-	// sandboxes see the same filenames (access-key, signing-key, signing-key.pub,
-	// allowed_signers, known_hosts) — only the $HOME prefix differs (/root for
-	// podman, <hostHome> for bwrap). The generated ~/.ssh/config and
+	// $HOME/.ssh/ inside the sandbox. Agents inside both bwrap and
+	// sandbox-exec sandboxes see the same filenames (access-key, signing-key,
+	// signing-key.pub, allowed_signers, known_hosts) — only the $HOME prefix
+	// differs. The generated ~/.ssh/config and
 	// ~/.gitconfig (see writeSshConfig and writeGitconfig) reference these
 	// canonical paths using the same prefix via sandboxHome().
 	sshDir := filepath.Join(home, ".ssh")
@@ -445,8 +441,7 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// duplicated those mounts here have been removed.
 
 	// ── Environment variables ────────────────────────────────────────────────
-	// Translate --env K=V (podman) → --setenv K V (bwrap).
-	// Inject the same set of env vars as the podman path.
+	// Inject the per-session env vars as --setenv K V pairs.
 	for _, kv := range m.credentialEnvVars() {
 		k, v, _ := strings.Cut(kv, "=")
 		args = append(args, "--setenv", k, v)
@@ -468,8 +463,6 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// terminal type as the tmux pane (e.g. tmux-256color). In bwrap mode the
 	// host terminfo tree is already bind-mounted (/etc, /nix, /run/current-system),
 	// so any terminfo entry the host has is resolvable inside the sandbox.
-	// This is intentionally different from the podman path, which hardcodes
-	// xterm-256color because the container image may not ship tmux-256color.
 	// Fallback to xterm-256color only if TERM is unset on the host (shouldn't
 	// happen from a tmux pane, but guard anyway).
 	{
@@ -527,8 +520,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		// subdirectory (run/<session>/hostapi.sock), so binding only that
 		// directory means the sandbox cannot see other sessions' sockets.
 		//
-		// A directory bind (not file bind) is required here for the same reason
-		// as the podman path: the sidecar creates the socket file after startup,
+		// A directory bind (not file bind) is required here: the sidecar
+		// creates the socket file after startup,
 		// and a file-level bind would pin the original inode — meaning the sandbox
 		// would not see the new socket after os.Remove + net.Listen replaced it.
 		// Binding the directory makes the socket file appear inside the sandbox

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -468,7 +468,7 @@ func TestBwrapBuildArgs_NixCacheDirBound(t *testing.T) {
 func TestBwrapBuildArgs_BareRepoBoundAtHostPath(t *testing.T) {
 	// When BareRoot and WorktreeGitDir are set, the bare repo (.bare dir) and
 	// worktree private git state are both bound at their host paths (Dst == Src),
-	// not remapped to /prism-git as in the podman path.
+	// with no canonical-path remapping.
 	bareRoot := t.TempDir()
 	bareDir := filepath.Join(bareRoot, ".bare")
 	if err := os.MkdirAll(bareDir, 0o755); err != nil {
@@ -1672,7 +1672,8 @@ func TestPrepareBwrap_WritesSSHConfigAndGitconfig(t *testing.T) {
 		t.Errorf("Gitconfig temp file not written: %v", err)
 	}
 
-	// Gitdir fixup files must NOT exist (they are podman-only).
+	// Gitdir fixup files must NOT exist (they belonged to the removed
+	// legacy container path).
 	if _, err := os.Stat(m.GitdirFilePath()); err == nil {
 		t.Errorf("gitdir fixup file should not be written by PrepareBwrap")
 	}

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -1,23 +1,23 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 //
-// The sidecar (running on the host) creates a podman container running
-// the agent in combined TUI + HTTP mode, health-checks it until the HTTP
-// endpoint responds, and stops/removes the container on shutdown. The tmux
-// agent window attaches to the container's PTY via "podman attach" so the
-// agent TUI is visible to the user.
+// Each isolation mode ("bwrap", "sandbox-exec", "host" — see
+// config.ValidIsolationModes) is implemented as an Isolator (isolator.go).
+// The Manager prepares the shared per-session artefacts (SSH config,
+// gitconfig, bind-mount sources) and dispatches lifecycle operations
+// (create, shutdown, cleanup) to the registered Isolator for the session's
+// mode.
 //
 // Health check: we probe GET /global/health (not GET /) because the root URL
 // may redirect to an external URL on some harnesses, adding network latency
-// on every container startup. /global/health is in ControlPlaneRoutes and
+// on every startup. /global/health is in ControlPlaneRoutes and
 // returns immediately with no external I/O.
 //
 // Design notes:
-//   - All podman operations use exec.Command("podman", ...) — no daemon or
-//     socket is required from Go's perspective, just a podman binary on PATH.
-//   - The container name is derived from the prism session name so it is
+//   - The sandbox name is derived from the prism session name so it is
 //     predictable and idempotent.
 //   - Credentials are injected as environment variables, never as mounted files.
-//   - The agent serve container port (ContainerPort) is bound to 127.0.0.1
+//   - The agent serve port (ContainerPort) is bound to 127.0.0.1
 //     only — not 0.0.0.0. The host-API TCP listener (Darwin only) intentionally
 //     binds 0.0.0.0 so the gvproxy bridge interface can reach it from the VM.
 package container
@@ -41,8 +41,9 @@ const (
 
 	// Image is the container image name used for all agent containers.
 	// The image is published to GHCR as a multi-arch image by CI and pulled
-	// on first use by the systemd/launchd service. podman resolves the correct
-	// arch (amd64/arm64) automatically from the multi-arch manifest.
+	// on first use by the systemd/launchd service. The container runtime
+	// resolves the correct arch (amd64/arm64) automatically from the
+	// multi-arch manifest.
 	Image = "ghcr.io/prismatic-koi/prism-agent:latest"
 
 	// DefaultHealthCheckTimeout is the maximum time to wait for the container
@@ -56,10 +57,8 @@ const (
 // isolationMode identifies which sandbox layer will consume the temp files
 // (gitconfig, ssh config) that writeGitconfig / writeSshConfig generate.
 //
-// The three sandboxes mount the SSH artefacts at different in-sandbox paths:
+// The sandboxes mount the SSH artefacts at different in-sandbox paths:
 //
-//   - podman runs as root, so canonical paths are /root/.ssh/{access-key,
-//     signing-key,signing-key.pub,allowed_signers} — the agent's $HOME is /root.
 //   - bwrap runs as the host user, so canonical paths are
 //     $HOME/.ssh/{access-key,signing-key,signing-key.pub,allowed_signers}
 //     where $HOME is the host user's home directory.
@@ -67,7 +66,7 @@ const (
 //     HOME (e.g. ~/.local/state/prism/sandbox-exec/<instance>) — the agent
 //     sees this as $HOME and the SSH artefacts are referenced under it.
 //
-// Agents inside all three sandboxes see the same generic filenames
+// Agents inside both sandboxes see the same generic filenames
 // (access-key, signing-key, …); only the $HOME prefix differs. The isolation
 // mode lets the generators substitute the correct prefix into the config
 // files they write.
@@ -208,8 +207,8 @@ type Config struct {
 	// listener (Darwin only). When non-zero, PRISM_HARNESS_PIPE is set to
 	// tcp://127.0.0.1:<HarnessPipeTCPPort> for sandbox-exec sessions (both
 	// the sidecar and the sandboxed extension run on the host loopback, so
-	// host.containers.internal — a podman/gvproxy convention — must not be
-	// used here). On Linux this is zero.
+	// host.containers.internal — a gvproxy container-VM convention — must not
+	// be used here). On Linux this is zero.
 	HarnessPipeTCPPort int
 
 	// InstanceID is the UUID instance identifier for the prism session that owns
@@ -267,15 +266,15 @@ type Config struct {
 	InitialPrompt string
 
 	// RuntimeEnv holds harness-specific environment variables to inject
-	// into the container. Each entry is emitted as --env KEY=VALUE (podman)
-	// or --setenv KEY VALUE (bwrap). Populated from
+	// into the sandbox. Each entry is emitted in the isolator's native
+	// syntax (e.g. --setenv KEY VALUE for bwrap). Populated from
 	// harness.Harness.RuntimeEnv() by the sidecar at container creation
 	// time. When nil, no harness-specific env vars are injected.
 	RuntimeEnv map[string]string
 
 	// AgentEnvVars holds the profile-level environment variables to inject
-	// into the agent shell. Each entry is emitted as --env KEY=VALUE (podman)
-	// or --setenv KEY VALUE (bwrap). Sourced from profiles.json agent_env_vars
+	// into the agent shell. Each entry is emitted in the isolator's native
+	// syntax (e.g. --setenv KEY VALUE for bwrap). Sourced from profiles.json agent_env_vars
 	// (written by Nix). These carry entries such as GIT_EDITOR=true,
 	// KUBECONFIG, and AWS_CONFIG_FILE into the sandboxed agent.
 	// When nil or empty, no profile env vars are injected.
@@ -355,13 +354,13 @@ type Config struct {
 	PIBinaryPath string
 }
 
-// NameForSession returns the stable podman container name for a session.
+// NameForSession returns the stable sandbox name for a session.
 // The name is derived from the session name with "@", "/", ".", and "~"
 // replaced by "-" and a "prism-" prefix, e.g. "prism-nixos-config-feature".
 //
 // The "~" replacement is needed for review agent session names which are
-// structured as "<parent>~review-<N>~<agentName>" — without it, podman would
-// reject the container name (allowed charset: [a-zA-Z0-9][a-zA-Z0-9_.-]*).
+// structured as "<parent>~review-<N>~<agentName>" — it keeps the name within
+// the conservative charset [a-zA-Z0-9][a-zA-Z0-9_.-]*.
 func NameForSession(sessionName string) string {
 	safe := strings.ReplaceAll(sessionName, "@", "-")
 	safe = strings.ReplaceAll(safe, "/", "-")
@@ -516,8 +515,8 @@ func WriteHarnessConfig(sessionName, content string) error {
 // The config only needs to handle GitHub; other SSH hosts are not expected
 // inside agent sandboxes. The IdentityFile path is $HOME/.ssh/access-key
 // using the sandbox-specific $HOME prefix, which matches the generic name
-// used by both the podman volume mount (/root/.ssh/access-key) and the bwrap
-// bind-mount (<hostHome>/.ssh/access-key).
+// used by the bwrap bind-mount (<hostHome>/.ssh/access-key) and the
+// sandbox-exec staging HOME.
 func (m *Manager) writeSshConfig(mode isolationMode) error {
 	identityFile := filepath.Join(sandboxHome(m, mode), ".ssh", "access-key")
 	sshConfig := "Host github.com\n" +
@@ -552,9 +551,6 @@ func (m *Manager) writeSshConfig(mode isolationMode) error {
 //
 // The mode argument controls the paths embedded in the generated file:
 //
-//   - isolationPodman: signingKey = /root/.ssh/signing-key.pub,
-//     allowedSignersFile = /root/.ssh/allowed_signers (paths inside the
-//     podman container, where the agent runs as root).
 //   - isolationBwrap: signingKey = <hostHome>/.ssh/signing-key.pub,
 //     allowedSignersFile = <hostHome>/.ssh/allowed_signers (paths inside
 //     the bwrap sandbox, where the agent runs as the host user).
@@ -639,7 +635,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 	if hasSigning {
 		// Read the signing public key content to build the allowed_signers file.
 		// Only write [gpg "ssh"] allowedSignersFile when the file was actually
-		// produced — if it can't be written, podman must not be given a
+		// produced — if it can't be written, the sandbox must not be given a
 		// bind-mount source path that doesn't exist on disk.
 		pubKeyContent, err := os.ReadFile(signingKeyPub)
 		if err != nil {
@@ -692,8 +688,8 @@ func (m *Manager) worktreeGitdirFilePath() string {
 // WorktreeGitdirFilePath is the exported version of worktreeGitdirFilePath for tests.
 func (m *Manager) WorktreeGitdirFilePath() string { return m.worktreeGitdirFilePath() }
 
-// PrepareBwrap writes the same temp files that Create() writes for podman
-// sessions (SSH config, gitconfig, opencode.json config) and returns the
+// PrepareBwrap writes the per-session temp files (SSH config, gitconfig,
+// opencode.json config) and returns the
 // complete bwrap argument list via bwrapIsolator.BuildArgs. It does NOT write
 // the gitdir fixup files (prism-gitdir-*, prism-wt-gitdir-*) because bwrap
 // uses Dst==Src mounts, so the host git paths are visible at their exact
@@ -734,25 +730,27 @@ func (m *Manager) PrepareSandboxExec() ([]string, error) {
 	return iso.Prepare(context.Background(), m)
 }
 
-// prepareVolumeDirs eagerly creates host directories that buildRunArgs() will
-// reference as bind-mount sources. podman exits 125 ("statfs: no such file or
-// directory") if any bind-mount source is absent, so we create them here —
-// before buildRunArgs() is called — so that buildRunArgs() itself remains a
-// pure argument builder with no filesystem side-effects.
+// prepareVolumeDirs eagerly creates host directories that the sandbox
+// argument builders will reference as bind-mount sources. A sandbox launch
+// fails with an unhelpful error if any bind-mount source is absent, so we
+// create them here — before the argument builders run — so that the builders
+// themselves remain pure with no filesystem side-effects.
 //
 // Directories are classified as critical or optional:
-//   - Critical directories are unconditionally bound by the container runtime
-//     (bwrap --bind, podman --volume). A missing critical dir causes the
+//   - Critical directories are unconditionally bound by the sandbox
+//     (bwrap --bind). A missing critical dir causes the
 //     runtime to abort at exec time with an unhelpful error, so we return an
 //     error immediately so the caller sees the real cause.
-//   - Optional directories are guarded by an os.Stat check in buildRunArgs
-//     and are skipped when absent. A failure to create them is logged but does
-//     not fail the call — the container still starts, just without that mount.
+//   - Optional directories are guarded by an os.Stat check in the argument
+//     builders and are skipped when absent. A failure to create them is
+//     logged but does not fail the call — the sandbox still starts, just
+//     without that mount.
 //
 // perSessionState controls whether the per-session pi state directory
-// (~/.local/share/pi/prism-sessions/<name>/) is created. The podman path
-// requires it (Darwin virtiofs WAL-mode locking workaround); the bwrap path
-// shares the host pi data dir directly and does not need a per-session dir.
+// (~/.local/share/pi/prism-sessions/<name>/) is created. The removed legacy
+// container path required it (Darwin virtiofs WAL-mode locking workaround);
+// the bwrap path shares the host pi data dir directly and does not need a
+// per-session dir.
 func (m *Manager) prepareVolumeDirs(perSessionState bool) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -760,12 +758,11 @@ func (m *Manager) prepareVolumeDirs(perSessionState bool) error {
 	}
 
 	// ── Critical directories ──────────────────────────────────────────────
-	// These are unconditionally bound by the container runtime. A single
+	// These are unconditionally bound by the sandbox. A single
 	// MkdirAll failure here is fatal — return immediately so the caller
 	// sees the real cause rather than a confusing runtime abort.
 
-	// Per-session pi state directory (podman only, critical because podman
-	// always binds it via --volume).
+	// Per-session pi state directory (legacy container path only).
 	if perSessionState {
 		piSessionDir := filepath.Join(home, ".local", "share", "pi", "prism-sessions", m.name)
 		if err := os.MkdirAll(piSessionDir, 0o755); err != nil {
@@ -773,15 +770,13 @@ func (m *Manager) prepareVolumeDirs(perSessionState bool) error {
 		}
 	}
 
-	// Per-session host-API socket directory (both podman and bwrap, security fix #960).
+	// Per-session host-API socket directory (security fix #960).
 	// Each session places its socket in its own subdirectory
 	// (~/.local/state/prism/run/<sessionName>/hostapi.sock) instead of the
 	// shared run/ directory. The directory must be pre-created here so it
-	// exists before the sandboxed process starts:
-	//   - podman: directory must pre-exist before "podman run" evaluates the
-	//     bind-mount source; the sidecar creates the socket inside it later.
-	//   - bwrap: directory must pre-exist before the sidecar calls
-	//     net.Listen("unix", sockPath); bwrap is exec'd after.
+	// exists before the sandboxed process starts: it must pre-exist before
+	// the sidecar calls net.Listen("unix", sockPath); the sandbox is exec'd
+	// after.
 	// Using 0o700 (owner-only) so other users on the host cannot list or
 	// access this session's socket directory.
 	if m.cfg.HostAPISockPath != "" {

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -75,7 +75,8 @@ func TestNameForSession_ReplacesDot(t *testing.T) {
 
 func TestNameForSession_ReplacesTilde(t *testing.T) {
 	// Review agent session names contain "~" (e.g. "nixos-config@feature~review-1~review-code").
-	// Podman rejects "~" in container names (allowed: [a-zA-Z0-9][a-zA-Z0-9_.-]*).
+	// "~" is outside the conservative sandbox-name charset
+	// ([a-zA-Z0-9][a-zA-Z0-9_.-]*), so it must be replaced.
 	name := NameForSession("nixos-config@feature~review-1~review-code")
 	want := "prism-nixos-config-feature-review-1-review-code"
 	if name != want {
@@ -562,7 +563,7 @@ func TestWriteGitconfig_BwrapMode_UsesHostHomePaths(t *testing.T) {
 	if !strings.Contains(content, wantAllowed) {
 		t.Errorf("bwrap gitconfig missing %q; content:\n%s", wantAllowed, content)
 	}
-	// Must NOT contain the podman-only /root/.ssh/... paths.
+	// Must NOT contain legacy container-path /root/.ssh/... paths.
 	if strings.Contains(content, "/root/.ssh/signing-key.pub") {
 		t.Errorf("bwrap gitconfig must not contain /root/.ssh/signing-key.pub; content:\n%s", content)
 	}
@@ -869,12 +870,6 @@ func TestHarnessConfigFilePath_MatchesManagerMethod(t *testing.T) {
 	}
 }
 
-// ── AgentEnvVars (--env K=V) ──────────────────────────────────────────────────
-
-// TestBuildRunArgs_AgentEnvVarsInjected verifies that plain entries in
-// Config.AgentEnvVars (e.g. GIT_EDITOR) are emitted as --env KEY=VALUE in the
-// podman run arg list, while KUBECONFIG and AWS_CONFIG_FILE are suppressed
-// because those files are bind-mounted at their canonical default paths.
 // ── issue #1960: git identity must be hard-required ─────────────────────────
 //
 // writeGitconfig must refuse to write a gitconfig without [user] in every
@@ -886,10 +881,7 @@ func TestHarnessConfigFilePath_MatchesManagerMethod(t *testing.T) {
 
 // gitconfigIdentityModes is the per-mode matrix exercised by the regression
 // tests below. Each entry names the mode constant used by writeGitconfig and
-// a label used in error messages. Podman is intentionally NOT covered here —
-// the podman path is no longer reachable in the spawn lifecycle, but the same
-// writeGitconfig codepath gates it, so the bwrap/sandbox-exec coverage below
-// proves the invariant for all three modes.
+// a label used in error messages.
 var gitconfigIdentityModes = []struct {
 	name string
 	mode isolationMode

--- a/modules/programs/prism/prism/internal/container/dispatch.go
+++ b/modules/programs/prism/prism/internal/container/dispatch.go
@@ -1,4 +1,5 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file extends the Isolator interface with the dispatch methods migrated
 // from the per-mode switch/if blocks scattered across cmd/ and internal/. Each
 // method body produces the same output as the previous per-mode branch — this
@@ -16,7 +17,7 @@
 //   - LogPaths()                  — D7: per-mode log file set; today no caller dispatches per-mode but the shape is in place
 //
 // The methods are declared on the interface in isolator.go and implemented per
-// isolator (podman, bwrap, sandbox-exec, host) below.
+// isolator (bwrap, sandbox-exec, host) below.
 package container
 
 import (
@@ -44,8 +45,8 @@ type CapStatus struct {
 	// RenderError / RenderWarning for the noun in messages.
 	Mode config.IsolationMode
 
-	// Limit is the configured cap. Zero means uncapped. For podman:
-	// DefaultConcurrencyCap. For bwrap: Config.BwrapConcurrencyCap.
+	// Limit is the configured cap. Zero means uncapped.
+	// For bwrap: Config.BwrapConcurrencyCap.
 	// For sandbox-exec: Config.SandboxExecConcurrencyCap. For host: 0.
 	Limit int
 
@@ -228,7 +229,7 @@ type AgentPaneOpts struct {
 // ArchivePaths describes the per-mode paths that the archive copy step
 // consumes. ExtraFiles are absolute paths copied into the archive root in
 // addition to the harness storage subtree (today: agent-run.log for bwrap +
-// sandbox-exec; empty for podman + host).
+// sandbox-exec; empty for host).
 //
 // This is a stopgap pending #1142 (B6.IF — ArchiveAdapter interface): once
 // that lands, archive will consume the ArchiveAdapter interface and the
@@ -248,7 +249,7 @@ type ArchivePaths struct {
 
 // LogPaths describes the per-mode log file set for a session. Today only the
 // SidecarLog and AgentRunLog fields are populated; future modes may add
-// further entries (e.g. bwrap-stderr, podman-events).
+// further entries (e.g. bwrap-stderr).
 //
 // The values are absolute host paths and may not yet exist on disk — callers
 // must os.Stat them before reading.
@@ -258,8 +259,8 @@ type LogPaths struct {
 	SidecarLog string
 
 	// AgentRunLog is the path to the agent-run log file for this session.
-	// Populated for bwrap and sandbox-exec. Empty for podman and host (the
-	// agent-run path is not used by those modes).
+	// Populated for bwrap and sandbox-exec. Empty for host (the
+	// agent-run path is not used by that mode).
 	AgentRunLog string
 }
 
@@ -321,13 +322,12 @@ func (b *bwrapIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
 	if opts.SessionName == "" {
 		return opts.DirectCmd
 	}
-	return appendAgentRunOverrides("prism agent-run --session "+shellQuotePodman(opts.SessionName), opts)
+	return appendAgentRunOverrides("prism agent-run --session "+shellQuoteContainer(opts.SessionName), opts)
 }
 
 // SidecarFlags returns the sidecar argv extensions for bwrap: --port and the
 // common AgentRole / PluginHostPath / InitialPrompt / ConfigContent flags.
-// --container is intentionally omitted because bwrap does not own a container
-// lifecycle. Mirrors the pre-refactor branch in StartSidecarWithOpts
+// Mirrors the pre-refactor branch in StartSidecarWithOpts
 // (internal/session/sidecar.go:336-352).
 func (b *bwrapIsolator) SidecarFlags(opts SidecarFlagOpts) []string {
 	return commonHostAPISidecarFlags(opts)
@@ -404,7 +404,7 @@ func (s *sandboxExecIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
 	if opts.SessionName == "" {
 		return opts.DirectCmd
 	}
-	return appendAgentRunOverrides("prism agent-run --session "+shellQuotePodman(opts.SessionName), opts)
+	return appendAgentRunOverrides("prism agent-run --session "+shellQuoteContainer(opts.SessionName), opts)
 }
 
 // SidecarFlags returns the sidecar argv extensions for sandbox-exec — same
@@ -502,26 +502,25 @@ func (h *hostIsolator) LogPaths() LogPaths {
 // the active profile slot, so the CLI override never reaches pi's argv.
 func appendAgentRunOverrides(cmd string, opts AgentPaneOpts) string {
 	if opts.Model != "" {
-		cmd += " --model " + shellQuotePodman(opts.Model)
+		cmd += " --model " + shellQuoteContainer(opts.Model)
 	}
 	if opts.Variant != "" {
-		cmd += " --variant " + shellQuotePodman(opts.Variant)
+		cmd += " --variant " + shellQuoteContainer(opts.Variant)
 	}
 	return cmd
 }
 
-// shellQuotePodman wraps s in single quotes for shell-safe embedding. It is a
-// local copy of internal/session.shellQuote — duplicated here to avoid a
+// shellQuoteContainer wraps s in single quotes for shell-safe embedding. It is
+// a local copy of internal/session.shellQuote — duplicated here to avoid a
 // circular dependency (internal/session imports internal/container). When the
 // helpers are unified during a future refactor the two should converge.
-func shellQuotePodman(s string) string {
+func shellQuoteContainer(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // commonHostAPISidecarFlags returns the SidecarFlags shared by bwrap,
-// sandbox-exec, and host. All three modes set up a host-API socket and harness
-// but do not own a container lifecycle, so --container is intentionally
-// omitted. Mirrors the pre-refactor branch in StartSidecarWithOpts
+// sandbox-exec, and host. All three modes set up a host-API socket and
+// harness. Mirrors the pre-refactor branch in StartSidecarWithOpts
 // (internal/session/sidecar.go:336-352).
 func commonHostAPISidecarFlags(opts SidecarFlagOpts) []string {
 	out := []string{"--port", fmt.Sprintf("%d", opts.Port)}

--- a/modules/programs/prism/prism/internal/container/env.go
+++ b/modules/programs/prism/prism/internal/container/env.go
@@ -5,8 +5,8 @@ import (
 )
 
 // EnvAppender appends a single environment variable (key, value) to args in
-// the isolator's native syntax and returns the extended slice. Podman uses
-// "--env", "K=V"; bwrap uses "--setenv", "K", "V".
+// the isolator's native syntax and returns the extended slice. Bwrap uses
+// "--setenv", "K", "V".
 type EnvAppender func(args []string, k, v string) []string
 
 // AppendStandardEnv appends the per-session environment variables derived
@@ -58,7 +58,7 @@ func AppendStandardEnv(args []string, cfg Config, appender EnvAppender) []string
 // canonical paths inside the sandbox).
 //
 // This is used by the sandbox-exec dispatch path in cmd/agent_run.go where
-// the env is a plain K=V slice (not a bwrap or podman argument list).
+// the env is a plain K=V slice (not a bwrap-style argument list).
 func AppendSandboxEnvVarsKV(env []string, cfg Config) []string {
 	sandboxMountedByDefault := map[string]bool{
 		"KUBECONFIG":      true,

--- a/modules/programs/prism/prism/internal/container/host.go
+++ b/modules/programs/prism/prism/internal/container/host.go
@@ -1,4 +1,5 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines hostIsolator, a no-op implementation of the Isolator
 // interface for IsolationHost ("host") mode, where the agent runs directly in
 // the tmux pane with no sandbox layer.

--- a/modules/programs/prism/prism/internal/container/isolator.go
+++ b/modules/programs/prism/prism/internal/container/isolator.go
@@ -1,4 +1,5 @@
-// Package container manages the agent session container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines the Isolator interface, which is the seam between the
 // Manager and the underlying isolation mechanism. Implementations are
 // bwrapIsolator (Linux), sandboxExecIsolator (Darwin), and hostIsolator.
@@ -18,12 +19,13 @@ import (
 // Each flag is cited with the call sites that would collapse to a capability
 // query after the per-phase migrations in A.1's §7.
 type Capabilities struct {
-	// IsContainer is always false now that podman isolation is removed.
+	// IsContainer is always false now that container isolation is removed
+	// (no current mode runs the agent in a separate container).
 	// Retained for call-site compatibility; callers checking IsContainer
 	// will consistently receive false.
 	IsContainer bool
 
-	// OwnsContainerLifecycle is always false now that podman isolation is
+	// OwnsContainerLifecycle is always false now that container isolation is
 	// removed. Retained for call-site compatibility; the sidecar's container
 	// startup branch will never fire.
 	OwnsContainerLifecycle bool
@@ -57,13 +59,13 @@ type Capabilities struct {
 	NeedsStartupConnectTimeout bool
 
 	// NeedsReadinessWait means the agent-pane command should be prefixed by
-	// the readiness-wait shell command. Always false now that podman is removed.
-	// Retained for call-site compatibility.
+	// the readiness-wait shell command. Always false now that container
+	// isolation is removed. Retained for call-site compatibility.
 	NeedsReadinessWait bool
 
 	// EmitsTmuxStatusColumns means the tmux event hooks should seed
 	// isolation-specific status columns for sessions in this mode. Always
-	// false now that podman is removed.
+	// false now that container isolation is removed.
 	// Retained for call-site compatibility.
 	EmitsTmuxStatusColumns bool
 }
@@ -93,9 +95,8 @@ type Isolator interface {
 	Capabilities() Capabilities
 
 	// BuildRunArgs returns the complete argument list for launching the isolated
-	// session process (e.g. all arguments after the "podman" binary for a
-	// podman run invocation). The returned slice must not be modified by the
-	// caller.
+	// session process (all arguments after the launcher binary). The returned
+	// slice must not be modified by the caller.
 	BuildRunArgs() []string
 
 	// Run launches the isolated process with the given argument list, using the
@@ -128,18 +129,16 @@ type Isolator interface {
 	// Returns nil for "yes" or a wrapped, user-facing error describing the
 	// missing prerequisite. For platform-only checks (bwrap → Linux,
 	// sandbox-exec → Darwin) the error names the required platform.
-	// Cites: cmd/spawn.go:190-204 (checkBwrapPlatform / checkSandboxExecPlatform);
-	//        internal/container/container.go:1315 (CheckAvailability for podman).
+	// Cites: cmd/spawn.go:190-204 (checkBwrapPlatform / checkSandboxExecPlatform).
 	Available() error
 
 	// Cap returns the soft concurrency-cap descriptor for this isolator.
-	// It is the unified replacement for cmd/concurrency.go's parallel
-	// checkConcurrencyCap (podman), checkBwrapConcurrencyCap (bwrap), and
-	// checkSandboxExecConcurrencyCap (sandbox-exec) functions.
+	// It is the unified replacement for the old per-mode concurrency-cap
+	// helpers that used to live in cmd/concurrency.go.
 	//
 	// dbPath is the path to prism.db; the implementation uses it to count
-	// active sessions of this isolation mode, may merge with a live process
-	// probe (podman), or may ignore it entirely (host: uncapped).
+	// active sessions of this isolation mode, or may ignore it entirely
+	// (host: uncapped).
 	//
 	// The returned CapStatus carries the count, limit, exceeded flag, the
 	// in-flight session list (for inclusion in the user-facing message), and
@@ -152,7 +151,7 @@ type Isolator interface {
 	// Implementations must NOT have side effects: Cap is called speculatively
 	// before any worktree, DB row, or tmux session is created.
 	//
-	// Cites: cmd/concurrency.go (podman, bwrap, sandbox-exec per-mode helpers).
+	// Cites: cmd/concurrency.go (per-mode helpers, since unified).
 	Cap(ctx context.Context, dbPath string) CapStatus
 
 	// WriteHarnessConfigBlob writes the harness configuration blob (the
@@ -169,7 +168,6 @@ type Isolator interface {
 
 	// AgentPaneCmd returns the shell command string emitted into the tmux
 	// agent pane for this session.
-	//   - podman:                "podman attach --sig-proxy=false <container>"
 	//   - bwrap, sandbox-exec:   "prism agent-run --session <session>"
 	//   - host:                  the DirectCmd supplied by the caller
 	// Cites: internal/session/session.go:265-298 (BuildOpencodeCmd switch).
@@ -187,8 +185,7 @@ type Isolator interface {
 	// archive copy step consumes. home is the value of os.UserHomeDir(); it
 	// is passed in rather than resolved here so callers can inject a temp
 	// directory under test. sessionName is the prism session name (used
-	// to derive the per-container storage path on podman and the agent-run
-	// log path on bwrap / sandbox-exec).
+	// to derive the agent-run log path on bwrap / sandbox-exec).
 	//
 	// Stopgap pending #1142 (B6.IF — ArchiveAdapter interface): once that
 	// lands, the archive-side dispatch moves to ArchiveAdapter and this
@@ -225,8 +222,8 @@ type Isolator interface {
 
 	// WriteGitconfig generates a minimal .gitconfig for this isolator's
 	// sandbox layout and writes it to the per-session temp path. The
-	// in-sandbox $HOME differs per mode — podman runs as root (/root),
-	// bwrap/sandbox-exec run as the host user — so each isolator picks
+	// in-sandbox $HOME differs per mode — bwrap runs as the host user,
+	// sandbox-exec uses a per-session staging HOME — so each isolator picks
 	// the correct $HOME prefix when emitting the signingKey and
 	// allowedSignersFile paths. Returns nil on success or a wrapped error.
 	// host: no-op (the agent reads the host gitconfig directly).
@@ -236,30 +233,29 @@ type Isolator interface {
 	WriteGitconfig(m *Manager) error
 
 	// Reset performs the heavier "wipe everything matching this mode"
-	// cleanup invoked by `prism reset`. For podman this is the existing
-	// `podman ps` / `podman rm -f prism-*` sweep. For bwrap, sandbox-exec,
+	// cleanup invoked by `prism reset`. For bwrap, sandbox-exec,
 	// and host the implementation is a no-op stub today; orphan-agent-run
 	// reaping is a future implementation. `prism reset` iterates over the
 	// registered isolators and calls Reset on each.
-	// Cites: cmd/reset.go:126 (resetRemovePodmanContainers).
+	// Cites: cmd/reset.go (runReset's per-isolator sweep).
 	Reset(ctx context.Context) error
 
 	// Prepare materialises any per-session temp files (SSH config,
 	// gitconfig, harness config, sandbox staging HOME, SBPL profile) that
 	// the sandbox needs at start time and returns the complete argument
 	// list for the sandbox launcher. Bwrap returns the bwrap argv;
-	// sandbox-exec returns the sandbox-exec argv. Podman/host return nil
-	// args and a non-nil error — they do not use this dispatch path
-	// (podman uses Create; host runs the agent directly in the tmux pane).
+	// sandbox-exec returns the sandbox-exec argv. Host returns nil
+	// args and a non-nil error — it does not use this dispatch path
+	// (host runs the agent directly in the tmux pane).
 	// Cites: internal/container/container.go:581 (Manager.PrepareBwrap);
 	//        internal/container/container.go:637 (Manager.PrepareSandboxExec).
 	Prepare(ctx context.Context, m *Manager) ([]string, error)
 
 	// Create starts a new isolated session: writes any pre-launch temp
 	// files, builds the launcher arg list, and runs it under the supplied
-	// context. Today only podman implements a non-stub body — bwrap and
+	// context. No current isolator implements a non-stub body — bwrap and
 	// sandbox-exec use Prepare + cmd/agent-run, and host runs the agent
-	// directly in the tmux pane. Non-podman implementations return nil
+	// directly in the tmux pane. Implementations return nil
 	// (host) or an error noting that Create is not the right entry point
 	// for that mode (bwrap, sandbox-exec).
 	// Cites: internal/container/lifecycle.go:79 (Manager.Create body).

--- a/modules/programs/prism/prism/internal/container/lifecycle.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle.go
@@ -42,15 +42,12 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 		_ = os.RemoveAll(stagingHome)
 	}
 
-	// Per-mode lifecycle cleanup (podman stop/rm for the podman isolator;
-	// no-op for the others) lives on the registered Isolator. See
+	// Per-mode lifecycle cleanup lives on the registered Isolator. See
 	// lifecycle_dispatch.go (issue #1140 A1.L1).
 	m.isolator.EnsureRemoved(ctx, m)
 }
 
-// Create creates and starts the podman container for this session.
-// It first calls EnsureRemoved to handle any stale container with the same name.
-// Returns an error if podman create or start fails.
+// Create dispatches session creation to the registered Isolator.
 //
 // Post A1.L5 (issue #1140): the per-mode session-start logic moved into the
 // registered Isolator's Create method. Manager.Create is a thin dispatcher.
@@ -106,9 +103,8 @@ func (m *Manager) WaitHealthy(ctx context.Context) error {
 	}
 }
 
-// dumpLogs writes the container's stdout/stderr to the sidecar log so that
-// startup failures are visible without needing to race `podman logs` before
-// the container is removed by Shutdown.
+// dumpLogs writes the sandboxed process's stdout/stderr to the sidecar log so
+// that startup failures are visible without racing the cleanup path.
 func (m *Manager) dumpLogs() {
 	m.isolator.DumpLogs()
 }
@@ -133,9 +129,9 @@ func (m *Manager) isHealthy(ctx context.Context) bool {
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
-// Shutdown stops and removes the container. Intended to be called on SIGTERM.
-// It delegates the podman stop/rm calls to the Isolator and then cleans up
-// the temp files created by Create.
+// Shutdown stops and removes the sandboxed process. Intended to be called on
+// SIGTERM. It delegates the per-mode teardown to the Isolator and then cleans
+// up the temp files created by Create.
 func (m *Manager) Shutdown() {
 	log.Printf("container: shutting down %q", m.name)
 

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -1,19 +1,20 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file extends the Isolator interface with the lifecycle dispatch methods
 // migrated from the per-mode branches in container.go, lifecycle.go, cmd/cleanup.go,
 // cmd/reset.go, and cmd/agent_run.go (issue #1140, A1.L1-L6).
 //
 // Methods added by this file:
 //
-//   - EnsureRemoved()   — L1: replaces Manager.EnsureRemoved + cleanup.go's open-coded podman stop/rm.
+//   - EnsureRemoved()   — L1: replaces Manager.EnsureRemoved + cleanup.go's open-coded teardown.
 //   - WriteGitconfig()  — L2: replaces (*Manager).writeGitconfig(mode) per-mode switch.
-//   - Reset()           — L3: replaces resetRemovePodmanContainers in cmd/reset.go.
+//   - Reset()           — L3: replaces the old container sweep in cmd/reset.go.
 //   - Prepare()         — L4: replaces Manager.PrepareBwrap / Manager.PrepareSandboxExec.
 //   - Create()          — L5: replaces Manager.Create body.
 //   - AgentRun()        — L6: replaces cmd/agent_run.go's per-mode dispatch switch.
 //
 // The methods are declared on the interface in isolator.go and implemented per
-// isolator (podman, bwrap, sandbox-exec, host) below.
+// isolator (bwrap, sandbox-exec, host) below.
 package container
 
 import (
@@ -45,7 +46,7 @@ type AgentRunOpts struct {
 
 	// StartTime is the wall-clock entry time captured by the cmd
 	// dispatcher. Handlers use it to emit `[timing]` markers symmetric to
-	// the podman path's sidecar-side instrumentation. Zero means "not
+	// the sidecar-side instrumentation. Zero means "not
 	// captured" — handlers fall back to time.Now() in that case.
 	StartTime time.Time
 
@@ -96,7 +97,7 @@ func lookupAgentRunHandler(mode config.IsolationMode) AgentRunHandler {
 // Bwrap sessions do not own a container lifecycle — there is nothing to stop
 // or rm — so this method is a temp-file unlink only. Mirrors the per-session
 // list in cmd/cleanup.go:1055-1059 (the legacy 5-file cleanup; the
-// harness-config file is intentionally excluded — see podmanIsolator.EnsureRemoved
+// harness-config file is intentionally excluded — see cleanupLegacyTempFiles
 // for the rationale).
 func (b *bwrapIsolator) EnsureRemoved(ctx context.Context, m *Manager) {
 	cleanupLegacyTempFiles(b.name)
@@ -302,8 +303,8 @@ func (h *hostIsolator) AgentRun(ctx context.Context, opts AgentRunOpts) error {
 // The harness-config, Claude credentials, and sandbox-exec staging files
 // are deliberately NOT cleaned here: those are owned by the Manager-level
 // lifecycle (Manager.EnsureRemoved retains the full cleanup list). Tests
-// that exercise the cleanup.go shortcut path
-// (TestRestoreSession_PodmanMode_TempFileWritten) rely on the
+// that exercise the cleanup.go shortcut path (see cmd/restore_test.go's
+// legacy-mode coverage) rely on the
 // harness-config file surviving this cleanup.
 func cleanupLegacyTempFiles(name string) {
 	_ = os.Remove(sessionTempPath("gitdir", "", name))

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -1,6 +1,7 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines the shared MountSpec shape and StandardSandboxMounts walk
-// used by the podman and bwrap mount-emission paths (issue #1149 A2.M1; design
+// used by the sandbox mount-emission paths (issue #1149 A2.M1; design
 // proposal A2 §3.1, §3.S6).
 //
 // The common decision tree — "which host artefact lives at which canonical
@@ -8,11 +9,9 @@
 // expressed once here, mode-agnostic. Each isolator walks the slice and
 // translates the entries into its own argument grammar via per-mode appenders:
 //
-//   - podmanIsolator.appendVolume(args, spec)        → "--volume SRC:DST[:Z][:ro]"
-//   - bwrapIsolator.appendBind(args, spec)           → "--ro-bind|--bind SRC DST"
-//   - sandboxExecIsolator.appendAllow(profile, spec) → "(subpath \"...\")" in SBPL
+//   - AppendBwrapBind(args, spec) → "--ro-bind|--bind SRC DST"
 //
-// Today only the podman and bwrap appenders are wired through the slice; the
+// Today only the bwrap appender is wired through the slice; the
 // sandbox-exec staging HOME is built via collectStagingHomeSymlinkTargets in
 // sandbox_exec_home.go, which serves the same purpose with a different
 // implementation strategy (sandbox-exec has no bind-mount mechanism, so the
@@ -29,9 +28,9 @@ import (
 // sandbox interior at a canonical path. It is mode-agnostic — each isolator
 // emits the syntax it needs via its own appender.
 //
-// The SandboxPath is the path the agent inside the sandbox sees. For podman,
-// HOME-relative paths are rooted at /root/...; for bwrap and sandbox-exec
-// they are rooted at the host user's $HOME (or staging HOME for sandbox-exec).
+// The SandboxPath is the path the agent inside the sandbox sees. For bwrap
+// and sandbox-exec, HOME-relative paths are rooted at the host user's $HOME
+// (or staging HOME for sandbox-exec).
 // StandardSandboxMounts computes the SandboxPath using the sandboxHomeDir
 // argument the caller provides, so the per-mode HOME prefix is captured at
 // the call site rather than baked into MountSpec.
@@ -45,8 +44,8 @@ type MountSpec struct {
 	// the sandbox. May or may not equal HostPath depending on the mode.
 	SandboxPath string
 
-	// ReadOnly mounts the artefact read-only when true. Podman emits ":ro";
-	// bwrap emits "--ro-bind"; sandbox-exec emits the file-read* allow rule
+	// ReadOnly mounts the artefact read-only when true. Bwrap emits
+	// "--ro-bind"; sandbox-exec emits the file-read* allow rule
 	// without file-write*.
 	ReadOnly bool
 
@@ -65,10 +64,9 @@ type MountSpec struct {
 	// failure already implies "missing").
 	OptionalIfMissing bool
 
-	// SELinuxRelabel adds the ":Z" label suffix on podman so that the
-	// container can read/write the bind-mounted directory on
-	// SELinux-enforcing hosts (Fedora, RHEL). Ignored by bwrap and
-	// sandbox-exec — neither participates in SELinux labelling.
+	// SELinuxRelabel marked the mount for an SELinux ":Z" relabel in the
+	// removed container path. Ignored by bwrap and sandbox-exec — neither
+	// participates in SELinux labelling. Retained for shape compatibility.
 	SELinuxRelabel bool
 }
 
@@ -107,9 +105,9 @@ func resolveMountHostPath(spec MountSpec) (string, bool) {
 // configuration, mode-agnostic. Each isolator walks the slice and emits
 // per-mode syntax via its own appender.
 //
-// sandboxHomeDir is the in-sandbox $HOME path (e.g. "/root" for podman or the
-// host user's home directory for bwrap). It is used as the prefix for every
-// HOME-relative SandboxPath in the returned slice.
+// sandboxHomeDir is the in-sandbox $HOME path (the host user's home
+// directory for bwrap, or the staging HOME for sandbox-exec). It is used as
+// the prefix for every HOME-relative SandboxPath in the returned slice.
 //
 // hostHome is the absolute host home directory (the source of HOME-relative
 // host artefacts). When empty, host-relative entries fall back to
@@ -146,9 +144,8 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 	// (issue #1558) and by listing .aws/sso and .aws/cli as writable in
 	// collectStagingHomeSymlinkTargets.
 	//
-	// Note: podman support was removed in #1327. This slice is only walked by
-	// bwrap (appendBwrapBind). The mode parameter is retained for potential
-	// future per-mode divergences.
+	// Note: this slice is only walked by bwrap (AppendBwrapBind). The mode
+	// parameter is retained for potential future per-mode divergences.
 	awsSSOReadOnly := false
 	awsCLIReadOnly := false
 	_ = mode // mode is retained for future per-mode mount tweaks
@@ -222,8 +219,8 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 
 		// ── AWS SSO cache (conditional, per-mode RO) ────────────────────
 		// Always written to ~/.aws/sso by the AWS CLI (regardless of
-		// AWS_CONFIG_FILE). Mounted at $HOME/.aws/sso. RO on podman
-		// (rationale: see awsSSOReadOnly above), RW on bwrap.
+		// AWS_CONFIG_FILE). Mounted at $HOME/.aws/sso. RW on bwrap
+		// (rationale: see awsSSOReadOnly above).
 		{
 			HostPath:          filepath.Join(hostHome, ".aws", "sso"),
 			SandboxPath:       filepath.Join(sandboxHomeDir, ".aws", "sso"),
@@ -285,38 +282,6 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 	return specs
 }
 
-// appendPodmanVolume appends a podman --volume argument pair for the given
-// MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
-// resolveMountHostPath and emits "--volume SRC:DST[:Z][:ro]" when the mount
-// should be active. Returns args unchanged when the mount is skipped.
-//
-// Podman has a subtle file-vs-directory distinction for SELinux-relabelled
-// mounts: directory mounts that the container should be able to populate use
-// "--mount type=bind,...", but for the canonical-name remap pattern used by
-// StandardSandboxMounts (where DST is created lazily by podman), --volume
-// SRC:DST[:Z][:ro] works for both files and directories. The existing
-// container.go always used --volume for these, so we keep that.
-//
-// Free function (not a method on podmanIsolator) because the emitter is
-// stateless and the podman mount block is exercised by tests that build a
-// Manager with a non-podman isolator, then call buildRunArgs directly. A
-// free function lets those tests continue to work without an awkward
-// type-cast or fresh-isolator instantiation.
-func appendPodmanVolume(args []string, spec MountSpec) []string {
-	src, ok := resolveMountHostPath(spec)
-	if !ok {
-		return args
-	}
-	flags := ""
-	if spec.SELinuxRelabel {
-		flags += ":Z"
-	}
-	if spec.ReadOnly {
-		flags += ":ro"
-	}
-	return append(args, "--volume", src+":"+spec.SandboxPath+flags)
-}
-
 // AppendBwrapBind appends a bwrap --ro-bind or --bind argument triple for the
 // given MountSpec. It applies the EvalSymlinks / OptionalIfMissing rules via
 // resolveMountHostPath and emits the correct flag based on spec.ReadOnly.
@@ -324,7 +289,7 @@ func appendPodmanVolume(args []string, spec MountSpec) []string {
 // Returns args unchanged when the mount is skipped.
 //
 // Free function (not a method on bwrapIsolator) — the emitter is stateless
-// and a free function is symmetric with appendPodmanVolume above.
+// and does not need access to isolator state.
 func AppendBwrapBind(args []string, spec MountSpec) []string {
 	src, ok := resolveMountHostPath(spec)
 	if !ok {

--- a/modules/programs/prism/prism/internal/container/registry.go
+++ b/modules/programs/prism/prism/internal/container/registry.go
@@ -1,4 +1,5 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines IsolationRegistry — a name→constructor map populated at
 // init() time by each isolator file — and the Resolve helper that centralises
 // the back-compat resolution logic that is currently scattered across multiple
@@ -18,8 +19,8 @@ import (
 )
 
 // ConstructorOpts carries the per-session parameters passed to an isolator
-// constructor. Name is the stable session identifier (the container name for
-// podman, or the raw session name for the other modes).
+// constructor. Name is the stable session identifier (the raw session name
+// for every current mode).
 type ConstructorOpts struct {
 	Name string
 }

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -1,4 +1,5 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines sandboxExecIsolator, an Apple sandbox-exec-based
 // implementation of the Isolator interface. It is symmetric to bwrapIsolator
 // in bwrap.go: BuildRunArgs() is a no-op stub, BuildArgs(m *Manager) is the

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -471,8 +471,8 @@ func (m *Manager) writeSshConfigToDir(stagingHome string) error {
 
 // writeGitconfigToDir generates a .gitconfig and (when signing is available)
 // allowed_signers for the sandbox-exec staging HOME. It is a thin wrapper
-// around writeGitconfig(isolationSandboxExec) — the canonical helper used
-// by podman and bwrap — and then materialises the resulting temp files into
+// around writeGitconfig(isolationSandboxExec) — the canonical helper also
+// used by bwrap — and then materialises the resulting temp files into
 // the staging HOME at the canonical paths the agent expects:
 //
 //	<stagingHome>/.gitconfig

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -1838,8 +1838,8 @@ func TestSandboxExecCleanup_RemovesStagingHome(t *testing.T) {
 		t.Fatalf("staging HOME not created: %v", statErr)
 	}
 
-	// Call EnsureRemoved (uses a background context; no podman calls needed
-	// because sandboxExecIsolator.Shutdown is a no-op).
+	// Call EnsureRemoved (uses a background context;
+	// sandboxExecIsolator.Shutdown is a no-op).
 	m.EnsureRemoved(context.Background())
 
 	// Staging HOME must be gone.

--- a/modules/programs/prism/prism/internal/container/shutdown.go
+++ b/modules/programs/prism/prism/internal/container/shutdown.go
@@ -1,18 +1,15 @@
-// Package container manages the podman container lifecycle for prism sidecar.
+// Package container manages sandbox lifecycle and mount preparation for
+// prism agent sessions.
 // This file defines the shared gracefulShutdown helper used by the bwrap and
 // sandbox-exec Isolator.Shutdown implementations (issue #1149 A2.GR; design
 // proposal A2 §3.7).
 //
 // Both bwrap and sandbox-exec sessions are supervised children rather than
-// long-lived container resources (only podman owns a container that survives
-// process death). When Manager.Shutdown is invoked on a bwrap or sandbox-exec
+// long-lived container resources. When Manager.Shutdown is invoked on a bwrap
+// or sandbox-exec
 // session, the polite teardown shape is the same: SIGTERM → grace period →
 // SIGKILL. Pre-A2.GR this body lived inline inside bwrapIsolator.Shutdown;
 // sandboxExecIsolator.Shutdown was a no-op.
-//
-// Podman's Shutdown stays separate (must-differ per A2 §3.7) because the
-// container's lifecycle is driven by `podman stop --time 10` followed by
-// `podman rm --force`, not by direct signal delivery.
 package container
 
 import (

--- a/modules/programs/prism/prism/internal/db/compare.go
+++ b/modules/programs/prism/prism/internal/db/compare.go
@@ -59,7 +59,7 @@ type CompareInputs struct {
 	// session ran under should read IsolationMode instead. Issue #2105.
 	IsolationFlag *string `json:"isolation_flag"`
 	// IsolationMode is the resolved effective isolation mode the session
-	// actually ran under (podman/bwrap/sandbox-exec/host), captured at
+	// actually ran under (bwrap/sandbox-exec/host), captured at
 	// spawn time post profile/config/Nix-default resolution. Always
 	// populated for sessions spawned post-#2105; nil only on pre-#2105 rows
 	// (the renderer falls back to IsolationFlag for those).

--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -213,7 +213,7 @@ CREATE TABLE IF NOT EXISTS spawn_inputs (
     ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
 
     -- Resolved effective isolation mode the session actually ran under
-    -- (podman/bwrap/sandbox-exec/host), captured at spawn time post profile/
+    -- (bwrap/sandbox-exec/host), captured at spawn time post profile/
     -- config/Nix-default resolution. Added in #2105 so stats compare surfaces
     -- a meaningful value even when --isolation was omitted. NULLABLE for
     -- back-compat with pre-#2105 rows; new rows are always populated by the
@@ -2118,7 +2118,7 @@ type SpawnInputs struct {
 	// session ran under should consult IsolationMode (below) instead.
 	IsolationFlag *string
 	// IsolationMode is the resolved effective isolation mode the session
-	// actually ran under ("podman", "bwrap", "sandbox-exec", "host"),
+	// actually ran under ("bwrap", "sandbox-exec", "host"),
 	// captured at spawn time after profile / config / Nix-default
 	// resolution. Always populated by the centralised writer post-#2105 so
 	// the `prism stats compare` Spawn Inputs block can surface it. nil only

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -4627,7 +4627,7 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 		{"nixos-config@fix-tmux~review-4~review~review-1~review", 0, noEnded, true},
 		// Bare review suffix with no role (listed first in issue #826 example output):
 		// matched by %~review-%-review
-		{"nixos-config@fix-tmux-podman-keybinds~review-1-review", 0, noEnded, true},
+		{"nixos-config@fix-tmux-keybinds~review-1-review", 0, noEnded, true},
 
 		// *** MUST NOT be matched: current valid shape <parent>~review-<N>-review-<role> ***
 		// These end in "-<role>" (non-empty after "-review-"), so the third LIKE
@@ -5456,7 +5456,7 @@ func TestMigration_V12ToV13_PostMigrationQueryReturnsZero(t *testing.T) {
 		{"nixos-config@fix-tmux~review-1~review", 0, noEnded},
 		{"nixos-config@fix-tmux~review-3~review", 0, noEnded},
 		// Bare review suffix (no role) — first example in issue #826.
-		{"nixos-config@fix-tmux-podman-keybinds~review-1-review", 0, noEnded},
+		{"nixos-config@fix-tmux-keybinds~review-1-review", 0, noEnded},
 		// A current valid shape — should NOT be counted by this query.
 		{"nixos-config@fix-tmux~review-2-review-code", 0, noEnded},
 	}
@@ -7757,12 +7757,12 @@ func TestActiveSessionCountForMode_OnlyMatchingMode(t *testing.T) {
 		t.Fatalf("SetIsolationMode bwrap: %v", err)
 	}
 
-	// Insert a podman session (should not be counted for sandbox-exec).
-	if err := d.UpsertStatus("repo@podman1", "repo", "/code/repo/podman1", "active", nil, nil); err != nil {
-		t.Fatalf("UpsertStatus podman: %v", err)
+	// Insert a host session (should not be counted for sandbox-exec).
+	if err := d.UpsertStatus("repo@host1", "repo", "/code/repo/host1", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus host: %v", err)
 	}
-	if err := d.SetIsolationMode("repo@podman1", "podman"); err != nil {
-		t.Fatalf("SetIsolationMode podman: %v", err)
+	if err := d.SetIsolationMode("repo@host1", "host"); err != nil {
+		t.Fatalf("SetIsolationMode host: %v", err)
 	}
 
 	count, err := d.ActiveSessionCountForMode("sandbox-exec")

--- a/modules/programs/prism/prism/internal/db/hot_path_indexes_test.go
+++ b/modules/programs/prism/prism/internal/db/hot_path_indexes_test.go
@@ -147,7 +147,7 @@ func TestHotPathIndexes_QueryPlanUsesIndex(t *testing.T) {
 			}
 		}
 		// Set isolation_mode round-robin across 5 modes.
-		modes := []string{"podman", "bwrap", "host", "sandbox-exec", "none"}
+		modes := []string{"legacy-mode", "bwrap", "host", "sandbox-exec", "none"}
 		if err := d.SetIsolationMode(sessionName, modes[i%len(modes)]); err != nil {
 			t.Fatalf("SetIsolationMode[%d]: %v", i, err)
 		}
@@ -209,7 +209,7 @@ func TestHotPathIndexes_QueryPlanUsesIndex(t *testing.T) {
 		{
 			name:      "ActiveSessionCountForMode",
 			query:     `SELECT COUNT(*) FROM agent_status WHERE ended_at IS NULL AND isolation_mode = ?`,
-			args:      []any{"podman"},
+			args:      []any{"bwrap"},
 			wantIndex: "idx_agent_status_active",
 		},
 	}

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -803,7 +803,7 @@ func (d *DB) ReleasePort(sessionName string) error {
 }
 
 // SetIsolationMode records the resolved isolation mode for the given session.
-// mode is one of "podman", "bwrap", or "host". This is persisted so that
+// mode is one of "bwrap", "sandbox-exec", or "host". This is persisted so that
 // prism restore can re-spawn the session in the same isolation mode.
 // It is a no-op when no row exists for sessionName (returns nil).
 func (d *DB) SetIsolationMode(sessionName, mode string) error {

--- a/modules/programs/prism/prism/internal/db/types.go
+++ b/modules/programs/prism/prism/internal/db/types.go
@@ -29,7 +29,7 @@ type Status struct {
 	ModelID          *string
 	RootAgentName    *string
 	RootModelID      *string
-	IsolationMode    string // "podman", "bwrap", or "host"; "" means not recorded (back-compat)
+	IsolationMode    string // "bwrap", "sandbox-exec", or "host"; "" means not recorded (back-compat); legacy rows may carry other values
 	InstanceID       *string
 	LastSeen         time.Time
 	EndedAt          *time.Time

--- a/modules/programs/prism/prism/internal/harness/archive/archive.go
+++ b/modules/programs/prism/prism/internal/harness/archive/archive.go
@@ -24,7 +24,8 @@ type SourceParams struct {
 	// (e.g. pi's ses_<ULID>, from sessions.harness_session_id).
 	// May be empty when the harness failed to start.
 	HarnessSessionID string
-	// IsolationMode is "podman", "bwrap", "sandbox-exec", or "host".
+	// IsolationMode is "bwrap", "sandbox-exec", or "host" (see
+	// config.ValidIsolationModes).
 	IsolationMode string
 	// Worktree is the absolute path of the session's worktree (e.g.
 	// "/home/ben/code/nixos-config/feature"). Used by harnesses that

--- a/modules/programs/prism/prism/internal/harness/harness.go
+++ b/modules/programs/prism/prism/internal/harness/harness.go
@@ -81,7 +81,7 @@ type Harness interface {
 	// ConfigEnvVar returns the environment variable name this harness uses
 	// to receive its serialised config content (e.g. "OPENCODE_CONFIG_CONTENT"
 	// for opencode-compat harnesses — empty for pi). The returned name is used in both host-mode (inline
-	// shell env-var prefix) and container-mode (podman --env) session
+	// shell env-var prefix) and container-mode (sandbox env injection) session
 	// creation to inject config overrides into the agent runtime.
 	ConfigEnvVar() string
 

--- a/modules/programs/prism/prism/internal/harness/pi/archive.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive.go
@@ -160,9 +160,9 @@ func (a *piArchiveAdapter) SourcePath(p harnessarchive.SourceParams) (string, er
 // which pi creates one subdirectory per encoded CWD. The two distinct branches
 // are:
 //
-//	host / bwrap / podman / "" → $PI_CODING_AGENT_DIR/sessions when the env var
-//	                              is set; else <home>/.pi/agent/sessions
-//	sandbox-exec               → <stagingHome>/.pi/agent/sessions
+//	host / bwrap / "" → $PI_CODING_AGENT_DIR/sessions when the env var
+//	                     is set; else <home>/.pi/agent/sessions
+//	sandbox-exec      → <stagingHome>/.pi/agent/sessions
 //
 // PI_CODING_AGENT_DIR mirrors pi's own ENV_AGENT_DIR honouring (pi reads it
 // as the agent data root at startup; see pi 0.79 dist/core/session-manager.js
@@ -197,7 +197,7 @@ func piSessionsRoot(p harnessarchive.SourceParams) (string, error) {
 		return filepath.Join(stagingHome, ".pi", "agent", "sessions"), nil
 
 	default:
-		// host, bwrap, podman, empty IsolationMode — all resolve to the
+		// host, bwrap, empty, or unknown IsolationMode — all resolve to the
 		// host PI data root: $PI_CODING_AGENT_DIR/sessions when set,
 		// else <home>/.pi/agent/sessions.
 		return hostPISessionsRoot()

--- a/modules/programs/prism/prism/internal/harness/pi/archive_test.go
+++ b/modules/programs/prism/prism/internal/harness/pi/archive_test.go
@@ -482,7 +482,8 @@ func TestArchiveAdapter_SourcePath_SandboxExec_EmptyInstanceID(t *testing.T) {
 }
 
 // TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome verifies that
-// non-sandbox-exec, non-bwrap isolation modes (podman, host, "") use the real
+// non-sandbox-exec isolation modes (host, "", and an unknown legacy value,
+// which exercises the defensive default branch) use the real
 // home directory for the sessions root WHEN PI_CODING_AGENT_DIR is unset.
 // The bwrap branch is covered separately by TestArchiveAdapter_SourcePath_Bwrap*
 // below.
@@ -496,7 +497,7 @@ func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesRealHome(t *testing.T) {
 	const sessionID = "pi-ses-xyz-nonse"
 	const worktree = "/tmp/test-non-sandbox"
 
-	for _, mode := range []string{"podman", "host", ""} {
+	for _, mode := range []string{"unknown-legacy-mode", "host", ""} {
 		t.Run("mode="+mode, func(t *testing.T) {
 			a := pi.NewArchiveAdapter()
 			p := harnessarchive.SourceParams{
@@ -531,7 +532,7 @@ func TestArchiveAdapter_SourcePath_NonSandboxExec_UsesPICodingAgentDir(t *testin
 	const sessionID = "pi-ses-env-mode"
 	const worktree = "/tmp/test-env-mode"
 
-	for _, mode := range []string{"podman", "host", "bwrap", ""} {
+	for _, mode := range []string{"unknown-legacy-mode", "host", "bwrap", ""} {
 		t.Run("mode="+mode, func(t *testing.T) {
 			a := pi.NewArchiveAdapter()
 			p := harnessarchive.SourceParams{

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
@@ -105,7 +105,7 @@ func requireNixBash(t *testing.T) string {
 // that read symlink targets under HOME) should use
 // newProfileManagerWithBareRoot.
 //
-// Note: container.New() initialises the Manager with a podmanIsolator by
+// Note: container.New() initialises the Manager with a hostIsolator by
 // default, but Manager.PrepareSandboxExec() creates its own
 // sandboxExecIsolator internally, so no isolator override is needed.
 func newProfileManager(t *testing.T) *container.Manager {

--- a/modules/programs/prism/prism/internal/review/review.go
+++ b/modules/programs/prism/prism/internal/review/review.go
@@ -24,7 +24,7 @@
 //
 // Each per-agent session.SpawnSession call only returns "the tmux session was
 // created and the sidecar process was kicked off" — the agent itself runs
-// inside the bwrap/podman/host process the tmux pane launches, several steps
+// inside the sandbox or host process the tmux pane launches, several steps
 // further along, and may take seconds to bind its TCP port (≈8.5s observed
 // in the worst healthy case captured in #1051) or never bind at all if
 // startup fails silently. The spawn loop therefore runs a per-agent
@@ -286,7 +286,8 @@ type Opts struct {
 	// minimal fallback prompt is used instead.
 	PRCtx *PRContext
 	// IsolationMode is the resolved isolation mode to use when spawning review
-	// agent sessions. Valid values: "podman", "bwrap", "host". When set, it is
+	// agent sessions. Valid values: "bwrap", "sandbox-exec", "host" (see
+	// config.ValidIsolationModes). When set, it is
 	// forwarded to session.SpawnOpts.IsolationMode for every spawned agent.
 	// When empty, spawnAgentOnlyLayout resolves the machine default from
 	// cfg.DefaultIsolationMode rather than silently falling back to host.

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -1592,7 +1592,7 @@ func TestRun_ProgressCallback_SpawnFailure(t *testing.T) {
 		{Name: "review-goal"},
 	}
 
-	// podman mode with nil ProfilesFile: with the RequireSlot gate (#1224),
+	// bwrap mode with nil ProfilesFile: with the RequireSlot gate (#1224),
 	// this now triggers a fan-out abort before the spawn loop, so no per-agent
 	// progress lines are emitted and Run returns a global error immediately.
 	opts := review.Opts{
@@ -1602,7 +1602,7 @@ func TestRun_ProgressCallback_SpawnFailure(t *testing.T) {
 		Agents:        agents,
 		Timeout:       30 * time.Second,
 		DBPath:        dbPath,
-		IsolationMode: "podman",
+		IsolationMode: "bwrap",
 		ProfilesFile:  nil,
 	}
 

--- a/modules/programs/prism/prism/internal/review/run.go
+++ b/modules/programs/prism/prism/internal/review/run.go
@@ -143,7 +143,8 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// Resolve the per-agent config blob. Each agent gets its own hardened
 		// opencode.json that declares only that one review agent.
 		//
-		// In sandboxed mode (podman or bwrap) a missing or empty blob means the
+		// In sandboxed mode (bwrap or sandbox-exec) a missing or empty blob
+		// means the
 		// sandbox falls back to the host config (wrong agent identity).
 		// ResolveAgentConfigContent surfaces this as an explicit error to
 		// prevent silent wrong-agent spawns. activeProfile (resolved above)
@@ -184,8 +185,6 @@ func Run(ctx context.Context, opts Opts, onSessionsCreated func(sessionNames []s
 		// checks for file existence (os.Stat) rather than reading ConfigContent
 		// from the session state, so it must be written here at spawn time.
 		// This mirrors the pattern in cmd/spawn.go:386-394 for regular bwrap spawns.
-		// Podman mode does NOT need this write — the sidecar's Create() path
-		// already writes the file before the container starts.
 		// Both bwrap and sandbox-exec write the per-agent opencode.json via
 		// Isolator.WriteHarnessConfigBlob so the dispatch goes via the
 		// registered isolator instead of the package-level WriteOpencodeConfig

--- a/modules/programs/prism/prism/internal/review/spawn_opts.go
+++ b/modules/programs/prism/prism/internal/review/spawn_opts.go
@@ -110,8 +110,8 @@ func newReviewerSpawnOpts(in reviewerSpawnInput) session.SpawnOpts {
 	// `--agent review-<role> --prompt "..."` with `Unknown options`,
 	// leaving the review agent idle forever.
 	//
-	// bwrap / sandbox-exec / podman set PRISM_HARNESS_PIPE via their own
-	// paths (bwrap.go --setenv, sandbox-exec profile, podman --env); only
+	// bwrap / sandbox-exec set PRISM_HARNESS_PIPE via their own
+	// paths (bwrap.go --setenv, sandbox-exec profile); only
 	// inject here for host mode. Mirrors the same block in cmd/spawn.go,
 	// cmd/switch.go, cmd/restore.go, and cmd/investigate.go (issue #2114).
 	if hShape, hShapeOK := harness.ShapeOf(in.HarnessName); hShapeOK && hShape == harness.TransportSocketPipe && in.IsolationMode == "host" {

--- a/modules/programs/prism/prism/internal/review/spawn_opts_harness_pipe_test.go
+++ b/modules/programs/prism/prism/internal/review/spawn_opts_harness_pipe_test.go
@@ -21,7 +21,7 @@ package review_test
 //     proves the gate does real work — for container-mode review
 //     invokers HarnessPipeSockPath stays empty, so the existing
 //     container-mode injection paths (bwrap --setenv, sandbox-exec
-//     profile, podman --env) remain responsible for PRISM_HARNESS_PIPE.
+//     profile) remain responsible for PRISM_HARNESS_PIPE.
 //   - TestNewReviewerSpawnOpts_SandboxExecMode_LeavesHarnessPipeSockPathEmpty
 //     mirrors the bwrap negative for sandbox-exec, the second container
 //     mode that the review fan-out can resolve to on Darwin hosts.
@@ -132,7 +132,7 @@ func TestNewReviewerSpawnOpts_BwrapMode_LeavesHarnessPipeSockPathEmpty(t *testin
 	}
 
 	if opts.HarnessPipeSockPath != "" {
-		t.Errorf("SpawnOpts.HarnessPipeSockPath = %q, want \"\" for bwrap review fan-out — container-mode injection paths (bwrap --setenv, sandbox-exec profile, podman --env) own PRISM_HARNESS_PIPE for container sessions; pre-computing the sock path here would double-inject (issue #2114 AC).",
+		t.Errorf("SpawnOpts.HarnessPipeSockPath = %q, want \"\" for bwrap review fan-out — container-mode injection paths (bwrap --setenv, sandbox-exec profile) own PRISM_HARNESS_PIPE for container sessions; pre-computing the sock path here would double-inject (issue #2114 AC).",
 			opts.HarnessPipeSockPath)
 	}
 }

--- a/modules/programs/prism/prism/internal/sandboxenv/sandboxenv.go
+++ b/modules/programs/prism/prism/internal/sandboxenv/sandboxenv.go
@@ -9,7 +9,7 @@
 // already uses to decide "am I inside a sandbox and need to proxy?":
 //
 //   - PRISM_HOST_API is set exclusively by the prism sidecar when launching a
-//     sandboxed session (bwrap, sandbox-exec, or podman container).
+//     sandboxed session (bwrap or sandbox-exec).
 //   - PRISM_SPAWN_PATH is also set in sandboxed sessions but serves as a
 //     working-directory hint only — it is NOT a sandbox sentinel and NOT a
 //     keybind discriminator. The dedicated tmux-keybind sentinel is
@@ -23,7 +23,7 @@ package sandboxenv
 import "os"
 
 // IsInsideSandbox reports whether the current process is running inside a
-// prism sandbox (bwrap, sandbox-exec, or podman container).
+// prism sandbox (bwrap or sandbox-exec).
 //
 // It uses PRISM_HOST_API != "" as the sentinel: the sidecar sets this variable
 // exclusively when launching a sandboxed session, so its presence is a reliable

--- a/modules/programs/prism/prism/internal/session/readiness.go
+++ b/modules/programs/prism/prism/internal/session/readiness.go
@@ -4,7 +4,7 @@ package session
 //
 // SpawnSession returns success as soon as it has created the tmux session and
 // kicked off the sidecar. That is "spawned", not "ready": the agent itself runs
-// inside the bwrap/podman/host process the tmux pane launches, several steps
+// inside the sandbox or host process the tmux pane launches, several steps
 // further along, and may take seconds to bind its TCP port — or never bind at
 // all if startup fails silently.
 //

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -86,11 +86,12 @@ type Opts struct {
 	// host port to bind.
 	Port int
 	// IsolationMode is the resolved isolation mode for this session.
-	// Valid values: "podman", "bwrap", "sandbox-exec", "host".
+	// Valid values: "bwrap", "sandbox-exec", "host" (see
+	// config.ValidIsolationModes).
 	IsolationMode string
-	// PluginHostPath is the host-side path to the agent plugin file that
-	// is bind-mounted into the container. Empty string = no plugin. Only used
-	// in podman mode.
+	// PluginHostPath is the host-side path to the agent plugin file.
+	// Empty string = no plugin. Retained for back-compat; no current
+	// isolation mode consumes it.
 	PluginHostPath string
 	// SkipStatusSeed, when true, causes setupFullLayout to skip the
 	// "prism event tmux-session-start" call that seeds agent_status.
@@ -143,15 +144,14 @@ type Opts struct {
 	// needing zsh aliases.
 	//
 	// Loaded from the agent_env_vars key of profiles.json (written by Nix).
-	// Ignored in podman mode — container sessions receive env vars via
-	// podman --env flags in the sidecar.
+	// Ignored in sandboxed modes — bwrap and sandbox-exec deliver env vars
+	// via their own injection paths (bwrap --setenv, sandbox-exec profile).
 	AgentEnvVars map[string]string
 	// ConfigEnvVarName is the environment variable name used to inject
 	// serialised config content into the agent runtime. Populated from
 	// harness.Harness.ConfigEnvVar() by callers that have a harness
 	// instance. When empty, config content injection is skipped in
-	// buildDirectAgentCmd (podman callers inject config via mounted
-	// files, not env vars).
+	// buildDirectAgentCmd.
 	ConfigEnvVarName string
 	// RuntimeEnvVars holds harness-specific environment variables to
 	// prepend to the agent command in host-mode sessions. Populated from
@@ -170,7 +170,7 @@ type Opts struct {
 	// agentPaneEnvVars injects PRISM_HARNESS_PIPE=unix://<path> into the
 	// agent tmux pane so the PI extension can connect to the sidecar socket.
 	// Ignored for bwrap/sandbox-exec (those modes set PRISM_HARNESS_PIPE via
-	// their own paths) and for podman (container mode uses ctrCfg).
+	// their own paths).
 	HarnessPipeSockPath string
 	// ModelsByRole is the per-role model override map (C.2). When non-empty
 	// it is forwarded to the sidecar via repeated --model-override flags.
@@ -355,7 +355,6 @@ func effectiveIsolationMode(opts Opts) string {
 // BuildAgentCmd returns the agent launch command string for the given opts.
 //
 // Isolation mode determines the command:
-//   - "podman":       "podman attach --sig-proxy=false <container-name>"
 //   - "bwrap":        "prism agent-run --session <session-name>"
 //   - "sandbox-exec": "prism agent-run --session <session-name>"
 //   - "host":         direct agent invocation (default)
@@ -528,8 +527,8 @@ func buildDirectAgentCmd(opts Opts) string {
 	// Prepend harness-specific runtime env vars. These are applied outermost
 	// (before AgentEnvVars and PRISM_SESSION_NAME) so they reach the agent
 	// runtime regardless of profile-level env overrides. Scoped to host-mode
-	// only — container-mode sessions receive env vars via podman --env or
-	// bwrap --setenv.
+	// only — sandboxed sessions receive env vars via bwrap --setenv or the
+	// sandbox-exec profile.
 	if len(opts.RuntimeEnvVars) > 0 {
 		keys := make([]string, 0, len(opts.RuntimeEnvVars))
 		for k := range opts.RuntimeEnvVars {
@@ -804,11 +803,7 @@ func agentPaneEnvVars(opts Opts) map[string]string {
 // window 0 "edit" (nvim auto-launched), window 1 "agent" (pi),
 // window 2 "term". Seeds agent_status via prism event tmux-session-start.
 //
-// In podman mode (isolation mode "podman"), the sidecar is started first and
-// the agent window runs a readiness-wait loop before running "podman attach".
-// This ensures the container is healthy before the PTY bridge tries to connect.
-//
-// In bwrap mode (isolation mode "bwrap"), the sidecar is still started (for
+// In bwrap mode (isolation mode "bwrap"), the sidecar is started (for
 // SSE, state machine, and host-API) but the agent window runs
 // "prism agent-run --session <name>" directly — no readiness wait, because
 // bwrap is owned by the tmux pane and doesn't use a sidecar-written ready file.
@@ -821,10 +816,10 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	_ = tmux.SendKeys(name+":0", nvimCmd)
 
 	// Start the sidecar before creating the agent window.
-	// In podman and bwrap mode the sidecar handles SSE, state transitions,
-	// and host-API — we must start it before the pane command so readiness
-	// signalling and prompt delivery are in place.
-	// In host mode the sidecar runs without --container (no container creation).
+	// In bwrap and sandbox-exec mode the sidecar handles SSE, state
+	// transitions, and host-API — we must start it before the pane command so
+	// readiness signalling and prompt delivery are in place.
+	// In host mode the sidecar connects to the directly-launched agent.
 	if opts.Port == 0 {
 		fmt.Fprintf(os.Stderr, "warning: sidecar skipped for %q — no port allocated\n", name)
 	} else {
@@ -847,9 +842,7 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	}
 
 	// Build the agent window command.
-	// In podman mode, prepend a readiness wait so the pane blocks until
-	// the sidecar has health-checked the container (AC-18, AC-19, AC-20).
-	// In bwrap mode, no readiness wait — "prism agent-run" runs immediately
+	// No readiness wait is needed — "prism agent-run" runs immediately
 	// and the sidecar does not write a ready file for bwrap sessions.
 	// opts.SessionName must be set by the caller before setupFullLayout is
 	// invoked — both ensureAndSwitch and restoreProjectSession do this.
@@ -867,9 +860,9 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	// critical ordering fix: prism agent-run in window 1 reads isolation_mode
 	// from agent_status immediately on start. If we write isolation_mode only
 	// after the window exists (as the old post-ensureAndSwitch block in
-	// cmd/spawn.go did), prism agent-run races and sees NULL → falls back to
-	// "podman" → dies with a mode mismatch error. Writing here, synchronously
-	// before NewWindow, removes the race entirely. See issue #894.
+	// cmd/spawn.go did), prism agent-run races and sees NULL → dies with a
+	// mode mismatch error. Writing here, synchronously before NewWindow,
+	// removes the race entirely. See issue #894.
 	if mode != "" {
 		// Always write isolation_mode when we have a non-empty mode.
 		if d, dbErr := openDB(); dbErr == nil {

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -204,7 +204,7 @@ func TestBuildAgentCmd_BwrapMode(t *testing.T) {
 }
 
 // TestBuildAgentCmd_HostMode verifies that IsolationMode="host" produces
-// a direct agent command (not podman attach).
+// a direct agent command (not a sandbox launcher command).
 func TestBuildAgentCmd_HostMode(t *testing.T) {
 	opts := Opts{
 		IsolationMode: "host",
@@ -213,9 +213,6 @@ func TestBuildAgentCmd_HostMode(t *testing.T) {
 		SessionName:   "nixos-config@feature",
 	}
 	cmd := BuildAgentCmd(opts)
-	if strings.HasPrefix(cmd, "podman") {
-		t.Errorf("host mode: got podman command %q, want direct pi invocation", cmd)
-	}
 	if strings.HasPrefix(cmd, "prism agent-run") {
 		t.Errorf("host mode: got prism agent-run command %q, want direct pi invocation", cmd)
 	}
@@ -225,7 +222,7 @@ func TestBuildAgentCmd_HostMode(t *testing.T) {
 }
 
 // TestBuildAgentCmd_EmptyIsolationMode verifies that an empty IsolationMode
-// falls back to the host command (not podman attach).
+// falls back to the host command (a direct pi invocation).
 func TestBuildAgentCmd_EmptyIsolationMode(t *testing.T) {
 	opts := Opts{
 		SessionName: "nixos-config@feature",
@@ -233,8 +230,8 @@ func TestBuildAgentCmd_EmptyIsolationMode(t *testing.T) {
 		Port:        14000,
 	}
 	cmd := BuildAgentCmd(opts)
-	if strings.HasPrefix(cmd, "podman attach") {
-		t.Errorf("empty IsolationMode: got podman command %q, want direct pi invocation", cmd)
+	if strings.HasPrefix(cmd, "prism agent-run") {
+		t.Errorf("empty IsolationMode: got %q, want direct pi invocation", cmd)
 	}
 	if !strings.Contains(cmd, "pi") {
 		t.Errorf("empty IsolationMode: cmd does not contain 'pi': %q", cmd)
@@ -400,7 +397,7 @@ func TestValidatePILaunchOpts(t *testing.T) {
 	})
 
 	t.Run("container modes pass the check (container paths have their own guard at agent_run.go:730)", func(t *testing.T) {
-		for _, mode := range []string{"bwrap", "sandbox-exec", "podman"} {
+		for _, mode := range []string{"bwrap", "sandbox-exec"} {
 			err := ValidatePILaunchOpts(Opts{
 				IsolationMode:  mode,
 				HarnessName:    "pi",

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -51,7 +51,7 @@ const sessionDirHashLen = 12
 // platform regardless of how long the session name itself is — see #1050.
 //
 // The mapping is pure and deterministic, so cleanup, debugging
-// (`prism logs <session>`), and bwrap/podman bind-mount construction can all
+// (`prism logs <session>`), and sandbox bind-mount construction can all
 // re-derive the directory from the session name without any persisted lookup.
 func SessionDirName(sessionName string) string {
 	sum := sha256.Sum256([]byte(sessionName))
@@ -81,8 +81,9 @@ func SidecarLogPath(sessionName string) (string, error) {
 }
 
 // SidecarReadyPath returns the readiness signal file path for the named session.
-// The sidecar creates this file after the container is healthy. The tmux pane
-// startup script polls for its existence before running "podman attach".
+// The sidecar's OnReady callback created this file in the removed container
+// isolation mode. No current isolation mode writes or polls it; the path
+// helper is retained so cleanup can remove stale files.
 //
 // Ready file: $XDG_STATE_HOME/prism/run/<session>-sidecar.ready
 func SidecarReadyPath(sessionName string) (string, error) {
@@ -103,12 +104,12 @@ func SidecarPIDPath(sessionName string) (string, error) {
 }
 
 // SidecarHostAPIPath returns the Unix socket path for the session's host-API server.
-// Each session gets its own subdirectory under run/ so that the podman container can
-// mount only that directory — providing socket isolation without exposing other
-// sessions' sockets (security fix #960). The subdirectory is pre-created by
-// container.prepareVolumeDirs before podman run, so the directory already exists
-// when podman evaluates the bind-mount, even though the socket file inside it is
-// created later by the sidecar (after the container becomes healthy).
+// Each session gets its own subdirectory under run/ so that the sandbox can
+// bind-mount only that directory — providing socket isolation without exposing
+// other sessions' sockets (security fix #960). The subdirectory is pre-created
+// by container.prepareVolumeDirs, so the directory already exists when the
+// sandbox evaluates the bind-mount, even though the socket file inside it is
+// created later by the sidecar.
 //
 // The directory name is a 12-hex-char SHA-256 prefix of the session name (see
 // SessionDirName) rather than the session name itself. This keeps the resulting
@@ -415,8 +416,8 @@ type StartSidecarOpts struct {
 	Port int
 	// IsolationMode is the resolved isolation mode for this session. When set,
 	// it is passed to the sidecar via --isolation-mode so the sidecar can
-	// branch on it (e.g. skip container creation for "bwrap", "sandbox-exec",
-	// and "host"). Valid values: "podman", "bwrap", "sandbox-exec", "host".
+	// branch on it. Valid values: "bwrap", "sandbox-exec", "host" (see
+	// config.ValidIsolationModes).
 	IsolationMode string
 	// AgentRole is "worker" or "coordinator". Passed via --agent-role when in
 	// container mode to select the appropriate credential set.
@@ -431,10 +432,8 @@ type StartSidecarOpts struct {
 	// readiness. Passed via --initial-prompt in container mode (#487).
 	// Empty string means no prompt delivery.
 	InitialPrompt string
-	// ConfigContent is the JSON blob for the container's harness config
-	// file. When non-empty and IsolationMode is "podman", it is forwarded to
-	// the sidecar via --config-content so the container can write it to a
-	// temp file and mount it at the harness config path inside the container.
+	// ConfigContent is the JSON blob for the session's harness config
+	// file.
 	//
 	// In host/bwrap/sandbox-exec mode, the config env var is injected
 	// directly by buildDirectAgentCmd (prepended to the agent shell
@@ -525,8 +524,7 @@ func StartSidecarWithOpts(sessionName string, opts StartSidecarOpts) error {
 	// D5 (issue #1133): the per-mode argv branches collapse into a single
 	// Isolator.SidecarFlags dispatch.
 	//
-	//   - podman:               --container --port --agent-role --plugin-path …
-	//   - bwrap, sandbox-exec:  --port --agent-role --plugin-path …  (no --container)
+	//   - bwrap, sandbox-exec:  --port --agent-role --plugin-path …
 	//   - host:                 --port --agent-role --plugin-path …  (same as bwrap/sandbox-exec)
 	//
 	// The pre-refactor branch lived at internal/session/sidecar.go:317-352.

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -206,14 +206,14 @@ func TestStartSidecar_CreatesDirectories(t *testing.T) {
 func TestBuildReadinessWaitCmd_ContainsReadyPath(t *testing.T) {
 	cmd := buildReadinessWaitCmd(
 		"/home/user/.local/state/prism/run/my-session-sidecar.ready",
-		"podman attach --sig-proxy=false prism-repo-main")
+		"agent-launcher --attach prism-repo-main")
 	if !strings.Contains(cmd, "/home/user/.local/state/prism/run/my-session-sidecar.ready") {
 		t.Errorf("readiness command does not reference ready path: %q", cmd)
 	}
 }
 
 func TestBuildReadinessWaitCmd_ContainsAttachCmd(t *testing.T) {
-	attach := "podman attach --sig-proxy=false prism-nixos-config-feature"
+	attach := "agent-launcher --attach prism-nixos-config-feature"
 	cmd := buildReadinessWaitCmd("/tmp/test.ready", attach)
 	if !strings.Contains(cmd, attach) {
 		t.Errorf("readiness command does not contain attach command %q: %q", attach, cmd)
@@ -221,7 +221,7 @@ func TestBuildReadinessWaitCmd_ContainsAttachCmd(t *testing.T) {
 }
 
 func TestBuildReadinessWaitCmd_TimeoutMessage(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach --sig-proxy=false prism-repo-main")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "agent-launcher --attach prism-repo-main")
 	// Verify the timeout message matches 120s (240 iterations × 0.5s).
 	if !strings.Contains(cmd, "120s") {
 		t.Errorf("readiness command should mention 120s timeout: %q", cmd)
@@ -235,7 +235,7 @@ func TestBuildReadinessWaitCmd_TimeoutMessage(t *testing.T) {
 func TestBuildReadinessWaitCmd_PathWithSpaces(t *testing.T) {
 	// Path with spaces must be properly quoted.
 	path := "/home/user name/.local/state/prism/run/my session-sidecar.ready"
-	cmd := buildReadinessWaitCmd(path, "podman attach --sig-proxy=false prism-repo-main")
+	cmd := buildReadinessWaitCmd(path, "agent-launcher --attach prism-repo-main")
 	// The path should be single-quoted.
 	if !strings.Contains(cmd, "'"+path+"'") {
 		t.Errorf("path with spaces not properly quoted in command: %q", cmd)
@@ -243,17 +243,17 @@ func TestBuildReadinessWaitCmd_PathWithSpaces(t *testing.T) {
 }
 
 func TestBuildReadinessWaitCmd_ExitsOneOnTimeout(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach --sig-proxy=false prism-repo-main")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "agent-launcher --attach prism-repo-main")
 	if !strings.Contains(cmd, "exit 1") {
 		t.Errorf("readiness command should exit 1 on timeout: %q", cmd)
 	}
 }
 
 // TestBuildReadinessWaitCmd_NoSidHandoff verifies that the readiness wait
-// script does not contain any .sid file read or -s flag injection.
-// "podman attach --sig-proxy=false" connects to the container PTY directly (RFC #691, Phase 1a).
+// script does not contain any .sid file read or -s flag injection — the
+// wrapped command connects to the agent PTY directly (RFC #691, Phase 1a).
 func TestBuildReadinessWaitCmd_NoSidHandoff(t *testing.T) {
-	cmd := buildReadinessWaitCmd("/tmp/test.ready", "podman attach --sig-proxy=false prism-repo-main")
+	cmd := buildReadinessWaitCmd("/tmp/test.ready", "agent-launcher --attach prism-repo-main")
 	if strings.Contains(cmd, ".sid") {
 		t.Errorf("readiness command should not reference .sid file: %q", cmd)
 	}

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -134,11 +134,12 @@ type SpawnOpts struct {
 	Layout Layout
 
 	// IsolationMode is the resolved isolation mode for this session.
-	// Valid values: "podman", "bwrap", "sandbox-exec", "host".
+	// Valid values: "bwrap", "sandbox-exec", "host" (see
+	// config.ValidIsolationModes).
 	IsolationMode string
 
-	// PluginHostPath is the host-side path to the agent plugin bind-mounted
-	// into the container.
+	// PluginHostPath is the host-side path to the agent plugin. Retained
+	// for back-compat; no current isolation mode consumes it.
 	PluginHostPath string
 
 	// InstanceID is the UUID for this session incarnation. For LayoutFull,
@@ -161,8 +162,8 @@ type SpawnOpts struct {
 
 	// AgentEnvVars are additional env vars prefixed to the agent command
 	// in host-mode sessions (see profiles.json agent_env_vars). Ignored in
-	// container/bwrap mode — those paths deliver env vars via podman --env
-	// in the sidecar.
+	// bwrap/sandbox-exec mode — those paths deliver env vars via their own
+	// injection mechanisms (bwrap --setenv, sandbox-exec profile).
 	AgentEnvVars map[string]string
 
 	// ForceFresh controls the startup guard for LayoutFull. When true, any
@@ -422,10 +423,7 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	//     reads the file when it sees the env var and feeds the contents
 	//     to the bwrap/sandbox-exec --prompt path.
 	//
-	// Podman mode delivers the prompt through the sidecar (StartSidecarOpts
-	// .InitialPrompt → agent --prompt inside the container), so it does
-	// not need a tmux-side env var at all and is intentionally skipped here.
-	// All other modes (host and sandbox) write the prompt file regardless of
+	// All modes (host and sandbox) write the prompt file regardless of
 	// layout — see the needsPromptFile gate below (#1195).
 	mode := resolveLayoutIsolationMode(opts)
 	var promptFilePath string
@@ -486,10 +484,6 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	//     mode in #1092. The "size" measured here adds the env-var
 	//     contribution so the guard reflects the bytes tmux actually
 	//     sees on its argv.
-	//
-	// Podman launch commands are `podman attach <ctr>`; the prompt is
-	// delivered through the sidecar and never touches tmux's argv, so the
-	// podman path is intentionally not guarded.
 	hostLaunchCmdSize := 0
 	switch {
 	case mode == "host" && opts.Layout == LayoutFull:
@@ -1046,10 +1040,9 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		mode = string(config.Load().DefaultIsolationMode)
 	}
 
-	// Start the sidecar BEFORE creating the agent window so that the
-	// readiness file (in podman mode) exists by the time the pane polls for
-	// it. For bwrap / host modes the sidecar still handles SSE, state, and
-	// host-API, and starting it up-front keeps the ordering consistent.
+	// Start the sidecar BEFORE creating the agent window — it handles SSE,
+	// state, and host-API, and starting it up-front keeps the ordering
+	// consistent across modes.
 	sidecarOpts := StartSidecarOpts{
 		Port:             port,
 		IsolationMode:    mode,
@@ -1072,10 +1065,8 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	}
 
 	// Build the agent command. BuildAgentCmd produces the right shape
-	// for the resolved isolation mode (podman attach / prism agent-run /
-	// direct pi). For podman mode, wrap it in the readiness-wait
-	// script so the pane blocks until the sidecar has health-checked the
-	// container.
+	// for the resolved isolation mode (prism agent-run for bwrap/sandbox-exec,
+	// direct pi for host).
 	buildOpts := Opts{
 		Prompt:           opts.Prompt,
 		PromptFilePath:   opts.PromptFilePath, // set by SpawnSession (#1195: keeps agentCmd O(1) in prompt size for host mode)
@@ -1100,8 +1091,8 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 	// prism agent-run (the bwrap entry point) reads isolation_mode from
 	// agent_status immediately on startup to validate the session mode. If the
 	// write happens after tmux.NewWindow, agent-run races and sees NULL →
-	// agent-run rejects the bwrap session with "has isolation mode 'podman',
-	// not bwrap". Writing here, synchronously before NewWindow, removes the
+	// agent-run rejects the bwrap session with a mode-mismatch error.
+	// Writing here, synchronously before NewWindow, removes the
 	// race. Mirrors the identical write in setupFullLayout (session.go).
 	// Non-fatal: a DB failure is logged and spawn continues.
 	if mode != "" {

--- a/modules/programs/prism/prism/internal/session/spawn_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_test.go
@@ -332,9 +332,10 @@ func TestSpawnSession_Validation_RequiresDB(t *testing.T) {
 // match "bwrap". If we write isolation_mode only after tmux.NewWindow, agent-run
 // races and sees NULL → the agent-run rejects the session.
 //
-// We test "bwrap" and "podman" modes to verify the write happens for both.
+// We test "bwrap" and "sandbox-exec" modes to verify the write happens for
+// both.
 func TestSpawnSession_AgentOnly_WritesIsolationMode(t *testing.T) {
-	for _, mode := range []string{"bwrap", "podman"} {
+	for _, mode := range []string{"bwrap", "sandbox-exec"} {
 		mode := mode
 		t.Run(mode, func(t *testing.T) {
 			d, _ := openSpawnTestDB(t)

--- a/modules/programs/prism/prism/internal/sidecar/events.go
+++ b/modules/programs/prism/prism/internal/sidecar/events.go
@@ -34,26 +34,26 @@ func (s *Sidecar) HandleEvent(evt harness.HarnessEvent) {
 		elapsed := time.Since(s.spawnTime).Round(time.Millisecond)
 		s.logger().Printf("sidecar: first event received from harness (%s after spawn)", elapsed)
 
-		// Bwrap path `[timing]` markers (#1052). The podman path emits these
-		// from sidecar.Run() around WaitHealthy / CreateSession; in bwrap
+		// Bwrap path `[timing]` markers (#1052). The container path emitted
+		// these from sidecar.Run() around WaitHealthy / CreateSession; in bwrap
 		// mode the agent is launched by the tmux pane (via prism agent-run)
 		// and the sidecar's only signal of readiness is the first SSE event,
 		// so the markers are emitted here.
 		//
-		//   - agent listening: equivalent to the podman WaitHealthy ok
-		//     marker — the agent's HTTP endpoint is reachable, since SSE has
+		//   - agent listening: equivalent to the container path's WaitHealthy
+		//     ok marker — the agent's HTTP endpoint is reachable, since SSE has
 		//     successfully connected and delivered an event.
 		//   - ready: the sidecar is processing events. In bwrap there is no
 		//     CreateSession step (the agent is started with --prompt by
 		//     agent-run, so the session pre-exists), which means listening
-		//     and ready coincide. Both lines are still emitted so the bwrap
-		//     and podman timelines have the same shape for grepping.
+		//     and ready coincide. Both lines are still emitted so all
+		//     timelines have the same shape for grepping.
 		//   - prompt delivered: when InitialPrompt is non-empty, the prompt
 		//     was supplied to the agent via --prompt at agent-run time. From
 		//     the sidecar's POV "delivered" is observable when the agent
 		//     starts emitting events — the prompt is in flight by then.
-		//     Emitted at the same moment for symmetry with the podman line
-		//     at sidecar.go:489.
+		//     Emitted at the same moment for symmetry with the container
+		//     path's marker.
 		if !container.CapabilitiesFor(s.cfg.IsolationMode).OwnsContainerLifecycle {
 			s.logger().Printf("[timing] harness listening: %s from start", elapsed)
 			s.logger().Printf("[timing] ready: %s from start", elapsed)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -23,8 +23,9 @@
 // The Harness value is injected at construction time via Config.Harness
 // (Phase 0a of the multi-harness migration, RFC #691).
 //
-// In container mode (Config.Container != nil), the sidecar also manages the
-// podman container lifecycle: create, health-check, stop, remove.
+// In container mode (Config.Container != nil — a legacy of the removed
+// container isolation mode; no current mode sets it), the sidecar also
+// manages the container lifecycle: create, health-check, stop, remove.
 //
 // All timer and clock operations go through an abstracted Clock interface so
 // that tests can control time deterministically.
@@ -70,7 +71,7 @@ const IdleDebounce = 2 * time.Second
 // will wait for the first SSE event from the harness. If no event is received
 // within this window, the session is transitioned to StateError via
 // writeStartupError. This mirrors the WaitHealthy/CreateSession timeout
-// mechanism added in #1011 for the podman path.
+// mechanism added in #1011 for the legacy container path.
 const DefaultStartupConnectTimeout = 5 * time.Minute
 
 // DefaultShutdownDrainTimeout is the upper bound on how long Shutdown waits
@@ -200,14 +201,16 @@ type Config struct {
 	// HTTPClient is the HTTP client used for coordinator notification delivery.
 	// If nil, defaultNotifyHTTPClient is used.
 	HTTPClient *http.Client
-	// IsolationMode is the effective isolation mode for this session (e.g.
-	// "podman", "bwrap", "sandbox-exec", or "host"). It is used to derive
+	// IsolationMode is the effective isolation mode for this session
+	// ("bwrap", "sandbox-exec", or "host" — see config.ValidIsolationModes).
+	// It is used to derive
 	// capability flags via container.CapabilitiesFor so that Run can branch on
 	// typed caps rather than raw mode strings or the Container!=nil proxy.
 	IsolationMode config.IsolationMode
 	// Container, when non-nil, enables container mode: the sidecar creates and
-	// manages a podman container running the agent in combined TUI + HTTP mode
-	// instead of relying on a directly-launched agent process.
+	// manages a container running the agent in combined TUI + HTTP mode
+	// instead of relying on a directly-launched agent process. Always nil in
+	// current code — no isolation mode owns a container lifecycle.
 	Container *container.Config
 	// HostAPISockPath, when non-empty, is the path at which the sidecar starts a
 	// Unix socket HTTP server exposing host-side tmux operations to agents running
@@ -220,8 +223,7 @@ type Config struct {
 	HostAPITCPPort int
 	// OnReady is called (once, synchronously) after the container is healthy
 	// and before the SSE loop starts. Used in container mode to write the
-	// readiness signal file that unblocks the tmux pane running "podman attach".
-	// No-op when nil.
+	// readiness signal file that unblocks the tmux pane. No-op when nil.
 	OnReady func()
 	// InitialPrompt, when non-empty, is passed to the container via
 	// agent --prompt <text> at startup. The agent process creates its
@@ -237,8 +239,8 @@ type Config struct {
 	// StartupConnectTimeout is the duration the sidecar waits for the first
 	// SSE event before concluding the harness never bound to its port and
 	// transitioning to StateError via writeStartupError. Only applies when
-	// NeedsStartupConnectTimeout is true (currently bwrap mode): podman mode
-	// uses WaitHealthy/CreateSession for the same protection. Defaults to
+	// NeedsStartupConnectTimeout is true (currently bwrap mode): container
+	// mode used WaitHealthy/CreateSession for the same protection. Defaults to
 	// DefaultStartupConnectTimeout (5m) when zero. Set to a small value in
 	// tests to exercise the timeout path without real wall-clock waits.
 	StartupConnectTimeout time.Duration
@@ -300,9 +302,10 @@ type Config struct {
 	// listener on Darwin (where Unix socket bind-mounts inside sandbox-exec
 	// are not reliable). The sidecar binds 127.0.0.1:<port> and exposes it to
 	// the sandboxed extension as tcp://127.0.0.1:<port> via PRISM_HARNESS_PIPE.
-	// Zero means no TCP listener (Linux path). Note: unlike the podman/gvproxy
-	// path (which uses host.containers.internal), sandbox-exec runs directly on
-	// the host, so loopback-only is both correct and more secure.
+	// Zero means no TCP listener (Linux path). Note: unlike the legacy
+	// container path (which used the gvproxy host.containers.internal
+	// convention), sandbox-exec runs directly on the host, so loopback-only is
+	// both correct and more secure.
 	HarnessPipeTCPPort int
 	// PipeMaxLineBytes overrides the per-frame byte cap enforced by the
 	// socket-pipe inbound reader. Zero means use socketPipeMaxLineBytes (16
@@ -397,7 +400,7 @@ type Sidecar struct {
 	hostAPITCPSrv *http.Server
 	// shuttingDown is set to true at the start of Shutdown(). Used by Run()
 	// to prevent OnReady from firing after SIGTERM even when the HTTP health
-	// probe succeeds during podman stop's grace period. Protected by mu.
+	// probe succeeds during the container-stop grace period. Protected by mu.
 	shuttingDown bool
 	// rootAgent is the name of the top-level agent for this session.
 	// Pre-set from Config.AgentRole in New() when non-empty (#555); falls back
@@ -661,7 +664,7 @@ type containerMgr struct {
 // permanent connection failure).
 //
 // When Config.Container is non-nil (container mode), Run first creates and
-// health-checks the podman container before subscribing to the SSE stream.
+// health-checks the container before subscribing to the SSE stream.
 // The container is stopped and removed by Shutdown().
 func (s *Sidecar) Run(ctx context.Context) error {
 	// Record spawn time for "first event received" log line (Gap 1b).
@@ -722,8 +725,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 		// host-side tooling.
 		// For bwrap mode, the per-session socket directory may not yet exist —
 		// prepareVolumeDirs runs in agent-run (after the sidecar starts). Create it
-		// here so net.Listen succeeds. For podman, prepareVolumeDirs already ran
-		// inside mgr.Create(), so this is a no-op.
+		// here so net.Listen succeeds.
 		if err := os.MkdirAll(filepath.Dir(s.cfg.HostAPISockPath), 0o700); err != nil {
 			s.logger().Printf("sidecar: host-API socket dir: %v", err)
 		}
@@ -987,7 +989,7 @@ func (s *Sidecar) Run(ctx context.Context) error {
 	// to StateError (same mechanism as #1011's WaitHealthy/CreateSession paths)
 	// and cancel the SSE loop so the sidecar exits cleanly.
 	//
-	// Podman mode already has WaitHealthy/CreateSession covering startup
+	// Container-owning modes have WaitHealthy/CreateSession covering startup
 	// failures, so NeedsStartupConnectTimeout is false there.
 	if container.CapabilitiesFor(s.cfg.IsolationMode).NeedsStartupConnectTimeout {
 		startupTimeout := s.cfg.StartupConnectTimeout
@@ -1258,7 +1260,7 @@ func (s *Sidecar) Shutdown() {
 // When OwnsContainerLifecycle is false (bwrap / host mode), this function is a
 // no-op: the harness is already running and the SSE loop connects directly. The
 // container startup sequence (mgr.Create → WaitHealthy → CreateSession →
-// OnReady → DeliverInitialPrompt) is only performed in podman container mode.
+// OnReady → DeliverInitialPrompt) is only performed in container mode.
 func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 	// Container mode: create and health-check the container before connecting.
 	if container.CapabilitiesFor(s.cfg.IsolationMode).OwnsContainerLifecycle {
@@ -1367,9 +1369,10 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 
 		// Signal readiness after the container is healthy (AC-7, AC-19).
 		// Guard with shuttingDown to prevent OnReady from firing after SIGTERM,
-		// even if WaitHealthy returned a genuine 200 during podman stop's grace
-		// period. Shutdown() sets shuttingDown=true before starting podman stop,
-		// so this check is reliable regardless of ctx cancellation timing.
+		// even if WaitHealthy returned a genuine 200 during the container-stop
+		// grace period. Shutdown() sets shuttingDown=true before stopping the
+		// container, so this check is reliable regardless of ctx cancellation
+		// timing.
 		s.mu.Lock()
 		isShuttingDown := s.shuttingDown
 		s.mu.Unlock()
@@ -1382,7 +1385,7 @@ func (s *Sidecar) runStartupHTTP(ctx context.Context) error {
 		// 1. GET /session  — retrieve the session the agent already created
 		//    (via --prompt on CLI). In non-container mode, POST /session creates
 		//    a new session. The harness adapter handles both cases.
-		// 2. Call OnReady  — unblocks the TUI pane, which runs "podman attach".
+		// 2. Call OnReady  — unblocks the TUI pane.
 		// 3. DeliverInitialPrompt — no-op in container mode (prompt already sent
 		//    via CLI). This entire block is inside `if s.cfg.Container != nil`
 		//    so it only runs in container mode; host-mode sessions never reach here.

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -2771,7 +2771,7 @@ func TestNotifyCoordinator_ParentWorkerStillNotifies(t *testing.T) {
 // (AC-16) prevents OnReady from firing when Shutdown() races a successful
 // health probe.
 //
-// The race: WaitHealthy returns a genuine 200 during podman stop's grace
+// The race: WaitHealthy returns a genuine 200 during the container-stop grace
 // period. Shutdown() has already set shuttingDown=true. The guard in Run()
 // checks the flag before calling OnReady — this test exercises that guard
 // directly by setting shuttingDown before the guard check runs.
@@ -9027,18 +9027,15 @@ func TestStartupConnectTimeout_ConfigurableViaField(t *testing.T) {
 	// field and relies on the default path.
 }
 
-// TestStartupConnectTimeout_PodmanModeSkipped verifies that the startup-connect
-// timeout goroutine is NOT started when Container != nil (podman mode). In
-// podman mode, WaitHealthy/CreateSession already provide startup-failure
-// protection (#1011); the SSE timeout would be redundant and might fire during
-// container startup.
+// TestStartupConnectTimeout_BwrapModeFiresWhenContainerNil verifies that the
+// startup-connect timeout goroutine IS started when Container == nil (bwrap
+// mode). In the legacy container mode (Container != nil),
+// WaitHealthy/CreateSession already provided startup-failure protection
+// (#1011); the SSE timeout would have been redundant and might have fired
+// during container startup.
 //
-// We cannot test the full podman path in a unit test, but we can verify the
-// bwrap-mode gate: by seeding firstEventLogged=false and leaving Container nil
-// vs non-nil, and observing whether the timeout fires.
-//
-// Container is a *container.Config. Setting it non-nil is the podman gate.
-// This test verifies the bwrap path is the one that fires by using the
+// Container is a *container.Config. Setting it non-nil was the container-mode
+// gate. This test verifies the bwrap path is the one that fires by using the
 // blockingHarness + a short timeout without Container set.
 func TestStartupConnectTimeout_BwrapModeFiresWhenContainerNil(t *testing.T) {
 	const timeout = 20 * time.Millisecond
@@ -9858,8 +9855,8 @@ func TestBwrapTimingMarkers_FirstEvent(t *testing.T) {
 // TestBwrapTimingMarkers_PromptDelivered verifies that when InitialPrompt is
 // non-empty (a prism prompt was supplied at agent-run launch via --prompt),
 // the sidecar emits a `[timing] prompt delivered: <d> from start` marker on
-// the first SSE event. AC #4 (#1052): mirrors the existing podman line at
-// sidecar.go:489 so the bwrap and podman timelines have the same shape.
+// the first SSE event. AC #4 (#1052): mirrors the legacy container-path
+// marker so all timelines have the same shape.
 func TestBwrapTimingMarkers_PromptDelivered(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("PRISM_TEST_MODE_RESTRICT_HOSTAPI", "1")

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -444,7 +444,7 @@ Add `--json` to any `prism merges` / `prism merges list` invocation (including w
 
 **Ctrl-C semantic.** Killing a `--wait` invocation (Ctrl-C, SIGTERM) interrupts the **local** wait only — the underlying merge / review / spawn keeps running. To recover the result later, re-run the same command (or `prism merges list` / `prism reviews list` / `prism checkin <session>`).
 
-**Inside a sandbox.** `--wait` works identically inside and outside a bwrap / podman / sandbox-exec sandbox. The CLI auto-detects `PRISM_HOST_API` and routes its terminal-state probes through the sidecar's read-only wait endpoints, so the host's prism.db is the source of truth in either case.
+**Inside a sandbox.** `--wait` works identically inside and outside a bwrap / sandbox-exec sandbox. The CLI auto-detects `PRISM_HOST_API` and routes its terminal-state probes through the sidecar's read-only wait endpoints, so the host's prism.db is the source of truth in either case.
 
 **Exit codes.** `--wait` paths use exit codes that distinguish failure modes:
 
@@ -835,7 +835,7 @@ The `--json` flag emits a single line to stdout instead:
 
 In `--json` mode the human-readable line is NOT emitted on stdout (mutual exclusion); it may still be mirrored to stderr for log capture. On error, `--json` emits `{"error": "<message>"}` to stderr and exits non-zero.
 
-The success signal reaches the caller identically from a direct-host invocation and from inside a bwrap / sandbox-exec / podman container: the container path's sidecar proxy captures the host-side child's stdout and stderr separately and re-emits them on the matching local streams, so the `OK` line lands on the container's stdout (and the mirror on stderr) byte-for-byte the same as a host invocation. `--json` is forwarded to the host child via the proxy request body, so the JSON envelope is also surfaced end-to-end.
+The success signal reaches the caller identically from a direct-host invocation and from inside a bwrap / sandbox-exec sandbox: the sandbox path's sidecar proxy captures the host-side child's stdout and stderr separately and re-emits them on the matching local streams, so the `OK` line lands on the container's stdout (and the mirror on stderr) byte-for-byte the same as a host invocation. `--json` is forwarded to the host child via the proxy request body, so the JSON envelope is also surfaced end-to-end.
 
 ### Sender-side idempotency — re-runs within 5 minutes are a no-op
 
@@ -926,7 +926,7 @@ Reads the last 10 turns from the prism DB as a rich narrative view. Use `--verbo
 prism logs <session>
 ```
 
-The raw sidecar log is where container startup errors, timing traces, and stderr from failed `podman run` commands land. This is the most informative diagnostic for infrastructure failures. See [`prism logs`](#prism-logs) below for full flag documentation.
+The raw sidecar log is where sandbox startup errors, timing traces, and stderr from failed launch commands land. This is the most informative diagnostic for infrastructure failures. See [`prism logs`](#prism-logs) below for full flag documentation.
 
 **Step 4 — Source cross-reference:**
 
@@ -978,15 +978,13 @@ prism logs <session> --harness-events --deliver=webhook:https://example.com/fram
 
 A lookup table of log patterns, their causes, and remediation hints:
 
-- **`statfs <path>: no such file or directory`** — podman was told to bind-mount a path that does not exist on the host. Common cause: a container-internal path (e.g. `/workspace`) leaked into a host-side `podman run` invocation. Check the preceding log line for the full `podman run` command. See incident #751 for a historical example.
+- **`statfs <path>: no such file or directory`** — the sandbox was told to bind-mount a path that does not exist on the host. Check the preceding log line for the full launch command. See incident #751 for a historical example.
 
-- **`exit status 125`** — the `podman container create` (or `podman run`) command failed at the OS level. The actual cause is on the preceding line(s) in the log — read upward from this line to find it.
+- **`startup-connect timeout fired`** — the session started but the sidecar never received the first SSE event from the agent. Usual causes: a misconfigured `harness-config.json` (agent not declared, malformed JSON), a missing bind-mount, or a missing `--agent` flag value. Check the sidecar log for the launch command line and any JSON parse errors.
 
-- **`container did not become ready within 120s`** — the container started but the sidecar never reached the ready state. Usual causes: a misconfigured `harness-config.json` (agent not declared, malformed JSON), a missing bind-mount, or a missing `--agent` flag value. Check the sidecar log for the `podman run` command line and any JSON parse errors.
+- **Session rows present in `prism sessions list` but no events in `prism checkin`** — the agent process either never started or died immediately after creation. Run `prism logs <session>` to see the full launch command line and its stderr output.
 
-- **Session rows present in `prism sessions list` but no events in `prism checkin`** — the container either never started or died immediately after creation. Run `prism logs <session>` to see the full podman command line and its stderr output.
-
-- **Session name doesn't match expected shape** (e.g. `~review` where `~review-1-review-code` is expected) — the agent-list construction produced the wrong agent names, or the `--agent` flag value is incorrect. Check the container's `harness-config.json` for the `agent` block contents and the sidecar log for the `--agent` flag value used in the command line.
+- **Session name doesn't match expected shape** (e.g. `~review` where `~review-1-review-code` is expected) — the agent-list construction produced the wrong agent names, or the `--agent` flag value is incorrect. Check the session's `harness-config.json` for the `agent` block contents and the sidecar log for the `--agent` flag value used in the command line.
 
 - **Zombie DB rows (session in `prism sessions list` but no live tmux session)** — a previous session's process died without cleaning up DB state. Use `prism cleanup --yes --session <name>` to end the row (stamps `ended_at`, releases any dangling port, clears the pi resume linkage) so it drops out of the active-session view. The row itself is preserved; re-spawning on the same branch name reuses it by re-seeding `state` back to `idle`.
 

--- a/modules/programs/prism/tmux.nix
+++ b/modules/programs/prism/tmux.nix
@@ -23,7 +23,6 @@ let
   # variable, expanded by tmux before the shell receives it.
   #
   # Matched values:
-  #   podman   — legacy podman isolation (`podman attach` is the pane command).
   #   bwrap    — bwrap isolation: `prism agent-run` execs bwrap directly, so
   #              the pane's direct child is the bwrap process.
   #   agent — defensive fallback for bwrap cases where tmux reports the
@@ -37,7 +36,7 @@ let
   # no binding keeps a hand-rolled pane_current_command equality check.
   sandboxedPaneGuard = pkgs.writeShellScript "prism-tmux-sandboxed-pane" ''
     case "$1" in
-      podman|bwrap) exit 0 ;;
+      bwrap) exit 0 ;;
       *) exit 1 ;;
     esac
   '';
@@ -98,7 +97,7 @@ let
     # No image: fall back to text clipboard paste.
     # This preserves pre-PR behaviour: before this keybind existed, the terminal
     # emulator's own bracketed-paste handled text Ctrl-V transparently through
-    # the sandbox (podman attach PTY / bwrap PTY). Since we now intercept C-v
+    # the sandbox PTY (bwrap). Since we now intercept C-v
     # we must replicate this.
     if [ -n "$WAYLAND_DISPLAY" ]; then
       txt="$(wl-paste --no-newline 2>/dev/null)"
@@ -166,7 +165,7 @@ in
               # sensible debugging behavior
               set -g remain-on-exit on
               # Enable OSC 52 clipboard passthrough so agent running inside a
-              # sandbox (podman or bwrap) can write to the host clipboard via the
+              # sandbox (bwrap) can write to the host clipboard via the
               # sandbox PTY bridge. Without this, tmux drops OSC 52 sequences and
               # clipboard is silently broken.
               set -g set-clipboard on
@@ -291,7 +290,7 @@ in
               bind a run-shell 'path=$(${pkgs.tmux}/bin/tmux display-message -p "#{pane_current_path}"); ${pkgs.tmux}/bin/tmux display-popup -E -d "$path" -w 60% -h 20% -b single -e "PRISM_KEYBIND_SPAWN=1" "${prism} spawn --attach"'
 
               # agent scrolling keybinds — active when the pane is a prism agent
-              # running under either supported isolation mode (podman or bwrap),
+              # running under bwrap isolation,
               # or hosting pi directly. See sandboxedPaneGuard above for the
               # matching rules. In any other pane (plain shell, editor, dashboard)
               # the literal keystroke is sent through unchanged.
@@ -332,8 +331,8 @@ in
               # Clipboard paste bridge for sandboxed agent panes (issue #752).
               #
               # When Ctrl-V is pressed in a pane whose current command is one of
-              # the sandboxed-agent values matched by sandboxedPaneGuard (podman
-              # attach / bwrap / direct pi):
+              # the sandboxed-agent values matched by sandboxedPaneGuard
+              # (bwrap / direct pi):
               #
               #   Image path: `prism clipboard paste-image` reads the host clipboard,
               #   stages the PNG to ~/.cache/prism/clipboard/<uuid>.png, and prints


### PR DESCRIPTION
Closes #2189

Podman was removed as a prism isolation mode some time ago (`config.ValidIsolationModes` lists only `bwrap`, `sandbox-exec`, `host`), but stale comments, CLI help text, docstrings, test fixtures, and docs still described podman as a live mode. This PR clears that fog per the categorised scope in the issue.

## What changed

- **Category A** — the 7 listed files' `Valid values:` doc-comments now list only `bwrap` / `sandbox-exec` / `host`, pointing at `config.ValidIsolationModes`.
- **Category B** — dead `podmanIsolator` / `shellQuotePodman` comment references removed or rewritten. `shellQuotePodman` (which still existed under that stale name) is renamed `shellQuoteContainer`; the dead `appendPodmanVolume` emitter (zero callers) is deleted.
- **Category C** — the `internal/container` package doc now describes the current bwrap/sandbox-exec lifecycle + mount-preparation responsibility. `cmd/sidecar.go`: `--isolation-mode` help lists only valid modes, the podman-mode docstrings are rewritten, and the deprecated `--container` flag is **removed**. A repo-wide search confirms nothing (tmux config, nix modules, scripts, Go code) passes `--container`.
- **Category D** — test loops iterating `"podman"` drop it (`spawn_test.go` now iterates bwrap + sandbox-exec; `session_test.go` drops the podman assertions; `review_test.go` fixture uses bwrap). The unknown-mode fallback coverage in `harness/pi/archive_test.go` is rewritten under the honest value `"unknown-legacy-mode"`.
- **Category F** — `prism/docs/sandbox-exec-testing.md`, `prism/docs/pi-wire-protocol.md`, `skills/prism/SKILL.md` (including the podman-specific failure-signature table, now describing the real `startup-connect timeout fired` signature), `tmux.nix` (podman dropped from `sandboxedPaneGuard` and comments), and `prism-tui.nix` swept. The correct "there is no `podman` mode" statements in `session-lifecycle.md` are preserved byte-for-byte.
- **AGENTS.md** — new note in the Prism section: podman is not an isolation mode; `config.ValidIsolationModes` is the source of truth; the remaining legacy fallbacks must not be "fixed" without a dedicated audit.

## Deliberately kept (legacy DB-row machinery)

- Category E read-time fallbacks untouched (empty diff): `internal/config/config.go`, `cmd/review.go`, `cmd/investigate.go`, `cmd/cleanup.go`, `cmd/review_test.go`, `cmd/restore_test.go`.
- **Scope note (escalated to coordinator during the run):** `internal/db/db.go` contains live schema migrations (v22→v23 backfill, v25→v26 `COALESCE(isolation_mode,'podman')`) that *write* the legacy `'podman'` value into old rows, plus `internal/db/db_test.go` tests pinning them. These are the same legacy DB-row class as category E but were not listed there; rewriting migrations is the separate audit the issue defers. They are kept verbatim, so the final `rg -i podman` state is: **category-E files + db migration machinery + the preserved session-lifecycle.md statement — everything else (A, B, C, D, F) is fully cleared.**

## Verification

- `go build ./...`, `go test ./...`, and CI-matching `go test ./... -race` — all pass.
- `nix build .#prism` from the repo root — passes.
- `rg -i podman modules/programs/prism/prism/` matches only the keep-list above.
- Repo-wide `--container` grep: zero matches.
- `nixfmt` run on touched `.nix` files.