### PR TITLE
pkgs/battery-monitor.nix: restore homeless-shelter gate for subpackages

### DIFF
--- a/pkgs/battery-monitor.nix
+++ b/pkgs/battery-monitor.nix
@@ -26,6 +26,34 @@ buildGoModule {
 
   doCheck = runChecks;
 
+  # Override checkPhase so the test suite covers ./..., not just the
+  # subPackages list. buildGoModule's default checkPhase iterates over
+  # `getGoDirs test`, which honours `subPackages` when set — so with
+  # `subPackages = [ "." ]` above (kept for buildPhase, which controls
+  # the binary output), the default check would only test the root
+  # package (`./.`), which has no test files. That silently masked the
+  # homeless-shelter sandbox signal for every subpackage under
+  # internal/... — the same regression pkgs/prism.nix had before #2168.
+  # See issue #2173 and AGENTS.md § "the homeless-shelter failure class".
+  #
+  # The `GOFLAGS=${GOFLAGS//-trimpath/}` strip mirrors the default
+  # checkPhase: buildGoModule adds -trimpath to GOFLAGS, which breaks
+  # tests that reference assets via their source paths. Race detection
+  # is intentionally not enabled here — the `go-tests-battery-monitor`
+  # CI job already runs `go test ./... -race` on an Ubuntu runner; this
+  # job's purpose is the $HOME=/homeless-shelter signal.
+  #
+  # The `-timeout 30m` flag is defensive: the suite finishes in well
+  # under a second on a host, but the bwrap sandbox is dramatically
+  # slower (see prism issue #2169 § Cluster 1), so we mirror the prism
+  # budget rather than risk a flaky per-package 10m default.
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    go test -timeout 30m ./...
+    runHook postCheck
+  '';
+
   vendorHash = "sha256-WUTGAYigUjuZLHO1YpVhFSWpvULDZfGMfOXZQqVYAfs=";
 
   ldflags = [


### PR DESCRIPTION
Closes #2173

## Summary

`pkgs/battery-monitor.nix` had the same architectural regression as `pkgs/prism.nix` before #2168: `subPackages = [ "." ]` + `doCheck = runChecks` without a `checkPhase` override meant buildGoModule's default `getGoDirs test` restricted the check to the root package (which has no test files). The 4 subpackage test files (`internal/config`, `internal/daemon`, `internal/source/razer`, `internal/state`) were silently never exercised under `$HOME=/homeless-shelter` by the `nix-build-battery-monitor-checked` CI job.

This PR mirrors the #2168 fix: override `checkPhase` to run `go test ./...` directly (with the same `-trimpath` strip and defensive `-timeout 30m` as prism; race detection deliberately omitted since `go-tests-battery-monitor` covers it on Ubuntu).

## Verification

Probe-test recipe from #2173, run locally (probe NOT committed):

1. **Probe added** (a test that `os.MkdirAll`s under `$HOME`): checked build **fails** with `mkdir /homeless-shelter: permission denied`, and the log shows all 4 subpackage suites executing (`config`, `daemon`, `razer`, `state` all `ok`) — the gate is live.
2. **Probe removed**: checked build (`battery-monitor.override { runChecks = true; }`) **passes** — no latent failures surfaced by the now-live gate.
3. `nix build .#battery-monitor` (default `runChecks = false`) **passes** — local/`nh switch` path unaffected.
4. Host `go test ./...` from the module dir passes.
5. `nixfmt` run on the touched file.