### PR TITLE
prism: fix latent sandbox test failures behind the homeless-shelter gate

### DIFF
--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -370,7 +370,7 @@ func TestInputsValue_PullsFromSpawnInputs(t *testing.T) {
 		BranchFlag:    strPtr("feature/x"),
 		AbtestPairID:  strPtr("pair-uuid-0001"),
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -407,7 +407,7 @@ func TestInputsValue_IsolationModePreferredOverFlag(t *testing.T) {
 		IsolationMode: strPtr("sandbox-exec"),
 		AgentFlag:     strPtr("worker"),
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -437,7 +437,7 @@ func TestInputsValue_IsolationModeFallsBackToFlagForLegacyRow(t *testing.T) {
 		// IsolationMode deliberately nil — simulating a pre-#2105 row.
 		AgentFlag: strPtr("worker"),
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -461,7 +461,7 @@ func TestInputsValue_IsolationModeAbsentRendersDash(t *testing.T) {
 		ProfileName: strPtr("anthropic"),
 		// Both IsolationFlag and IsolationMode deliberately nil.
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -483,7 +483,7 @@ func TestInputsValue_PartialRowSurfacesWhatExists(t *testing.T) {
 		ProfileName: strPtr("anthropic-opus-max"),
 		// All other flags intentionally nil — partial row case.
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})

--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -17,7 +17,6 @@ package cmd
 // tmux, sidecar, or a real agent.
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -371,7 +370,7 @@ func TestInputsValue_PullsFromSpawnInputs(t *testing.T) {
 		BranchFlag:    strPtr("feature/x"),
 		AbtestPairID:  strPtr("pair-uuid-0001"),
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -408,7 +407,7 @@ func TestInputsValue_IsolationModePreferredOverFlag(t *testing.T) {
 		IsolationMode: strPtr("sandbox-exec"),
 		AgentFlag:     strPtr("worker"),
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -438,7 +437,7 @@ func TestInputsValue_IsolationModeFallsBackToFlagForLegacyRow(t *testing.T) {
 		// IsolationMode deliberately nil — simulating a pre-#2105 row.
 		AgentFlag: strPtr("worker"),
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -462,7 +461,7 @@ func TestInputsValue_IsolationModeAbsentRendersDash(t *testing.T) {
 		ProfileName: strPtr("anthropic"),
 		// Both IsolationFlag and IsolationMode deliberately nil.
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -484,7 +483,7 @@ func TestInputsValue_PartialRowSurfacesWhatExists(t *testing.T) {
 		ProfileName: strPtr("anthropic-opus-max"),
 		// All other flags intentionally nil — partial row case.
 	}
-	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateActive, inputs)
 
 	sess, _ := d.SessionByInstanceID(iid)
 	runs := loadCompareRuns(d, []*db.Session{sess})
@@ -589,17 +588,51 @@ func TestRenderCompareTable_LiveSessionStillShowsDash(t *testing.T) {
 		t.Errorf("rendered output missing profile_name on live session:\n%s", out)
 	}
 	// But aggregate axes must read "—" — the session is still in progress.
-	// "100" / "150" are the seeded tokens from writeAssistantTurn — they
-	// must not surface for a still-active session. Use word-boundary regex
-	// rather than substring containment because the instance_id row in the
-	// rendered table is a UUID and ~1/256 UUIDs happen to end in "100" or
-	// "150", triggering a false-positive leak detection (issue #2169 §
-	// Cluster 4). Word boundaries ensure we only match the token values
-	// (which are whitespace-surrounded in the table), not UUID substrings.
-	leakRe := regexp.MustCompile(`\b(100|150)\b`)
-	if leakRe.MatchString(out) {
-		t.Errorf("rendered output leaks aggregate data for an active session:\n%s", out)
+	// Assert against the aggregate-row cells directly rather than scanning
+	// the whole rendered table for the seeded token values ("100" / "150"):
+	// the table also contains the generated instance UUID, and a UUID that
+	// happens to contain those digits made the whole-table scan flake.
+	// Cell-level assertions are independent of whatever characters uuid.New()
+	// produces. Every aggregate row must render the em-dash placeholder in
+	// all three pairwise cells (run-A, run-B, Δ); a numeric cell means
+	// aggregate data leaked for a still-active session.
+	aggregateAxes := []string{
+		"tokens_input", "tokens_output", "tokens_cache_read", "tokens_cache_write",
+		"cost_usd", "tool_call", "tool_error", "msg_assistant",
+		"time_to_first_event", "time_to_finished",
 	}
+	for _, axis := range aggregateAxes {
+		cells, ok := tableRowCells(out, axis)
+		if !ok {
+			t.Errorf("aggregate row %q not found in rendered output:\n%s", axis, out)
+			continue
+		}
+		if len(cells) != 3 {
+			t.Errorf("aggregate row %q: expected 3 cells (run-A, run-B, Δ); got %d: %v", axis, len(cells), cells)
+			continue
+		}
+		for i, cell := range cells {
+			if cell != "—" {
+				t.Errorf("aggregate row %q cell %d = %q; want %q (aggregates must not surface for a still-active session)", axis, i, cell, "—")
+			}
+		}
+	}
+}
+
+// tableRowCells extracts the whitespace-separated value cells of the rendered
+// compare-table row whose label is axis+":". The renderer pads each cell with
+// spaces and none of the placeholder/count values contain embedded spaces, so
+// strings.Fields yields the label followed by one field per cell. ok is false
+// when no row with that label was rendered.
+func tableRowCells(out, axis string) (cells []string, ok bool) {
+	label := axis + ":"
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == label {
+			return fields[1:], true
+		}
+	}
+	return nil, false
 }
 
 // ── Helper ───────────────────────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -453,25 +453,38 @@ func TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir(t *testing.T) {
 		// They legitimately leave PIExtensionDir empty and must NOT be
 		// blocked by the guard.
 		//
-		// LayoutBare opens a real tmux session, so the subtest requires
-		// tmux on PATH. tmux is intentionally NOT in nativeCheckInputs in
-		// pkgs/prism.nix (see the long comment there), so this subtest is
-		// skipped in the nix build sandbox. The sibling LayoutFull subtest
-		// above still runs because it asserts an error before any tmux
-		// call. Tracked in issue #2169 § Cluster 2.
-		if _, err := exec.LookPath("tmux"); err != nil {
-			t.Skip("tmux not found in PATH — skipping LayoutBare subtest; see issue #2169")
-		}
+		// The guard under test fires BEFORE any tmux invocation, so its
+		// behaviour is observable even when tmux is absent from $PATH
+		// (tmux is intentionally NOT in nativeCheckInputs in pkgs/prism.nix
+		// — see the long comment there — so the nix build sandbox runs
+		// this subtest without tmux):
+		//
+		//   - tmux available: Create must succeed end-to-end.
+		//   - tmux absent: Create must fail at the tmux launch ("new-session"),
+		//     NOT at the PIExtensionDir guard. If the guard were wrongly
+		//     applied to LayoutBare it would reject before reaching tmux,
+		//     producing a "piExtensionDir" error in both environments — so
+		//     either branch catches the regression.
 		name := "unit-test-2065-bare"
-		defer tmux.KillSession(name)
+		_, tmuxErr := exec.LookPath("tmux")
+		tmuxAvailable := tmuxErr == nil
+		if tmuxAvailable {
+			defer tmux.KillSession(name)
+		}
 		err := Create(name, dir, Opts{
 			Layout:         LayoutBare,
 			IsolationMode:  "host",
 			HarnessName:    "pi",
 			PIExtensionDir: "",
 		})
-		if err != nil {
+		if err != nil && strings.Contains(err.Error(), "piExtensionDir") {
 			t.Errorf("LayoutBare must not be blocked by the PIExtensionDir guard; got: %v", err)
+		}
+		if tmuxAvailable && err != nil {
+			t.Errorf("LayoutBare Create failed with tmux available: %v", err)
+		}
+		if !tmuxAvailable && err == nil {
+			t.Errorf("expected Create to fail at the tmux launch when tmux is absent from $PATH; got nil")
 		}
 	})
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -1195,10 +1195,20 @@ func (s *Sidecar) Shutdown() {
 			// the wait by ShutdownDrainTimeout so an unresponsive writer
 			// (e.g. blocked on a stalled conn) cannot stall Shutdown longer
 			// than the documented budget.
+			//
+			// The drain bound is armed via s.cfg.Clock (not time.After) so
+			// tests can substitute the fake clock and assert the ack path
+			// behaviourally — "Shutdown returns without the drain timer
+			// firing" — instead of measuring wall-clock latency, which is
+			// scheduler- and I/O-noise-dependent. With the real clock the
+			// behaviour is identical to time.After.
+			drainTimedOut := make(chan struct{})
+			drainTimer := s.cfg.Clock.AfterFunc(drainTimeout, func() { close(drainTimedOut) })
 			select {
 			case <-ackCh:
 				// Healthy path — writer acked the flush.
-			case <-time.After(drainTimeout):
+				drainTimer.Stop()
+			case <-drainTimedOut:
 				s.logger().Printf("sidecar: Shutdown: abort-frame flush timed out after %s; tearing down connection anyway", drainTimeout)
 				// Clear the ack channel so a late writer iteration does not
 				// attempt to close a channel we have already abandoned. We

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
@@ -11,20 +11,24 @@ package sidecar
 //
 // The current implementation replaces the sleep with an ack signal: the writer
 // goroutine closes harnessPipeAbortAck after the abort frame's write attempt
-// completes. Shutdown selects on the ack or on time.After(ShutdownDrainTimeout)
-// — defaulting to DefaultShutdownDrainTimeout (250ms) — so:
+// completes. Shutdown selects on the ack or on a drain timer armed via
+// s.cfg.Clock with ShutdownDrainTimeout — defaulting to
+// DefaultShutdownDrainTimeout (250ms) — so:
 //
-//   - Healthy connection: Shutdown returns within a scheduler tick of the
-//     flush (well under 100ms).
+//   - Healthy connection: Shutdown returns as soon as the writer acks the
+//     flush, without waiting out the drain timer.
 //   - Unhealthy connection (writer blocked on a stalled conn / queue full):
-//     Shutdown returns within ShutdownDrainTimeout.
+//     Shutdown returns when the drain timer fires.
 //
-// These tests assert both bounds.
+// These tests assert both paths behaviourally on the fake clock (whose timers
+// fire only when a test calls Fire) rather than measuring wall-clock latency:
+// real-time latency budgets proved scheduler- and I/O-noise-dependent — the
+// nix build sandbox pushed the healthy path past a 50ms budget with no code
+// regression.
 
 import (
 	"bufio"
 	"encoding/json"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -32,21 +36,22 @@ import (
 
 // TestShutdown_AbortFlush_HealthyPath_FastAck verifies that on a healthy
 // connection (writer goroutine responsive, conn able to accept writes),
-// Shutdown returns very quickly after the abort frame is acked by the writer
-// — well under the previous 100ms hard sleep and well under the 250ms
-// ShutdownDrainTimeout bound. Issue #1849 AC: "On a healthy connection,
-// Shutdown returns within ~10ms of the abort frame being flushed".
+// Shutdown returns because the writer acked the abort-frame flush — NOT
+// because the drain timeout expired. Issue #1849 AC: "On a healthy
+// connection, Shutdown returns within ~10ms of the abort frame being
+// flushed" — i.e. the old unconditional 100ms hard sleep is gone.
+//
+// The assertion is behavioural, on the fake clock, rather than a wall-clock
+// latency budget: the sidecar's drain timer is registered on the injected
+// testClock, whose timers NEVER fire on their own. Shutdown can therefore
+// only return via the writer's ack — if the ack path were broken (or a hard
+// sleep-until-timeout were reintroduced on the drain timer), Shutdown would
+// block forever and the liveness bound below would catch it. This replaces a
+// previous `elapsed < 50ms` assertion that measured scheduler/I-O noise and
+// failed in the nix build sandbox (observed 104ms) with no code regression.
 func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
-	// In the nix build sandbox ($NIX_BUILD_TOP set), bwrap I/O overhead
-	// inflates the measured latency past the 50ms budget without indicating
-	// a real regression (observed: 104ms). The latency assertion's intent is
-	// "well under the old 100ms hard sleep on a host", and the nix sandbox
-	// is not a host. Tracked in issue #2169 § Cluster 3.
-	if os.Getenv("NIX_BUILD_TOP") != "" {
-		t.Skip("skipping latency-budget test in nix build sandbox: bwrap I/O overhead inflates measured latency past the 50ms budget; see issue #2169")
-	}
 	sockPath := shortSockPath(t)
-	sc := newSocketPipeSidecar(t, sockPath)
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
 	wait := runSocketPipeSidecar(sc)
 
 	conn, _ := dialAndHandshake(t, sockPath)
@@ -55,8 +60,8 @@ func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
 	// Drain frames from the conn in the background so the writer's
 	// c.Write(abortFrame) returns immediately. Without a concurrent reader the
 	// kernel send buffer would absorb the small frame anyway, but explicitly
-	// reading guarantees we're not measuring buffer-fill latency on a slow CI
-	// runner.
+	// reading guarantees the writer cannot block on a full buffer on a slow
+	// CI runner.
 	readerDone := make(chan struct{})
 	go func() {
 		defer close(readerDone)
@@ -74,19 +79,26 @@ func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
 	// channel is in place. Belt-and-braces: poll briefly.
 	waitForOutChNonNil(t, sc, 2*time.Second)
 
-	start := time.Now()
-	sc.Shutdown()
-	elapsed := time.Since(start)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc.Shutdown()
+	}()
 
-	// 50ms is a conservative cap for a single in-process channel send +
-	// writer-goroutine ack close; in practice this completes in well under
-	// 1ms. We deliberately do NOT assert < 10ms because CI runners under load
-	// can easily blow past that without indicating a real regression. The
-	// important invariant is "well under the old 100ms hard sleep".
-	if elapsed > 50*time.Millisecond {
-		t.Errorf("Shutdown took %s on a healthy connection; expected well under 50ms (old hard-sleep was 100ms)", elapsed)
+	select {
+	case <-done:
+		// Healthy path proven: the fake drain timer cannot fire, so Shutdown
+		// returning at all means the writer's ack released it.
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown did not return on a healthy connection; the abort-frame ack never arrived (the fake drain timer cannot fire, so only the ack can release Shutdown)")
 	}
-	t.Logf("healthy-path Shutdown latency: %s", elapsed)
+
+	// The drain bound must still have been armed while waiting for the ack —
+	// it is the guard against an unresponsive writer, and the healthy path
+	// must not skip it.
+	if tm := clk.WaitForTimerWithDuration(DefaultShutdownDrainTimeout, 2*time.Second); tm == nil {
+		t.Errorf("no drain timer with the default %s bound was registered during Shutdown", DefaultShutdownDrainTimeout)
+	}
 
 	_ = conn.Close()
 	<-readerDone
@@ -95,17 +107,27 @@ func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
 
 // TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout verifies that
 // when the writer goroutine cannot flush the abort frame (because a prior
-// frame is wedged on a stalled conn), Shutdown still returns within the
-// documented ShutdownDrainTimeout bound. Issue #1849 AC: "On an unhealthy
-// connection (writer goroutine blocked, conn stalled), Shutdown returns
-// within a bounded wait time (≤ 250ms, or the documented ShutdownDrainTimeout)".
+// frame is wedged on a stalled conn), Shutdown blocks until the drain timer
+// fires and then returns. Issue #1849 AC: "On an unhealthy connection (writer
+// goroutine blocked, conn stalled), Shutdown returns within a bounded wait
+// time (≤ 250ms, or the documented ShutdownDrainTimeout)".
+//
+// The bound is asserted behaviourally on the fake clock: Shutdown must (a)
+// arm a drain timer with the configured ShutdownDrainTimeout, (b) NOT return
+// while the writer is wedged and the timer has not fired — the only other
+// release path is the ack, which the wedged writer cannot deliver — and (c)
+// return promptly once the test fires the timer manually. This replaces the
+// previous real-sleep elapsed-time window (90ms–350ms), making the test
+// independent of scheduler and I/O latency.
 func TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout(t *testing.T) {
 	sockPath := shortSockPath(t)
-	sc := newSocketPipeSidecar(t, sockPath)
-	// Use a small ShutdownDrainTimeout so the test runs quickly while still
-	// exercising the bounded-wait branch. The default would be 250ms; 100ms
-	// here keeps total runtime tight.
-	sc.cfg.ShutdownDrainTimeout = 100 * time.Millisecond
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
+	// A distinctive drain timeout so the timer can be located unambiguously
+	// among any other timers registered on the fake clock (idle debounce is
+	// 2s, reconnect recovery 60s). The value itself never elapses — the fake
+	// clock only fires when the test says so.
+	const drainTimeout = 123 * time.Millisecond
+	sc.cfg.ShutdownDrainTimeout = drainTimeout
 	wait := runSocketPipeSidecar(sc)
 
 	conn, _ := dialAndHandshake(t, sockPath)
@@ -139,25 +161,43 @@ func TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout(t *testing.T) {
 	// Give the writer a chance to pick up the wedge frame and block on Write.
 	time.Sleep(50 * time.Millisecond)
 
-	// Now invoke Shutdown. The abort frame will be queued behind the wedged
-	// frame; the writer can't process it, so harnessPipeAbortAck will never
-	// be closed via the normal path. Shutdown must fall back to the timeout
-	// and proceed.
-	start := time.Now()
-	sc.Shutdown()
-	elapsed := time.Since(start)
+	// Now invoke Shutdown in the background. The abort frame will be queued
+	// behind the wedged frame; the writer can't process it, so
+	// harnessPipeAbortAck will never be closed via the normal path. Shutdown
+	// must arm the drain timer and wait for it.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc.Shutdown()
+	}()
 
-	// Lower bound: the timeout must actually be respected (not 0).
-	// Upper bound: timeout + slack for goroutine scheduling and the rest of
-	// Shutdown's teardown work. 250ms slack is generous but keeps the test
-	// stable on slow CI.
-	if elapsed < 90*time.Millisecond {
-		t.Errorf("Shutdown returned in %s — earlier than the configured 100ms ShutdownDrainTimeout; the bound is not being honoured", elapsed)
+	// (a) Shutdown reached the bounded wait: the drain timer was armed with
+	// the configured timeout.
+	tm := clk.WaitForTimerWithDuration(drainTimeout, 2*time.Second)
+	if tm == nil {
+		t.Fatal("Shutdown never armed the drain timer with the configured ShutdownDrainTimeout")
 	}
-	if elapsed > 100*time.Millisecond+250*time.Millisecond {
-		t.Errorf("Shutdown took %s; expected ≤ %s (drain timeout 100ms + 250ms slack)", elapsed, 350*time.Millisecond)
+
+	// (b) Shutdown must still be blocked: the writer is wedged (no ack
+	// possible) and the fake timer has not fired. The 100ms observation
+	// window is a detection bound for a violation, not a latency budget —
+	// a correct implementation blocks here indefinitely.
+	select {
+	case <-done:
+		t.Fatal("Shutdown returned before the drain timer fired; the bounded wait is not being honoured")
+	case <-time.After(100 * time.Millisecond):
+		// Still blocked — expected.
 	}
-	t.Logf("unhealthy-path Shutdown latency: %s (drain timeout 100ms)", elapsed)
+
+	// (c) Fire the drain timer: Shutdown must now complete.
+	tm.Fire()
+	select {
+	case <-done:
+		// Bounded-wait branch proven: the timer (and only the timer)
+		// released Shutdown.
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown did not return after the drain timer fired")
+	}
 
 	_ = conn.Close()
 	// Closing the conn unblocks the writer's c.Write; outCh will drain and
@@ -166,21 +206,20 @@ func TestShutdown_AbortFlush_UnhealthyPath_BoundedByDrainTimeout(t *testing.T) {
 }
 
 // TestShutdown_AbortFlush_DefaultTimeoutApplies verifies that when
-// Config.ShutdownDrainTimeout is left at zero, Shutdown uses
-// DefaultShutdownDrainTimeout (250ms) as the upper bound. We don't actually
-// wait the full 250ms — we just assert that the constant is what's
-// documented and that Shutdown honours it on a healthy path (returning fast,
-// not waiting the default).
+// Config.ShutdownDrainTimeout is left at zero, Shutdown arms the drain timer
+// with DefaultShutdownDrainTimeout (250ms). The constant itself is asserted
+// against the documented AC value, and the timer registration is observed on
+// the fake clock — no wall-clock measurement.
 func TestShutdown_AbortFlush_DefaultTimeoutApplies(t *testing.T) {
 	if DefaultShutdownDrainTimeout != 250*time.Millisecond {
 		t.Errorf("DefaultShutdownDrainTimeout = %s, want 250ms (AC: ≤ 250ms)", DefaultShutdownDrainTimeout)
 	}
 
 	sockPath := shortSockPath(t)
-	sc := newSocketPipeSidecar(t, sockPath)
+	sc, clk := newSocketPipeSidecarWithClock(t, sockPath)
 	// Leave sc.cfg.ShutdownDrainTimeout at its zero value — the default
-	// should kick in. A healthy-path Shutdown must still return quickly
-	// (well under the default) because the writer acks promptly.
+	// should kick in. A healthy-path Shutdown still returns via the writer's
+	// ack (the fake drain timer never fires on its own).
 	wait := runSocketPipeSidecar(sc)
 
 	conn, _ := dialAndHandshake(t, sockPath)
@@ -196,11 +235,21 @@ func TestShutdown_AbortFlush_DefaultTimeoutApplies(t *testing.T) {
 	}()
 	waitForOutChNonNil(t, sc, 2*time.Second)
 
-	start := time.Now()
-	sc.Shutdown()
-	elapsed := time.Since(start)
-	if elapsed >= DefaultShutdownDrainTimeout {
-		t.Errorf("Shutdown took %s on a healthy connection with default timeout; the default should be an upper bound, not a floor", elapsed)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc.Shutdown()
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown did not return on a healthy connection with the default drain timeout")
+	}
+
+	// The drain timer must have been armed with the default bound — not 0,
+	// which would make the timeout branch a no-op fall-through.
+	if tm := clk.WaitForTimerWithDuration(DefaultShutdownDrainTimeout, 2*time.Second); tm == nil {
+		t.Errorf("no drain timer with the default %s bound was registered during Shutdown", DefaultShutdownDrainTimeout)
 	}
 
 	_ = conn.Close()

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_test.go
@@ -28,6 +28,10 @@ type testTimer struct {
 	mu        sync.Mutex
 	stopped   bool
 	fn        func()
+	// d is the duration the timer was registered with via AfterFunc.
+	// Immutable after creation; used by tests to locate a specific timer
+	// (e.g. the Shutdown drain timer) among others on the same clock.
+	d time.Duration
 	// stoppedCh is closed exactly once when the timer transitions to the
 	// stopped state (via Stop or Fire). Tests can use this to synchronise on
 	// timer cancellation deterministically rather than polling the Stopped()
@@ -127,7 +131,7 @@ func (c *testClock) Now() time.Time {
 func (c *testClock) AfterFunc(d time.Duration, f func()) Timer {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	t := &testTimer{fn: f, stoppedCh: make(chan struct{})}
+	t := &testTimer{fn: f, d: d, stoppedCh: make(chan struct{})}
 	c.timers = append(c.timers, t)
 	// Notify any waiter blocked in WaitForTimerCount that a new timer was
 	// registered. Close-and-replace gives a broadcast semantics: every
@@ -211,6 +215,42 @@ func (c *testClock) WaitForNextTimer(timeout time.Duration) *testTimer {
 	n := len(c.timers)
 	c.mu.Unlock()
 	return c.WaitForTimerCount(n+1, timeout)
+}
+
+// WaitForTimerWithDuration blocks until a timer registered with duration d
+// exists on the clock, returning the first such timer in registration order,
+// or nil if none appears before timeout elapses. Like WaitForTimerCount it
+// observes the AfterFunc registration event via timerCreatedCh rather than
+// polling, so it is deterministic under scheduler load. Use this when the
+// timer of interest has a distinctive duration (e.g. Shutdown's drain timer)
+// and other timers may be registered concurrently (idle debounce, recovery).
+func (c *testClock) WaitForTimerWithDuration(d, timeout time.Duration) *testTimer {
+	deadline := time.Now().Add(timeout)
+	for {
+		c.mu.Lock()
+		var found *testTimer
+		for _, t := range c.timers {
+			if t.d == d {
+				found = t
+				break
+			}
+		}
+		ch := c.timerCreatedCh
+		c.mu.Unlock()
+		if found != nil {
+			return found
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil
+		}
+		select {
+		case <-ch:
+			// A new timer was registered; loop to re-check for a match.
+		case <-time.After(remaining):
+			return nil
+		}
+	}
 }
 
 // waitForCondition polls fn at a short interval until it returns true, or

--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -44,15 +44,34 @@ buildGoModule {
   # runs `go test ./... -race` on an Ubuntu runner; this job's purpose
   # is the $HOME=/homeless-shelter signal, not race coverage.
   #
-  # The `-timeout 30m` flag overrides the default 10m per-package budget:
-  # the bwrap sandbox is slower than the host (the `internal/sidecar` and
-  # `internal/db` packages each push close to the default 10m limit there
-  # even when they finish in tens of seconds on a host). The sandbox
-  # slowdown is tracked in issue #2169 § Cluster 1; this is a sandbox
-  # workaround, not a logic fix.
+  # TMPDIR is redirected onto tmpfs (/dev/shm) because the test suite is
+  # fsync-bound, not CPU-bound. The `internal/db` and `internal/sidecar`
+  # packages open hundreds of throwaway SQLite databases under t.TempDir(),
+  # and SQLite (WAL mode, default `synchronous`) fsyncs on every committed
+  # transaction — ~36,000 fsync calls for a single `internal/db` package
+  # run (measured with strace). On a developer host $TMPDIR is tmpfs,
+  # where fsync is a no-op (~1µs) and the package finishes in ~4s. The
+  # nix sandbox's build directory is disk-backed, where each fsync costs
+  # milliseconds: the same package measured 245s with TMPDIR on btrfs
+  # (~68× slower), and overran the default 10m per-package `go test`
+  # budget in CI sandbox runs. Pointing TMPDIR at the sandbox's /dev/shm
+  # tmpfs removes the fsync cost entirely and restores host-comparable
+  # runtimes. The temp DBs are tiny (a few MiB each), so /dev/shm's size
+  # cap is not a concern. GOCACHE and the build outputs are unaffected —
+  # only paths derived from os.TempDir() move.
+  #
+  # The `-timeout 30m` flag is belt-and-braces for environments where
+  # /dev/shm is unavailable (e.g. a non-Linux sandbox) and TMPDIR stays
+  # disk-backed: the fsync-bound packages then need minutes, not seconds,
+  # and the default 10m per-package budget can fire spuriously. It is an
+  # upper bound for pathological environments, not an expectation — with
+  # TMPDIR on tmpfs the whole suite completes in well under the default.
   checkPhase = ''
     runHook preCheck
     export GOFLAGS=''${GOFLAGS//-trimpath/}
+    if [ -d /dev/shm ] && [ -w /dev/shm ]; then
+      export TMPDIR="$(mktemp -d /dev/shm/prism-go-test.XXXXXX)"
+    fi
     go test -timeout 30m ./...
     runHook postCheck
   '';


### PR DESCRIPTION
Closes #2169

Resolves all four clusters of latent test failures surfaced when the homeless-shelter gate was restored in #2168, and removes every interim `t.Skip` guard referencing the issue.

## Cluster 1 — `internal/sidecar` / `internal/db` sandbox timeout: root cause found and fixed

**Decision: root-cause fix, not a timeout adjustment.** The suite is **fsync-bound, not CPU-bound**:

- The `internal/db` and `internal/sidecar` packages open hundreds of throwaway SQLite databases under `t.TempDir()`. SQLite (WAL mode, default `synchronous`) fsyncs on every committed transaction — **35,962 fsync calls** for a single `internal/db` package run, measured with `strace -c`.
- On a developer host, `$TMPDIR` is tmpfs, where fsync is ~1µs: the package finishes in **3.6s**.
- The nix sandbox's build dir is disk-backed. A/B test on the same machine/binary with `TMPDIR` on btrfs: **245s** (~68×). With CI sandbox contention on top, that overran the 10-minute per-package budget (the observed 599.945s / 162× from the issue).

**Fix:** `checkPhase` now redirects `TMPDIR` to a fresh dir under the sandbox's `/dev/shm` tmpfs, restoring host-equivalent fsync cost. Verified in the checked build log: `internal/db` **599.9s → 4.1s**, `internal/sidecar` 10-min-timeout → **23.6s**. The `-timeout 30m` flag is kept as documented belt-and-braces for environments without `/dev/shm` (rationale stands alone in the comment, no issue deferral).

## Cluster 2 — LayoutBare subtest no longer needs tmux to be meaningful

The `LayoutBare + empty PIExtensionDir` subtest now asserts the guard in both environments instead of skipping:

- tmux on PATH: `Create` must succeed end-to-end (unchanged).
- tmux absent: `Create` must fail at the tmux launch (`new-session: exec: ...`), **not** with a `piExtensionDir` guard error. The guard fires before any tmux invocation, so a wrongly-applied guard produces a `piExtensionDir` error in both environments — either branch catches the regression (verified by mutating `Create` to apply the guard to LayoutBare: both branches fail).

## Cluster 3 — fake clock for the Shutdown abort-flush tests

`Shutdown`'s drain wait is now armed via `s.cfg.Clock.AfterFunc` instead of `time.After` (identical behaviour on the real clock). The abort-flush tests assert behaviour on the fake clock instead of measuring wall-clock latency:

- **Healthy path**: fake timers never self-fire, so Shutdown returning at all proves the writer's ack released it (verified: breaking the ack path makes the test fail). Also asserts the drain timer was armed with the default bound.
- **Unhealthy path**: asserts Shutdown arms the configured drain timer, stays blocked while the writer is wedged, and returns once the test fires the timer — replacing the 90–350ms real-sleep window.
- **DefaultTimeoutApplies**: asserts the 250ms default registration on the fake clock instead of an elapsed-time bound.

`testTimer` now records its `AfterFunc` duration, and `testClock` gains `WaitForTimerWithDuration` to locate a specific timer deterministically.

## Cluster 4 — UUID substring flake fixed via direct cell assertions

`TestRenderCompareTable_LiveSessionStillShowsDash` now locates each aggregate row by its label and asserts all three pairwise cells (run-A, run-B, Δ) are the em-dash placeholder — fully independent of the generated instance UUID. Coverage preserved: seeding a terminal state (so aggregates render numbers) makes the test fail on the exact leaked cells.

## Verification

- `go build ./...`, `go test ./...`, and `go test ./... -race` pass on the host from `modules/programs/prism/prism/`.
- `nix build .#prism` passes.
- The checked build passes locally: `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'` — full suite green inside the sandbox, no skips referencing #2169 remain.
- Each reworked test was verified non-vacuous by reverting/mutating the code under test and confirming failure.