### PR TITLE
fix sandbox-environment quirks surfaced by the homeless-shelter gate (#2169)

### DIFF
--- a/modules/programs/prism/prism/cmd/stats_compare_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_test.go
@@ -17,7 +17,6 @@ package cmd
 // tmux, sidecar, or a real agent.
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -589,16 +588,32 @@ func TestRenderCompareTable_LiveSessionStillShowsDash(t *testing.T) {
 		t.Errorf("rendered output missing profile_name on live session:\n%s", out)
 	}
 	// But aggregate axes must read "—" — the session is still in progress.
-	// "100" / "150" are the seeded tokens from writeAssistantTurn — they
-	// must not surface for a still-active session. Use word-boundary regex
-	// rather than substring containment because the instance_id row in the
-	// rendered table is a UUID and ~1/256 UUIDs happen to end in "100" or
-	// "150", triggering a false-positive leak detection (issue #2169 §
-	// Cluster 4). Word boundaries ensure we only match the token values
-	// (which are whitespace-surrounded in the table), not UUID substrings.
-	leakRe := regexp.MustCompile(`\b(100|150)\b`)
-	if leakRe.MatchString(out) {
-		t.Errorf("rendered output leaks aggregate data for an active session:\n%s", out)
+	// Assert directly against the per-axis cells (via buildAxisRows, the
+	// same code path renderCompareTable uses internally) rather than
+	// substring-scanning the rendered table for the seeded token values
+	// ("100" / "150"). The whole-table substring approach was flaky:
+	// ~1/256 UUIDs happen to end in "100" or "150", so the instance_id
+	// row's UUID could match by coincidence regardless of what the
+	// aggregate cells actually contained. Asserting against the cells
+	// themselves is both flake-free and a stricter check — it fails if
+	// the aggregate cell renders any non-em-dash value, not just the two
+	// magic seeded numbers.
+	aggregateAxes := []string{
+		"tokens_input", "tokens_output", "tokens_cache_read", "tokens_cache_write",
+		"cost_usd", "tool_call", "tool_error", "msg_assistant",
+		"time_to_first_event", "time_to_finished",
+	}
+	rows := buildAxisRows(aggregateAxes, runs, false)
+	if len(rows) != len(aggregateAxes) {
+		t.Fatalf("buildAxisRows returned %d rows, want %d", len(rows), len(aggregateAxes))
+	}
+	const emDash = "—"
+	for _, row := range rows {
+		for i, v := range row.Values {
+			if v != emDash {
+				t.Errorf("aggregate cell %s[run=%d] = %q for an active session; want %q", row.Name, i, v, emDash)
+			}
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -447,22 +446,37 @@ func TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir(t *testing.T) {
 		}
 	})
 
-	t.Run("LayoutBare + empty PIExtensionDir: accepted (no agent pane to misconfigure)", func(t *testing.T) {
-		// LayoutBare is the dashboard's dead-session recovery path and
-		// the scratchpad fallback in restore. Both run with no agent.
-		// They legitimately leave PIExtensionDir empty and must NOT be
-		// blocked by the guard.
+	t.Run("LayoutBare + empty PIExtensionDir: guard does not fire", func(t *testing.T) {
+		// LayoutBare is the dashboard's dead-session recovery path and the
+		// scratchpad fallback in restore. Both run with no agent. They
+		// legitimately leave PIExtensionDir empty and must NOT be blocked
+		// by the guard that LayoutFull applies.
 		//
-		// LayoutBare opens a real tmux session, so the subtest requires
-		// tmux on PATH. tmux is intentionally NOT in nativeCheckInputs in
-		// pkgs/prism.nix (see the long comment there), so this subtest is
-		// skipped in the nix build sandbox. The sibling LayoutFull subtest
-		// above still runs because it asserts an error before any tmux
-		// call. Tracked in issue #2169 § Cluster 2.
-		if _, err := exec.LookPath("tmux"); err != nil {
-			t.Skip("tmux not found in PATH — skipping LayoutBare subtest; see issue #2169")
-		}
+		// The original shape of this subtest opened a real tmux session
+		// and asserted err == nil. That made the assertion depend on
+		// `tmux` being on $PATH, which is intentionally NOT the case in
+		// the nix build sandbox (see the long comment in pkgs/prism.nix)
+		// — the subtest then failed with "exec: tmux: not found" rather
+		// than catching anything about the PIExtensionDir guard.
+		//
+		// The guard is a fail-fast check at the top of session.Create:
+		//
+		//   if opts.Layout == LayoutFull {
+		//       if err := ValidatePILaunchOpts(opts); err != nil { ... }
+		//   }
+		//
+		// The assertion that matters is "this branch is not entered for
+		// LayoutBare". We can express that without invoking tmux by
+		// calling Create and checking that whatever error comes back (if
+		// any — None if tmux is on PATH, a tmux-exec error if not) is
+		// NOT the ValidatePILaunchOpts error. A regression that lifted
+		// the guard out of the LayoutFull branch would produce a
+		// "PIExtensionDir is not set" error here, which we explicitly
+		// reject.
 		name := "unit-test-2065-bare"
+		// Best-effort cleanup in case tmux IS available and the session
+		// actually got created. Safe to call when tmux is missing —
+		// KillSession just returns an error we ignore.
 		defer tmux.KillSession(name)
 		err := Create(name, dir, Opts{
 			Layout:         LayoutBare,
@@ -470,7 +484,7 @@ func TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir(t *testing.T) {
 			HarnessName:    "pi",
 			PIExtensionDir: "",
 		})
-		if err != nil {
+		if err != nil && strings.Contains(err.Error(), "PIExtensionDir is not set") {
 			t.Errorf("LayoutBare must not be blocked by the PIExtensionDir guard; got: %v", err)
 		}
 	})

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_shutdown_abort_flush_test.go
@@ -37,13 +37,25 @@ import (
 // ShutdownDrainTimeout bound. Issue #1849 AC: "On a healthy connection,
 // Shutdown returns within ~10ms of the abort frame being flushed".
 func TestShutdown_AbortFlush_HealthyPath_FastAck(t *testing.T) {
-	// In the nix build sandbox ($NIX_BUILD_TOP set), bwrap I/O overhead
-	// inflates the measured latency past the 50ms budget without indicating
-	// a real regression (observed: 104ms). The latency assertion's intent is
-	// "well under the old 100ms hard sleep on a host", and the nix sandbox
-	// is not a host. Tracked in issue #2169 § Cluster 3.
+	// This is a wall-clock assertion: the 50ms budget is meant to distinguish
+	// "ack-signal completes in ~1ms" from "old hard-sleep takes ~100ms". It
+	// is sensitive to scheduler latency on the host running the test.
+	//
+	// In the nix build sandbox (which uses bwrap on Linux and sandbox-exec
+	// on Darwin), Unix-socket I/O and goroutine wake-ups are measurably
+	// slower than on the host filesystem — enough that an entirely healthy
+	// abort-flush ack roundtrip routinely exceeds 50ms (observed: 104ms).
+	// That is a property of the sandbox, not a regression in the production
+	// code path under test. Skipping in that environment preserves the
+	// latency signal where it is meaningful (real hosts, CI's host runner)
+	// without producing false-positive failures inside the nix build.
+	//
+	// Coverage is preserved by the sibling tests in this file: AckArrives→
+	// AfterFlush still verifies the abort frame actually reaches the wire
+	// under sandbox conditions, and the unhealthy-path / default-timeout
+	// tests still exercise the bounded-wait branch unaffected.
 	if os.Getenv("NIX_BUILD_TOP") != "" {
-		t.Skip("skipping latency-budget test in nix build sandbox: bwrap I/O overhead inflates measured latency past the 50ms budget; see issue #2169")
+		t.Skip("nix build sandbox: bwrap/sandbox-exec I/O overhead inflates ack-roundtrip wall-clock latency past the 50ms budget without indicating a regression; latency signal is preserved on host runs")
 	}
 	sockPath := shortSockPath(t)
 	sc := newSocketPipeSidecar(t, sockPath)

--- a/pkgs/prism.nix
+++ b/pkgs/prism.nix
@@ -44,12 +44,35 @@ buildGoModule {
   # runs `go test ./... -race` on an Ubuntu runner; this job's purpose
   # is the $HOME=/homeless-shelter signal, not race coverage.
   #
-  # The `-timeout 30m` flag overrides the default 10m per-package budget:
-  # the bwrap sandbox is slower than the host (the `internal/sidecar` and
-  # `internal/db` packages each push close to the default 10m limit there
-  # even when they finish in tens of seconds on a host). The sandbox
-  # slowdown is tracked in issue #2169 § Cluster 1; this is a sandbox
-  # workaround, not a logic fix.
+  # The `-timeout 30m` flag overrides Go's default 10m per-package budget.
+  # This is a deliberate, permanent calibration for the nix-sandbox
+  # environment; it is not an interim workaround.
+  #
+  # Empirical baseline:
+  #   - `internal/db` (~270 tests, each calling db.Open which runs all
+  #     schema migrations): ~3.5s on a host shell, ~600s inside the nix
+  #     build sandbox — a ~170× slowdown.
+  #   - `internal/sidecar` (~150 tests, each constructing a Sidecar with
+  #     fresh db.Open + Unix-socket listeners + many goroutines): finishes
+  #     in tens of seconds on a host, brushes against the 10m default in
+  #     the sandbox.
+  #
+  # Root cause: the slowdown is dominated by per-syscall overhead, not
+  # fsync — a host-side microbench shows `synchronous=OFF` and
+  # `temp_store=MEMORY` produce no measurable speedup (db.Open averages
+  # ~6ms baseline and ~5.7ms with both pragmas). The most likely culprit
+  # is bwrap's per-syscall cost (user-namespace remapping + seccomp filter
+  # evaluation) multiplied by the many small syscalls modernc.org/sqlite
+  # makes per Open + per query. Mitigating it cleanly would require
+  # changing how the production driver opens databases (e.g. an in-memory
+  # mode for tests, or batching the migration run), which is out of scope
+  # for the gate — the gate's job is to surface $HOME-touching failures,
+  # not to optimise SQLite-in-bwrap throughput.
+  #
+  # 30m gives ~3× headroom over the worst observed package runtime (600s),
+  # which absorbs CI runner load variance without masking a genuine
+  # infinite-loop regression. Raising it further would weaken the
+  # "a stuck test eventually fails" signal without practical benefit.
   checkPhase = ''
     runHook preCheck
     export GOFLAGS=''${GOFLAGS//-trimpath/}


### PR DESCRIPTION
Fixes the four clusters of latent test failures surfaced by restoring the
`nix-build-prism-checked` homeless-shelter gate in #2168 / #2172.

All four were hidden behind interim `t.Skip` guards that deferred to issue
#2169; this PR removes those guards (or refactors the tests so the guard is
unnecessary) so the AC clause "skips that remain state their own environment
condition and rationale rather than deferring to the issue number" is
satisfied.

## Cluster 4 — UUID substring flake (`cmd/stats_compare_test.go`)

`TestRenderCompareTable_LiveSessionStillShowsDash` substring-scanned the
whole rendered table for the seeded token values (`"100"` / `"150"`). About
1/256 generated UUIDs end in either string, so the `instance_id` row could
match by coincidence regardless of what the aggregate cells actually
contained.

Fix: replace the substring scan with a direct assertion against
`buildAxisRows(aggregateAxes, runs, false)` — the same code path
`renderCompareTable` uses internally — and check each cell equals `"—"`.
The new check is both flake-free and **stricter** than the original: it
fails if the aggregate cell renders any non-em-dash value, not just the two
magic seeded numbers.

Verified non-vacuous by temporarily flipping the expected character: every
aggregate cell row fails as expected.

## Cluster 2 — `tmux` not in `$PATH` (`internal/session/session_test.go`)

`TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir/LayoutBare_+_empty_PIExtensionDir`
called `Create` with `LayoutBare` and asserted `err == nil`, which made the
subtest depend on `tmux` being on `$PATH`. `tmux` is intentionally absent
from `nativeCheckInputs` (see the long comment in `pkgs/prism.nix`).

Refactor (preferred over a skip): keep calling `Create` with the same
options but assert that the returned error, if any, does **not** contain
`"PIExtensionDir is not set"` — the marker the `LayoutFull` guard would
produce.

- If `tmux` is on `$PATH` (host run): `Create` succeeds, error is `nil`, no
  guard message — passes.
- If `tmux` is missing (nix sandbox): `Create` fails at
  `tmux.NewSessionDetached` with `"exec: tmux: not found"`, which does
  **not** contain the guard marker — passes.
- If a regression lifts `ValidatePILaunchOpts` out of the `LayoutFull`
  branch: the guard fires for `LayoutBare`, error contains `"PIExtensionDir
  is not set"` — fails.

Verified non-vacuous by temporarily lifting the guard out of the
`LayoutFull` conditional: the LayoutBare subtest fails as expected with the
guard message.

## Cluster 3 — 50ms shutdown latency budget (`internal/sidecar/`)

`TestShutdown_AbortFlush_HealthyPath_FastAck` measures wall-clock latency to
distinguish the new ack-signal implementation (~1ms on a healthy host) from
the old 100ms hard-sleep. The 50ms cap is sensitive to scheduler latency.
In the nix sandbox, Unix-socket I/O and goroutine wake-ups are measurably
slower (observed 104ms) without indicating a regression.

Considered: refactoring to use a fake clock. **Not pursued** because the
ackCh path uses a real writer goroutine writing to a real Unix socket — the
wall-clock measurement is around real I/O, not around a `time.After` the
clock abstraction could substitute. Plumbing a fake clock into this test
would require non-trivial production-code changes (`Shutdown` would have to
use `Clock.AfterFunc` for the drain timeout) and would leave the
healthy-path wall-clock measurement unchanged.

Chosen: documented skip with **self-contained** rationale (no `see issue
#NNNN` deferral). The skip clearly explains the latency-budget intent,
identifies the environment property responsible (bwrap / sandbox-exec
syscall overhead), and notes that sibling tests
(`AckArrivesAfterFlush`, `UnhealthyPath_BoundedByDrainTimeout`,
`DefaultTimeoutApplies`) preserve coverage of the abort-flush mechanism
under sandbox conditions.

## Cluster 1 — `internal/db` + `internal/sidecar` sandbox slowdown (`pkgs/prism.nix`)

The `-timeout 30m` override is already in place (from #2172) but was framed
as an interim workaround referencing issue #2169.

**Decision: principled timeout adjustment, not a root-cause fix.**

The issue spec explicitly permitted this: "attempt to identify the root
cause of the 162× slowdown if tractable, but do NOT disappear into an
open-ended profiling exercise. A principled timeout adjustment with the
rationale documented (in code comments and the PR description) is an
acceptable resolution."

What I investigated before settling on the timeout decision:

- **Hypothesis: fsync.** Falsified. A host-side microbench
  (`internal/db/bench_local_test.go`, removed before commit) measured 30
  back-to-back `db.Open` calls under each of: baseline, `synchronous=OFF`,
  `temp_store=MEMORY`, and both together. All four cases averaged
  5.7–6.0 ms per `Open` — no measurable speedup. The bottleneck is not
  fsync.
- **Hypothesis: per-syscall overhead under bwrap.** Plausible but not
  feasible to confirm without running inside the actual nix build sandbox
  (which would have required disappearing into an open-ended profiling
  exercise — explicitly out of scope per the spec). modernc.org/sqlite is
  pure Go and makes many small syscalls per `Open`/query; bwrap's
  user-namespace remapping + seccomp filter evaluation cost compounds per
  syscall. The 270 tests in `internal/db` each call `db.Open` (full
  migrations) and the 150 tests in `internal/sidecar` each construct a
  `Sidecar` (db.Open + Unix-socket listeners + many goroutines), so the
  per-syscall amplification fits the observed magnitude (~170× for
  internal/db, brushing the 10m limit for internal/sidecar).
- **A real fix would require production-code changes** (e.g. an in-memory
  test mode, batched migration runs) which is out of scope for this gate
  — the gate's job is to surface `$HOME`-touching failures, not to optimise
  SQLite-in-bwrap throughput.

`30m` gives ~3× headroom over the worst observed package runtime (600s for
`internal/db`), which absorbs CI runner load variance without masking a
genuine infinite-loop regression. The comment is updated in `pkgs/prism.nix`
to make it a deliberate, permanent calibration with documented empirical
baseline and root-cause hypothesis.

## Verification

- `go build ./...` and `go test ./...` pass from
  `modules/programs/prism/prism/`.
- `nix build .#prism` passes (default attribute, `runChecks = false`).
- `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'`
  passes — this is the homeless-shelter sandbox CI runs.
- No remaining `2169` references in prism Go sources or `pkgs/`.
- All targeted tests verified non-vacuous (catch regressions when the fix
  is reverted, pass when applied).

Closes #2169.
