### PR TITLE
kitty: disable config auto-reload watcher (auto_reload_config -1)

### DIFF
--- a/modules/programs/kitty.nix
+++ b/modules/programs/kitty.nix
@@ -11,6 +11,17 @@ let
   background = if type == "dark" then bg0 else bg_dim;
 
   kittyconf = ''
+    # Disable config auto-reload entirely (issue #2198, #2180-class FD-exhaustion
+    # incidents). kitty >= 0.47.1 spawns a `kitten __watch_conf__` watcher that
+    # resolves the HM config symlink into /nix/store and, on nixpkgs no-cgo
+    # Darwin builds, kqueue-watches the entire store — one FD per store entry,
+    # ~115k FDs per kitty instance — exhausting the host FD pool (the same bug
+    # manifests as inotify-watch exhaustion on Linux, hence no platform gate).
+    # The upstream 0.47.2 fix does NOT help nixpkgs Darwin builds (fswatcher's
+    # kqueue backend ignores the depth option), and auto-reload never worked
+    # with store-immutable configs anyway. Manual reload: ctrl+shift+f5.
+    auto_reload_config -1
+
     symbol_map U+1f636,U+200D,U+1F32B,U+FE0F Noto Color Emoji
     prefer_color_emoji yes
     hide_window_decorations titlebar-only


### PR DESCRIPTION
Closes #2198
Refs #2181

## What

Adds `auto_reload_config -1` to the kitty config in `modules/programs/kitty.nix`, disabling the `kitten __watch_conf__` config watcher entirely. Cross-platform — not gated to Darwin (the same bug class manifests as inotify-watch exhaustion on Linux).

## Why

kitty ≥ 0.47.1 spawns a `kitten __watch_conf__` watcher per instance that resolves the Home Manager config symlink into `/nix/store` and, on nixpkgs no-cgo Darwin builds, kqueue-watches the entire store — one FD per store entry, observed at 61,443–115,333 FDs per kitten process and 244,822 total (`kern.num_files`) with three OS windows open. This is the #2180-class system-wide FD-exhaustion incident.

The upstream 0.47.2 fix does **not** help nixpkgs no-cgo Darwin builds: fswatcher's kqueue backend ignores the depth option. And auto-reload never worked here anyway — HM configs are store-immutable, so there is nothing useful to watch.

**Automatic config reload is disabled by design.** Manual reload remains available via `ctrl+shift+f5`.

## Verification crib (post-switch, live host)

1. `darwin-rebuild switch` (or `nh switch`), then fully restart kitty (quit all instances, relaunch).
2. `pgrep -fl __watch_conf__` → expect **no** watcher processes.
3. For each surviving `kitten` process: no open *directory* FDs on `/nix/store` or `/nix/store/.links` (executable/text mappings of the kitten binary itself are exempt) — e.g. `lsof -p <pid> | grep -c '/nix/store'` should show only binary mappings; total open FDs per process below **200** (`lsof -p <pid> | wc -l`).
4. With three kitty OS windows open: `sysctl -n kern.num_files` → expect below **20,000** steady-state (was 244,822).
5. Run a `darwin-rebuild switch` that creates new store paths — kitten FD counts should not grow proportionally (constant small delta only).
6. kitty starts and renders with the existing themed config — config delivery unchanged on both Darwin and Linux.

## Validation

- `nixfmt --check modules/programs/kitty.nix` — clean.
- Eval renders the directive correctly into the generated kitty.conf; theming intact (validated in the originating session).
- Local sandbox cannot run the full flake eval (`~/.local/share/nix/trusted-settings.json` access); CI's `validate-flakes` job is the authoritative eval gate for this PR.