### PR TITLE
darwin: raise kern.maxfiles / kern.maxfilesperproc via nix-darwin module (FD isolation Layer 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,18 +113,37 @@ says so.
 Specifically, do NOT override any of `XDG_DATA_HOME`, `NIX_STORE_DIR`,
 `NIX_DATA_DIR`, or `HOME` to try to "isolate" or "reset" nix between
 retries. Pointing nix's local profile / trust DB / daemon-socket linkage at
-an empty tempdir forces nix to bootstrap a fresh single-user store, and
-inside sandbox-exec (no host nix-daemon access) the parallel evaluation
-leaks file descriptors that the next retry inherits. On Darwin this
-exhausts the system-wide `kern.maxfiles` cap; once hit, *every* process on
-the host that calls `open()` fails (Karabiner, Chrome, Finder, the agent's
-own harness), and recovery requires a reboot. This actually happened — see
-issue #2180 for the post-incident writeup.
+an empty tempdir forces nix to bootstrap a fresh single-user store, which
+opens large numbers of file descriptors and adds real pressure to the
+host-wide FD pool. During the #2180 incident the host had no headroom to
+absorb that: the root cause was kitty's kitten config watcher recursively
+kqueue-watching `/nix/store` — one open FD per store entry — which had
+pre-consumed nearly the entire system-wide `kern.maxfiles` pool (see issue
+#2198). The env-override retries were marginal extra pressure on an
+already-exhausted pool, and once `kern.num_files` reaches `kern.maxfiles`,
+*every* process on the host that calls `open()` fails (Karabiner, Chrome,
+Finder, the agent's own harness) and recovery requires a reboot. This
+actually happened — see issue #2180 for the incident retrospective (its
+causal story is superseded by #2198). The guidance stands regardless of
+the root cause: escalate, don't work around.
 
 The pi extension's pre-tool-call deny list (`BLOCKED_BASH_PATTERNS` in
 `modules/programs/prism/pi/extensions/prism.ts`) also blocks this command
 shape as defence in depth; if you see that block fire, the correct response
 is still `prism escalate`, not a different workaround.
+
+### Darwin FD-exhaustion defences (#2180 class)
+
+`modules/darwin/sysctls.nix` is the **Layer 2** (host-wide) defence against
+#2180-class FD exhaustion (parent: #2181). It raises `kern.maxfiles` to
+524288 and `kern.maxfilesperproc` to 262144 via a boot-time launchd daemon
+(`RunAtLoad`, so the values survive reboots — `/etc/sysctl.conf` is not
+read at boot on modern macOS) paired with an activation script (so the
+values apply during `darwin-rebuild switch` without a reboot). Both paths
+are idempotent and never lower a sysctl that is already at or above target.
+This is headroom only — the root-cause leak is the kitten `/nix/store`
+watcher, tracked in #2198. Do not raise these values further to absorb
+that leak.
 
 ### sandbox-exec testing convention
 

--- a/flake.nix
+++ b/flake.nix
@@ -121,7 +121,7 @@
           modules = [
             ./machines/${configFile}/configuration.nix
             home-manager.darwinModules.home-manager
-            ./modules/darwin/impermanence-stub.nix
+            ./modules/darwin
           ]
           ++ extraModules;
         };

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -2,5 +2,6 @@
 {
   imports = [
     ./impermanence-stub.nix
+    ./sysctls.nix
   ];
 }

--- a/modules/darwin/sysctls.nix
+++ b/modules/darwin/sysctls.nix
@@ -1,0 +1,76 @@
+# FD isolation Layer 2 (issue #2191, parent #2181): raise the Darwin
+# file-descriptor sysctls so legitimate host workload plus burst load
+# (nix builds, darwin-rebuild switches) cannot exhaust the system-wide
+# FD pool — the #2180-class failure mode where kern.num_files reaches
+# kern.maxfiles and every open() on the host fails.
+#
+# This is headroom, not the leak fix: the root cause of the 2026-06-11
+# incidents is kitty's kitten config watcher recursively kqueue-watching
+# /nix/store (issue #2198). Do not raise these values further to absorb
+# that leak — fix #2198 instead.
+#
+# Values were proven good on m4mac on 2026-06-11: after a manual
+# `sysctl -w kern.maxfiles=524288 kern.maxfilesperproc=262144`, a
+# previously-failing `darwin-rebuild switch` completed cleanly.
+# (Darwin defaults observed beforehand: kern.maxfiles=122880,
+# kern.maxfilesperproc=61440.)
+{ pkgs, lib, ... }:
+let
+  maxFiles = 524288;
+  maxFilesPerProc = 262144;
+
+  # Idempotent and never lowers: each sysctl is written only when the
+  # running kernel value is below the target, so re-running (a second
+  # switch, every boot) is a no-op once the values are in place, and a
+  # kernel already at or above target is left alone.
+  raiseFdSysctls = pkgs.writeShellScript "raise-fd-sysctls" ''
+    set -eu
+
+    raise() {
+      key=$1
+      target=$2
+      current=$(/usr/sbin/sysctl -n "$key")
+      if [ "$current" -lt "$target" ]; then
+        /usr/sbin/sysctl -w "$key=$target"
+      fi
+    }
+
+    # Order matters: kern.maxfilesperproc may not exceed kern.maxfiles,
+    # so raise the system-wide cap first.
+    raise kern.maxfiles ${toString maxFiles}
+    raise kern.maxfilesperproc ${toString maxFilesPerProc}
+  '';
+in
+{
+  # Persistence across reboots. /etc/sysctl.conf is NOT read at boot on
+  # modern macOS — launchd dropped that behaviour when it went
+  # closed-source after 10.9 (the sysctl.conf(5) man page is stale
+  # FreeBSD-inherited documentation, and the file does not exist on the
+  # host). A launchd daemon running `sysctl -w` at boot (RunAtLoad, as
+  # root) is the persistence mechanism instead.
+  # /bin/wait4path guards against the daemon starting before the /nix
+  # APFS volume is mounted at boot (the script's interpreter lives in
+  # the store). Logs go to /var/log, not /tmp: a root daemon writing a
+  # predictable /tmp path would be a symlink-attack hazard.
+  launchd.daemons.fd-sysctls = {
+    serviceConfig = {
+      ProgramArguments = [
+        "/bin/sh"
+        "-c"
+        "/bin/wait4path ${raiseFdSysctls} && exec ${raiseFdSysctls}"
+      ];
+      RunAtLoad = true;
+      KeepAlive = false;
+      StandardOutPath = "/var/log/fd-sysctls.log";
+      StandardErrorPath = "/var/log/fd-sysctls.log";
+    };
+  };
+
+  # Apply during `darwin-rebuild switch` itself so the first activation
+  # needs no reboot. nix-darwin activation runs as root, which
+  # `sysctl -w` requires.
+  system.activationScripts.extraActivation.text = lib.mkAfter ''
+    echo "ensuring kern.maxfiles >= ${toString maxFiles} and kern.maxfilesperproc >= ${toString maxFilesPerProc} (FD isolation Layer 2, #2191)..."
+    ${raiseFdSysctls}
+  '';
+}


### PR DESCRIPTION
Closes #2191
Refs #2181

## Summary

Adds `modules/darwin/sysctls.nix` — the **Layer 2** (host-wide) defence against #2180-class FD exhaustion. Raises `kern.maxfiles` to **524288** and `kern.maxfilesperproc` to **262144**, the values proven good on m4mac on 2026-06-11 (a manual `sysctl -w` with these values unblocked a previously-failing `darwin-rebuild switch`; they are live on the host now but do not survive reboot).

### Mechanism

- **Persistence across reboots:** a launchd daemon (`org.nixos.fd-sysctls`, `RunAtLoad`, runs as root) re-applies the values at every boot. `/etc/sysctl.conf` is **not** read at boot on modern macOS — launchd dropped that behaviour when it went closed-source after 10.9; the `sysctl.conf(5)` man page is stale FreeBSD-inherited documentation and the file does not exist on the host. The daemon uses `/bin/wait4path` so it cannot race the `/nix` APFS volume mount, and logs to `/var/log` (not a predictable `/tmp` path, which would be a symlink hazard for a root daemon).
- **Apply during switch (no reboot needed):** a `system.activationScripts.extraActivation` block (`lib.mkAfter`, merges cleanly with m4mac's existing `extraActivation`) runs the same script during `darwin-rebuild switch`. nix-darwin activation runs as root, which `sysctl -w` requires.
- **Idempotent / never lowers:** both paths share one `writeShellScript`; each sysctl is written only when the running kernel value is *below* target. Re-running a switch is a no-op; a kernel already at or above target (the current host state) is left untouched. `kern.maxfiles` is raised before `kern.maxfilesperproc` since the per-proc value may not exceed the system-wide cap.

### Wiring

`modules/darwin/default.nix` was previously dead code — flake.nix imported `impermanence-stub.nix` directly. flake.nix now imports `./modules/darwin`, making the `default.nix` import chain (and the new module) live. No behaviour change for the stub.

### AGENTS.md

- New subsection **"Darwin FD-exhaustion defences (#2180 class)"** naming the module as the Layer 2 defence.
- The **"When `nix build` fails inside a sandbox"** causal explanation is corrected: the root cause of the system-wide exhaustion was kitty's kitten config watcher recursively kqueue-watching `/nix/store` (#2198), pre-consuming the FD pool; the env-override retries were marginal pressure on an already-exhausted pool. The escalate-don't-override guidance is unchanged.

This is headroom, not the leak fix — #2198 (kitten watcher) is the root-cause fix. Do not raise these values further to absorb that leak.

## Validation

- `nixfmt` clean on all changed nix files; `nix-instantiate --parse` passes on `flake.nix`, `modules/darwin/default.nix`, `modules/darwin/sysctls.nix`.
- **Local flake-CLI eval was unavailable in-sandbox**: `nix build` / `nix eval` (even `--dry-run`) fail with `opening file ".../.local/share/nix/trusted-settings.json": Operation not permitted` — the flake's `nixConfig` block triggers a real-home read that sandbox-exec denies. Per AGENTS.md no env workarounds were attempted; escalated informationally to the coordinator.
- **Full pre-merge Nix evaluation was instead performed via non-flake `nix-instantiate`** (the old CLI does not process flake `nixConfig`, so it sidesteps the trusted-settings read without touching the environment):
  - `nix-instantiate --eval --expr 'let f = builtins.getFlake (toString ./.); in f.darwinConfigurations.m4mac.system.drvPath'` → instantiates the **complete system derivation** cleanly (`/nix/store/9m0p82z8h56ly220ba25gsl38m0rhfsc-darwin-system-26.11.6a77112.drv`).
  - Module-level assertions against the same eval: `launchd.daemons.fd-sysctls.serviceConfig.ProgramArguments` renders the wait4path-wrapped store script with `RunAtLoad = true`, and `system.activationScripts.extraActivation.text` contains **both** m4mac's pre-existing Plexamp block and the new sysctls block — the `lib.mkAfter` merge is confirmed in real eval, not just by inspection.
- **CI coverage caveat (corrected after review round 1):** `nix flake check --all-systems` (the `validate-flakes` PR job) does **not** deep-evaluate `darwinConfigurations.m4mac` — it only shallow-checks the output attrset. The only CI job that evaluates/builds the darwin system is `build-and-cache`, which runs on push to `main` (post-merge) or `workflow_dispatch`. A dispatch on this branch (`gh workflow run build-and-cache --ref darwin-fd-sysctls`) was attempted but the token lacks workflow-dispatch permission (HTTP 403). The non-flake full-system eval above is the pre-merge evaluation evidence; the post-merge `build-and-cache` run on main and the user's `darwin-rebuild switch` (crib below) are the build-level backstops.
- Non-prism PR: no Go tests required.

## Verification crib (user, on m4mac, post-merge)

After `darwin-rebuild switch`:

```bash
sysctl -n kern.maxfiles          # expect >= 524288
sysctl -n kern.maxfilesperproc   # expect >= 262144
sudo launchctl print system/org.nixos.fd-sysctls | head -20   # daemon loaded
```

Idempotency — run a second switch with no other changes; the activation step must not error:

```bash
darwin-rebuild switch --flake .#m4mac   # (or nh equivalent) — expect clean re-run
```

After a reboot (no manual sysctl -w beforehand):

```bash
sysctl -n kern.maxfiles          # expect >= 524288  (daemon re-applied at boot)
sysctl -n kern.maxfilesperproc   # expect >= 262144
cat /var/log/fd-sysctls.log      # daemon output, if any writes were needed
```

Never-lower check (optional): with values already at target, re-run the script via a switch — `sysctl -n` values must be unchanged, not reset downward.

