### PR TITLE
prism: allow sandboxed read of nix trusted-settings.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,40 @@ This is not a hypothetical: PR #1455 (`TestDeliverToSession_PiPath_DeliverAsForw
 
 **Scope — this gate applies only to prism-touching PRs.** PRs that touch only non-prism files (other modules, dotfiles, docs) do **not** trigger the `go-tests` or `nix-build-prism-checked` jobs. The relaxation introduced in #1441 stands for those paths.
 
+### In-sandbox nix validation on this repo (flake CLI and trusted-settings)
+
+This repo's `flake.nix` has a `nixConfig` block (`extra-substituters` /
+`extra-trusted-public-keys`). Any flake-CLI nix command therefore makes nix
+consult `~/.local/share/nix/trusted-settings.json` in the **real** home
+(inside a sandbox, `XDG_DATA_HOME` points at the real `~/.local/share`).
+`--no-accept-flake-config` does NOT avoid the lookup.
+
+As of issue #2201 the sandbox-exec profile grants **read-only** access to
+that single file, so flake-CLI commands (`nix build .#prism --dry-run`,
+`nix flake metadata`, the pre-PR `nix build .#prism`, …) work inside worker
+sandboxes. Notes:
+
+- The allowance applies to sandboxes **spawned after the fix is deployed**
+  (next `nh switch`). In a sandbox pre-dating it, flake CLI fails with
+  `error: opening file "…/trusted-settings.json": Operation not permitted`.
+  The sanctioned fallback for eval-level validation in that case is the
+  non-flake pattern, which does not process flake `nixConfig` and so
+  sidesteps the read entirely:
+
+  ```bash
+  # From the repo root
+  nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'
+  ```
+
+- A `warning: ignoring untrusted flake configuration setting` from the flake
+  CLI is harmless — it means the host trust list does not (yet) cover this
+  repo's settings; eval proceeds without the extra substituters.
+- Do not try to accept-and-persist flake config from inside a sandbox
+  (e.g. answering an interactive trust prompt with "permanently mark"):
+  the write path to `trusted-settings.json` is still denied, by design.
+- Never reach for env overrides when nix misbehaves in a sandbox — see the
+  next section.
+
 ### When `nix build` fails inside a sandbox
 
 The local `nix build .#prism` is a *pre-PR* check, not the authoritative

--- a/modules/programs/prism/prism/docs/sandbox-exec-testing.md
+++ b/modules/programs/prism/prism/docs/sandbox-exec-testing.md
@@ -149,6 +149,9 @@ integration test coverage exists for:
 - **Staging-HOME credential reads** — symlink targets resolved at staging
   time (e.g. `~/.config/aws/readonly-config`, the SSH access key) accessed
   via the in-sandbox `$HOME` path.
+- **Nix flake trusted-settings read** — the single-file read-only allow on
+  `~/.local/share/nix/trusted-settings.json` that flake-CLI nix commands
+  need when the target flake declares a `nixConfig` block (issue #2201).
 - **Explicit denies** — `~/.aws`, `/private/etc/wireguard`,
   `/private/etc/wpa_supplicant`, `/private/etc/ssh` are blocked.
 - **Network egress** — `(allow network*)` permits outbound TCP.

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -299,6 +299,32 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
+	// ── 5b. Nix flake trusted-settings read (issue #2201) ────────────────
+	// Flake-CLI nix commands consult $XDG_DATA_HOME/nix/trusted-settings.json
+	// whenever the target flake declares a nixConfig block (e.g. this repo's
+	// extra-substituters / extra-trusted-public-keys). XDG_DATA_HOME inside
+	// the sandbox points at the real host ~/.local/share — see the env
+	// assembly in cmd/agent_run_sandbox_exec_darwin.go — so under
+	// deny-default the read fails EPERM and nix aborts the entire eval,
+	// making every flake CLI command unusable on such repos.
+	//
+	// The file holds the user's accept/ignore decisions for flake-provided
+	// config settings; its contents are not secret. The allow is read-only
+	// and single-file (literal, not subpath): nix only ever writes the file
+	// from an interactive "permanently mark this value as trusted" prompt
+	// (readTrustedList/writeTrustedList in nix's src/libflake/config.cc),
+	// and persisting trust decisions from inside a sandbox should remain
+	// blocked. When the file does not exist, nix's pathExists probe returns
+	// false (the literal allow covers the stat, so it yields ENOENT rather
+	// than EPERM) and nix proceeds with an empty trusted list — its normal
+	// missing-file path.
+	if home != "" {
+		nixTrustedSettings := filepath.Join(home, ".local", "share", "nix", "trusted-settings.json")
+		sb.WriteString("(allow file-read* file-test-existence\n")
+		sb.WriteString("  (literal " + quoteSBPL(nixTrustedSettings) + "))\n")
+		sb.WriteString("\n")
+	}
+
 	// ── 6. Staging HOME + worktree + bare repo + host-API socket (RW) ────
 	// Session-specific read-write paths. Locked in #1012 and #1017.
 	// file-test-existence and file-read-metadata added alongside file-read*

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -449,6 +449,53 @@ func TestGenerateProfile_AWSSSOAndCLICarveouts(t *testing.T) {
 	}
 }
 
+// TestGenerateProfile_NixTrustedSettingsReadAllow verifies that the profile
+// contains a read-only, single-file (literal) allow for
+// ~/.local/share/nix/trusted-settings.json (issue #2201). Flake-CLI nix
+// commands consult this file whenever the target flake declares a nixConfig
+// block; without the allow the read fails EPERM under deny-default and nix
+// aborts the entire eval.
+//
+// The rule must be:
+//   - a (literal ...), not a (subpath ...) — single-file scope only;
+//   - read-only — no file-write* anywhere near it (nix only writes the file
+//     from an interactive trust prompt, which should remain blocked).
+//
+// This substring assertion is necessary but not sufficient — the paired
+// Darwin integration tests in
+// internal/integration/sandbox_exec_nix_trusted_settings_darwin_test.go
+// prove the rule is load-bearing against /usr/bin/sandbox-exec per
+// docs/sandbox-exec-testing.md.
+func TestGenerateProfile_NixTrustedSettingsReadAllow(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	trustedSettings := filepath.Join(fakeHome, ".local", "share", "nix", "trusted-settings.json")
+
+	// The exact rule block as emitted by generateProfile: a read-only allow
+	// with file-test-existence (so nix's pathExists probe gets ENOENT, not
+	// EPERM, when the file is missing) on a single literal path.
+	wantBlock := "(allow file-read* file-test-existence\n" +
+		"  (literal \"" + trustedSettings + "\"))\n"
+	if !strings.Contains(profile, wantBlock) {
+		t.Errorf("profile missing the nix trusted-settings read-only allow block:\n%s\nfull profile:\n%s", wantBlock, profile)
+	}
+
+	// The path must appear exactly once — in the read-only block above. A
+	// second occurrence would mean it leaked into another (potentially
+	// writable) clause.
+	if got := strings.Count(profile, trustedSettings); got != 1 {
+		t.Errorf("trusted-settings path must appear exactly once in the profile (read-only literal); found %d occurrences.\nfull profile:\n%s", got, profile)
+	}
+
+	// Single-file scope: the path must never be granted as a subpath.
+	if strings.Contains(profile, "(subpath \""+trustedSettings+"\")") {
+		t.Errorf("trusted-settings path must be a (literal ...), not a (subpath ...); full profile:\n%s", profile)
+	}
+}
+
 // TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded verifies that when
 // ~/.aws/sso and ~/.aws/cli symlinks exist in the staging HOME, their resolved
 // targets are included in the collected set (not excluded by the deniedPrefixes

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_nix_trusted_settings_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_nix_trusted_settings_darwin_test.go
@@ -1,0 +1,152 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_nix_trusted_settings_darwin_test.go — integration coverage for
+// the single-file read-only allow on ~/.local/share/nix/trusted-settings.json
+// (issue #2201).
+//
+// Flake-CLI nix commands consult $XDG_DATA_HOME/nix/trusted-settings.json
+// whenever the target flake declares a nixConfig block. Inside a sandbox-exec
+// session XDG_DATA_HOME points at the real host ~/.local/share (see
+// cmd/agent_run_sandbox_exec_darwin.go), so under deny-default the read
+// failed EPERM and nix aborted the entire eval — making every flake CLI
+// command unusable on repos with a nixConfig block (e.g. nixos-config).
+//
+// Per docs/sandbox-exec-testing.md the coverage is a positive/negative pair:
+//
+//   - TestSandboxExecProfile_NixTrustedSettingsReadable proves the generated
+//     profile permits opening the file for reading. The test NEVER creates or
+//     modifies the real host file (it is the user's actual nix trust store),
+//     so it asserts on whichever state the host is in: when the file exists
+//     the read must exit 0; when it is absent the open must be attempted and
+//     fail with ENOENT ("No such file or directory") — NOT EPERM ("Operation
+//     not permitted"). Both branches prove the sandbox allowed the open,
+//     which is exactly the property nix needs (nix's pathExists/readFile
+//     tolerate ENOENT but abort on EPERM). The ENOENT branch also covers the
+//     issue #2201 edge-case AC: a missing host file follows nix's normal
+//     missing-file path instead of crashing.
+//
+//   - TestSandboxExecProfile_NixTrustedSettingsDeniedWithoutRule mutates the
+//     profile to remove the allow block and asserts the same read fails with
+//     "Operation not permitted" — proving the positive test is not green by
+//     accident.
+//
+// Both tests use newProfileManagerWithBareRoot: production worker sessions
+// always have BareRoot set, so the ancestor metadata block is present, and
+// the rule under test grants file-read-data which the BareRoot ancestor
+// block (file-test-existence/file-read-metadata only) cannot mask in the
+// negative test.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// nixTrustedSettingsPath returns the host path of nix's flake
+// trusted-settings file, derived the same way generateProfile derives it
+// (os.UserHomeDir() + .local/share/nix/trusted-settings.json).
+func nixTrustedSettingsPath(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	return filepath.Join(home, ".local", "share", "nix", "trusted-settings.json")
+}
+
+// TestSandboxExecProfile_NixTrustedSettingsReadable is the positive half:
+// under the unmodified production profile, opening
+// ~/.local/share/nix/trusted-settings.json for reading must not be denied by
+// the sandbox.
+func TestSandboxExecProfile_NixTrustedSettingsReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	target := nixTrustedSettingsPath(t)
+
+	m := newProfileManagerWithBareRoot(t)
+	prepared, _ := preparePositiveProfile(t, m)
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+
+	// Regardless of whether the host file exists, the sandbox must not be
+	// the thing that blocks the open.
+	if strings.Contains(string(out), "Operation not permitted") {
+		t.Errorf("read of %s was denied by the sandbox (EPERM) under the production profile.\n"+
+			"The nix trusted-settings allow (issue #2201) is missing or not load-bearing —\n"+
+			"flake-CLI nix commands will abort inside worker sandboxes on repos with a nixConfig block.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	}
+
+	// Branch on actual host state — the test must never create or modify
+	// the user's real trusted-settings.json.
+	if _, statErr := os.Stat(target); statErr == nil {
+		// File exists on the host: the sandboxed read must succeed outright.
+		if runErr != nil {
+			t.Errorf("host file %s exists but the sandboxed read failed.\nExit: %v\nOutput: %s\nProfile: %s",
+				target, runErr, string(out), profilePath)
+		}
+	} else if os.IsNotExist(statErr) {
+		// File absent on the host: the open must have been attempted and
+		// failed with ENOENT — the sane missing-file path nix tolerates.
+		if runErr == nil {
+			t.Errorf("cat of missing file %s exited 0 — test environment is inconsistent.\nOutput: %s",
+				target, string(out))
+		}
+		if !strings.Contains(string(out), "No such file or directory") {
+			t.Errorf("cat of missing file %s did not fail with ENOENT; the sandbox may be interfering.\nExit: %v\nOutput: %s\nProfile: %s",
+				target, runErr, string(out), profilePath)
+		}
+	} else {
+		t.Fatalf("stat %s: %v", target, statErr)
+	}
+}
+
+// TestSandboxExecProfile_NixTrustedSettingsDeniedWithoutRule is the paired
+// negative test: with the trusted-settings allow block removed from the
+// generated profile, the same read must fail with EPERM. This proves the
+// positive test exercises the rule itself rather than passing by accident
+// (e.g. via some broader allow).
+func TestSandboxExecProfile_NixTrustedSettingsDeniedWithoutRule(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	target := nixTrustedSettingsPath(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	// Remove the entire self-contained allow block as emitted by
+	// generateProfile. withMutatedProfile fails the test if the substitution
+	// does not match anything, so format drift in the generator is caught.
+	ruleBlock := "(allow file-read* file-test-existence\n" +
+		"  (literal " + sbplQuoteForTest(target) + "))\n"
+	profilePath := withMutatedProfile(t, m, func(p string) string {
+		return strings.Replace(p, ruleBlock, "", 1)
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read of %s succeeded WITHOUT the trusted-settings allow rule — some broader allow\n"+
+			"covers the path and the positive test is not isolating the rule under test.\nOutput: %s\nProfile: %s",
+			target, string(out), profilePath)
+	}
+	if !strings.Contains(string(out), "Operation not permitted") {
+		t.Errorf("read of %s without the allow rule did not fail with EPERM.\nExit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	}
+}


### PR DESCRIPTION
Closes #2201

## Problem

Any flake-CLI nix command on this repo fails inside a sandbox-exec worker sandbox:

```
error: opening file "/Users/bensherman/.local/share/nix/trusted-settings.json": Operation not permitted
```

`flake.nix`'s `nixConfig` block makes nix consult `$XDG_DATA_HOME/nix/trusted-settings.json` — and inside sandboxes `XDG_DATA_HOME` deliberately points at the real `~/.local/share` (shared agent DB/state, see `cmd/agent_run_sandbox_exec_darwin.go`). The deny-default SBPL profile blocked the read; nix treats EPERM (unlike ENOENT) as fatal and aborts the whole eval. `--no-accept-flake-config` does not avoid the lookup.

## Fix (issue option 1 + option 4)

**Profile:** `generateProfile` now emits a **read-only, single-file** allow:

```
(allow file-read* file-test-existence
  (literal "<home>/.local/share/nix/trusted-settings.json"))
```

**Docs:** AGENTS.md gains an "In-sandbox nix validation on this repo" section documenting the flake-CLI path and the sanctioned `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` fallback for sandboxes pre-dating this fix (replacing PR #2200's tribal knowledge).

## Why read-only suffices (verified against nix 2.34 source, `src/libflake/config.cc`)

- `readTrustedList()`: `pathExists` → `readFile`. Read access is all the happy path needs.
- **Missing file** (edge-case AC): `pathExists` returns false → empty trusted list → nix proceeds normally. The literal allow includes the stat, so a missing file yields ENOENT, not EPERM.
- **Writes** happen only on an interactive "permanently mark this value as trusted" prompt (`logger->ask(...).value_or('n')` — non-interactive defaults to no). Untrusted settings degrade to `warning: ignoring untrusted flake configuration setting` and eval continues. Persisting trust decisions from inside a sandbox stays blocked **by design** — no new writable paths.
- Everything else the flake CLI needs already works in-sandbox: PR #2200 ran a full flake eval (store copy + daemon access) via `nix-instantiate`; this read was the only flake-CLI blocker.

## Tests (per docs/sandbox-exec-testing.md)

- `TestGenerateProfile_NixTrustedSettingsReadAllow` (unit, substring): exact rule block present; path appears exactly once (never in a writable clause, never as subpath). **Vacuous-pass check done**: fails with the generator change reverted, passes with it.
- `TestSandboxExecProfile_NixTrustedSettingsReadable` (Darwin integration, positive): invokes `/usr/bin/sandbox-exec` against the generated profile; the open must not be denied. Never creates/modifies the real host file — asserts exit 0 when it exists, ENOENT-not-EPERM when absent (which also exercises the missing-file edge case).
- `TestSandboxExecProfile_NixTrustedSettingsDeniedWithoutRule` (Darwin integration, negative): removes the rule block via `withMutatedProfile` (which hard-fails on no-op mutations) and asserts the same read fails with `Operation not permitted` — proving the positive is not green by accident.

## Validation & environment caveats

- `go build ./...`, `go vet`, new unit test green.
- **Chicken-and-egg**: this session runs inside a sandbox that predates the fix, so (a) `nix build .#prism` is not runnable here (it hits the exact bug being fixed — eval validated instead via the sanctioned non-flake pattern: full flake eval **and** `packages.aarch64-darwin.prism.drvPath` instantiation both succeed); (b) the new Darwin integration tests **skip** here (nested sandbox-exec is blocked — existing `requireSandboxExec` guard) and need a host run to observe a pass. CI's `nix-build-prism-checked` remains the authoritative gate.
- `go test ./...` shows 4 failing packages (`cmd`, `internal/container`, `internal/integration`, `internal/tmux`) — all **pre-existing environmental** failures reproduced on a clean tree: tmux server `fork failed: Operation not permitted` and nested `sandbox_apply: Operation not permitted`. Escalated to the coordinator as a follow-up (skip-guard gap); unrelated to this change.
- AGENTS.md edit is scoped to the in-sandbox nix validation section only — disjoint from the #2190 worker's Layer-1 FD-cap note.
