### PR TITLE
prism: per-process RLIMIT_NOFILE on agent exec (bwrap + sandbox-exec) — FD isolation Layer 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,19 @@ This is headroom only — the root-cause leak is the kitten `/nix/store`
 watcher, tracked in #2198. Do not raise these values further to absorb
 that leak.
 
+The **Layer 1** (per-process) defence pairs with it: agents spawned via the
+bwrap and sandbox-exec exec paths get a bounded `RLIMIT_NOFILE` — defaults
+soft 8192 / hard 16384, named constants `DefaultAgentMaxOpenFilesSoft` /
+`DefaultAgentMaxOpenFilesHard` in `internal/config` (issue #2190). The hard
+cap is kernel-enforced: an agent cannot raise it with `ulimit -n` from
+inside its sandbox. Tune per-machine via the `agentMaxOpenFilesSoft` /
+`agentMaxOpenFilesHard` options on `modules/programs/prism/prism-tui.nix`
+(rendered into config.json as `agent_max_open_files_soft` /
+`agent_max_open_files_hard`). Host-mode agents are deliberately uncapped and
+inherit the host's limits. Layer 1 makes the "one agent runs away with FDs"
+class structurally impossible; it is defence-in-depth, not the #2180
+root-cause fix.
+
 ### sandbox-exec testing convention
 
 Any change to `internal/container/sandbox_exec.go::generateProfile`,

--- a/modules/programs/prism/prism-tui.nix
+++ b/modules/programs/prism/prism-tui.nix
@@ -74,6 +74,12 @@ let
     sidecar_circuit_breaker_threshold = config.nx.programs.prism.sidecarCircuitBreakerThreshold;
     bwrap_concurrency_cap = config.nx.programs.prism.bwrapConcurrencyCap;
     sandbox_exec_concurrency_cap = config.nx.programs.prism.sandboxExecConcurrencyCap;
+    # agent_max_open_files_soft/hard: per-process RLIMIT_NOFILE caps applied
+    # to agent processes spawned via the bwrap and sandbox-exec exec paths
+    # (Layer 1 FD isolation, #2190). Kernel-enforced — the agent cannot raise
+    # the hard cap from inside its sandbox. Host-mode agents are not capped.
+    agent_max_open_files_soft = config.nx.programs.prism.agentMaxOpenFilesSoft;
+    agent_max_open_files_hard = config.nx.programs.prism.agentMaxOpenFilesHard;
     pi_extension_dir = config.nx.programs.prism.piExtensionDir;
     # github_token_path: absolute path to the sops-decrypted GitHub token file.
     # Last-resort fallback read by credentialEnvVars when the inherited
@@ -148,6 +154,34 @@ in
         sandbox-exec spawns are refused. 0 means uncapped. Default of 50
         mirrors bwrapConcurrencyCap. Darwin-only isolation mode; this option
         is rendered into config.json on all machines but only used on Darwin.
+      '';
+    };
+
+    nx.programs.prism.agentMaxOpenFilesSoft = lib.mkOption {
+      type = lib.types.int;
+      default = 8192;
+      description = ''
+        Soft RLIMIT_NOFILE cap applied to agent processes spawned via the
+        bwrap and sandbox-exec exec paths (Layer 1 FD isolation, issue
+        #2190). Written to config.json as agent_max_open_files_soft. Must
+        not exceed agentMaxOpenFilesHard (prism clamps it down at exec time
+        if it does). Zero or negative values fall back to the compiled-in
+        default (8192). Host-mode agents are not capped.
+      '';
+    };
+
+    nx.programs.prism.agentMaxOpenFilesHard = lib.mkOption {
+      type = lib.types.int;
+      default = 16384;
+      description = ''
+        Hard RLIMIT_NOFILE cap applied to agent processes spawned via the
+        bwrap and sandbox-exec exec paths (Layer 1 FD isolation, issue
+        #2190). Kernel-enforced: the agent cannot raise it from inside its
+        sandbox (ulimit -n above this value fails with EPERM). Written to
+        config.json as agent_max_open_files_hard. Values above the host's
+        hard limit are clamped to the host hard limit with a warning in the
+        agent-run log. Zero or negative values fall back to the compiled-in
+        default (16384). Host-mode agents are not capped.
       '';
     };
 

--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -423,9 +423,22 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 	// stitch them via wall-clock from each log to bound "exec → agent up".
 	logTimingTo(logFile, "bwrap exec", time.Since(agentRunStart))
 
+	// Layer 1 FD isolation (#2190): cap the sandbox child's RLIMIT_NOFILE so
+	// a misbehaving agent cannot exhaust the host-wide FD pool. The caps are
+	// applied to this process immediately before Start() and restored
+	// immediately after — the child inherits them at fork time, while the
+	// parent's own FD bookkeeping (PTY, stderr pipe, log file) is unaffected.
+	// Warnings (host-hard clamping, setrlimit failures) go to the agent-run
+	// log; failures never abort the spawn.
+	restoreRlimit := container.ApplyAgentRlimitNofile(
+		cfg.AgentMaxOpenFilesSoft, cfg.AgentMaxOpenFilesHard,
+		func(format string, args ...any) { logAgentRunWarning(logFile, format, args...) })
+
 	if err := bwrapCmd.Start(); err != nil {
+		restoreRlimit()
 		return fmt.Errorf("agent-run: start bwrap: %w", err)
 	}
+	restoreRlimit()
 
 	// Close the write end of the stderr pipe in the parent now that bwrap has
 	// inherited it. This is required so that reads from the read end return
@@ -673,6 +686,20 @@ func logTimingTo(logFile *os.File, phase string, d time.Duration) {
 	// per-session agent-run.log keeps every [timing] marker for post-mortem
 	// `grep '\[timing\]'` diagnostics (see issue #1818).
 	proglog.Debugf("%s", line)
+	if logFile != nil {
+		_, _ = logFile.WriteString(line)
+	}
+}
+
+// logAgentRunWarning writes a single "[agent-run] warning: ..." line to both
+// stderr (the tmux pane) and the per-session agent-run log file (when
+// non-nil). Mirrors logTimingTo's dual-destination shape so warnings are
+// greppable post-mortem in agent-run.log alongside the [timing] markers.
+// Used by the #2190 RLIMIT_NOFILE clamp/apply path on both the bwrap and
+// sandbox-exec dispatch paths.
+func logAgentRunWarning(logFile *os.File, format string, args ...any) {
+	line := fmt.Sprintf("[agent-run] warning: "+format+"\n", args...)
+	fmt.Fprint(os.Stderr, line)
 	if logFile != nil {
 		_, _ = logFile.WriteString(line)
 	}

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -382,9 +382,23 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	// the moment of cmd.Start (fork+exec). Mirrors `[timing] bwrap exec`.
 	logTimingTo(logFile, "sandbox-exec exec", time.Since(agentRunStart))
 
+	// Layer 1 FD isolation (#2190): cap the sandbox child's RLIMIT_NOFILE so
+	// a misbehaving agent cannot exhaust the host-wide FD pool (the #2180
+	// failure class). The caps are applied to this process immediately before
+	// Start() and restored immediately after — the child inherits them at
+	// fork time, while the parent's own FD bookkeeping (stderr pipe, log
+	// file, kqueue watcher) is unaffected. Warnings (host-hard clamping,
+	// setrlimit failures) go to the agent-run log; failures never abort the
+	// spawn. Mirrors the bwrap dispatch path in agent_run.go.
+	restoreRlimit := container.ApplyAgentRlimitNofile(
+		cfg.AgentMaxOpenFilesSoft, cfg.AgentMaxOpenFilesHard,
+		func(format string, args ...any) { logAgentRunWarning(logFile, format, args...) })
+
 	if err := sandboxCmd.Start(); err != nil {
+		restoreRlimit()
 		return fmt.Errorf("agent-run: start sandbox-exec: %w", err)
 	}
+	restoreRlimit()
 
 	// Close the write end of the stderr pipe in the parent now that sandbox-exec
 	// has inherited it. Required so reads from the read end return EOF when

--- a/modules/programs/prism/prism/internal/config/config.go
+++ b/modules/programs/prism/prism/internal/config/config.go
@@ -127,6 +127,19 @@ type Config struct {
 	// sandboxExecConcurrencyCap option (written to config.json). Darwin only.
 	SandboxExecConcurrencyCap int `json:"sandbox_exec_concurrency_cap"`
 
+	// AgentMaxOpenFilesSoft / AgentMaxOpenFilesHard are the RLIMIT_NOFILE
+	// (soft, hard) caps applied to agent processes spawned via the bwrap and
+	// sandbox-exec exec paths (Layer 1 FD isolation, issue #2190). The hard
+	// cap is kernel-enforced: the agent cannot raise it from inside the
+	// sandbox. Zero or negative values fall back to the compiled-in defaults
+	// (DefaultAgentMaxOpenFilesSoft / DefaultAgentMaxOpenFilesHard). Clamping
+	// rules (configured hard > host hard → host hard + warning; soft > hard →
+	// soft clamped to hard) are applied at exec time by
+	// internal/container.ResolveAgentRlimitNofile. The host-mode agent path is
+	// deliberately NOT capped — host-mode agents inherit the host's limits.
+	AgentMaxOpenFilesSoft int `json:"agent_max_open_files_soft"`
+	AgentMaxOpenFilesHard int `json:"agent_max_open_files_hard"`
+
 	// Project layout (JSON arrays).
 	WorktreeExclude  []string `json:"worktree_exclude"`
 	ProjectLocations []string `json:"project_locations"`
@@ -181,6 +194,8 @@ type parsedConfig struct {
 	SidecarCircuitBreakerThreshold *int               `json:"sidecar_circuit_breaker_threshold"`
 	BwrapConcurrencyCap            *int               `json:"bwrap_concurrency_cap"`
 	SandboxExecConcurrencyCap      *int               `json:"sandbox_exec_concurrency_cap"`
+	AgentMaxOpenFilesSoft          *int               `json:"agent_max_open_files_soft"`
+	AgentMaxOpenFilesHard          *int               `json:"agent_max_open_files_hard"`
 	WorktreeExclude                *[]string          `json:"worktree_exclude"`
 	ProjectLocations               *[]string          `json:"project_locations"`
 	ProjectSpecific                *[]string          `json:"project_specific"`
@@ -202,6 +217,21 @@ const DefaultBwrapConcurrencyCap = 50
 // sandboxExecConcurrencyCap option (written to config.json). Zero means uncapped.
 const DefaultSandboxExecConcurrencyCap = 50
 
+// DefaultAgentMaxOpenFilesSoft / DefaultAgentMaxOpenFilesHard are the
+// compiled-in default RLIMIT_NOFILE (soft, hard) caps for agent processes
+// spawned via the bwrap and sandbox-exec exec paths (Layer 1 FD isolation,
+// issue #2190). The values are the #2181 starting estimates: high enough for
+// legitimate agent workloads (agent-initiated nix builds run via the root
+// nix-daemon, so the agent process itself does not hold build FDs), low
+// enough that a runaway agent hits its own cap long before the host-wide
+// pool (kern.maxfiles on Darwin) is at risk. Tunable per-machine via the
+// agentMaxOpenFilesSoft / agentMaxOpenFilesHard Nix options (written to
+// config.json).
+const (
+	DefaultAgentMaxOpenFilesSoft = 8192
+	DefaultAgentMaxOpenFilesHard = 16384
+)
+
 // defaults returns the compiled-in fallback Config (gruvbox-dark palette,
 // standard paths). These values are used whenever no config file is found.
 func defaults() Config {
@@ -221,6 +251,8 @@ func defaults() Config {
 		SshSigningKeyName:         "prismatic-koi-ed25519-signingkey",
 		BwrapConcurrencyCap:       DefaultBwrapConcurrencyCap,
 		SandboxExecConcurrencyCap: DefaultSandboxExecConcurrencyCap,
+		AgentMaxOpenFilesSoft:     DefaultAgentMaxOpenFilesSoft,
+		AgentMaxOpenFilesHard:     DefaultAgentMaxOpenFilesHard,
 		WorktreeExclude:           []string{"obsidian"},
 		ProjectLocations:          []string{"~/code"},
 		ProjectSpecific:           []string{"~/documents/obsidian"},
@@ -351,6 +383,12 @@ func load() Config {
 	}
 	if parsed.SandboxExecConcurrencyCap != nil {
 		cfg.SandboxExecConcurrencyCap = *parsed.SandboxExecConcurrencyCap
+	}
+	if parsed.AgentMaxOpenFilesSoft != nil {
+		cfg.AgentMaxOpenFilesSoft = *parsed.AgentMaxOpenFilesSoft
+	}
+	if parsed.AgentMaxOpenFilesHard != nil {
+		cfg.AgentMaxOpenFilesHard = *parsed.AgentMaxOpenFilesHard
 	}
 
 	// For slice fields: nil pointer means absent (keep default); non-nil

--- a/modules/programs/prism/prism/internal/config/config_test.go
+++ b/modules/programs/prism/prism/internal/config/config_test.go
@@ -190,6 +190,75 @@ func TestSshBinAbsentKeepsEmpty(t *testing.T) {
 	}
 }
 
+// TestAgentMaxOpenFilesDefaults verifies that the compiled-in defaults for
+// the #2190 Layer-1 FD caps apply when no config file is present, and that
+// they equal the named constants.
+func TestAgentMaxOpenFilesDefaults(t *testing.T) {
+	t.Setenv("PRISM_CONFIG_FILE", "/nonexistent/path/config.json")
+
+	cfg := config.LoadFresh()
+
+	if cfg.AgentMaxOpenFilesSoft != config.DefaultAgentMaxOpenFilesSoft {
+		t.Errorf("AgentMaxOpenFilesSoft: got %d, want default %d", cfg.AgentMaxOpenFilesSoft, config.DefaultAgentMaxOpenFilesSoft)
+	}
+	if cfg.AgentMaxOpenFilesHard != config.DefaultAgentMaxOpenFilesHard {
+		t.Errorf("AgentMaxOpenFilesHard: got %d, want default %d", cfg.AgentMaxOpenFilesHard, config.DefaultAgentMaxOpenFilesHard)
+	}
+	// The #2190 AC pins the default values themselves: at least
+	// (soft 8192, hard 16384) when nothing overrides them.
+	if config.DefaultAgentMaxOpenFilesSoft != 8192 {
+		t.Errorf("DefaultAgentMaxOpenFilesSoft: got %d, want 8192", config.DefaultAgentMaxOpenFilesSoft)
+	}
+	if config.DefaultAgentMaxOpenFilesHard != 16384 {
+		t.Errorf("DefaultAgentMaxOpenFilesHard: got %d, want 16384", config.DefaultAgentMaxOpenFilesHard)
+	}
+}
+
+// TestAgentMaxOpenFilesFromFile verifies that explicit values in config.json
+// override the compiled-in defaults.
+func TestAgentMaxOpenFilesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"agent_max_open_files_soft": 4096, "agent_max_open_files_hard": 65536}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	if cfg.AgentMaxOpenFilesSoft != 4096 {
+		t.Errorf("AgentMaxOpenFilesSoft: got %d, want 4096", cfg.AgentMaxOpenFilesSoft)
+	}
+	if cfg.AgentMaxOpenFilesHard != 65536 {
+		t.Errorf("AgentMaxOpenFilesHard: got %d, want 65536", cfg.AgentMaxOpenFilesHard)
+	}
+}
+
+// TestAgentMaxOpenFilesAbsentKeepsDefaults verifies that a config file
+// without the agent_max_open_files_* keys keeps the compiled-in defaults
+// (the parsedConfig pointers distinguish absent from explicit zero).
+func TestAgentMaxOpenFilesAbsentKeepsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	raw := `{"color_primary": "#ff0000"}`
+	if err := os.WriteFile(cfgPath, []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PRISM_CONFIG_FILE", cfgPath)
+
+	cfg := config.LoadFresh()
+
+	if cfg.AgentMaxOpenFilesSoft != config.DefaultAgentMaxOpenFilesSoft {
+		t.Errorf("AgentMaxOpenFilesSoft: got %d, want default %d when absent", cfg.AgentMaxOpenFilesSoft, config.DefaultAgentMaxOpenFilesSoft)
+	}
+	if cfg.AgentMaxOpenFilesHard != config.DefaultAgentMaxOpenFilesHard {
+		t.Errorf("AgentMaxOpenFilesHard: got %d, want default %d when absent", cfg.AgentMaxOpenFilesHard, config.DefaultAgentMaxOpenFilesHard)
+	}
+}
+
 func TestIsolationModeFromNewField(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.json")

--- a/modules/programs/prism/prism/internal/container/rlimit.go
+++ b/modules/programs/prism/prism/internal/container/rlimit.go
@@ -1,0 +1,136 @@
+package container
+
+// rlimit.go — per-process RLIMIT_NOFILE caps for agent exec paths (issue #2190).
+//
+// Layer 1 of the FD-isolation work (#2181): every agent process spawned under
+// bwrap or sandbox-exec is launched with a bounded RLIMIT_NOFILE so a single
+// misbehaving agent cannot exhaust the host's FD pool no matter what commands
+// it runs. The hard cap is kernel-enforced — an unprivileged agent cannot
+// raise it from inside the sandbox (`ulimit -n <higher>` / setrlimit above
+// the hard limit fails with EPERM).
+//
+// The limits are applied to the *parent* (prism agent-run) immediately before
+// cmd.Start() and restored immediately after, because Darwin's
+// syscall.SysProcAttr has no Rlimits field — inheritance across fork/exec is
+// the only portable way to set a child's rlimits. The restore is best-effort:
+// an unprivileged process cannot raise its own hard limit back up, so the
+// fallback restores only the soft limit under the new (lower) hard cap. That
+// leaves the supervising parent itself capped, which is harmless — its own FD
+// bookkeeping (PTY, stderr pipe, log file) is a handful of descriptors — and
+// is arguably extra defence-in-depth.
+//
+// The host-mode agent path is deliberately NOT capped (out of scope per
+// #2181's reassessment): host-mode agents inherit the host's RLIMIT_NOFILE.
+
+import (
+	"syscall"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// AgentRlimitNofile is the resolved RLIMIT_NOFILE pair for an agent exec,
+// after the #2190 clamping rules have been applied by
+// ResolveAgentRlimitNofile.
+type AgentRlimitNofile struct {
+	// Soft and Hard are the resolved limits to apply.
+	Soft uint64
+	Hard uint64
+	// HardClamped reports that the configured hard limit exceeded the host's
+	// hard limit and was clamped down to it. Callers must surface a warning
+	// to the agent's log file when set (#2190 edge-case AC).
+	HardClamped bool
+	// HostHard is the host hard limit observed at resolve time; used for the
+	// HardClamped warning message.
+	HostHard uint64
+}
+
+// ResolveAgentRlimitNofile applies the #2190 clamping rules to the configured
+// (soft, hard) pair against the host's hard limit:
+//
+//  1. Non-positive configured values fall back to the compiled-in defaults
+//     (config.DefaultAgentMaxOpenFilesSoft / DefaultAgentMaxOpenFilesHard).
+//     The config loader's defaults make this unreachable for an absent key,
+//     but a hand-edited config.json must not produce a zero cap that would
+//     make every open() in the sandbox fail.
+//  2. Configured hard > host hard → clamp hard to the host hard limit and
+//     set HardClamped (the caller warns to the agent log).
+//  3. Configured soft > resolved hard → clamp soft down to hard (silent
+//     normalisation per the #2190 edge-case AC).
+//
+// Pure function — separated from ApplyAgentRlimitNofile so the clamping
+// rules are unit-testable on any platform without touching process state.
+func ResolveAgentRlimitNofile(cfgSoft, cfgHard int, hostHard uint64) AgentRlimitNofile {
+	if cfgSoft <= 0 {
+		cfgSoft = config.DefaultAgentMaxOpenFilesSoft
+	}
+	if cfgHard <= 0 {
+		cfgHard = config.DefaultAgentMaxOpenFilesHard
+	}
+	res := AgentRlimitNofile{
+		Soft:     uint64(cfgSoft),
+		Hard:     uint64(cfgHard),
+		HostHard: hostHard,
+	}
+	if res.Hard > hostHard {
+		res.Hard = hostHard
+		res.HardClamped = true
+	}
+	if res.Soft > res.Hard {
+		res.Soft = res.Hard
+	}
+	return res
+}
+
+// ApplyAgentRlimitNofile resolves the configured RLIMIT_NOFILE caps against
+// the host's current limits, applies them to the current process so the
+// about-to-be-spawned sandbox child inherits them at fork time, and returns
+// a best-effort restore func that the caller must invoke once cmd.Start()
+// has returned (on both the success and error paths).
+//
+// warnf is called (printf-style) for every non-fatal anomaly: clamping the
+// configured hard limit to the host hard limit, and Getrlimit/Setrlimit
+// failures. Failures never abort the agent spawn — the worst case is the
+// child inheriting the host's limits, which is the pre-#2190 status quo.
+//
+// Calling syscall.Setrlimit here also disables the Go runtime's
+// restore-original-RLIMIT_NOFILE-on-exec behaviour (Go ≥ 1.19 raises the
+// soft limit to the hard limit at startup and silently undoes that for
+// exec'd children), which is exactly what we need: the child must inherit
+// the resolved (soft, hard) pair verbatim.
+func ApplyAgentRlimitNofile(cfgSoft, cfgHard int, warnf func(format string, args ...any)) (restore func()) {
+	noop := func() {}
+
+	var prev syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &prev); err != nil {
+		warnf("cannot read host RLIMIT_NOFILE: %v — agent will inherit host limits", err)
+		return noop
+	}
+
+	res := ResolveAgentRlimitNofile(cfgSoft, cfgHard, prev.Max)
+	if res.HardClamped {
+		warnf("configured agent_max_open_files_hard %d exceeds host hard limit %d — clamping to host hard limit",
+			cfgHard, res.HostHard)
+	}
+
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Cur: res.Soft, Max: res.Hard}); err != nil {
+		warnf("cannot set RLIMIT_NOFILE to (soft %d, hard %d): %v — agent will inherit host limits",
+			res.Soft, res.Hard, err)
+		return noop
+	}
+
+	return func() {
+		// Attempt a full restore first. This fails with EPERM whenever
+		// prev.Max > res.Hard (an unprivileged process cannot raise its own
+		// hard limit), in which case fall back to restoring the soft limit
+		// under the now-lowered hard cap so the parent's soft headroom is
+		// as close to its original value as the kernel allows.
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &prev); err == nil {
+			return
+		}
+		softOnly := syscall.Rlimit{Cur: prev.Cur, Max: res.Hard}
+		if softOnly.Cur > softOnly.Max {
+			softOnly.Cur = softOnly.Max
+		}
+		_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &softOnly)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/rlimit_test.go
+++ b/modules/programs/prism/prism/internal/container/rlimit_test.go
@@ -1,0 +1,190 @@
+package container
+
+// rlimit_test.go — unit tests for the #2190 RLIMIT_NOFILE clamping rules and
+// the apply/restore round-trip. The clamping rules are tested as a pure
+// function (ResolveAgentRlimitNofile) so they run on any platform without
+// touching process state; the apply test mutates the test process's own
+// limits and restores them, choosing values relative to the current limits so
+// it never needs privilege.
+
+import (
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+func TestResolveAgentRlimitNofile(t *testing.T) {
+	const bigHostHard = 1 << 20 // 1048576 — typical Linux hard limit
+
+	tests := []struct {
+		name            string
+		cfgSoft         int
+		cfgHard         int
+		hostHard        uint64
+		wantSoft        uint64
+		wantHard        uint64
+		wantHardClamped bool
+	}{
+		{
+			name:    "defaults pass through under a big host hard limit",
+			cfgSoft: config.DefaultAgentMaxOpenFilesSoft, cfgHard: config.DefaultAgentMaxOpenFilesHard,
+			hostHard: bigHostHard,
+			wantSoft: config.DefaultAgentMaxOpenFilesSoft, wantHard: config.DefaultAgentMaxOpenFilesHard,
+		},
+		{
+			name:    "configured hard above host hard is clamped with flag",
+			cfgSoft: 8192, cfgHard: bigHostHard * 2,
+			hostHard: bigHostHard,
+			wantSoft: 8192, wantHard: bigHostHard,
+			wantHardClamped: true,
+		},
+		{
+			name:    "soft above hard is clamped down to hard",
+			cfgSoft: 32768, cfgHard: 16384,
+			hostHard: bigHostHard,
+			wantSoft: 16384, wantHard: 16384,
+		},
+		{
+			name:    "host hard below both clamps hard then soft follows",
+			cfgSoft: 8192, cfgHard: 16384,
+			hostHard: 4096,
+			wantSoft: 4096, wantHard: 4096,
+			wantHardClamped: true,
+		},
+		{
+			name:    "zero values fall back to compiled-in defaults",
+			cfgSoft: 0, cfgHard: 0,
+			hostHard: bigHostHard,
+			wantSoft: config.DefaultAgentMaxOpenFilesSoft, wantHard: config.DefaultAgentMaxOpenFilesHard,
+		},
+		{
+			name:    "negative values fall back to compiled-in defaults",
+			cfgSoft: -1, cfgHard: -100,
+			hostHard: bigHostHard,
+			wantSoft: config.DefaultAgentMaxOpenFilesSoft, wantHard: config.DefaultAgentMaxOpenFilesHard,
+		},
+		{
+			name:    "host hard equal to configured hard is not a clamp",
+			cfgSoft: 8192, cfgHard: 16384,
+			hostHard: 16384,
+			wantSoft: 8192, wantHard: 16384,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveAgentRlimitNofile(tt.cfgSoft, tt.cfgHard, tt.hostHard)
+			if got.Soft != tt.wantSoft {
+				t.Errorf("Soft: got %d, want %d", got.Soft, tt.wantSoft)
+			}
+			if got.Hard != tt.wantHard {
+				t.Errorf("Hard: got %d, want %d", got.Hard, tt.wantHard)
+			}
+			if got.HardClamped != tt.wantHardClamped {
+				t.Errorf("HardClamped: got %v, want %v", got.HardClamped, tt.wantHardClamped)
+			}
+			if got.HostHard != tt.hostHard {
+				t.Errorf("HostHard: got %d, want %d", got.HostHard, tt.hostHard)
+			}
+		})
+	}
+}
+
+// TestApplyAgentRlimitNofile_AppliesAndRestores verifies the apply/restore
+// round-trip against the live process: after Apply the process limits equal
+// the resolved pair (this is what a child spawned between Apply and restore
+// inherits); after restore the soft limit is back to a usable value.
+//
+// The test picks its target hard limit at or below the current hard limit so
+// it never needs privilege. Restoring a lowered hard limit is best-effort
+// (unprivileged processes cannot raise it back), so the post-restore
+// assertion only checks the soft limit — the hard limit may legitimately
+// remain at the applied value for the rest of this test binary's life, which
+// is documented behaviour of ApplyAgentRlimitNofile.
+func TestApplyAgentRlimitNofile_AppliesAndRestores(t *testing.T) {
+	var orig syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &orig); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+
+	targetHard := uint64(16384)
+	if orig.Max < targetHard {
+		targetHard = orig.Max
+	}
+	targetSoft := targetHard / 2
+
+	var warnings []string
+	warnf := func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	restore := ApplyAgentRlimitNofile(int(targetSoft), int(targetHard), warnf)
+
+	var applied syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &applied); err != nil {
+		t.Fatalf("Getrlimit after apply: %v", err)
+	}
+	if applied.Cur != targetSoft || applied.Max != targetHard {
+		t.Errorf("applied limits: got (soft %d, hard %d), want (soft %d, hard %d)",
+			applied.Cur, applied.Max, targetSoft, targetHard)
+	}
+	// targetHard ≤ orig.Max by construction, so no clamp warning may fire.
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+
+	restore()
+
+	var restored syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &restored); err != nil {
+		t.Fatalf("Getrlimit after restore: %v", err)
+	}
+	wantSoft := orig.Cur
+	if wantSoft > restored.Max {
+		wantSoft = restored.Max
+	}
+	if restored.Cur != wantSoft {
+		t.Errorf("restored soft limit: got %d, want %d", restored.Cur, wantSoft)
+	}
+}
+
+// TestApplyAgentRlimitNofile_WarnsOnHostHardClamp verifies the #2190
+// edge-case AC: a configured hard limit above the host hard limit is clamped
+// and produces a warning naming both values.
+func TestApplyAgentRlimitNofile_WarnsOnHostHardClamp(t *testing.T) {
+	var orig syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &orig); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+	if orig.Max >= 1<<62 {
+		// Host hard limit is effectively unlimited (e.g. RLIM_INFINITY) —
+		// a configured int can never exceed it, so the clamp path is
+		// unreachable here. The pure-function clamp coverage in
+		// TestResolveAgentRlimitNofile still applies.
+		t.Skipf("host hard limit %d too large to exceed with an int config value", orig.Max)
+	}
+
+	cfgHard := int(orig.Max) + 1000
+	cfgSoft := 1024
+
+	var warnings []string
+	warnf := func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	restore := ApplyAgentRlimitNofile(cfgSoft, cfgHard, warnf)
+	defer restore()
+
+	var applied syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &applied); err != nil {
+		t.Fatalf("Getrlimit after apply: %v", err)
+	}
+	if applied.Max != orig.Max {
+		t.Errorf("applied hard limit: got %d, want host hard %d (clamped)", applied.Max, orig.Max)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings: got %d (%v), want exactly 1 clamp warning", len(warnings), warnings)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/rlimit_test.go
+++ b/modules/programs/prism/prism/internal/container/rlimit_test.go
@@ -9,6 +9,9 @@ package container
 
 import (
 	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -147,6 +150,79 @@ func TestApplyAgentRlimitNofile_AppliesAndRestores(t *testing.T) {
 	}
 	if restored.Cur != wantSoft {
 		t.Errorf("restored soft limit: got %d, want %d", restored.Cur, wantSoft)
+	}
+}
+
+// shObservedNofile runs `sh -c 'echo "$(ulimit -Sn) $(ulimit -Hn)"'` as a
+// plain (un-sandboxed) child and returns the RLIMIT_NOFILE pair it observed,
+// or an error when sh is unavailable or its output is unparsable (callers
+// skip in that case — some build sandboxes lack a capable sh).
+func shObservedNofile() (soft, hard uint64, err error) {
+	shBin, err := exec.LookPath("sh")
+	if err != nil {
+		return 0, 0, fmt.Errorf("sh not in PATH: %w", err)
+	}
+	out, err := exec.Command(shBin, "-c", `echo "$(ulimit -Sn) $(ulimit -Hn)"`).CombinedOutput()
+	if err != nil {
+		return 0, 0, fmt.Errorf("sh ulimit probe: %w — %s", err, out)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("sh ulimit probe: want two fields, got %q", out)
+	}
+	soft, sErr := strconv.ParseUint(fields[0], 10, 64)
+	hard, hErr := strconv.ParseUint(fields[1], 10, 64)
+	if sErr != nil || hErr != nil {
+		return 0, 0, fmt.Errorf("sh ulimit probe: cannot parse %q", out)
+	}
+	return soft, hard, nil
+}
+
+// TestApplyAgentRlimitNofile_ChildInherits verifies the load-bearing
+// property the exec paths rely on: a child spawned between Apply and restore
+// inherits the resolved (soft, hard) pair verbatim.
+//
+// This specifically pins the Go-runtime subtlety documented on
+// ApplyAgentRlimitNofile: Go ≥ 1.19 raises the soft limit to the hard limit
+// at startup and silently restores the *original* soft limit for exec'd
+// children — unless the program calls syscall.Setrlimit, which disables that
+// restore. If a future refactor switched to a raw syscall wrapper that did
+// not disable it, the process-level assertions in
+// TestApplyAgentRlimitNofile_AppliesAndRestores would still pass while every
+// spawned agent silently inherited the wrong soft limit; this test is the
+// one that would catch it. The bwrap/sandbox-exec integration tests under
+// internal/integration/ assert the same property through the real sandbox
+// binaries but cannot run in every environment (they skip without bwrap /
+// nested sandbox-exec); this plain-child variant runs everywhere a capable
+// sh exists.
+func TestApplyAgentRlimitNofile_ChildInherits(t *testing.T) {
+	if _, _, err := shObservedNofile(); err != nil {
+		t.Skipf("environment cannot observe child rlimits: %v", err)
+	}
+
+	var orig syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &orig); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+
+	targetHard := uint64(8192)
+	if orig.Max < targetHard {
+		targetHard = orig.Max
+	}
+	targetSoft := targetHard / 2
+
+	restore := ApplyAgentRlimitNofile(int(targetSoft), int(targetHard), func(format string, args ...any) {
+		t.Logf("rlimit warning: "+format, args...)
+	})
+	defer restore()
+
+	gotSoft, gotHard, err := shObservedNofile()
+	if err != nil {
+		t.Fatalf("observe child rlimits after apply: %v", err)
+	}
+	if gotSoft != targetSoft || gotHard != targetHard {
+		t.Errorf("child observed (soft %d, hard %d), want (soft %d, hard %d)",
+			gotSoft, gotHard, targetSoft, targetHard)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/rlimit_bwrap_test.go
+++ b/modules/programs/prism/prism/internal/integration/rlimit_bwrap_test.go
@@ -1,0 +1,165 @@
+package integration_test
+
+// rlimit_bwrap_test.go — Layer 1 FD isolation (#2190): integration coverage
+// for the bwrap exec path's RLIMIT_NOFILE cap.
+//
+// The production path (cmd/agent_run.go runAgentRunBwrapHandler) calls
+// container.ApplyAgentRlimitNofile immediately before bwrapCmd.Start() and
+// restores immediately after; the spawned sandbox inherits the resolved
+// (soft, hard) pair at fork time. These tests exercise the same helper
+// against a real bwrap spawn and observe the limits from *inside* the
+// sandbox via the shell's ulimit builtin (equivalent to reading
+// /proc/self/limits — both report getrlimit(RLIMIT_NOFILE) for the sandboxed
+// process).
+//
+// No-op-proofing (the negative-test discipline from
+// docs/sandbox-exec-testing.md, applied to the rlimit mechanism): the
+// enforcement under test is rlimit inheritance, not a sandbox profile rule,
+// so the "mutation" is applying a *different* configured pair and asserting
+// the observed limits track it. Two runs with different configured values
+// must observe different limits — a vacuous observer (e.g. one that reported
+// the host limits regardless) would fail that cross-check. The security AC
+// (`ulimit -n <above hard>` fails with EPERM inside the sandbox) is covered
+// by its own subtest.
+//
+// Linux-only in practice: requireBwrap skips when bwrap is unavailable
+// (always on Darwin) and on GitHub Actions runners where unprivileged userns
+// is blocked (#1510). requireUsableBwrap additionally probes an actual spawn
+// so the test skips rather than fails inside environments (e.g. the Nix
+// build sandbox) where bwrap is present but cannot create namespaces.
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// requireUsableBwrap extends requireBwrap (stdio_test.go) with a live spawn
+// probe. bwrap can be present on PATH but unable to create user namespaces
+// (Nix build sandbox, locked-down kernels); in that case every test here
+// would fail for environmental reasons unrelated to the rlimit cap, so skip.
+func requireUsableBwrap(t *testing.T) string {
+	t.Helper()
+	bin := requireBwrap(t)
+	probe := exec.Command(bin, bwrapSandboxArgs("true")...)
+	if out, err := probe.CombinedOutput(); err != nil {
+		t.Skipf("bwrap present but not usable in this environment: %v — %s", err, out)
+	}
+	return bin
+}
+
+// bwrapSandboxArgs returns a minimal bwrap argv that binds the host root
+// read-only (so /bin/sh and its libraries resolve) and runs script under
+// /bin/sh. The production sandbox argv is far richer (see
+// internal/container/bwrap.go) but rlimit inheritance is a property of
+// fork/exec, not of the mount/namespace layout — a minimal sandbox observes
+// the same limits the production one does.
+func bwrapSandboxArgs(script string) []string {
+	return []string{
+		"--ro-bind", "/", "/",
+		"--dev", "/dev",
+		"--proc", "/proc",
+		"--unshare-pid",
+		"/bin/sh", "-c", script,
+	}
+}
+
+// bwrapObservedNofile spawns /bin/sh under bwrap and reports the
+// RLIMIT_NOFILE (soft, hard) pair observed inside the sandbox.
+func bwrapObservedNofile(t *testing.T, bwrapBin string) (soft, hard uint64) {
+	t.Helper()
+	cmd := exec.Command(bwrapBin, bwrapSandboxArgs(`echo "$(ulimit -Sn) $(ulimit -Hn)"`)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bwrap ulimit probe: %v — %s", err, out)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) != 2 {
+		t.Fatalf("bwrap ulimit probe: want two fields, got %q", out)
+	}
+	soft, sErr := strconv.ParseUint(fields[0], 10, 64)
+	hard, hErr := strconv.ParseUint(fields[1], 10, 64)
+	if sErr != nil || hErr != nil {
+		t.Fatalf("bwrap ulimit probe: cannot parse %q (soft err %v, hard err %v)", out, sErr, hErr)
+	}
+	return soft, hard
+}
+
+// TestBwrapAgentRlimitNofile covers the #2190 bwrap-path ACs:
+//
+//   - the spawned sandbox's RLIMIT_NOFILE matches the resolved (soft, hard)
+//     config values;
+//   - the observation tracks the configured values (no-op proof);
+//   - the sandbox cannot raise its limit above the configured hard cap.
+//
+// Subtests run sequentially and use descending hard values: an unprivileged
+// process cannot raise its hard limit back after the best-effort restore, so
+// each subsequent apply must not require raising it.
+func TestBwrapAgentRlimitNofile(t *testing.T) {
+	bwrapBin := requireUsableBwrap(t)
+
+	var hostLim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &hostLim); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+
+	// applyAndObserve mirrors the production call shape: apply → spawn →
+	// restore, returning what the sandbox observed.
+	applyAndObserve := func(t *testing.T, cfgSoft, cfgHard int) (uint64, uint64) {
+		t.Helper()
+		restore := container.ApplyAgentRlimitNofile(cfgSoft, cfgHard, func(format string, args ...any) {
+			t.Logf("rlimit warning: "+format, args...)
+		})
+		defer restore()
+		return bwrapObservedNofile(t, bwrapBin)
+	}
+
+	const (
+		firstSoft, firstHard   = 4096, 8192
+		secondSoft, secondHard = 2048, 4096
+	)
+
+	var firstObservedSoft, firstObservedHard uint64
+
+	t.Run("configured limits visible inside sandbox", func(t *testing.T) {
+		want := container.ResolveAgentRlimitNofile(firstSoft, firstHard, hostLim.Max)
+		gotSoft, gotHard := applyAndObserve(t, firstSoft, firstHard)
+		if gotSoft != want.Soft || gotHard != want.Hard {
+			t.Errorf("inside bwrap: got (soft %d, hard %d), want (soft %d, hard %d)",
+				gotSoft, gotHard, want.Soft, want.Hard)
+		}
+		firstObservedSoft, firstObservedHard = gotSoft, gotHard
+	})
+
+	t.Run("different configured limits are tracked (no-op proof)", func(t *testing.T) {
+		want := container.ResolveAgentRlimitNofile(secondSoft, secondHard, hostLim.Max)
+		gotSoft, gotHard := applyAndObserve(t, secondSoft, secondHard)
+		if gotSoft != want.Soft || gotHard != want.Hard {
+			t.Errorf("inside bwrap: got (soft %d, hard %d), want (soft %d, hard %d)",
+				gotSoft, gotHard, want.Soft, want.Hard)
+		}
+		if gotSoft == firstObservedSoft && gotHard == firstObservedHard {
+			t.Errorf("observed limits (%d, %d) identical across different configured pairs — the observation is a no-op",
+				gotSoft, gotHard)
+		}
+	})
+
+	t.Run("ulimit cannot raise above the hard cap", func(t *testing.T) {
+		restore := container.ApplyAgentRlimitNofile(secondSoft, secondHard, func(format string, args ...any) {
+			t.Logf("rlimit warning: "+format, args...)
+		})
+		defer restore()
+
+		raiseTo := container.ResolveAgentRlimitNofile(secondSoft, secondHard, hostLim.Max).Hard + 1000
+		cmd := exec.Command(bwrapBin, bwrapSandboxArgs(fmt.Sprintf("ulimit -n %d", raiseTo))...)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("ulimit -n %d succeeded inside the sandbox — the hard cap is not kernel-enforced: %s", raiseTo, out)
+		}
+	})
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_rlimit_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_rlimit_darwin_test.go
@@ -1,0 +1,151 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_rlimit_darwin_test.go — Layer 1 FD isolation (#2190):
+// integration coverage for the sandbox-exec exec path's RLIMIT_NOFILE cap.
+//
+// The production path (cmd/agent_run_sandbox_exec_darwin.go
+// runAgentRunSandboxExec) calls container.ApplyAgentRlimitNofile immediately
+// before sandboxCmd.Start() and restores immediately after; the spawned
+// sandbox inherits the resolved (soft, hard) pair at fork time. These tests
+// exercise the same helper against a real /usr/bin/sandbox-exec spawn under
+// the production-generated SBPL profile (per docs/sandbox-exec-testing.md:
+// profile from Manager.PrepareSandboxExec, Nix-built bash as the test
+// binary) and observe the limits from *inside* the sandbox via bash's
+// ulimit builtin (getrlimit(RLIMIT_NOFILE) for the sandboxed process).
+//
+// Negative-test discipline (docs/sandbox-exec-testing.md requires every
+// positive test to prove it is not green by accident): the enforcement under
+// test here is rlimit inheritance across fork/exec, not an SBPL profile rule
+// — RLIMIT_NOFILE is invisible to the sandbox profile, so withMutatedProfile
+// cannot exercise it. The no-op proof is instead applying a *different*
+// configured pair and asserting the observed limits track it: two runs with
+// different configured values must observe different limits, which a vacuous
+// observer (e.g. one reporting host limits regardless) would fail. The
+// security AC (`ulimit -n <above hard>` fails inside the sandbox) has its
+// own subtest.
+//
+// This file does not modify generateProfile / PrepareSandboxExec /
+// PrepareSandboxExecHome — the profile is used as generated (plus the
+// standard test-harness extras from augmentProfileForTest that let a
+// Nix-built binary start under the sandbox).
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// sandboxExecObservedNofile runs Nix bash under sandbox-exec with the given
+// profile and reports the RLIMIT_NOFILE (soft, hard) pair observed inside
+// the sandbox.
+func sandboxExecObservedNofile(t *testing.T, profilePath, nixBash string) (soft, hard uint64) {
+	t.Helper()
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", `echo "$(ulimit -Sn) $(ulimit -Hn)"`)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sandbox-exec ulimit probe: %v — %s", err, out)
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) != 2 {
+		t.Fatalf("sandbox-exec ulimit probe: want two fields, got %q", out)
+	}
+	soft, sErr := strconv.ParseUint(fields[0], 10, 64)
+	hard, hErr := strconv.ParseUint(fields[1], 10, 64)
+	if sErr != nil || hErr != nil {
+		t.Fatalf("sandbox-exec ulimit probe: cannot parse %q (soft err %v, hard err %v)", out, sErr, hErr)
+	}
+	return soft, hard
+}
+
+// TestSandboxExecAgentRlimitNofile covers the #2190 sandbox-exec-path ACs:
+//
+//   - the spawned sandbox's RLIMIT_NOFILE matches the resolved (soft, hard)
+//     config values;
+//   - the observation tracks the configured values (no-op proof);
+//   - the sandbox cannot raise its limit above the configured hard cap
+//     (`ulimit -n <higher>` fails).
+//
+// Subtests run sequentially and use descending hard values: an unprivileged
+// process cannot raise its hard limit back after the best-effort restore, so
+// each subsequent apply must not require raising it.
+func TestSandboxExecAgentRlimitNofile(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+	prepared, _ := preparePositiveProfile(t, m)
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	var hostLim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &hostLim); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+
+	// applyAndObserve mirrors the production call shape: apply → spawn →
+	// restore, returning what the sandbox observed.
+	applyAndObserve := func(t *testing.T, cfgSoft, cfgHard int) (uint64, uint64) {
+		t.Helper()
+		restore := container.ApplyAgentRlimitNofile(cfgSoft, cfgHard, func(format string, args ...any) {
+			t.Logf("rlimit warning: "+format, args...)
+		})
+		defer restore()
+		return sandboxExecObservedNofile(t, profilePath, nixBash)
+	}
+
+	const (
+		firstSoft, firstHard   = 4096, 8192
+		secondSoft, secondHard = 2048, 4096
+	)
+
+	var firstObservedSoft, firstObservedHard uint64
+
+	t.Run("configured limits visible inside sandbox", func(t *testing.T) {
+		want := container.ResolveAgentRlimitNofile(firstSoft, firstHard, hostLim.Max)
+		gotSoft, gotHard := applyAndObserve(t, firstSoft, firstHard)
+		if gotSoft != want.Soft || gotHard != want.Hard {
+			t.Errorf("inside sandbox-exec: got (soft %d, hard %d), want (soft %d, hard %d)",
+				gotSoft, gotHard, want.Soft, want.Hard)
+		}
+		firstObservedSoft, firstObservedHard = gotSoft, gotHard
+	})
+
+	t.Run("different configured limits are tracked (no-op proof)", func(t *testing.T) {
+		want := container.ResolveAgentRlimitNofile(secondSoft, secondHard, hostLim.Max)
+		gotSoft, gotHard := applyAndObserve(t, secondSoft, secondHard)
+		if gotSoft != want.Soft || gotHard != want.Hard {
+			t.Errorf("inside sandbox-exec: got (soft %d, hard %d), want (soft %d, hard %d)",
+				gotSoft, gotHard, want.Soft, want.Hard)
+		}
+		if gotSoft == firstObservedSoft && gotHard == firstObservedHard {
+			t.Errorf("observed limits (%d, %d) identical across different configured pairs — the observation is a no-op",
+				gotSoft, gotHard)
+		}
+	})
+
+	t.Run("ulimit cannot raise above the hard cap", func(t *testing.T) {
+		restore := container.ApplyAgentRlimitNofile(secondSoft, secondHard, func(format string, args ...any) {
+			t.Logf("rlimit warning: "+format, args...)
+		})
+		defer restore()
+
+		raiseTo := container.ResolveAgentRlimitNofile(secondSoft, secondHard, hostLim.Max).Hard + 1000
+		cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+			nixBash, "-c", fmt.Sprintf("ulimit -n %d", raiseTo))
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Errorf("ulimit -n %d succeeded inside the sandbox — the hard cap is not kernel-enforced: %s", raiseTo, out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Layer 1 FD isolation (defence-in-depth per the #2181 reassessment): agent processes spawned via the **bwrap** and **sandbox-exec** exec paths are launched with a bounded, kernel-enforced `RLIMIT_NOFILE`, so the "one agent runs away with FDs" class is structurally impossible regardless of what commands the agent runs.

Closes #2190
Closes #2181

### Config plumbing (`internal/config`)

- New flat scalar fields `AgentMaxOpenFilesSoft` / `AgentMaxOpenFilesHard` (`agent_max_open_files_soft` / `agent_max_open_files_hard`), naming consistent with the existing `bwrap_concurrency_cap` scalar.
- Named-constant defaults `DefaultAgentMaxOpenFilesSoft = 8192` / `DefaultAgentMaxOpenFilesHard = 16384`, with entries in `parsedConfig` (pointer-int so absent ≠ explicit zero), `defaults()`, and the merge block.

### Exec-path changes

- New `internal/container/rlimit.go`:
  - `ResolveAgentRlimitNofile` — pure clamping rules: non-positive config → defaults; configured hard > host hard → clamp to host hard (flagged for a warning); soft > hard → soft clamped down to hard.
  - `ApplyAgentRlimitNofile` — the portable Getrlimit/Setrlimit/restore shape from the issue (Darwin's `SysProcAttr` has no Rlimits field). Applied immediately before `bwrapCmd.Start()` (`cmd/agent_run.go`) and `sandboxCmd.Start()` (`cmd/agent_run_sandbox_exec_darwin.go`), restored immediately after; the child inherits the resolved pair at fork time. Restore is best-effort (an unprivileged process cannot raise its hard limit back — documented; the capped supervising parent uses a handful of FDs).
  - Calling `syscall.Setrlimit` also disables the Go ≥1.19 runtime's restore-original-soft-limit-on-exec behaviour, which is load-bearing for inheritance — pinned by a dedicated test (below).
- Warnings (host-hard clamp, get/setrlimit failures) go to the per-session agent-run log + stderr via a new `logAgentRunWarning` helper mirroring `logTimingTo`. Failures never abort the spawn (worst case: child inherits host limits, the pre-#2190 status quo).
- **Host-mode path untouched**: `internal/container/dispatch.go` `hostIsolator.AgentPaneCmd` and `internal/session/session.go` `buildDirectAgentCmd` are not modified. No podman references introduced or "fixed" (#2189 territory, legacy DB-row fallbacks untouched).

### Nix

- `modules/programs/prism/prism-tui.nix`: new `agentMaxOpenFilesSoft` / `agentMaxOpenFilesHard` options (defaults 8192/16384), rendered into the generated `config.json`. `nixfmt` applied.

### Tests

- `internal/config/config_test.go`: defaults-when-absent, explicit override, absent-key-keeps-defaults (and pins the 8192/16384 default values per the AC).
- `internal/container/rlimit_test.go`: table-driven clamp-rule tests (all platforms); apply/restore round-trip; host-hard clamp warning; and `TestApplyAgentRlimitNofile_ChildInherits` — a plain-child inheritance test that pins the Go-runtime exec-restore subtlety and runs in environments where the sandbox tests skip.
- `internal/integration/rlimit_bwrap_test.go`: spawns a real bwrap sandbox and asserts the resolved (soft, hard) from inside via `ulimit` (equivalent observation to `/proc/self/limits`); includes a no-op proof (two different configured pairs must observe different limits) and the security AC (`ulimit -n <above hard>` fails inside the sandbox). Probes bwrap usability and skips cleanly where userns is blocked (#1510, nix sandbox).
- `internal/integration/sandbox_exec_rlimit_darwin_test.go`: per `docs/sandbox-exec-testing.md` — Darwin-only, profile generated via `Manager.PrepareSandboxExec()` + the standard test-harness augmentation, invokes `/usr/bin/sandbox-exec` against Nix-built bash, same three subtests. Note on the negative-test discipline: `RLIMIT_NOFILE` is invisible to the SBPL profile, so `withMutatedProfile` cannot exercise it — the no-op proof is applying a *different* configured pair and asserting the observation tracks it (rationale documented in the file). This PR does **not** touch `generateProfile` / `PrepareSandboxExec` / `PrepareSandboxExecHome`.

### #2181 body updated

Per the closure plan, the podman AC and host-mode AC in #2181 have been struck (via `gh issue edit 2181`) with dated annotations; the bwrap and sandbox-exec ACs delivered here remain.

## Verification

From `modules/programs/prism/prism/`: `go build ./...` and `go vet` clean; `go test ./...` — all packages pass except a set of **pre-existing environmental failures identical on clean main `9f111317`** (verified by running the same suite against a `git archive` of main and diffing the failure sets — byte-identical test-name sets): tmux tests (`fork failed: Operation not permitted` inside this worker sandbox) and `internal/container` `TestSandboxExecIntegration_*` (nested `sandbox_apply` blocked; escalated to the coordinator as a known gap — that file lacks the nested-sandbox skip probe the integration package has).

**`nix build .#prism` was not runnable from this worker sandbox** (known issue #2201, being fixed in parallel; no env-override workarounds attempted per AGENTS.md). Eval-level validation performed instead via `nix-instantiate --eval` of the m4mac darwinConfiguration's generated `prism/config.json`, confirming it renders `"agent_max_open_files_soft":8192,"agent_max_open_files_hard":16384` and the module system evaluates cleanly. CI's `go-tests` and `nix-build-prism-checked` jobs are the authoritative gates for this PR.

The new sandbox integration tests skip in this environment (no bwrap on Darwin; nested sandbox-exec blocked) — they will exercise on the host machine and on Linux dev hosts respectively; the plain-child inheritance test covers the load-bearing inheritance property everywhere, and passes locally.

### Parallel-work note

Branch `sandbox-nix-trusted-settings` (#2201) is in flight touching `internal/container/sandbox_exec.go::generateProfile` and AGENTS.md. This PR does not touch `generateProfile`, and its AGENTS.md edit is scoped to a single Layer-1 paragraph appended to the existing "Darwin FD-exhaustion defences" section, so the diffs stay disjoint (trivial rebase at worst).
