### PR TITLE
prism: gate sandbox-exec integration tests on actual capability probe

### DIFF
--- a/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_integration_test.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container/sandboxexectest"
 )
 
 // writeProfileForIntegration writes the generated profile for the given
@@ -65,14 +67,6 @@ func runUnderSandbox(t *testing.T, profilePath string, env []string, args ...str
 		}
 	}
 	return output, exitCode
-}
-
-// sandboxExecAvailable returns true if /usr/bin/sandbox-exec exists.
-// Tests skip gracefully if it is absent (e.g. in a CI environment without
-// the full macOS toolchain).
-func sandboxExecAvailable() bool {
-	_, err := os.Stat("/usr/bin/sandbox-exec")
-	return err == nil
 }
 
 // newIntegrationManager returns a Manager wired up with a sandboxExecIsolator
@@ -139,9 +133,7 @@ func profileStagingHome(t *testing.T, m *Manager) string {
 // TestSandboxExecIntegration_EchoHi verifies that /bin/echo hi exits 0 under
 // the v3 profile (P1 in F.1 §3.1).
 func TestSandboxExecIntegration_EchoHi(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	m, stagingHome := newIntegrationManager(t)
 	profilePath := writeProfileForIntegration(t, m)
 
@@ -157,9 +149,7 @@ func TestSandboxExecIntegration_EchoHi(t *testing.T) {
 // TestSandboxExecIntegration_LsEtcHosts verifies that /bin/ls /etc/hosts
 // exits 0 under the v3 profile (P2 in F.1 §3.1).
 func TestSandboxExecIntegration_LsEtcHosts(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	m, stagingHome := newIntegrationManager(t)
 	profilePath := writeProfileForIntegration(t, m)
 
@@ -172,9 +162,7 @@ func TestSandboxExecIntegration_LsEtcHosts(t *testing.T) {
 // TestSandboxExecIntegration_CatEtcHosts verifies that /bin/cat /etc/hosts
 // exits 0 and prints the hosts file content under the v3 profile (P3 in F.1 §3.1).
 func TestSandboxExecIntegration_CatEtcHosts(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	m, stagingHome := newIntegrationManager(t)
 	profilePath := writeProfileForIntegration(t, m)
 
@@ -194,9 +182,7 @@ func TestSandboxExecIntegration_CatEtcHosts(t *testing.T) {
 // On hosts where /var/select/developer_dir is absent, DEVELOPER_DIR is set
 // to /Library/Developer/CommandLineTools via baseEnv.
 func TestSandboxExecIntegration_GitVersion(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	if _, err := os.Stat("/usr/bin/git"); err != nil {
 		t.Skip("/usr/bin/git not present")
 	}
@@ -215,9 +201,7 @@ func TestSandboxExecIntegration_GitVersion(t *testing.T) {
 // TestSandboxExecIntegration_UnameDashA verifies that /usr/bin/uname -a exits
 // 0 and prints the Darwin uname line under the v3 profile (P5 in F.1 §3.1).
 func TestSandboxExecIntegration_UnameDashA(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	m, stagingHome := newIntegrationManager(t)
 	profilePath := writeProfileForIntegration(t, m)
 
@@ -233,9 +217,7 @@ func TestSandboxExecIntegration_UnameDashA(t *testing.T) {
 // TestSandboxExecIntegration_WhichPi verifies that /usr/bin/which
 // pi exits 0 under the v3 profile (P6 in F.1 §3.1).
 func TestSandboxExecIntegration_WhichPi(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	// Only run this test if pi is resolvable in PATH.
 	whichOut, err := exec.Command("/usr/bin/which", "pi").Output()
 	if err != nil || strings.TrimSpace(string(whichOut)) == "" {
@@ -256,9 +238,7 @@ func TestSandboxExecIntegration_WhichPi(t *testing.T) {
 // TestSandboxExecIntegration_SSHVersion verifies that /usr/bin/ssh -V exits
 // 0 and prints the OpenSSH version string under the v3 profile (P7 in F.1 §3.1).
 func TestSandboxExecIntegration_SSHVersion(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	if _, err := os.Stat("/usr/bin/ssh"); err != nil {
 		t.Skip("/usr/bin/ssh not present")
 	}
@@ -280,9 +260,7 @@ func TestSandboxExecIntegration_SSHVersion(t *testing.T) {
 // Exit 0 or any non-SIGABRT exit code is acceptable — "unexpected error"
 // from a missing server is fine. SIGABRT (exit code 134 on Darwin) is not.
 func TestSandboxExecIntegration_PiNoSIGABRT(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	// Find pi in PATH.
 	piPath, err := exec.LookPath("pi")
 	if err != nil || piPath == "" {
@@ -302,9 +280,7 @@ func TestSandboxExecIntegration_PiNoSIGABRT(t *testing.T) {
 // TestSandboxExecIntegration_NixBashEchoHi verifies that a Nix-built bash
 // exits 0 and prints "hi" under the v3 profile (P9 in F.1 §3.1).
 func TestSandboxExecIntegration_NixBashEchoHi(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	// Find bash via PATH — on a Nix host this will resolve to a Nix store path.
 	bashPath, err := exec.LookPath("bash")
 	if err != nil {
@@ -332,9 +308,7 @@ func TestSandboxExecIntegration_NixBashEchoHi(t *testing.T) {
 // the host home directory is NOT readable from inside the sandbox (N1 in
 // F.1 §3.2). Uses a real (or dummy) key file.
 func TestSandboxExecIntegration_SSHKeyDenied(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	realHome, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory")
@@ -388,9 +362,7 @@ func TestSandboxExecIntegration_SSHKeyDenied(t *testing.T) {
 // TestSandboxExecIntegration_AWSCredentialsDenied verifies that the host
 // ~/.aws/credentials is NOT readable from inside the sandbox (N2 in F.1 §3.2).
 func TestSandboxExecIntegration_AWSCredentialsDenied(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	realHome, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory")
@@ -436,9 +408,7 @@ func TestSandboxExecIntegration_AWSCredentialsDenied(t *testing.T) {
 // TestSandboxExecIntegration_HomeCodeDirectoryDenied verifies that the host
 // ~/code directory is NOT accessible from inside the sandbox (N3 in F.1 §3.2).
 func TestSandboxExecIntegration_HomeCodeDirectoryDenied(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	realHome, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory")
@@ -473,9 +443,7 @@ func TestSandboxExecIntegration_HomeCodeDirectoryDenied(t *testing.T) {
 // TestSandboxExecIntegration_DocumentsDenied verifies that a file under
 // ~/Documents is NOT readable from inside the sandbox (N5 in F.1 §3.2).
 func TestSandboxExecIntegration_DocumentsDenied(t *testing.T) {
-	if !sandboxExecAvailable() {
-		t.Skip("sandbox-exec not available")
-	}
+	sandboxexectest.Require(t)
 	realHome, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot determine home directory")

--- a/modules/programs/prism/prism/internal/container/sandboxexectest/sandboxexectest.go
+++ b/modules/programs/prism/prism/internal/container/sandboxexectest/sandboxexectest.go
@@ -1,0 +1,100 @@
+// Package sandboxexectest provides the shared capability gate used by the
+// sandbox-exec integration tests in internal/container and
+// internal/integration (issue #2203).
+//
+// Both test suites invoke /usr/bin/sandbox-exec directly, which only works
+// when sandbox_apply is actually permitted in the current environment.
+// A mere stat of the binary is not sufficient as an availability gate:
+//
+//   - Inside the Nix build sandbox, sandbox-exec exists but cannot nest a
+//     second sandbox (NIX_BUILD_TOP is set, HOME=/homeless-shelter).
+//   - Inside an outer prism sandbox-exec worker session, sandbox-exec exists
+//     but macOS refuses to nest: every invocation fails with
+//     "sandbox_apply: Operation not permitted".
+//
+// Require performs an actual sandbox-apply capability probe so tests skip
+// (with an explanatory message) instead of failing for environmental reasons
+// unrelated to the rule under test. The probe result is cached for the
+// lifetime of the test binary — the environment cannot change mid-run.
+package sandboxexectest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Path is the absolute path of Apple's sandbox-exec binary. Tests invoke it
+// directly rather than via PATH so they are pinned to the Apple-shipped
+// version (third-party shims under PATH are rejected by SIP and would skew
+// the test signal anyway).
+const Path = "/usr/bin/sandbox-exec"
+
+var (
+	probeOnce sync.Once
+	// probeSkipReason is non-empty when sandbox-exec cannot be used in this
+	// environment; it is the message passed to t.Skipf.
+	probeSkipReason string
+)
+
+// Require skips the test when /usr/bin/sandbox-exec is not present or cannot
+// actually apply an SBPL profile in this environment (Nix build sandbox, or
+// nested under an outer prism sandbox-exec session). It is the shared
+// availability gate for all sandbox-exec integration tests.
+//
+// It deliberately skips ONLY on known environmental restrictions — any other
+// probe outcome leaves the tests running so genuine regressions still fail
+// loudly (the probe must not over-skip).
+func Require(t testing.TB) {
+	t.Helper()
+	probeOnce.Do(func() { probeSkipReason = probe(Path) })
+	if probeSkipReason != "" {
+		t.Skip(probeSkipReason)
+	}
+}
+
+// probe checks whether the sandbox-exec binary at path is usable. It returns
+// a non-empty skip reason when it is not, and "" when tests should proceed.
+// Factored out of Require (with the path injectable) for unit testing.
+func probe(path string) string {
+	// The Nix build sandbox sets NIX_BUILD_TOP and sets HOME to
+	// /homeless-shelter. Running sandbox-exec inside the Nix sandbox produces
+	// "sandbox_apply: Operation not permitted" because the Nix sandboxed
+	// builder cannot nest a second sandbox-exec invocation.
+	if nixBuildTop := os.Getenv("NIX_BUILD_TOP"); nixBuildTop != "" {
+		return fmt.Sprintf("skipping sandbox-exec integration test inside Nix build sandbox (NIX_BUILD_TOP=%s)", nixBuildTop)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Sprintf("sandbox-exec not found at %s: %v", path, err)
+	}
+
+	// Detect the nested-sandbox case (test is running inside an outer prism
+	// sandbox-exec session). Probe with a permissive profile and /bin/echo —
+	// if sandbox_apply itself fails, every test gated on this helper would
+	// fail for environmental reasons unrelated to the rule under test. Skip
+	// rather than emit a misleading red.
+	dir, err := os.MkdirTemp("", "sandbox-exec-probe-")
+	if err != nil {
+		return fmt.Sprintf("cannot create temp dir for sandbox-exec probe: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	probePath := filepath.Join(dir, "probe.sb")
+	if err := os.WriteFile(probePath, []byte("(version 1)\n(allow default)\n"), 0o600); err != nil {
+		return fmt.Sprintf("cannot write sandbox-exec probe profile: %v", err)
+	}
+
+	out, err := exec.Command(path, "-f", probePath, "/bin/echo", "probe-ok").CombinedOutput()
+	if err != nil && strings.Contains(string(out), "sandbox_apply: Operation not permitted") {
+		return fmt.Sprintf("skipping sandbox-exec integration test — nested sandbox-exec is blocked in this environment (likely running inside an outer prism sandbox-exec session): %s", strings.TrimSpace(string(out)))
+	}
+
+	// Any other probe outcome: do not skip. A flaky or unexpected probe
+	// failure must not silently hide real test signal.
+	return ""
+}

--- a/modules/programs/prism/prism/internal/container/sandboxexectest/sandboxexectest_test.go
+++ b/modules/programs/prism/prism/internal/container/sandboxexectest/sandboxexectest_test.go
@@ -1,0 +1,37 @@
+package sandboxexectest
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProbe_NixBuildSandbox verifies that the probe reports the Nix build
+// sandbox restriction when NIX_BUILD_TOP is set, regardless of platform.
+func TestProbe_NixBuildSandbox(t *testing.T) {
+	t.Setenv("NIX_BUILD_TOP", "/nix/var/nix/builds/test")
+	reason := probe(Path)
+	if reason == "" {
+		t.Fatal("probe: want non-empty skip reason inside Nix build sandbox, got \"\"")
+	}
+	if !strings.Contains(reason, "Nix build sandbox") {
+		t.Errorf("probe: skip reason should name the Nix build sandbox; got: %q", reason)
+	}
+}
+
+// TestProbe_BinaryAbsent verifies that the probe reports a missing
+// sandbox-exec binary (the non-Darwin / stripped-CI case) with a skip
+// reason, exactly as the old stat-only gate did.
+func TestProbe_BinaryAbsent(t *testing.T) {
+	// Ensure the NIX_BUILD_TOP branch does not fire first (this test also
+	// runs inside the Nix checked build, where it is set).
+	t.Setenv("NIX_BUILD_TOP", "")
+	missing := filepath.Join(t.TempDir(), "no-such-sandbox-exec")
+	reason := probe(missing)
+	if reason == "" {
+		t.Fatal("probe: want non-empty skip reason for absent binary, got \"\"")
+	}
+	if !strings.Contains(reason, "not found") {
+		t.Errorf("probe: skip reason should say the binary was not found; got: %q", reason)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
@@ -20,50 +20,26 @@ import (
 	"testing"
 
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/container/sandboxexectest"
 )
 
 // sandboxExecPath is the absolute path of Apple's sandbox-exec binary. The
 // integration tests invoke it directly rather than via PATH so the tests are
 // pinned to the Apple-shipped version (third-party shims under PATH are
 // rejected by SIP and would skew the test signal anyway).
-const sandboxExecPath = "/usr/bin/sandbox-exec"
+const sandboxExecPath = sandboxexectest.Path
 
-// requireSandboxExec skips the test when /usr/bin/sandbox-exec is not present
-// or when the test is running inside the Nix build sandbox (where sandbox-exec
-// is itself restricted and cannot apply SBPL profiles). It also probes for
-// the nested-sandbox-exec case (running under an outer prism sandbox-exec
-// session): kqueue / sandbox_apply refuses to nest, producing the same
-// "sandbox_apply: Operation not permitted" symptom.
+// requireSandboxExec skips the test when /usr/bin/sandbox-exec is not present,
+// when the test is running inside the Nix build sandbox (where sandbox-exec
+// is itself restricted and cannot apply SBPL profiles), or when running
+// nested under an outer prism sandbox-exec session (sandbox_apply refuses to
+// nest, producing "sandbox_apply: Operation not permitted").
+//
+// The actual capability probe is shared with internal/container's
+// integration tests — see sandboxexectest.Require (issue #2203).
 func requireSandboxExec(t *testing.T) {
 	t.Helper()
-
-	// The Nix build sandbox sets NIX_BUILD_TOP to a path under
-	// /nix/var/nix/builds/ and sets HOME to /homeless-shelter. Running
-	// sandbox-exec inside the Nix sandbox produces "sandbox_apply: Operation
-	// not permitted" because the Nix sandboxed builder cannot nest a second
-	// sandbox-exec invocation.
-	if nixBuildTop := os.Getenv("NIX_BUILD_TOP"); nixBuildTop != "" {
-		t.Skipf("skipping sandbox-exec integration test inside Nix build sandbox (NIX_BUILD_TOP=%s)", nixBuildTop)
-	}
-
-	if _, err := os.Stat(sandboxExecPath); err != nil {
-		t.Skipf("sandbox-exec not found at %s: %v", sandboxExecPath, err)
-	}
-
-	// Detect the nested-sandbox case (test is running inside an outer
-	// prism sandbox-exec session). Probe with a permissive profile and
-	// /bin/echo — if sandbox_apply itself fails, every test in this
-	// file would fail for environmental reasons unrelated to the rule
-	// under test. Skip rather than emit a misleading red.
-	probeProfile := "(version 1)\n(allow default)\n"
-	probePath := filepath.Join(t.TempDir(), "probe.sb")
-	if err := os.WriteFile(probePath, []byte(probeProfile), 0o600); err != nil {
-		t.Skipf("cannot write sandbox-exec probe profile: %v", err)
-	}
-	probeCmd := exec.Command(sandboxExecPath, "-f", probePath, "/bin/echo", "probe-ok")
-	if out, err := probeCmd.CombinedOutput(); err != nil && strings.Contains(string(out), "sandbox_apply: Operation not permitted") {
-		t.Skipf("skipping sandbox-exec integration test — nested sandbox-exec is blocked in this environment (likely running inside an outer prism sandbox-exec session): %s", string(out))
-	}
+	sandboxexectest.Require(t)
 }
 
 // requireNixBash resolves the Nix-built bash binary via PATH → symlink chain


### PR DESCRIPTION
Closes #2203

## Problem

Running `go test ./...` from `modules/programs/prism/prism/` inside a prism sandbox-exec worker session failed in `internal/container/sandbox_exec_integration_test.go`: all 13 `TestSandboxExecIntegration_*` tests errored with `sandbox_apply: Operation not permitted`. Nested sandbox-exec is blocked by macOS, so these tests can never pass inside a worker sandbox — they should skip.

The gate, `sandboxExecAvailable()`, only stat'd `/usr/bin/sandbox-exec`, so it reported "available" in environments where `sandbox_apply` is denied. `internal/integration`'s `requireSandboxExec` already modelled the correct pattern (an actual sandbox-apply capability probe).

## Fix

Extracted the probe into a shared test-support package — `internal/container/sandboxexectest` (following the `internal/sidecar/sidecartest` precedent) — as the single source of truth, since `requireSandboxExec` lives in an external `_test.go` package and cannot be imported across packages:

- `NIX_BUILD_TOP` set → skip (Nix build sandbox)
- `/usr/bin/sandbox-exec` absent → skip (non-Darwin / stripped CI — same as the old stat gate)
- probe run fails with `sandbox_apply: Operation not permitted` → skip (nested sandbox-exec), with a skip message naming the nested-sandbox restriction
- any other outcome → run (the probe deliberately does not over-skip; genuine regressions still fail loudly)

The probe result is cached via `sync.Once` (one sandbox-exec exec per test binary). Both `internal/container`'s 13 integration-test gates and `internal/integration`'s `requireSandboxExec` now delegate to `sandboxexectest.Require`. Deterministic unit tests cover the `NIX_BUILD_TOP` and binary-absent branches on all platforms.

## Verification (inside a sandbox-exec worker session — primary evidence per the issue)

- **Before:** `go test ./internal/container/ -run TestSandboxExecIntegration` → 13 FAILs with `sandbox_apply: Operation not permitted`.
- **After:** all 13 SKIP with `skipping sandbox-exec integration test — nested sandbox-exec is blocked in this environment (likely running inside an outer prism sandbox-exec session): …`.
- `go build ./...`, `go vet`, and `go test -race ./internal/container/...` all green.
- `go test ./...`: remaining failures are exclusively the #2204 tmux fork-EPERM class (`cmd/`, `internal/tmux/`, and tmux-harness tests in `internal/integration/` — verified pre-existing on a clean tree; escalated to the coordinator that #2204's package list should mention `internal/integration` too). No failures attributable to nested sandbox-exec remain.
- Non-over-skip on a genuine Darwin host: the probe logic preserves the behaviour of the known-good `requireSandboxExec` (skip only on the specific `sandbox_apply` symptom), and `internal/integration`'s sandbox-exec suite continues to gate through the same shared code path.

Note: pre-existing gofmt drift (doc-comment quote normalisation from a newer Go toolchain) exists in 4 files including an untouched region of `sandbox_exec_helpers_darwin_test.go`; left alone as out of scope.
