### PR TITLE
prism: deny git stash for worker-class agents (#2202)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,44 @@ reason this gap surfaced. See
 `modules/programs/prism/prism/docs/stdout-capture-testing.md` for the full
 convention and the canonical `captureStdout` helper (issue #1798).
 
+### Setting WIP aside — do not use git stash
+
+**Worker-class prism sessions must never use `git stash`** (any subcommand
+— `stash -u`, `stash pop`, `stash apply`, `stash list`, …). In the
+bare+worktree layout the stash stack (`refs/stash` + its reflog) lives in
+the shared bare repo, so it is repo-wide, not per-worktree. Two sessions
+that stash concurrently race on a single LIFO stack — `git stash pop` takes
+whatever is at `stash@{0}`, which may belong to another worktree. On
+2026-06-11 two concurrent workers' pops crossed and silently swapped their
+WIP (issue #2202). The pi extension's deny list (`BLOCKED_BASH_PATTERNS` in
+`modules/programs/prism/pi/extensions/prism.ts`) blocks `git stash` for
+worker-class agents as defence in depth; the coordinator — the single
+session on the main worktree — is exempt and is then the only prism writer
+to the shared stack.
+
+Sanctioned WIP-set-aside patterns — both are worktree-local:
+
+- **Temp commit** (preferred — commit history is disposable on squash-merged
+  branches):
+
+  ```bash
+  git add -A && git commit -m wip   # set WIP aside
+  # ... do the other thing (e.g. rerun a test against HEAD~1 via a checkout) ...
+  git reset --soft HEAD~1           # restore: changes return, staged
+  ```
+
+- **Patch file**:
+
+  ```bash
+  git diff > /tmp/wip.patch && git restore .   # set WIP aside
+  # ... do the other thing ...
+  git apply /tmp/wip.patch                     # restore
+  ```
+
+The "verify your tests aren't no-ops" discipline (revert fix → rerun test →
+re-apply) is the common trigger for reaching for a stash — use one of the
+patterns above instead.
+
 ### File naming and organisation
 
 Names of files and directories should be in lowercase, with dashes between words — kebab case, not camel case.

--- a/modules/programs/prism/agents/worker.md
+++ b/modules/programs/prism/agents/worker.md
@@ -117,7 +117,12 @@ the source of truth when AGENTS.md is silent or stale.
 When you write a new test for a fix, briefly verify the test actually catches
 the bug it's meant to catch. The minimal discipline:
 
-1. Revert your fix locally (e.g. `git stash`, or comment out the change).
+1. Revert your fix locally (e.g. `git diff > /tmp/fix.patch && git restore .`,
+   restoring afterwards with `git apply /tmp/fix.patch`, or comment out the
+   change). Never use `git stash` — the stash stack is shared across all
+   prism worktrees in the repo and concurrent stash/pop silently swaps WIP
+   between sessions (issue #2202); see "Setting WIP aside" in the repo's
+   AGENTS.md for the sanctioned patterns.
 2. Re-run only the new test. Confirm it **FAILS**.
 3. Re-apply your fix. Confirm the new test **PASSES**.
 

--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -33,9 +33,10 @@ import {
   processDoomLoop,
   isGitPush,
   EXCLUDED_BASH_BASES,
-  // Pre-tool-call bash deny list (#1528, #2180)
+  // Pre-tool-call bash deny list (#1528, #2180, #2202)
   BLOCKED_BASH_PATTERNS,
   checkBlockedBash,
+  isWorkerClassRole,
   stripCommandSubstitutions,
   newDoomLoopState,
   snapshotGuardState,
@@ -1606,8 +1607,8 @@ describe("isGitPush", () => {
 // ---------------------------------------------------------------------------
 
 describe("BLOCKED_BASH_PATTERNS", () => {
-  it("contains exactly three entries", () => {
-    assert.equal(BLOCKED_BASH_PATTERNS.length, 3)
+  it("contains exactly four entries", () => {
+    assert.equal(BLOCKED_BASH_PATTERNS.length, 4)
   })
 
   it("has the git-worktree-prune entry", () => {
@@ -1623,6 +1624,21 @@ describe("BLOCKED_BASH_PATTERNS", () => {
   it("has the nix-build-with-env-override entry (#2180)", () => {
     const ids = BLOCKED_BASH_PATTERNS.map((p) => p.id)
     assert.ok(ids.includes("nix-build-with-env-override"))
+  })
+
+  it("has the git-stash entry (#2202)", () => {
+    const ids = BLOCKED_BASH_PATTERNS.map((p) => p.id)
+    assert.ok(ids.includes("git-stash"))
+  })
+
+  it("only the git-stash entry is role-scoped; the pre-#2202 entries are unscoped", () => {
+    for (const p of BLOCKED_BASH_PATTERNS) {
+      if (p.id === "git-stash") {
+        assert.equal(typeof p.appliesToRole, "function")
+      } else {
+        assert.equal(p.appliesToRole, undefined)
+      }
+    }
   })
 
   it("every entry has id, match, and reason fields", () => {
@@ -2001,6 +2017,256 @@ describe("checkBlockedBash — reason string content", () => {
 
   it("reason is prefixed with 'blocked by prism extension'", () => {
     const hit = checkBlockedBash("git worktree prune")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.startsWith("blocked by prism extension:"))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// git-stash deny entry (#2202)
+// ---------------------------------------------------------------------------
+
+describe("isWorkerClassRole (#2202)", () => {
+  it("is true for worker", () => {
+    assert.equal(isWorkerClassRole("worker"), true)
+  })
+
+  it("is true for every review-* role", () => {
+    for (const role of [
+      "review-goal",
+      "review-code",
+      "review-context",
+      "review-qa",
+      "review-security",
+    ]) {
+      assert.equal(isWorkerClassRole(role), true, role)
+    }
+  })
+
+  it("is true for the other non-coordinator prism roles", () => {
+    for (const role of ["ac", "investigate", "retro"]) {
+      assert.equal(isWorkerClassRole(role), true, role)
+    }
+  })
+
+  it("is false for coordinator", () => {
+    assert.equal(isWorkerClassRole("coordinator"), false)
+  })
+
+  it("is false for the empty role (pi launched outside prism)", () => {
+    assert.equal(isWorkerClassRole(""), false)
+  })
+})
+
+describe("checkBlockedBash — git stash (positive cases, worker role, #2202)", () => {
+  it("blocks plain 'git stash'", () => {
+    const hit = checkBlockedBash("git stash", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash -u' (the incident command)", () => {
+    const hit = checkBlockedBash("git stash -u", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash pop' (the other incident command)", () => {
+    const hit = checkBlockedBash("git stash pop", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash apply'", () => {
+    const hit = checkBlockedBash("git stash apply", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash list' (read-only subcommands included per AC)", () => {
+    const hit = checkBlockedBash("git stash list", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash push -m wip'", () => {
+    const hit = checkBlockedBash("git stash push -m wip", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash drop' and 'git stash clear'", () => {
+    for (const cmd of ["git stash drop", "git stash clear"]) {
+      const hit = checkBlockedBash(cmd, "worker")
+      assert.notEqual(hit, null, cmd)
+      assert.equal(hit!.id, "git-stash", cmd)
+    }
+  })
+
+  it("blocks 'git -C /path stash'", () => {
+    const hit = checkBlockedBash("git -C /some/path stash", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git --git-dir=/p/.git stash pop'", () => {
+    const hit = checkBlockedBash("git --git-dir=/p/.git stash pop", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks the second segment of 'cd /repo && git stash pop'", () => {
+    const hit = checkBlockedBash("cd /repo && git stash pop", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+
+  it("blocks 'git stash' inside a command substitution", () => {
+    const hit = checkBlockedBash("echo $(git stash list)", "worker")
+    assert.notEqual(hit, null)
+    assert.equal(hit!.id, "git-stash")
+  })
+})
+
+describe("checkBlockedBash — git stash role scoping (#2202)", () => {
+  it("blocks for every review-* role (defence-in-depth on top of prompt rules)", () => {
+    for (const role of [
+      "review-goal",
+      "review-code",
+      "review-context",
+      "review-qa",
+      "review-security",
+    ]) {
+      const hit = checkBlockedBash("git stash pop", role)
+      assert.notEqual(hit, null, role)
+      assert.equal(hit!.id, "git-stash", role)
+    }
+  })
+
+  it("does NOT block for the coordinator (AC: coordinator behaviour unchanged)", () => {
+    assert.equal(checkBlockedBash("git stash", "coordinator"), null)
+    assert.equal(checkBlockedBash("git stash pop", "coordinator"), null)
+    assert.equal(checkBlockedBash("git stash -u", "coordinator"), null)
+  })
+
+  it("does NOT block when no role is passed (non-prism pi launch / legacy call shape)", () => {
+    assert.equal(checkBlockedBash("git stash"), null)
+    assert.equal(checkBlockedBash("git stash", ""), null)
+  })
+
+  it("unscoped entries still fire regardless of role (coordinator included)", () => {
+    const prune = checkBlockedBash("git worktree prune", "coordinator")
+    assert.notEqual(prune, null)
+    assert.equal(prune!.id, "git-worktree-prune")
+    const nix = checkBlockedBash(
+      "XDG_DATA_HOME=/tmp/x nix build .#prism",
+      "coordinator",
+    )
+    assert.notEqual(nix, null)
+    assert.equal(nix!.id, "nix-build-with-env-override")
+  })
+})
+
+describe("checkBlockedBash — git stash (negative cases / false positives, #2202)", () => {
+  it("does NOT block 'stash' inside a double-quoted commit message", () => {
+    assert.equal(
+      checkBlockedBash('git commit -m "replace git stash with temp commit"', "worker"),
+      null,
+    )
+  })
+
+  it("does NOT block 'stash' inside a single-quoted commit message", () => {
+    assert.equal(
+      checkBlockedBash("git commit -am 'wip: do not git stash'", "worker"),
+      null,
+    )
+  })
+
+  it("does NOT block 'stash' as part of a file path argument", () => {
+    assert.equal(
+      checkBlockedBash("git add docs/git-stash.md", "worker"),
+      null,
+    )
+    assert.equal(checkBlockedBash("cat notes/stash.txt", "worker"), null)
+  })
+
+  it("does NOT block 'stash' as part of a branch name", () => {
+    assert.equal(
+      checkBlockedBash("git push -u origin worker-git-stash-deny", "worker"),
+      null,
+    )
+    assert.equal(
+      checkBlockedBash("git checkout stash-fix-branch", "worker"),
+      null,
+    )
+  })
+
+  it("does NOT block rg/grep searching for the literal string", () => {
+    assert.equal(checkBlockedBash('rg "git stash" modules/', "worker"), null)
+    assert.equal(
+      checkBlockedBash('grep -rn "git stash" AGENTS.md', "worker"),
+      null,
+    )
+  })
+
+  it("does NOT block git log --grep with the literal string", () => {
+    assert.equal(
+      checkBlockedBash('git log --grep="git stash"', "worker"),
+      null,
+    )
+  })
+
+  it("does NOT block a heredoc body containing 'git stash'", () => {
+    const cmd = "cat <<'EOF'\ngit stash -u\ngit stash pop\nEOF"
+    assert.equal(checkBlockedBash(cmd, "worker"), null)
+  })
+
+  it("does NOT match 'stash' embedded in a longer word", () => {
+    assert.equal(checkBlockedBash("git stashed", "worker"), null)
+  })
+
+  it("does NOT match unrelated git subcommands", () => {
+    assert.equal(checkBlockedBash("git status", "worker"), null)
+    assert.equal(checkBlockedBash("git stat", "worker"), null)
+  })
+})
+
+describe("checkBlockedBash — git-stash reason string (#2202)", () => {
+  it("names the shared-stash hazard", () => {
+    const hit = checkBlockedBash("git stash", "worker")
+    assert.notEqual(hit, null)
+    assert.ok(
+      hit!.reason.includes("refs/stash"),
+      `reason should name the shared stash stack: ${hit!.reason}`,
+    )
+    assert.ok(
+      hit!.reason.toLowerCase().includes("swap"),
+      `reason should name the WIP-swap failure mode: ${hit!.reason}`,
+    )
+  })
+
+  it("names the sanctioned temp-commit alternative", () => {
+    const hit = checkBlockedBash("git stash", "worker")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.includes("git commit -am wip"))
+    assert.ok(hit!.reason.includes("git reset --soft HEAD~1"))
+  })
+
+  it("names the sanctioned patch-file alternative", () => {
+    const hit = checkBlockedBash("git stash", "worker")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.includes("git diff > /tmp/wip.patch"))
+    assert.ok(hit!.reason.includes("git restore ."))
+  })
+
+  it("points the agent at the AGENTS.md subsection", () => {
+    const hit = checkBlockedBash("git stash", "worker")
+    assert.notEqual(hit, null)
+    assert.ok(hit!.reason.includes("AGENTS.md"))
+  })
+
+  it("is prefixed with 'blocked by prism extension'", () => {
+    const hit = checkBlockedBash("git stash", "worker")
     assert.notEqual(hit, null)
     assert.ok(hit!.reason.startsWith("blocked by prism extension:"))
   })

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -687,11 +687,41 @@ function segmentIsGitPush(segment: string): boolean {
  * when the segment is a real invocation of the blocked command. The `reason`
  * surfaces verbatim to the agent via pi's tool-result channel and should
  * name the recommended alternative.
+ *
+ * `appliesToRole` optionally scopes a pattern to specific agent roles.
+ * When present, the pattern fires only for sessions whose `--agent` role
+ * satisfies the predicate; when absent, the pattern applies to every
+ * session that loads the extension (the pre-existing convention — the
+ * git-worktree-* and nix-build entries are unscoped because their hazards
+ * apply to coordinators too).
  */
 export interface BlockedBashPattern {
   id: string
   match: (segment: string) => boolean
   reason: string
+  appliesToRole?: (agentRole: string) => boolean
+}
+
+/**
+ * Worker-class role predicate for role-scoped deny-list entries (#2202).
+ *
+ * "Worker-class" means any prism-spawned agent role other than the
+ * coordinator: worker, review-*, ac, investigate, retro, and any future
+ * non-coordinator role. The coordinator is excluded because it is the
+ * single session on the main worktree acting as the user's proxy — with
+ * every worker-class session denied stash access, the coordinator is the
+ * only prism writer to the shared stash stack, so the cross-session race
+ * cannot occur from prism sessions.
+ *
+ * An empty role means pi was launched outside prism's spawn path (no
+ * --agent flag) — e.g. a plain repo without the bare+worktree layout —
+ * where the shared-stash hazard does not apply, so worker-scoped entries
+ * do not fire. Prism always passes --agent for spawned sessions.
+ *
+ * Exported for unit testing.
+ */
+export function isWorkerClassRole(agentRole: string): boolean {
+  return agentRole !== "" && agentRole !== "coordinator"
 }
 
 /**
@@ -764,6 +794,34 @@ export const BLOCKED_BASH_PATTERNS: readonly BlockedBashPattern[] = [
       "than attempting environment workarounds; CI runs the authoritative " +
       "build so a local failure is not a merge blocker.",
   },
+  {
+    // #2202 — `git stash` is not worktree-scoped. In the bare+worktree
+    // layout the stash stack (refs/stash + its reflog) lives in the shared
+    // bare repo, so every prism session in the repo races on a single LIFO
+    // stack. On 2026-06-11 two concurrent workers ran `git stash -u` +
+    // `git stash pop` within the same minute and the pops crossed,
+    // silently swapping their WIP. All stash subcommands are blocked —
+    // including read-only ones like `stash list` — because any stash use
+    // normalises the stack as a workspace tool. Scoped to worker-class
+    // roles: the coordinator (single session on the main worktree) is
+    // exempt, consistent with the AC for #2202.
+    id: "git-stash",
+    match: (segment: string) =>
+      /\bgit(\s+-C\s+\S+|\s+--git-dir\S*(\s+\S+)?)*\s+stash\b/.test(
+        segment,
+      ),
+    appliesToRole: isWorkerClassRole,
+    reason:
+      "blocked by prism extension: `git stash` is not worktree-scoped \u2014 " +
+      "the stash stack (refs/stash) lives in the shared bare repo and is " +
+      "shared by every prism session in this repo. Concurrent stash/pop " +
+      "across sessions race on a single LIFO stack and can silently swap " +
+      "WIP between workers (issue #2202). Set WIP aside with a temp commit " +
+      "(`git commit -am wip`, restore with `git reset --soft HEAD~1`) or a " +
+      "patch file (`git diff > /tmp/wip.patch` then `git restore .`, " +
+      "restore with `git apply /tmp/wip.patch`) instead \u2014 see AGENTS.md " +
+      "\u00a7 'Setting WIP aside \u2014 do not use git stash'.",
+  },
 ]
 
 /**
@@ -775,10 +833,17 @@ export const BLOCKED_BASH_PATTERNS: readonly BlockedBashPattern[] = [
  * does not fire a block but `cd /repo && git worktree prune` does
  * (the second segment).
  *
+ * `agentRole` is the session's `--agent` role (from pi.getFlag("agent")).
+ * Patterns with an `appliesToRole` predicate are skipped when the role
+ * does not satisfy it; unscoped patterns apply regardless of role. The
+ * default of "" preserves the pre-#2202 behaviour for callers that do
+ * not pass a role: unscoped patterns still fire, worker-scoped ones do not.
+ *
  * Exported for unit testing.
  */
 export function checkBlockedBash(
   command: string,
+  agentRole: string = "",
 ): { id: string; reason: string } | null {
   const stripped = stripQuotedAndHeredocRegions(command)
   // Two passes:
@@ -798,6 +863,12 @@ export function checkBlockedBash(
   ])
   for (const segment of segments) {
     for (const pattern of BLOCKED_BASH_PATTERNS) {
+      if (
+        pattern.appliesToRole !== undefined &&
+        !pattern.appliesToRole(agentRole)
+      ) {
+        continue
+      }
       if (pattern.match(segment)) {
         return { id: pattern.id, reason: pattern.reason }
       }
@@ -2494,7 +2565,13 @@ export default function prismExtension(pi: ExtensionAPI): void {
         ? (input as Record<string, unknown>).command
         : undefined
     if (typeof command !== "string") return
-    const hit = checkBlockedBash(command)
+    // Role-scoped entries (#2202) need the session's agent role. Sourced
+    // synchronously from pi.getFlag("agent") — bound before any hook fires
+    // (see the before_agent_start handler) — so this is race-free even on
+    // the first turn.
+    const roleFlagValue = pi.getFlag("agent")
+    const agentRole = typeof roleFlagValue === "string" ? roleFlagValue : ""
+    const hit = checkBlockedBash(command, agentRole)
     if (hit !== null) {
       return { block: true, reason: hit.reason }
     }


### PR DESCRIPTION
Closes #2202

## What

Two changes (candidate fixes 1 + 2 from the issue):

1. **Deny-list entry** — `BLOCKED_BASH_PATTERNS` in
   `modules/programs/prism/pi/extensions/prism.ts` gets a fourth entry,
   `git-stash`, blocking every stash subcommand (`stash`, `stash -u`,
   `stash pop`, `stash apply`, `stash list`, `push`, `drop`, `clear`)
   before execution. The reason string names the shared-stash hazard
   (repo-wide `refs/stash` stack in the bare repo; concurrent stash/pop
   silently swaps WIP between sessions) and both sanctioned alternatives
   (temp commit / patch file), pointing at the new AGENTS.md section.

2. **Docs** — AGENTS.md gets a "Setting WIP aside — do not use git stash"
   section documenting the hazard and the sanctioned temp-commit
   (`git add -A && git commit -m wip` / `git reset --soft HEAD~1`) and
   patch-file (`git diff > /tmp/wip.patch && git restore .` /
   `git apply /tmp/wip.patch`) flows.

## Role scoping (AC 4)

The existing three entries are unscoped — they fire for every session that
loads the extension, coordinator included (the #1528 motivating incident
was a coordinator). The git-stash hazard is different: the AC requires the
coordinator's behaviour to be unchanged. So `BlockedBashPattern` gains an
optional `appliesToRole` predicate (absent = unscoped, preserving the
existing entries' behaviour exactly), and the new entry is scoped via an
exported `isWorkerClassRole` helper: any non-empty role other than
`coordinator` (worker, review-*, ac, investigate, retro). With every
worker-class session denied, the coordinator is the only prism writer to
the shared stack, so the cross-session race cannot occur from prism
sessions. The empty role (pi launched outside prism's spawn path, where
the bare+worktree layout doesn't apply) is also exempt; prism always
passes `--agent` for spawned sessions. The `tool_call` handler sources the
role synchronously from `pi.getFlag("agent")` — the same race-free source
used for role system-prompt injection (#2064), bound before any hook fires.

## Also

`agents/worker.md`'s "verify your tests aren't no-ops" step previously
recommended `git stash` for the revert — the documented invitation to this
exact race (called out in the issue). It now names the patch-file flow and
warns against stash. One-line-scope coherence fix: without it the worker
role prompt would instruct workers to run a command the extension blocks.

## False-positive safety (AC 3)

The matcher follows the existing convention (quoted/heredoc regions
stripped, shell-separator segmentation, optional `git -C <path>` /
`--git-dir[=]<path>` prefixes). Negative tests cover `stash` as data:
commit messages, file paths (`git add docs/git-stash.md`), branch names
(`git push -u origin worker-git-stash-deny` — this PR's own branch),
rg/grep patterns, `git log --grep`, heredoc bodies, and embedded-word
forms (`git stashed`).

## Testing

- `tsx --test prism.test.ts prism.role-prompt.test.ts` — 377/377 pass.
- 36 new tests: all AC-named subcommands, role scoping (worker and all
  five review-* roles blocked; coordinator and empty role not; unscoped
  entries unaffected by role), false-positive negatives, reason-string
  content (hazard + both alternatives + AGENTS.md pointer).
- No-op check: reverting only `prism.ts` and re-running surfaces 24
  failures; re-applying returns to green — the new tests are not
  vacuous-pass.
- No prism Go source touched, so the go-tests / nix-build-prism-checked CI
  jobs are not in play; no `.nix` files changed (nixfmt not applicable).
- Per the irony hazard in the spawn prompt: the no-op check above was done
  with the patch-file pattern, not `git stash`.
