### PR TITLE
prism: skip tmux-server tests on in-sandbox fork EPERM instead of failing

### DIFF
--- a/modules/programs/prism/prism/cmd/dashboard_test.go
+++ b/modules/programs/prism/prism/cmd/dashboard_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/dashboard"
 	"github.com/prismatic-koi/prism/internal/tmux"
+	"github.com/prismatic-koi/prism/internal/tmux/tmuxtest"
 )
 
 // ─── package-level test server registry ──────────────────────────────────────
@@ -78,12 +79,13 @@ type cmdTestServer struct {
 	bin    string
 }
 
+// newCmdTestServer starts an isolated tmux server for a cmd test. Skips (via
+// tmuxtest.RequireServer) when tmux is absent from PATH or when tmux server
+// creation is blocked by the sandbox (fork EPERM inside prism sandbox-exec
+// worker sessions — issue #2204).
 func newCmdTestServer(t *testing.T) *cmdTestServer {
 	t.Helper()
-	bin, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not found in PATH — skipping integration test")
-	}
+	bin := tmuxtest.RequireServer(t)
 	socket := fmt.Sprintf("prism-cmd-test-%d-%s", os.Getpid(), randCmdHex(8))
 	s := &cmdTestServer{socket: socket, bin: bin}
 
@@ -98,8 +100,7 @@ func newCmdTestServer(t *testing.T) *cmdTestServer {
 	// after CombinedOutput is safe and correct.
 	startCmd := exec.Command(bin, "-L", socket, "-f", "/dev/null", "new-session", "-ds", "bootstrap", "-c", "/tmp")
 	startCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	var startOut []byte
-	startOut, err = startCmd.CombinedOutput()
+	startOut, err := startCmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("start test tmux server: %v\n%s", err, startOut)
 	}

--- a/modules/programs/prism/prism/internal/integration/integration_test.go
+++ b/modules/programs/prism/prism/internal/integration/integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/session"
 	"github.com/prismatic-koi/prism/internal/tmux"
+	"github.com/prismatic-koi/prism/internal/tmux/tmuxtest"
 )
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -52,14 +53,13 @@ func openTestDB(t *testing.T) *db.DB {
 	return d
 }
 
-// requireTmux skips the test immediately if tmux is not available in PATH.
+// requireTmux skips the test when tmux is not available in PATH, or when
+// tmux server creation is blocked by the sandbox (fork EPERM inside prism
+// sandbox-exec worker sessions — issue #2204). Its only caller is
+// newTmuxServer, so server-start capability is exactly what it must verify.
 func requireTmux(t *testing.T) string {
 	t.Helper()
-	bin, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not found in PATH — skipping tmux integration test")
-	}
-	return bin
+	return tmuxtest.RequireServer(t)
 }
 
 // tmuxServer holds a headless tmux server running on a unique socket.

--- a/modules/programs/prism/prism/internal/tmux/harness_test.go
+++ b/modules/programs/prism/prism/internal/tmux/harness_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/prismatic-koi/prism/internal/tmux"
+	"github.com/prismatic-koi/prism/internal/tmux/tmuxtest"
 )
 
 // ─── sandbox detection ────────────────────────────────────────────────────────
@@ -111,13 +112,14 @@ type server struct {
 
 // newServer starts a fresh headless tmux server on a unique socket and returns
 // a handle. The server is automatically killed in t.Cleanup.
+//
+// Skips (via tmuxtest.RequireServer) when tmux is absent from PATH or when
+// tmux server creation is blocked by the sandbox (fork EPERM inside prism
+// sandbox-exec worker sessions — issue #2204).
 func newServer(t *testing.T) *server {
 	t.Helper()
 
-	bin, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux not found in PATH — skipping integration test")
-	}
+	bin := tmuxtest.RequireServer(t)
 
 	socket := fmt.Sprintf("prism-test-%d-%s", os.Getpid(), randHex(8))
 	s := &server{socket: socket, bin: bin}

--- a/modules/programs/prism/prism/internal/tmux/tmuxtest/tmuxtest.go
+++ b/modules/programs/prism/prism/internal/tmux/tmuxtest/tmuxtest.go
@@ -1,0 +1,109 @@
+// Package tmuxtest provides a shared capability probe for test suites that
+// need to start a private tmux server (tmux -L <socket>).
+//
+// # Why this exists (issue #2204)
+//
+// Inside a prism sandbox-exec worker session the sandbox profile denies the
+// fork tmux needs to daemonise its server process. Every attempt to bootstrap
+// a private test server fails with:
+//
+//	create window failed: fork failed: Operation not permitted
+//
+// Without a guard, the tmux-server-backed suites in cmd/, internal/tmux/, and
+// internal/integration/ fail (rather than skip) on a clean tree whenever
+// `go test ./...` runs inside such a session — training agents to dismiss red
+// suites. RequireServer turns that environmental failure into an explicit,
+// explanatory skip.
+//
+// # No over-skip guarantee
+//
+// The guard probes actual capability — it attempts to start (and immediately
+// kill) a throwaway private tmux server once per test binary — instead of
+// sniffing platform or sandbox heuristics. It skips only when the probe fails
+// with the known fork-denial signature. On hosts where tmux server creation
+// works (developer shells, CI Linux runners), the probe succeeds and the
+// tests run as before. If the probe fails for any *other* reason, the guard
+// deliberately does not skip: the test proceeds and surfaces the real error,
+// preserving today's failure signal.
+package tmuxtest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// forkDenialSignature is the error tmux emits when the sandbox profile blocks
+// the fork required to daemonise the tmux server. This is the exact signature
+// observed inside prism sandbox-exec worker sessions (issue #2204).
+const forkDenialSignature = "fork failed: Operation not permitted"
+
+var (
+	probeOnce sync.Once
+	probeOut  string // combined output of the probe attempt
+	probeErr  error  // non-nil when the probe failed to start a server
+)
+
+// RequireServer skips t when this environment cannot start a private tmux
+// server, and otherwise returns the resolved path to the tmux binary.
+//
+// Two skip conditions:
+//
+//  1. tmux is absent from PATH (preserves the long-standing behaviour of the
+//     per-package harnesses).
+//  2. tmux is present but server creation is denied with the in-sandbox
+//     fork-EPERM signature ("fork failed: Operation not permitted"), as
+//     happens inside prism sandbox-exec worker sessions whose profile blocks
+//     the tmux daemon fork.
+//
+// The capability probe runs at most once per test binary (sync.Once) and
+// starts a throwaway server on a unique socket, killing it immediately. Probe
+// failures that do not match the fork-denial signature do not cause a skip —
+// the caller's own server bootstrap will reproduce and report the real error.
+func RequireServer(t testing.TB) string {
+	t.Helper()
+
+	bin, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not found in PATH — skipping tmux integration test")
+	}
+
+	probeOnce.Do(func() {
+		probeOut, probeErr = probeServerStart(bin)
+	})
+
+	if probeErr != nil && IsSandboxForkDenial(probeOut) {
+		t.Skipf("skipping: cannot start a private tmux server in this environment — "+
+			"the fork tmux needs to daemonise its server is denied by the sandbox "+
+			"(%q), as inside prism sandbox-exec worker sessions (issue #2204); "+
+			"run from a host shell or CI to exercise this test. probe error: %v",
+			forkDenialSignature, probeErr)
+	}
+
+	return bin
+}
+
+// IsSandboxForkDenial reports whether the given tmux output matches the
+// in-sandbox fork-denial signature that blocks tmux server creation.
+func IsSandboxForkDenial(output string) bool {
+	return strings.Contains(output, forkDenialSignature)
+}
+
+// probeServerStart attempts to bootstrap a throwaway private tmux server on a
+// unique socket and returns the combined output and error of the attempt. Any
+// server it manages to start is killed before returning. -f /dev/null
+// suppresses the user's tmux.conf so no hooks fire against live prism state.
+func probeServerStart(bin string) (string, error) {
+	socket := fmt.Sprintf("prism-tmuxtest-probe-%d-%d", os.Getpid(), time.Now().UnixNano())
+	cmd := exec.Command(bin, "-L", socket, "-f", "/dev/null",
+		"new-session", "-ds", "probe", "-c", os.TempDir())
+	out, err := cmd.CombinedOutput()
+	// Best-effort teardown: if the server started, kill it; if it did not,
+	// this fails harmlessly.
+	_ = exec.Command(bin, "-L", socket, "kill-server").Run()
+	return string(out), err
+}

--- a/modules/programs/prism/prism/internal/tmux/tmuxtest/tmuxtest_test.go
+++ b/modules/programs/prism/prism/internal/tmux/tmuxtest/tmuxtest_test.go
@@ -1,0 +1,56 @@
+package tmuxtest
+
+import "testing"
+
+// TestIsSandboxForkDenial verifies the fork-denial classifier matches the
+// exact in-sandbox signature (issue #2204) and nothing broader — the guard
+// must not skip on unrelated tmux failures (no over-skip).
+func TestIsSandboxForkDenial(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "observed in-sandbox signature",
+			output: "create window failed: fork failed: Operation not permitted\n",
+			want:   true,
+		},
+		{
+			name:   "bare fork denial",
+			output: "fork failed: Operation not permitted",
+			want:   true,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+		{
+			name:   "unrelated tmux error",
+			output: "error connecting to /tmp/tmux-501/default (No such file or directory)",
+			want:   false,
+		},
+		{
+			name:   "permission error without fork",
+			output: "open: Operation not permitted",
+			want:   false,
+		},
+		{
+			name:   "fork failure with different errno",
+			output: "create window failed: fork failed: Resource temporarily unavailable",
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsSandboxForkDenial(tc.output); got != tc.want {
+				t.Errorf("IsSandboxForkDenial(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2204

## Problem

Inside a prism sandbox-exec worker session, the sandbox profile denies the fork tmux needs to daemonise its server. Every test that bootstraps a private tmux server failed on a clean tree with:

```
create window failed: fork failed: Operation not permitted
```

Affected suites (verified red on clean main from inside this worker's own sandbox-exec session): `cmd/` (35 call sites via `newCmdTestServer`), `internal/tmux/` (26 via `newServer`), and `internal/integration/` (`TestTmuxHarness_ThreeWindowLayout`, `TestSessionCreate_*` via `newTmuxServer` — per the issue's scope extension).

## Fix

New shared package `internal/tmux/tmuxtest` with `RequireServer(t)`:

- **Capability probe, not a heuristic**: attempts to start (and immediately kill) a throwaway private tmux server once per test binary (`sync.Once`). No platform or env-var sniffing, so healthy hosts are unaffected.
- **Skips only on the exact fork-denial signature** (`fork failed: Operation not permitted`), with an explanatory message naming the in-sandbox fork restriction and issue #2204.
- **No over-skip**: unknown probe failures do *not* skip — the caller's own server bootstrap reproduces and reports the real error. On dev shells, CI Linux runners, and bwrap sandboxes the probe succeeds and the tests execute exactly as before.
- **tmux absent from PATH** still skips with the long-standing message (preserves prior behaviour; nix-sandbox builds keep skipping since tmux is intentionally not in nativeCheckInputs).

All three harness constructors now delegate to the shared guard. The probe lives in a new package rather than `internal/integration/sandbox_exec_helpers_darwin_test.go` to stay disjoint from the in-flight #2203 branch (`container-sandbox-exec-skip-guard`).

## Verification

- **Before** (clean main, inside this sandbox-exec worker session): `cmd`, `internal/tmux`, `internal/integration` all FAIL with fork EPERM.
- **After**: all three packages pass with explanatory skips; `go test ./...` shows the only remaining red as `internal/container` — #2203's territory, expected until its PR lands.
- `go build ./...`, `go vet`, and `go test -race` on the touched packages: green.
- Classifier unit test (`TestIsSandboxForkDenial`) verified non-vacuous: inverting the classifier makes the no-over-skip cases fail.

## Notes

- Local `nix build .#prism` could not run: this worker's sandbox predates the #2201 trusted-settings fix (`trusted-settings.json: Operation not permitted`). Used the AGENTS.md-sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — green. CI's `nix-build-prism-checked` is the authoritative gate.
- One transient `go test -race ./cmd/` failure was observed on the first -race run (before any uncached rerun); 4 subsequent uncached runs were clean and the failing test name was not captured. Orthogonal to this change (all tmux-server tests uniformly skip in this environment).