### PR TITLE
prism (sandbox-exec): per-session work dir for generated ssh/git configs (Step 2 of #2132)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -316,17 +316,23 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		env = append(env, "PI_CODING_AGENT_DIR="+ctrCfg.PIAgentConfigSandboxDir)
 	}
 
-	// GIT_SSH_COMMAND: force ssh to use the staging HOME's .ssh/config, and
-	// use the Nix-built openssh binary when cfg.SshBin is set.
+	// GIT_CONFIG_GLOBAL + GIT_SSH_COMMAND: point git and ssh at the generated
+	// configs in the per-session work dir (issue #2213, Step 2 of #2132):
 	//
-	// Two problems solved here:
+	//   GIT_CONFIG_GLOBAL=<sessionDir>/gitconfig
+	//   GIT_SSH_COMMAND="<sshBin> -F <sessionDir>/ssh-config"
 	//
-	// 1. macOS's /usr/bin/ssh resolves its config file via getpwuid() rather
-	//    than $HOME, so it always reads /Users/<user>/.ssh/config regardless of
-	//    the HOME env var override. The staging .ssh/config has the correct
-	//    IdentityFile and StrictHostKeyChecking accept-new. Without -F, ssh
-	//    reads the host config, tries to write to the host known_hosts (not in
-	//    the SBPL profile's write-allow set), and aborts.
+	// The work dir was created by PrepareSessionWorkDir() inside
+	// PrepareSandboxExec() above. The embedded key paths are the stable sops
+	// symlink paths (~/.ssh/<keyname>), so they survive secrets.d/<N>
+	// rotation mid-session (#1410/#1573).
+	//
+	// Why -F with the Nix-built openssh binary (cfg.SshBin):
+	//
+	// 1. openssh resolves its default config via getpwuid() rather than
+	//    $HOME, so without -F it always reads /Users/<user>/.ssh/config
+	//    regardless of the HOME env var override. The generated ssh-config
+	//    has the correct IdentityFile and StrictHostKeyChecking accept-new.
 	//
 	// 2. /usr/bin/ssh links against Apple's libnetwork.dylib, which reads
 	//    /private/var/db/nsurlstoraged/dafsaData.bin (the DAFSA domain suffix
@@ -336,13 +342,13 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	//    The Nix-built openssh links against its own libresolv/libldns (Nix
 	//    store paths under /nix, which are fully allowed), bypassing Apple's
 	//    network stack entirely.
-	if stagingHome, stagingErr := m.SandboxExecHomePath(); stagingErr == nil && stagingHome != "" {
-		sshBin := ctrCfg.SshBin
-		if sshBin == "" {
-			sshBin = "ssh"
-		}
-		sshConfigPath := filepath.Join(stagingHome, ".ssh", "config")
-		env = append(env, "GIT_SSH_COMMAND="+sshBin+" -F "+sshConfigPath)
+	//
+	// Known gap, accepted in #2132 Step 2: libgit2/go-git-class tools ignore
+	// GIT_CONFIG_GLOBAL; they fall back to $HOME-derived config, which does
+	// not exist — benign for read-only operations (e.g. nix flake metadata),
+	// which need no git identity.
+	if sessionDir, workDirErr := m.SessionWorkDir(); workDirErr == nil && sessionDir != "" {
+		env = append(env, container.SessionWorkDirGitEnv(sessionDir, ctrCfg.SshBin)...)
 	}
 
 	// argv[0] is "sandbox-exec" (from BuildArgs); the well-known binary path

--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -270,8 +270,10 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			}
 			// Other archive errors are non-fatal — cleanup continues.
 			if instanceIDForSessions != "" {
-				// Remove the sandbox-exec staging HOME for this session instance.
+				// Remove the sandbox-exec staging HOME for this session instance,
+				// then the per-session work dir that contains it (issue #2213).
 				container.RemoveSandboxExecStagingHome(instanceIDForSessions)
+				container.RemoveSessionWorkDir(instanceIDForSessions)
 			}
 			_ = d.PurgeBusMessages(m.session)
 			d.Close()
@@ -760,10 +762,12 @@ func headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot str
 		}
 		// Other archive errors are non-fatal — cleanup continues.
 		if instanceIDForSessions != "" {
-			// Remove the sandbox-exec staging HOME for this session instance.
+			// Remove the sandbox-exec staging HOME for this session instance,
+			// then the per-session work dir that contains it (issue #2213).
 			// Non-fatal and idempotent — silently skips when the directory
 			// does not exist (e.g. non-sandbox-exec sessions).
 			container.RemoveSandboxExecStagingHome(instanceIDForSessions)
+			container.RemoveSessionWorkDir(instanceIDForSessions)
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -846,8 +850,10 @@ func closeSession(session string) error {
 		}
 		// Other archive errors are non-fatal — cleanup continues.
 		if instanceIDForSessions != "" {
-			// Remove the sandbox-exec staging HOME for this session instance.
+			// Remove the sandbox-exec staging HOME for this session instance,
+			// then the per-session work dir that contains it (issue #2213).
 			container.RemoveSandboxExecStagingHome(instanceIDForSessions)
+			container.RemoveSessionWorkDir(instanceIDForSessions)
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()
@@ -960,8 +966,10 @@ func headlessCloseSessionWithJSONTo(session string, jsonMode bool, stdout io.Wri
 		}
 		// Other archive errors are non-fatal — cleanup continues.
 		if instanceIDForSessions != "" {
-			// Remove the sandbox-exec staging HOME for this session instance.
+			// Remove the sandbox-exec staging HOME for this session instance,
+			// then the per-session work dir that contains it (issue #2213).
 			container.RemoveSandboxExecStagingHome(instanceIDForSessions)
+			container.RemoveSessionWorkDir(instanceIDForSessions)
 		}
 		_ = d.PurgeBusMessages(session)
 		d.Close()

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -63,13 +63,14 @@ const (
 //     $HOME/.ssh/{access-key,signing-key,signing-key.pub,allowed_signers}
 //     where $HOME is the host user's home directory.
 //   - sandbox-exec also runs as the host user but with a per-session staging
-//     HOME (e.g. ~/.local/state/prism/sandbox-exec/<instance>) — the agent
-//     sees this as $HOME and the SSH artefacts are referenced under it.
+//     HOME (~/.local/state/prism/sessions/<instance>/home/) — the agent
+//     sees this as $HOME and the staged SSH artefacts live under it. Post
+//     issue #2213 the generated git/ssh configs themselves live in the
+//     per-session work dir (the staging HOME's parent) and embed stable
+//     host key paths — see session_work_dir.go.
 //
-// Agents inside both sandboxes see the same generic filenames
-// (access-key, signing-key, …); only the $HOME prefix differs. The isolation
-// mode lets the generators substitute the correct prefix into the config
-// files they write.
+// The isolation mode lets the mode-based generators substitute the correct
+// $HOME prefix into the config files they write.
 type isolationMode int
 
 const (
@@ -515,8 +516,11 @@ func WriteHarnessConfig(sessionName, content string) error {
 // The config only needs to handle GitHub; other SSH hosts are not expected
 // inside agent sandboxes. The IdentityFile path is $HOME/.ssh/access-key
 // using the sandbox-specific $HOME prefix, which matches the generic name
-// used by the bwrap bind-mount (<hostHome>/.ssh/access-key) and the
-// sandbox-exec staging HOME.
+// used by the bwrap bind-mount (<hostHome>/.ssh/access-key).
+//
+// Only the bwrap Prepare path calls this; sandbox-exec generates its ssh
+// config into the per-session work dir instead (writeSshConfigToDir in
+// session_work_dir.go, issue #2213) with the stable host key path.
 func (m *Manager) writeSshConfig(mode isolationMode) error {
 	identityFile := filepath.Join(sandboxHome(m, mode), ".ssh", "access-key")
 	sshConfig := "Host github.com\n" +
@@ -563,7 +567,45 @@ func (m *Manager) writeSshConfig(mode isolationMode) error {
 // only the $HOME prefix differs. Generic filenames (signing-key.pub,
 // allowed_signers, …) are used in every case so agents see a uniform layout
 // regardless of mode.
+//
+// Note: the production sandbox-exec path no longer consumes this writer —
+// writeGitconfigToDir (session_work_dir.go) generates the work-dir gitconfig
+// with stable host key paths instead (issue #2213, Step 2 of #2132). The
+// isolationSandboxExec mode value remains supported for the mode matrix
+// until the staging HOME is deleted in Step 5.
 func (m *Manager) writeGitconfig(mode isolationMode) error {
+	// Canonical in-sandbox paths for the signing artefacts. Both paths live
+	// at $HOME/.ssh/<generic-name> where $HOME depends on the isolation mode
+	// (see sandboxHome). Agents inside the sandbox see generic filenames —
+	// signing-key.pub / allowed_signers — regardless of which sandbox layer
+	// they're running under.
+	sandboxSshDir := filepath.Join(sandboxHome(m, mode), ".ssh")
+	return m.writeGitconfigArtefacts(
+		filepath.Join(sandboxSshDir, "signing-key.pub"),
+		filepath.Join(sandboxSshDir, "allowed_signers"),
+		m.gitconfigFilePath(),
+		m.allowedSignersFilePath(),
+	)
+}
+
+// writeGitconfigArtefacts is the canonical gitconfig generator shared by the
+// per-mode writeGitconfig (bwrap / sandbox-exec staging layout, temp-file
+// destinations) and the session-work-dir writer writeGitconfigToDir
+// (stable host key paths, work-dir destinations — issue #2213).
+//
+// Parameters:
+//
+//   - embedSigningKeyPub — the path embedded as user.signingKey in the
+//     generated gitconfig (what git/ssh-keygen will read inside the sandbox).
+//   - embedAllowedSigners — the path embedded as gpg.ssh.allowedSignersFile.
+//   - gitconfigDst — where the generated gitconfig is written on the host.
+//   - allowedSignersDst — where the generated allowed_signers is written on
+//     the host.
+//
+// The signing availability check and the allowed_signers content always read
+// the host's stable sops symlink paths (~/.ssh/<SshSigningKeyName>{,.pub});
+// only the embedded paths and destinations vary by caller.
+func (m *Manager) writeGitconfigArtefacts(embedSigningKeyPub, embedAllowedSigners, gitconfigDst, allowedSignersDst string) error {
 	// Reset allowedSignersReady so that a retry or second call doesn't carry
 	// stale state from a previous successful write into a new call that may fail.
 	m.allowedSignersReady = false
@@ -597,15 +639,6 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 
 	var sb strings.Builder
 
-	// Canonical in-sandbox paths for the signing artefacts. Both paths live
-	// at $HOME/.ssh/<generic-name> where $HOME depends on the isolation mode
-	// (see sandboxHome). Agents inside the sandbox see generic filenames —
-	// signing-key.pub / allowed_signers — regardless of which sandbox layer
-	// they're running under.
-	sandboxSshDir := filepath.Join(sandboxHome(m, mode), ".ssh")
-	sandboxSigningKeyPub := filepath.Join(sandboxSshDir, "signing-key.pub")
-	sandboxAllowedSigners := filepath.Join(sandboxSshDir, "allowed_signers")
-
 	// [user] section — required. Missing identity is a hard error (issue
 	// #1960): without a configured [user] section, git falls back to
 	// OS-level identity guessing inside the sandbox (e.g. `worker@prism`,
@@ -627,7 +660,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 	sb.WriteString("    name = " + m.cfg.GitUserName + "\n")
 	sb.WriteString("    email = " + m.cfg.GitUserEmail + "\n")
 	if hasSigning {
-		sb.WriteString("    signingKey = " + sandboxSigningKeyPub + "\n")
+		sb.WriteString("    signingKey = " + embedSigningKeyPub + "\n")
 	}
 
 	// [commit] and [gpg] sections — only when signing keys are available.
@@ -642,7 +675,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 			log.Printf("container: failed to read signing public key %q: %v; skipping allowed_signers", signingKeyPub, err)
 		} else {
 			allowedSignersContent := m.cfg.GitUserEmail + " " + strings.TrimSpace(string(pubKeyContent)) + "\n"
-			if err := os.WriteFile(m.allowedSignersFilePath(), []byte(allowedSignersContent), 0o644); err != nil {
+			if err := os.WriteFile(allowedSignersDst, []byte(allowedSignersContent), 0o644); err != nil {
 				log.Printf("container: failed to write allowed_signers file: %v", err)
 			} else {
 				m.allowedSignersReady = true
@@ -657,7 +690,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 			sb.WriteString("\n[gpg]\n")
 			sb.WriteString("    format = ssh\n")
 			sb.WriteString("\n[gpg \"ssh\"]\n")
-			sb.WriteString("    allowedSignersFile = " + sandboxAllowedSigners + "\n")
+			sb.WriteString("    allowedSignersFile = " + embedAllowedSigners + "\n")
 		}
 	}
 
@@ -667,7 +700,7 @@ func (m *Manager) writeGitconfig(mode isolationMode) error {
 	sb.WriteString("\n[init]\n")
 	sb.WriteString("    defaultBranch = main\n")
 
-	if err := os.WriteFile(m.gitconfigFilePath(), []byte(sb.String()), 0o644); err != nil {
+	if err := os.WriteFile(gitconfigDst, []byte(sb.String()), 0o644); err != nil {
 		return err
 	}
 	return nil

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -998,12 +998,17 @@ func TestWriteGitconfig_AllModes_EmptyIdentityRefused(t *testing.T) {
 	}
 }
 
-// TestPrepareSandboxExecHome_EmptyIdentityAborts asserts that the failure
-// from writeGitconfig propagates up through PrepareSandboxExecHome (the
-// sandbox-exec staging entry point) so the session does not start. The
-// previous behaviour logged the error and continued, which is what allowed
+// TestSandboxExecPrepare_EmptyIdentityAborts asserts that the failure from
+// the gitconfig generator propagates up through sandboxExecIsolator.Prepare
+// (the sandbox-exec session entry point) so the session does not start. The
+// pre-#1960 behaviour logged the error and continued, which is what allowed
 // the bug to surface only post-merge.
-func TestPrepareSandboxExecHome_EmptyIdentityAborts(t *testing.T) {
+//
+// Post issue #2213 (Step 2 of #2132) the generated gitconfig lives in the
+// per-session work dir, so the hard error surfaces from
+// PrepareSessionWorkDir rather than PrepareSandboxExecHome — both stations
+// are asserted here to pin the #1960 "hard-fails at Prepare" guarantee.
+func TestSandboxExecPrepare_EmptyIdentityAborts(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
 	// PrepareSandboxExecHome requires the various host dirs that newFakeHome
@@ -1018,14 +1023,31 @@ func TestPrepareSandboxExecHome_EmptyIdentityAborts(t *testing.T) {
 	m := New(Config{
 		SessionName: "repo@feat",
 		InstanceID:  "empty-identity-test",
+		Worktree:    t.TempDir(),
 		// Explicitly leave GitUserName and GitUserEmail unset to exercise
 		// the refusal path.
 	})
-	stagingHome, err := m.PrepareSandboxExecHome()
+
+	// Station 1: the work-dir writer itself refuses.
+	sessionDir, err := m.PrepareSessionWorkDir()
 	if err == nil {
-		t.Fatalf("PrepareSandboxExecHome returned stagingHome=%q nil error, want error", stagingHome)
+		t.Fatalf("PrepareSessionWorkDir returned sessionDir=%q nil error, want error", sessionDir)
 	}
 	if !strings.Contains(err.Error(), "git identity missing") {
-		t.Errorf("PrepareSandboxExecHome error %q must mention 'git identity missing'", err.Error())
+		t.Errorf("PrepareSessionWorkDir error %q must mention 'git identity missing'", err.Error())
+	}
+
+	// Station 2: the isolator Prepare entry point propagates the refusal and
+	// produces no args — the session must not launch.
+	iso := &sandboxExecIsolator{name: m.name}
+	args, prepErr := iso.Prepare(context.Background(), m)
+	if prepErr == nil {
+		t.Fatalf("Prepare returned nil error, want git-identity error (args=%v)", args)
+	}
+	if !strings.Contains(prepErr.Error(), "git identity missing") {
+		t.Errorf("Prepare error %q must mention 'git identity missing'", prepErr.Error())
+	}
+	if args != nil {
+		t.Errorf("Prepare args must be nil on error; got %v", args)
 	}
 }

--- a/modules/programs/prism/prism/internal/container/lifecycle.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle.go
@@ -41,6 +41,12 @@ func (m *Manager) EnsureRemoved(ctx context.Context) {
 	if stagingHome, err := m.sandboxExecHomePath(); err == nil {
 		_ = os.RemoveAll(stagingHome)
 	}
+	// Remove the per-session work dir (generated ssh-config / gitconfig /
+	// allowed_signers — issue #2213). The staging HOME is nested under it,
+	// so this also covers any staging remnants.
+	if sessionDir, err := m.sessionWorkDirPath(); err == nil {
+		_ = os.RemoveAll(sessionDir)
+	}
 
 	// Per-mode lifecycle cleanup lives on the registered Isolator. See
 	// lifecycle_dispatch.go (issue #1140 A1.L1).
@@ -148,6 +154,10 @@ func (m *Manager) Shutdown() {
 	// Remove the per-session sandbox-exec staging HOME directory tree.
 	if stagingHome, err := m.sandboxExecHomePath(); err == nil {
 		_ = os.RemoveAll(stagingHome)
+	}
+	// Remove the per-session work dir (issue #2213).
+	if sessionDir, err := m.sessionWorkDirPath(); err == nil {
+		_ = os.RemoveAll(sessionDir)
 	}
 
 	log.Printf("container: %q removed", m.name)

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -192,16 +192,21 @@ func (s *sandboxExecIsolator) EnsureRemoved(ctx context.Context, m *Manager) {
 	cleanupLegacyTempFiles(s.name)
 }
 
-// WriteGitconfig generates a minimal .gitconfig for the sandbox-exec sandbox.
-// sandbox-exec runs as the host user but with a per-session staging HOME, so
-// the signingKey and allowedSignersFile paths embed <stagingHome>/.ssh/...
-// (post A2.G1: writeGitconfig now covers sandbox-exec via the third
-// isolationSandboxExec mode value, with sandboxHome(m, isolationSandboxExec)
-// resolving to the staging HOME). The temp file written here is then
-// materialised into <stagingHome>/.gitconfig by writeGitconfigToDir, which
-// is invoked from PrepareSandboxExecHome.
+// WriteGitconfig generates the gitconfig for the sandbox-exec sandbox. Post
+// issue #2213 (Step 2 of #2132) the generated gitconfig lives in the
+// per-session work dir (<sessionDir>/gitconfig) and embeds the stable sops
+// symlink key paths (~/.ssh/<keyname>) rather than staging-HOME paths; the
+// dispatcher wires it in via GIT_CONFIG_GLOBAL. This delegates to the same
+// work-dir writer that PrepareSessionWorkDir uses.
 func (s *sandboxExecIsolator) WriteGitconfig(m *Manager) error {
-	return m.writeGitconfig(isolationSandboxExec)
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		return fmt.Errorf("container: sandbox-exec: %w", err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return fmt.Errorf("container: sandbox-exec: create session work dir %s: %w", sessionDir, err)
+	}
+	return m.writeGitconfigToDir(sessionDir)
 }
 
 // Reset is a no-op for sandbox-exec today — same rationale as bwrap.Reset.
@@ -231,6 +236,16 @@ func (s *sandboxExecIsolator) Prepare(ctx context.Context, m *Manager) ([]string
 			stagingHome, err)
 	}
 	_ = stagingHome // consumed by generateProfile via m.sandboxExecHomePath()
+
+	// Prepare the per-session work dir (issue #2213, Step 2 of #2132): the
+	// generated ssh-config / gitconfig / allowed_signers the dispatcher wires
+	// in via GIT_SSH_COMMAND / GIT_CONFIG_GLOBAL. Hard-fail on error — this
+	// preserves the #1960 missing-git-identity hard error at Prepare time,
+	// and a session without these configs would have no git identity and no
+	// ssh auth route.
+	if _, err := m.PrepareSessionWorkDir(); err != nil {
+		return nil, fmt.Errorf("container: sandbox-exec: cannot prepare session work dir: %w", err)
+	}
 
 	if _, err := writeProfile(m); err != nil {
 		return nil, err

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -103,7 +103,10 @@ func (s *sandboxExecIsolator) BuildRunArgs() []string {
 //   - Deny of sensitive /private/etc subtrees (wireguard, wpa_supplicant, ssh),
 //     both /etc/... and /private/etc/... forms (symlink non-transparency)
 //   - Host ~/.aws deny (only staged entries accessible)
-//   - Staging HOME / worktree / bare repo / host-API socket dir (RW)
+//   - Literal RO grant for the real ~/.ssh/known_hosts — never (subpath ~/.ssh)
+//     (issue #2213)
+//   - Session work dir (covers the nested staging HOME) / worktree / bare
+//     repo / host-API socket dir (RW)
 //   - Symlink target allows (RW for cache/credential dirs, RO for key/config) for every symlink in the staging HOME
 //   - Process and IPC primitives required by dyld, AMFI, and the agent
 //   - (allow network*)
@@ -116,9 +119,12 @@ func generateProfile(m *Manager) string {
 		home = os.Getenv("HOME")
 	}
 
-	// Derive the staging HOME path. When it cannot be determined (e.g. no
-	// home dir) the staging-HOME-derived rules are simply omitted.
+	// Derive the staging HOME path (used for the symlink-target collection
+	// below) and the per-session work dir (issue #2213; the staging HOME is
+	// nested under it at <sessionDir>/home/). When they cannot be determined
+	// (e.g. no home dir) the derived rules are simply omitted.
 	stagingHome, stagingErr := m.sandboxExecHomePath()
+	sessionDir, sessionDirErr := m.sessionWorkDirPath()
 
 	var sb strings.Builder
 	// ── Version 3 header and deny-default ────────────────────────────────
@@ -325,13 +331,39 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
-	// ── 6. Staging HOME + worktree + bare repo + host-API socket (RW) ────
+	// ── 5c. Real ~/.ssh/known_hosts read-only literal (issue #2213) ──────
+	// The generated <sessionDir>/ssh-config is passed to ssh via -F
+	// (GIT_SSH_COMMAND), and openssh resolves its default UserKnownHostsFile
+	// against the real home (getpwuid → pw_dir, not $HOME) — so ssh inside
+	// the sandbox reads the real ~/.ssh/known_hosts. Previously that read was
+	// only possible via the staging-HOME symlink walk (the per-symlink
+	// literal emitted by collectStagingHomeSymlinkTargets); this explicit
+	// grant decouples it from the staging mechanism ahead of Step 5 of #2132.
+	//
+	// The grant is read-only and single-file. NEVER widen this to
+	// (subpath ~/.ssh): the real ~/.ssh may hold non-sops private keys (e.g.
+	// the daily-driver key) that must stay unreadable in-sandbox. With
+	// StrictHostKeyChecking accept-new, ssh's attempt to append an unknown
+	// host key fails (no write grant) with a non-fatal warning — accepted.
+	if home != "" {
+		knownHosts := filepath.Join(home, ".ssh", "known_hosts")
+		sb.WriteString("(allow file-read* file-test-existence\n")
+		sb.WriteString("  (literal " + quoteSBPL(knownHosts) + "))\n")
+		sb.WriteString("\n")
+	}
+
+	// ── 6. Session work dir + worktree + bare repo + host-API socket (RW) ─
 	// Session-specific read-write paths. Locked in #1012 and #1017.
 	// file-test-existence and file-read-metadata added alongside file-read*
 	// and file-write* for dyld/AMFI compatibility in the v3 profile.
-	if stagingErr == nil {
+	//
+	// The first entry is the per-session work dir (issue #2213) — it covers
+	// the generated ssh-config / gitconfig / allowed_signers AND the staging
+	// HOME nested under it at <sessionDir>/home/ (the staging HOME remains
+	// in place until Step 5 of #2132 deletes it).
+	if sessionDirErr == nil {
 		sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
-		sb.WriteString("  (subpath " + quoteSBPL(stagingHome) + ")\n")
+		sb.WriteString("  (subpath " + quoteSBPL(sessionDir) + ")\n")
 		// Worktree — the git checkout the agent works in.
 		if m.cfg.Worktree != "" {
 			sb.WriteString("  (subpath " + quoteSBPL(m.cfg.Worktree) + ")\n")

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -11,8 +11,9 @@ package container
 //
 // Design decisions locked by the coordinator in issue #1017:
 //
-//  1. .claude/ is a symlink to host ~/.claude (matches bwrap's RW treatment at
-//     bwrap.go:306-308). Writes to .credentials.json (e.g. token refreshes)
+//  1. .claude/ is a symlink to host ~/.claude (matches bwrap's RW treatment —
+//     the ~/.claude mount in mounts.go StandardSandboxMounts). Writes to
+//     .credentials.json (e.g. token refreshes)
 //     flow through the symlink to the host's ~/.claude/.credentials.json.
 //
 //  2. .config/prism/agents/ is symlinked into the staging HOME for ALL roles
@@ -20,8 +21,9 @@ package container
 //     before_agent_start. The dir is pure markdown with no secrets, so the
 //     former review-prefix exclusion was dropped (issue #2032; design #2031).
 //
-//  3. .cache/nix/ is included as an RW symlink to ~/.cache/nix (matches bwrap
-//     unconditional RW bind at bwrap.go:333-335).
+//  3. .cache/nix/ is included as an RW symlink to ~/.cache/nix (matches
+//     bwrap's unconditional RW bind — the ~/.cache/nix mount in mounts.go
+//     StandardSandboxMounts).
 
 import (
 	"fmt"
@@ -71,8 +73,11 @@ func (m *Manager) sandboxExecHomePath() (string, error) {
 // Rules:
 //   - When a source path does not exist on the host, the symlink is skipped.
 //     No dangling symlinks are created.
-//   - Generated regular files (.gitconfig, .ssh/config, opencode.json) are
-//     written as regular files, not symlinks.
+//   - The staging HOME contains symlinks only. The generated git/ssh config
+//     files (gitconfig, ssh-config, allowed_signers) live in the per-session
+//     work dir (the staging HOME's parent — see PrepareSessionWorkDir in
+//     session_work_dir.go, issue #2213) and are wired into the sandbox via
+//     GIT_CONFIG_GLOBAL / GIT_SSH_COMMAND rather than via $HOME paths.
 //   - .cache/nix/ is always included as an RW symlink to ~/.cache/nix.
 //   - .config/prism/agents/ is symlinked in for ALL roles (including review-*)
 //     so the PI extension can read <role>.md (issue #2032). The former
@@ -132,8 +137,8 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	}
 
 	// ── SSH keys ──────────────────────────────────────────────────────────────
-	// Mirror bwrap.go:369-388: resolve via EvalSymlinks and mount at generic
-	// canonical names under $HOME/.ssh/.
+	// Mirror bwrap's SSH-key staging (the EvalSymlinks block in
+	// bwrap.go BuildArgs): mount at generic canonical names under $HOME/.ssh/.
 	sshDir := filepath.Join(home, ".ssh")
 
 	accessKeyName := m.cfg.SshAccessKeyName
@@ -204,11 +209,11 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		filepath.Join(stagingHome, ".ssh", "allowed_signers"),
 	)
 
-	// .ssh/config — regular generated file (not a symlink), using staging HOME
-	// as the in-sandbox $HOME prefix so IdentityFile resolves correctly.
-	if err := m.writeSshConfigToDir(stagingHome); err != nil {
-		log.Printf("container: sandbox-exec: write staging .ssh/config: %v", err)
-	}
+	// Note (#2213): the generated ssh config is no longer written into the
+	// staging HOME. It lives at <sessionDir>/ssh-config (see
+	// writeSshConfigToDir in session_work_dir.go) and is passed to ssh via
+	// -F in GIT_SSH_COMMAND. The .ssh/* symlinks above remain so existing
+	// staging-HOME reads keep working until Step 5 of #2132 deletes them.
 
 	// ── AWS ───────────────────────────────────────────────────────────────────
 	// Use symlinkIfExists (not symlinkIfResolvable) for the config and
@@ -294,7 +299,8 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// ~/.claude/, and since this is a symlink to host ~/.claude, those writes
 	// flow through to the host path and are immediately reflected in subsequent
 	// sessions. On Linux, ~/.claude/.credentials.json already lives on disk;
-	// the bwrap path bind-mounts ~/.claude/ with RW access (bwrap.go:306-308).
+	// the bwrap path bind-mounts ~/.claude/ with RW access (mounts.go
+	// StandardSandboxMounts).
 	symlinkIfExists(
 		filepath.Join(home, ".claude"),
 		filepath.Join(stagingHome, ".claude"),
@@ -317,14 +323,15 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 
 	// ── .cache/ ───────────────────────────────────────────────────────────────
 
-	// bun cache — only linked when writable (mirrors bwrap.go:474-477).
+	// bun cache — only linked when writable (mirrors bwrap's conditional
+	// isWritable-gated bind of ~/.cache/bun).
 	bunCacheDir := filepath.Join(home, ".cache", "bun")
 	if isWritable(bunCacheDir) {
 		symlinkIfExists(bunCacheDir, filepath.Join(stagingHome, ".cache", "bun"))
 	}
 
-	// nix cache — always included as RW symlink (matches bwrap.go:333-335,
-	// unconditional RW bind of ~/.cache/nix).
+	// nix cache — always included as RW symlink (matches bwrap's
+	// unconditional RW bind of ~/.cache/nix in mounts.go).
 	nixCacheDir := filepath.Join(home, ".cache", "nix")
 	symlinkIfExists(nixCacheDir, filepath.Join(stagingHome, ".cache", "nix"))
 
@@ -336,19 +343,12 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		symlinkIfExists(clipboardCacheDir, filepath.Join(stagingHome, ".cache", "prism", "clipboard"))
 	}
 
-	// ── .gitconfig — regular generated file ──────────────────────────────────
-	// Use the existing writeGitconfig helper with a synthetic isolationMode
-	// that uses the staging HOME as $HOME. We write the gitconfig to the
-	// staging path directly.
-	//
-	// A failure here is fatal — return the error so the session does not
-	// start with a missing or broken gitconfig. Previously we logged and
-	// continued, which is what let issue #1960 (missing [user] section →
-	// synthetic in-sandbox identity → noisy Co-authored-by trailer) sneak
-	// through unnoticed.
-	if err := m.writeGitconfigToDir(stagingHome); err != nil {
-		return "", fmt.Errorf("container: sandbox-exec: write staging .gitconfig: %w", err)
-	}
+	// Note (#2213): the generated gitconfig is no longer written into the
+	// staging HOME. It lives at <sessionDir>/gitconfig (see
+	// writeGitconfigToDir in session_work_dir.go) and is wired in via
+	// GIT_CONFIG_GLOBAL. The missing-git-identity hard error (#1960) is
+	// preserved: PrepareSessionWorkDir fails Prepare before the session
+	// starts (see sandboxExecIsolator.Prepare in lifecycle_dispatch.go).
 
 	// ── .nix-profile symlink ──────────────────────────────────────────────────
 	symlinkIfExists(
@@ -452,74 +452,6 @@ func isWritable(path string) bool {
 	return true
 }
 
-// writeSshConfigToDir writes a generated .ssh/config file into the given
-// staging HOME directory. The IdentityFile path uses stagingHome as the
-// in-sandbox $HOME prefix so it resolves correctly inside the sandbox.
-func (m *Manager) writeSshConfigToDir(stagingHome string) error {
-	identityFile := filepath.Join(stagingHome, ".ssh", "access-key")
-	sshConfig := "Host github.com\n" +
-		"  StrictHostKeyChecking accept-new\n" +
-		"  IdentityFile " + identityFile + "\n" +
-		"  IdentitiesOnly yes\n"
-	dst := filepath.Join(stagingHome, ".ssh", "config")
-	_ = os.Remove(dst) // idempotent
-	if err := os.WriteFile(dst, []byte(sshConfig), 0o600); err != nil {
-		return fmt.Errorf("write %s: %w", dst, err)
-	}
-	return nil
-}
-
-// writeGitconfigToDir generates a .gitconfig and (when signing is available)
-// allowed_signers for the sandbox-exec staging HOME. It is a thin wrapper
-// around writeGitconfig(isolationSandboxExec) — the canonical helper also
-// used by bwrap — and then materialises the resulting temp files into
-// the staging HOME at the canonical paths the agent expects:
-//
-//	<stagingHome>/.gitconfig
-//	<stagingHome>/.ssh/allowed_signers   (when signing is configured)
-//
-// The temp files written by writeGitconfig (m.gitconfigFilePath() and
-// m.allowedSignersFilePath()) embed sandbox-relative paths derived from
-// sandboxHome(m, isolationSandboxExec) — which resolves to stagingHome — so
-// the file content is identical whether read from the temp path or from the
-// staging HOME copy. We materialise into the staging HOME because
-// sandbox-exec has no bind-mount mechanism: the agent reads the file
-// directly from $HOME inside the sandbox.
-func (m *Manager) writeGitconfigToDir(stagingHome string) error {
-	if err := m.writeGitconfig(isolationSandboxExec); err != nil {
-		return fmt.Errorf("write gitconfig: %w", err)
-	}
-
-	// Copy the generated gitconfig into the staging HOME at the canonical
-	// path the agent expects (<stagingHome>/.gitconfig).
-	gitconfigContent, err := os.ReadFile(m.gitconfigFilePath())
-	if err != nil {
-		return fmt.Errorf("read generated gitconfig %s: %w", m.gitconfigFilePath(), err)
-	}
-	gitconfigDst := filepath.Join(stagingHome, ".gitconfig")
-	_ = os.Remove(gitconfigDst) // idempotent: replace any prior symlink/file
-	if err := os.WriteFile(gitconfigDst, gitconfigContent, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", gitconfigDst, err)
-	}
-
-	// When writeGitconfig produced an allowed_signers file (i.e. signing is
-	// configured and the public key was readable), copy it into the staging
-	// HOME's .ssh directory so git verify-commit succeeds inside the sandbox.
-	if m.allowedSignersReady {
-		signersContent, readErr := os.ReadFile(m.allowedSignersFilePath())
-		if readErr != nil {
-			return fmt.Errorf("read generated allowed_signers %s: %w", m.allowedSignersFilePath(), readErr)
-		}
-		signersDst := filepath.Join(stagingHome, ".ssh", "allowed_signers")
-		_ = os.Remove(signersDst) // idempotent: replace prior symlink/file
-		if err := os.WriteFile(signersDst, signersContent, 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", signersDst, err)
-		}
-	}
-
-	return nil
-}
-
 // SandboxExecHomePath is the exported version of sandboxExecHomePath. It
 // returns the staging HOME path for this Manager's session/instance. Used by
 // cmd/agent_run.go to override HOME in the env passed to syscall.Exec.
@@ -597,7 +529,7 @@ type StagingSymlinkTarget struct {
 // writable, consistent with how PrepareSandboxExecHome populates them:
 //   - .cache/opencode  — opencode refreshes models.json and writes bin/ shims
 //   - .cache/bun       — bun writes transpile outputs and lockfile updates
-//   - .cache/nix       — unconditional RW (mirrors bwrap.go:333-335)
+//   - .cache/nix       — unconditional RW (mirrors bwrap's mounts.go bind)
 //   - .claude          — write-through for .credentials.json on Darwin
 //   - .mcp-auth        — MCP auth token writes
 //

--- a/modules/programs/prism/prism/internal/container/session_work_dir.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir.go
@@ -1,0 +1,249 @@
+package container
+
+// session_work_dir.go — per-session work directory for generated git/ssh
+// configs (issue #2213, Step 2 of the #2132 staging-HOME elimination train).
+//
+// The session work dir lives at
+//
+//	~/.local/state/prism/sessions/<instance_id>/
+//
+// — the parent of the sandbox-exec staging HOME
+// (~/.local/state/prism/sessions/<instance_id>/home/). Unlike the staging
+// HOME it contains no symlinks: just the generated regular files that git
+// and ssh need inside a sandbox-exec session:
+//
+//	<sessionDir>/ssh-config        — minimal ssh config for github.com
+//	<sessionDir>/gitconfig         — git identity + signing config
+//	<sessionDir>/allowed_signers   — for git verify-commit (when signing
+//	                                 is configured)
+//
+// The files are wired into the sandbox via env vars set by the dispatcher
+// (cmd/agent_run_sandbox_exec_darwin.go):
+//
+//	GIT_CONFIG_GLOBAL=<sessionDir>/gitconfig
+//	GIT_SSH_COMMAND="<sshBin> -F <sessionDir>/ssh-config"
+//
+// Embedded key paths are the STABLE sops symlink paths
+// (~/.ssh/<SshAccessKeyName>, ~/.ssh/<SshSigningKeyName>.pub) — never
+// filepath.EvalSymlinks-resolved secrets.d/<N> paths (sops rotates
+// secrets.d/<N> on every darwin-rebuild switch, which would leave the
+// embedded path dangling mid-session — issues #1410/#1573) and never
+// staging-HOME paths (the staging HOME is deleted in Step 5 of #2132).
+// The in-sandbox read of the resolved key content rides on the existing
+// (subpath "/private/var/folders") allow in the SBPL profile, which
+// survives rotation.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SessionWorkDirPath returns the per-session work directory path for the
+// given instance ID:
+//
+//	~/.local/state/prism/sessions/<instanceID>/
+//
+// This is the parent directory of the sandbox-exec staging HOME
+// (SandboxExecStagingHomePath returns <sessionDir>/home). Callers that have
+// an instance_id but no Manager (e.g. cmd/cleanup.go) use this directly.
+func SessionWorkDirPath(instanceID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv("HOME")
+	}
+	if home == "" {
+		return "", fmt.Errorf("container: session work dir: cannot determine user home directory")
+	}
+	if instanceID == "" {
+		return "", fmt.Errorf("container: session work dir: instanceID is empty")
+	}
+	return filepath.Join(home, ".local", "state", "prism", "sessions", instanceID), nil
+}
+
+// sessionWorkDirPath returns the session work dir path for this Manager's
+// session. InstanceID namespaces the directory so concurrent sessions have
+// independent work dirs; like sandboxExecHomePath, it falls back to the
+// container name when InstanceID is unset (e.g. tests that construct a
+// Manager directly without a full spawn lifecycle).
+func (m *Manager) sessionWorkDirPath() (string, error) {
+	instanceID := m.cfg.InstanceID
+	if instanceID == "" {
+		instanceID = m.name
+	}
+	return SessionWorkDirPath(instanceID)
+}
+
+// SessionWorkDir is the exported version of sessionWorkDirPath. Used by
+// cmd/agent_run_sandbox_exec_darwin.go to build the GIT_CONFIG_GLOBAL and
+// GIT_SSH_COMMAND env vars for the sandboxed process.
+func (m *Manager) SessionWorkDir() (string, error) {
+	return m.sessionWorkDirPath()
+}
+
+// SessionWorkDirSshConfigPath returns the path of the generated ssh config
+// inside the given session work dir.
+func SessionWorkDirSshConfigPath(sessionDir string) string {
+	return filepath.Join(sessionDir, "ssh-config")
+}
+
+// SessionWorkDirGitconfigPath returns the path of the generated gitconfig
+// inside the given session work dir.
+func SessionWorkDirGitconfigPath(sessionDir string) string {
+	return filepath.Join(sessionDir, "gitconfig")
+}
+
+// SessionWorkDirAllowedSignersPath returns the path of the generated
+// allowed_signers file inside the given session work dir.
+func SessionWorkDirAllowedSignersPath(sessionDir string) string {
+	return filepath.Join(sessionDir, "allowed_signers")
+}
+
+// SessionWorkDirGitEnv returns the env var pairs (K=V form) that point git
+// and ssh inside the sandbox at the generated work-dir configs:
+//
+//	GIT_CONFIG_GLOBAL=<sessionDir>/gitconfig
+//	GIT_SSH_COMMAND=<sshBin> -F <sessionDir>/ssh-config
+//
+// sshBin should be cfg.SshBin (the Nix-built openssh binary); when empty,
+// "ssh" (PATH resolution) is used as the fallback.
+//
+// Known gap, accepted in #2132 Step 2: libgit2/go-git-class tools ignore
+// GIT_CONFIG_GLOBAL and fall back to $HOME/XDG-derived git config inside
+// the sandbox. Those readers do not need the generated identity/signing
+// config — reads work without any global gitconfig — so the fallback is
+// benign (acceptance probe: `nix flake metadata` in-sandbox).
+func SessionWorkDirGitEnv(sessionDir, sshBin string) []string {
+	if sshBin == "" {
+		sshBin = "ssh"
+	}
+	return []string{
+		"GIT_CONFIG_GLOBAL=" + SessionWorkDirGitconfigPath(sessionDir),
+		"GIT_SSH_COMMAND=" + sshBin + " -F " + SessionWorkDirSshConfigPath(sessionDir),
+	}
+}
+
+// PrepareSessionWorkDir creates the per-session work directory and writes
+// the generated ssh-config, gitconfig, and (when signing is configured)
+// allowed_signers files into it. Returns the absolute path to the work dir.
+//
+// All failures are hard errors: the work-dir configs are the only route to
+// git identity and ssh auth inside a sandbox-exec session, so a session must
+// not start without them. In particular, a missing git identity surfaces the
+// writeGitconfigArtefacts hard error from issue #1960 (refuse to start a
+// session without [user] in the gitconfig).
+//
+// Calling PrepareSessionWorkDir a second time is idempotent: the directory
+// creation is a no-op and the generated files are overwritten.
+func (m *Manager) PrepareSessionWorkDir() (string, error) {
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return "", fmt.Errorf("container: session work dir: create %s: %w", sessionDir, err)
+	}
+	if err := m.writeSshConfigToDir(sessionDir); err != nil {
+		return "", fmt.Errorf("container: session work dir: %w", err)
+	}
+	if err := m.writeGitconfigToDir(sessionDir); err != nil {
+		return "", fmt.Errorf("container: session work dir: %w", err)
+	}
+	return sessionDir, nil
+}
+
+// writeSshConfigToDir writes the generated ssh config to
+// <sessionDir>/ssh-config. The IdentityFile is the STABLE sops symlink path
+// ~/.ssh/<SshAccessKeyName> — deliberately not resolved via
+// filepath.EvalSymlinks, so the embedded path survives sops secrets.d/<N>
+// rotation (issues #1410/#1573):
+//
+//	~/.ssh/<accessKeyName>                              (stable sops symlink)
+//	  → /private/var/folders/.../secrets.d/<current>/…  (sops re-targets this)
+//
+// The SBPL profile grants (allow file-read* (subpath "/private/var/folders"))
+// so the sandbox can follow the chain to whatever secrets.d/<N> is current,
+// even after a rotation that occurred after session spawn.
+//
+// ssh is pointed at this file via `-F` in GIT_SSH_COMMAND (see
+// SessionWorkDirGitEnv); openssh resolves its default UserKnownHostsFile
+// against the real home (getpwuid → pw_dir, not $HOME), which is why the
+// SBPL profile carries a literal read-only grant for ~/.ssh/known_hosts.
+func (m *Manager) writeSshConfigToDir(sessionDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		home = os.Getenv("HOME")
+	}
+	if home == "" {
+		return fmt.Errorf("write ssh-config: cannot determine user home directory")
+	}
+	accessKeyName := m.cfg.SshAccessKeyName
+	if accessKeyName == "" {
+		accessKeyName = "prismatic-koi-ed25519"
+	}
+	identityFile := filepath.Join(home, ".ssh", accessKeyName)
+	sshConfig := "Host github.com\n" +
+		"  StrictHostKeyChecking accept-new\n" +
+		"  IdentityFile " + identityFile + "\n" +
+		"  IdentitiesOnly yes\n"
+	dst := SessionWorkDirSshConfigPath(sessionDir)
+	_ = os.Remove(dst) // idempotent: replace any prior file
+	if err := os.WriteFile(dst, []byte(sshConfig), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
+}
+
+// writeGitconfigToDir generates the gitconfig and (when signing is
+// available) allowed_signers files into the session work dir:
+//
+//	<sessionDir>/gitconfig
+//	<sessionDir>/allowed_signers   (when signing is configured)
+//
+// It is a thin wrapper around writeGitconfigArtefacts — the canonical
+// generator also used by the per-mode writeGitconfig — with:
+//
+//   - user.signingKey embedding the STABLE sops symlink path
+//     ~/.ssh/<SshSigningKeyName>.pub (never the EvalSymlinks-resolved
+//     secrets.d/<N> path, which rotates — #1410/#1573 — and never a
+//     staging-HOME path).
+//   - gpg.ssh.allowedSignersFile embedding <sessionDir>/allowed_signers.
+//
+// Note (#2132): this deliberately breaks the former "uniform generic
+// key-path layout across isolation modes" property — sandbox-exec sessions
+// now see the real host key names rather than the generic signing-key.pub
+// alias. bwrap keeps its existing generic-name bind-mount layout.
+func (m *Manager) writeGitconfigToDir(sessionDir string) error {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		home = os.Getenv("HOME")
+	}
+	if home == "" {
+		return fmt.Errorf("write gitconfig: cannot determine user home directory")
+	}
+	signingKeyName := m.cfg.SshSigningKeyName
+	if signingKeyName == "" {
+		signingKeyName = "prismatic-koi-ed25519-signingkey"
+	}
+	return m.writeGitconfigArtefacts(
+		filepath.Join(home, ".ssh", signingKeyName+".pub"),
+		SessionWorkDirAllowedSignersPath(sessionDir),
+		SessionWorkDirGitconfigPath(sessionDir),
+		SessionWorkDirAllowedSignersPath(sessionDir),
+	)
+}
+
+// RemoveSessionWorkDir removes the session work directory tree for the given
+// instance ID, including the sandbox-exec staging HOME nested under it at
+// <sessionDir>/home/. It is idempotent — calling it when the directory does
+// not exist is a no-op.
+//
+// Called from cmd/cleanup.go alongside RemoveSandboxExecStagingHome so the
+// generated work-dir configs do not accumulate after sessions end.
+func RemoveSessionWorkDir(instanceID string) {
+	sessionDir, err := SessionWorkDirPath(instanceID)
+	if err != nil {
+		return // can't derive path — nothing to do
+	}
+	_ = os.RemoveAll(sessionDir)
+}

--- a/modules/programs/prism/prism/internal/container/session_work_dir_test.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir_test.go
@@ -1,0 +1,471 @@
+package container
+
+// session_work_dir_test.go — unit tests for the per-session work dir
+// (issue #2213, Step 2 of #2132): path layout, generated-config content,
+// stable sops symlink-path embedding (the #1410/#1573 rotation property),
+// env-var wiring, and SBPL profile rules.
+//
+// Darwin-only integration coverage (real /usr/bin/sandbox-exec, positive +
+// profile-mutation negative pairs) lives in
+// internal/integration/sandbox_exec_session_work_dir_darwin_test.go per
+// docs/sandbox-exec-testing.md.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSessionWorkDirPath_Layout verifies the work dir path shape
+// (~/.local/state/prism/sessions/<instance_id>/ — no home/ suffix, no
+// symlinks) and the invariant that the sandbox-exec staging HOME is nested
+// directly under it at <sessionDir>/home.
+func TestSessionWorkDirPath_Layout(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	const instanceID = "work-dir-layout-test"
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  instanceID,
+	})
+
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+	want := filepath.Join(fakeHome, ".local", "state", "prism", "sessions", instanceID)
+	if sessionDir != want {
+		t.Errorf("sessionWorkDirPath = %q, want %q", sessionDir, want)
+	}
+
+	// The exported method and package-level function must agree.
+	exported, err := m.SessionWorkDir()
+	if err != nil || exported != sessionDir {
+		t.Errorf("SessionWorkDir() = (%q, %v), want (%q, nil)", exported, err, sessionDir)
+	}
+	pkgLevel, err := SessionWorkDirPath(instanceID)
+	if err != nil || pkgLevel != sessionDir {
+		t.Errorf("SessionWorkDirPath(%q) = (%q, %v), want (%q, nil)", instanceID, pkgLevel, err, sessionDir)
+	}
+
+	// Invariant: the staging HOME is <sessionDir>/home. Step 5 of #2132
+	// deletes the staging HOME; until then the work dir is its parent so a
+	// single (subpath <sessionDir>) SBPL rule covers both.
+	stagingHome, err := m.sandboxExecHomePath()
+	if err != nil {
+		t.Fatalf("sandboxExecHomePath: %v", err)
+	}
+	if stagingHome != filepath.Join(sessionDir, "home") {
+		t.Errorf("staging HOME %q is not <sessionDir>/home (sessionDir=%q)", stagingHome, sessionDir)
+	}
+}
+
+// TestSessionWorkDirPath_EmptyInstanceIDFallsBackToName mirrors the
+// sandboxExecHomePath fallback: tests that construct a Manager without a
+// full spawn lifecycle get a name-derived work dir rather than an error.
+func TestSessionWorkDirPath_EmptyInstanceIDFallsBackToName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := newSandboxExecManager(Config{SessionName: "repo@feat"})
+
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+	if !strings.Contains(sessionDir, m.name) {
+		t.Errorf("work dir %q does not contain the session-derived name %q", sessionDir, m.name)
+	}
+}
+
+// TestPrepareSessionWorkDir_WritesConfigsWithStablePaths is the core content
+// assertion for the AC: the generated gitconfig, ssh-config, and
+// allowed_signers live under ~/.local/state/prism/sessions/<id>/ and contain
+// no occurrence of the staging-HOME path or any secrets.d/<N> path — only
+// stable ~/.ssh/<keyname> paths and work-dir paths.
+func TestPrepareSessionWorkDir_WritesConfigsWithStablePaths(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "work-dir-content-test",
+	})
+
+	sessionDir, err := m.PrepareSessionWorkDir()
+	if err != nil {
+		t.Fatalf("PrepareSessionWorkDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sessionDir) })
+
+	stagingHome, err := m.sandboxExecHomePath()
+	if err != nil {
+		t.Fatalf("sandboxExecHomePath: %v", err)
+	}
+
+	// ── ssh-config ────────────────────────────────────────────────────────
+	sshConfigBytes, err := os.ReadFile(SessionWorkDirSshConfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read generated ssh-config: %v", err)
+	}
+	sshConfig := string(sshConfigBytes)
+	// IdentityFile must be the STABLE sops symlink path (default key name).
+	wantIdentity := "IdentityFile " + filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519")
+	if !strings.Contains(sshConfig, wantIdentity+"\n") {
+		t.Errorf("ssh-config missing %q; content:\n%s", wantIdentity, sshConfig)
+	}
+
+	// ── gitconfig ─────────────────────────────────────────────────────────
+	gitconfigBytes, err := os.ReadFile(SessionWorkDirGitconfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read generated gitconfig: %v", err)
+	}
+	gitconfig := string(gitconfigBytes)
+	for _, want := range []string{
+		"[user]",
+		"name = test-user",
+		"email = test@example.com",
+		// signingKey must be the STABLE sops symlink path (newFakeHome
+		// creates the default-named signing key pair, so signing is on).
+		"signingKey = " + filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519-signingkey.pub"),
+		// allowedSignersFile must point into the work dir.
+		"allowedSignersFile = " + SessionWorkDirAllowedSignersPath(sessionDir),
+		"gpgsign = true",
+	} {
+		if !strings.Contains(gitconfig, want) {
+			t.Errorf("gitconfig missing %q; content:\n%s", want, gitconfig)
+		}
+	}
+
+	// ── allowed_signers ───────────────────────────────────────────────────
+	signersBytes, err := os.ReadFile(SessionWorkDirAllowedSignersPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read generated allowed_signers: %v", err)
+	}
+	if !strings.HasPrefix(string(signersBytes), "test@example.com ") {
+		t.Errorf("allowed_signers does not start with the git email; content: %q", string(signersBytes))
+	}
+
+	// ── Forbidden path classes (the load-bearing AC assertion) ───────────
+	for name, content := range map[string]string{
+		"ssh-config":      sshConfig,
+		"gitconfig":       gitconfig,
+		"allowed_signers": string(signersBytes),
+	} {
+		if strings.Contains(content, stagingHome) {
+			t.Errorf("%s embeds the staging-HOME path %q — must use stable host paths; content:\n%s",
+				name, stagingHome, content)
+		}
+		if strings.Contains(content, "secrets.d") {
+			t.Errorf("%s embeds a resolved secrets.d path — breaks on sops rotation (#1410/#1573); content:\n%s",
+				name, content)
+		}
+	}
+}
+
+// TestPrepareSessionWorkDir_CustomKeyNamesHonoured verifies that
+// cfg.SshAccessKeyName / cfg.SshSigningKeyName override the default key
+// names in the embedded paths.
+func TestPrepareSessionWorkDir_CustomKeyNamesHonoured(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Create the custom-named keys in the fake ~/.ssh.
+	for _, f := range []string{"custom-access", "custom-signing", "custom-signing.pub"} {
+		if err := os.WriteFile(filepath.Join(fakeHome, ".ssh", f), []byte("dummy"), 0o600); err != nil {
+			t.Fatalf("write custom key %s: %v", f, err)
+		}
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:       "repo@feat",
+		InstanceID:        "work-dir-custom-keys-test",
+		SshAccessKeyName:  "custom-access",
+		SshSigningKeyName: "custom-signing",
+	})
+
+	sessionDir, err := m.PrepareSessionWorkDir()
+	if err != nil {
+		t.Fatalf("PrepareSessionWorkDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sessionDir) })
+
+	sshConfig, err := os.ReadFile(SessionWorkDirSshConfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read ssh-config: %v", err)
+	}
+	if want := filepath.Join(fakeHome, ".ssh", "custom-access"); !strings.Contains(string(sshConfig), want) {
+		t.Errorf("ssh-config does not embed custom access key path %q; content:\n%s", want, sshConfig)
+	}
+
+	gitconfig, err := os.ReadFile(SessionWorkDirGitconfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+	if want := filepath.Join(fakeHome, ".ssh", "custom-signing.pub"); !strings.Contains(string(gitconfig), want) {
+		t.Errorf("gitconfig does not embed custom signing key path %q; content:\n%s", want, gitconfig)
+	}
+}
+
+// TestPrepareSessionWorkDir_SurvivesSopsRotation pins the #1410/#1573
+// two-hop property at the unit level: the embedded paths must point at the
+// stable ~/.ssh/<keyname> symlink, so that after a simulated
+// secrets.d/<N> → secrets.d/<N+1> rotation the embedded path still resolves
+// to live content. (The Darwin integration suite proves the in-sandbox read
+// rides the /private/var/folders allow; this test proves we never embed the
+// concrete rotating path in the first place.)
+func TestPrepareSessionWorkDir_SurvivesSopsRotation(t *testing.T) {
+	fakeHome := newFakeHome(t)
+	sshDir := filepath.Join(fakeHome, ".ssh")
+
+	// Simulate the sops layout: concrete keys live in secrets.d/<N>/ and
+	// ~/.ssh/<keyname> is a stable symlink to the current generation.
+	secretsV1 := filepath.Join(fakeHome, "secrets.d", "1")
+	if err := os.MkdirAll(secretsV1, 0o700); err != nil {
+		t.Fatalf("mkdir secrets.d/1: %v", err)
+	}
+	for _, k := range []string{"prismatic-koi-ed25519", "prismatic-koi-ed25519-signingkey", "prismatic-koi-ed25519-signingkey.pub"} {
+		concrete := filepath.Join(secretsV1, k)
+		if err := os.WriteFile(concrete, []byte("v1-"+k), 0o600); err != nil {
+			t.Fatalf("write concrete key: %v", err)
+		}
+		// Replace the regular files newFakeHome created with symlinks into
+		// secrets.d/1 (the realistic sops layout).
+		link := filepath.Join(sshDir, k)
+		_ = os.Remove(link)
+		if err := os.Symlink(concrete, link); err != nil {
+			t.Fatalf("symlink %s: %v", link, err)
+		}
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "work-dir-rotation-test",
+	})
+	sessionDir, err := m.PrepareSessionWorkDir()
+	if err != nil {
+		t.Fatalf("PrepareSessionWorkDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sessionDir) })
+
+	sshConfig, err := os.ReadFile(SessionWorkDirSshConfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read ssh-config: %v", err)
+	}
+	gitconfig, err := os.ReadFile(SessionWorkDirGitconfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read gitconfig: %v", err)
+	}
+
+	// The concrete secrets.d path must NOT be embedded anywhere.
+	for name, content := range map[string]string{"ssh-config": string(sshConfig), "gitconfig": string(gitconfig)} {
+		if strings.Contains(content, "secrets.d") {
+			t.Fatalf("%s embeds a concrete secrets.d path — would dangle after rotation; content:\n%s", name, content)
+		}
+	}
+
+	// Simulate a darwin-rebuild switch: rotate secrets.d/1 → secrets.d/2 and
+	// re-target the stable symlinks. The embedded paths (written BEFORE the
+	// rotation) must still resolve to the new generation's content.
+	secretsV2 := filepath.Join(fakeHome, "secrets.d", "2")
+	if err := os.MkdirAll(secretsV2, 0o700); err != nil {
+		t.Fatalf("mkdir secrets.d/2: %v", err)
+	}
+	for _, k := range []string{"prismatic-koi-ed25519", "prismatic-koi-ed25519-signingkey", "prismatic-koi-ed25519-signingkey.pub"} {
+		concrete := filepath.Join(secretsV2, k)
+		if err := os.WriteFile(concrete, []byte("v2-"+k), 0o600); err != nil {
+			t.Fatalf("write v2 concrete key: %v", err)
+		}
+		link := filepath.Join(sshDir, k)
+		_ = os.Remove(link)
+		if err := os.Symlink(concrete, link); err != nil {
+			t.Fatalf("re-target symlink %s: %v", link, err)
+		}
+	}
+	if err := os.RemoveAll(secretsV1); err != nil {
+		t.Fatalf("remove secrets.d/1: %v", err)
+	}
+
+	// Extract the embedded IdentityFile path and read through it.
+	var identityFile string
+	for _, line := range strings.Split(string(sshConfig), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "IdentityFile "); ok {
+			identityFile = rest
+		}
+	}
+	if identityFile == "" {
+		t.Fatalf("ssh-config has no IdentityFile line; content:\n%s", sshConfig)
+	}
+	got, err := os.ReadFile(identityFile)
+	if err != nil {
+		t.Fatalf("embedded IdentityFile %q does not resolve after rotation: %v", identityFile, err)
+	}
+	if string(got) != "v2-prismatic-koi-ed25519" {
+		t.Errorf("embedded IdentityFile resolves to %q after rotation, want the v2 content", string(got))
+	}
+}
+
+// TestPrepareSessionWorkDir_Idempotent verifies that a second call succeeds
+// and overwrites the generated files in place.
+func TestPrepareSessionWorkDir_Idempotent(t *testing.T) {
+	newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "work-dir-idempotent-test",
+	})
+
+	first, err := m.PrepareSessionWorkDir()
+	if err != nil {
+		t.Fatalf("first PrepareSessionWorkDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(first) })
+
+	second, err := m.PrepareSessionWorkDir()
+	if err != nil {
+		t.Fatalf("second PrepareSessionWorkDir: %v", err)
+	}
+	if first != second {
+		t.Errorf("work dir path changed between calls: %q vs %q", first, second)
+	}
+	if _, err := os.Stat(SessionWorkDirGitconfigPath(second)); err != nil {
+		t.Errorf("gitconfig missing after second call: %v", err)
+	}
+}
+
+// TestRemoveSessionWorkDir verifies removal of the work dir tree, including
+// the staging HOME nested under it.
+func TestRemoveSessionWorkDir(t *testing.T) {
+	newFakeHome(t)
+
+	const instanceID = "work-dir-remove-test"
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  instanceID,
+	})
+
+	sessionDir, err := m.PrepareSessionWorkDir()
+	if err != nil {
+		t.Fatalf("PrepareSessionWorkDir: %v", err)
+	}
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+
+	RemoveSessionWorkDir(instanceID)
+
+	if _, err := os.Stat(sessionDir); err == nil {
+		t.Errorf("session work dir still exists after RemoveSessionWorkDir: %s", sessionDir)
+	}
+	if _, err := os.Stat(stagingHome); err == nil {
+		t.Errorf("nested staging HOME still exists after RemoveSessionWorkDir: %s", stagingHome)
+	}
+
+	// Idempotent: a second removal is a no-op.
+	RemoveSessionWorkDir(instanceID)
+}
+
+// TestSessionWorkDirGitEnv verifies the env-var pairs the dispatcher injects
+// (AC: the sandbox env carries GIT_CONFIG_GLOBAL=<sessionDir>/gitconfig and
+// GIT_SSH_COMMAND referencing <sessionDir>/ssh-config).
+func TestSessionWorkDirGitEnv(t *testing.T) {
+	const dir = "/Users/u/.local/state/prism/sessions/abc"
+
+	got := SessionWorkDirGitEnv(dir, "/nix/store/xyz/bin/ssh")
+	want := []string{
+		"GIT_CONFIG_GLOBAL=" + dir + "/gitconfig",
+		"GIT_SSH_COMMAND=/nix/store/xyz/bin/ssh -F " + dir + "/ssh-config",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("SessionWorkDirGitEnv returned %d vars, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("SessionWorkDirGitEnv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// Empty sshBin falls back to PATH-resolved "ssh".
+	gotDefault := SessionWorkDirGitEnv(dir, "")
+	if gotDefault[1] != "GIT_SSH_COMMAND=ssh -F "+dir+"/ssh-config" {
+		t.Errorf("SessionWorkDirGitEnv with empty sshBin = %q, want PATH-resolved ssh", gotDefault[1])
+	}
+}
+
+// TestGenerateProfile_SessionWorkDirAndKnownHostsRules pins the SBPL profile
+// AC: the profile contains (subpath "<sessionDir>") and a read-only literal
+// for ~/.ssh/known_hosts, and contains no (subpath "<HOME>/.ssh") — the
+// real ~/.ssh may hold non-sops private keys that must stay unreadable.
+func TestGenerateProfile_SessionWorkDirAndKnownHostsRules(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "work-dir-profile-test",
+		Worktree:    t.TempDir(),
+	})
+
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+
+	profile := generateProfile(m)
+
+	// RW subpath for the session work dir (covers the nested staging HOME).
+	if want := "(subpath " + quoteSBPL(sessionDir) + ")"; !strings.Contains(profile, want) {
+		t.Errorf("profile missing the session work dir rule %q; full profile:\n%s", want, profile)
+	}
+
+	// Read-only literal for the real known_hosts.
+	knownHostsLiteral := "(literal " + quoteSBPL(filepath.Join(fakeHome, ".ssh", "known_hosts")) + ")"
+	if !strings.Contains(profile, knownHostsLiteral) {
+		t.Errorf("profile missing the known_hosts literal %q; full profile:\n%s", knownHostsLiteral, profile)
+	}
+	// The known_hosts grant must be read-only: locate its allow block and
+	// assert it carries no file-write*.
+	idx := strings.Index(profile, knownHostsLiteral)
+	blockStart := strings.LastIndex(profile[:idx], "(allow ")
+	if blockStart == -1 {
+		t.Fatalf("cannot locate the allow block containing the known_hosts literal")
+	}
+	block := profile[blockStart : idx+len(knownHostsLiteral)]
+	if strings.Contains(block, "file-write") {
+		t.Errorf("known_hosts allow block grants write access — must be read-only:\n%s", block)
+	}
+
+	// NEVER (subpath ~/.ssh).
+	if forbidden := "(subpath " + quoteSBPL(filepath.Join(fakeHome, ".ssh")) + ")"; strings.Contains(profile, forbidden) {
+		t.Errorf("profile contains forbidden rule %q — it would cover future non-sops private keys; full profile:\n%s",
+			forbidden, profile)
+	}
+}
+
+// TestSandboxExecWriteGitconfig_IsolatorWritesWorkDirGitconfig verifies that
+// the Isolator-interface WriteGitconfig for sandbox-exec produces the
+// work-dir gitconfig (post-#2213 there is no staging-HOME gitconfig).
+func TestSandboxExecWriteGitconfig_IsolatorWritesWorkDirGitconfig(t *testing.T) {
+	newFakeHome(t)
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "work-dir-isolator-gitconfig-test",
+	})
+
+	iso := &sandboxExecIsolator{name: m.name}
+	if err := iso.WriteGitconfig(m); err != nil {
+		t.Fatalf("WriteGitconfig: %v", err)
+	}
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sessionDir) })
+
+	content, err := os.ReadFile(SessionWorkDirGitconfigPath(sessionDir))
+	if err != nil {
+		t.Fatalf("read work-dir gitconfig after WriteGitconfig: %v", err)
+	}
+	if !strings.Contains(string(content), "[user]") {
+		t.Errorf("work-dir gitconfig missing [user] section; content:\n%s", content)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
@@ -241,6 +241,13 @@ func preparePositiveProfile(t *testing.T, m *container.Manager) (preparedProfile
 		if stagingHome, homeErr := m.SandboxExecHomePath(); homeErr == nil {
 			_ = os.RemoveAll(stagingHome)
 		}
+		// PrepareSandboxExec also creates the per-session work dir (the
+		// staging HOME's parent — issue #2213) with the generated git/ssh
+		// configs; remove it so test instance dirs don't accumulate under
+		// the real ~/.local/state/prism/sessions/.
+		if sessionDir, dirErr := m.SessionWorkDir(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
 		if len(args) >= 3 {
 			_ = os.Remove(args[2])
 		}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_session_work_dir_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_session_work_dir_darwin_test.go
@@ -1,0 +1,314 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_session_work_dir_darwin_test.go — integration coverage for
+// the per-session work dir introduced by issue #2213 (Step 2 of #2132):
+//
+//   - Work-dir RW + config readability: the sandbox can read the generated
+//     <sessionDir>/gitconfig and write files under <sessionDir> via the
+//     (subpath "<sessionDir>") rule. The generated configs embed only stable
+//     ~/.ssh/<keyname> paths — never staging-HOME or secrets.d/<N> paths.
+//   - GIT_CONFIG_GLOBAL: a Nix-built git inside the sandbox resolves its
+//     global config from <sessionDir>/gitconfig.
+//   - known_hosts: the real ~/.ssh/known_hosts is readable via the explicit
+//     read-only (literal ...) grant — and the profile never contains
+//     (subpath "<HOME>/.ssh").
+//
+// Each positive test has a paired profile-mutation negative test proving the
+// positive is not green by accident (docs/sandbox-exec-testing.md, #1192).
+// The #2207 capability-probe gating applies via requireSandboxExec.
+//
+// Shared helpers:
+//   - requireSandboxExec, requireNixBash, newProfileManager,
+//     newProfileManagerWithBareRoot, preparePositiveProfile,
+//     writeAugmentedPositiveProfile, withMutatedProfile
+//     → sandbox_exec_helpers_darwin_test.go
+//   - sbplQuoteForTest → sandbox_exec_staging_home_darwin_test.go
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// requireNixGit resolves the Nix-built git binary via PATH → symlink chain
+// and returns its /nix/store/... absolute path. Skips the test when git is
+// not found or does not resolve to a Nix store path (Apple-signed binaries
+// SIGABRT under the deny-default test profile shape — see requireNixBash).
+func requireNixGit(t *testing.T) string {
+	t.Helper()
+
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skipf("git not found in PATH: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(gitPath)
+	if err != nil {
+		t.Skipf("EvalSymlinks(%q): %v", gitPath, err)
+	}
+	if !strings.HasPrefix(resolved, "/nix/store/") {
+		t.Skipf("git resolves to %q which is not a /nix/store/ path — cannot use as test binary", resolved)
+	}
+	return resolved
+}
+
+// sessionWorkDirFixture prepares the production profile for m and returns
+// the session work dir path plus the prepared profile. It asserts the
+// work-dir configs were generated and contain no forbidden path classes
+// (staging-HOME paths, secrets.d/<N> paths) — the content half of the
+// #2213 AC — before any sandbox is launched.
+func sessionWorkDirFixture(t *testing.T, m *container.Manager) (string, preparedProfile) {
+	t.Helper()
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+	stagingHome, err := m.SandboxExecHomePath()
+	if err != nil {
+		t.Fatalf("SandboxExecHomePath: %v", err)
+	}
+
+	for _, name := range []string{"ssh-config", "gitconfig"} {
+		content, readErr := os.ReadFile(filepath.Join(sessionDir, name))
+		if readErr != nil {
+			t.Fatalf("generated %s missing from work dir: %v", name, readErr)
+		}
+		if strings.Contains(string(content), stagingHome) {
+			t.Fatalf("generated %s embeds the staging-HOME path %q:\n%s", name, stagingHome, content)
+		}
+		if strings.Contains(string(content), "secrets.d") {
+			t.Fatalf("generated %s embeds a resolved secrets.d path (#1410/#1573):\n%s", name, content)
+		}
+	}
+
+	// The profile must carry the work-dir subpath rule.
+	if want := "(subpath " + sbplQuoteForTest(sessionDir) + ")"; !strings.Contains(prepared.content, want) {
+		t.Fatalf("generated profile missing %q.\nProfile:\n%s", want, prepared.content)
+	}
+
+	return sessionDir, prepared
+}
+
+// TestSandboxExecSessionWorkDir_ConfigsReadableAndWritable is the positive
+// integration test for the (subpath "<sessionDir>") rule (#2213). From
+// inside sandbox-exec it reads the generated gitconfig and writes a probe
+// file into the work dir, asserting exit 0.
+func TestSandboxExecSessionWorkDir_ConfigsReadableAndWritable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+	sessionDir, prepared := sessionWorkDirFixture(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	gitconfigPath := filepath.Join(sessionDir, "gitconfig")
+	probe := filepath.Join(sessionDir, "prism-2213-write-probe.tmp")
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "cat "+shQuote(gitconfigPath)+" && echo hi > "+shQuote(probe))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("work-dir read+write failed under production profile.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s", runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), "[user]") {
+		t.Errorf("in-sandbox gitconfig read succeeded but output lacks [user]; output:\n%s", out)
+	}
+	if _, statErr := os.Stat(probe); statErr != nil {
+		t.Errorf("write probe exited 0 but probe file is missing: %v", statErr)
+	}
+}
+
+// TestSandboxExecSessionWorkDir_DeniedWithoutSubpath is the paired negative
+// test. It re-targets the (subpath "<sessionDir>") entry at a non-existent
+// sibling path and asserts that both the gitconfig read and the work-dir
+// write fail — proving ConfigsReadableAndWritable (and the GIT_CONFIG_GLOBAL
+// positive below, which reads through the same rule) are not green by
+// accident.
+//
+// Mutation strategy: ReplaceAll on the quoted path rather than deleting the
+// line — this keeps the SBPL syntactically valid regardless of where the
+// entry sits in its allow block, and sandbox-exec silently ignores rules
+// for non-existent paths.
+func TestSandboxExecSessionWorkDir_DeniedWithoutSubpath(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p,
+			sbplQuoteForTest(sessionDir),
+			sbplQuoteForTest(sessionDir+".prism-2213-disabled"))
+	})
+
+	gitconfigPath := filepath.Join(sessionDir, "gitconfig")
+	probe := filepath.Join(sessionDir, "prism-2213-write-probe-denied.tmp")
+
+	// Read and write probed separately so a partial regression (e.g. read
+	// allowed via some unrelated rule) is reported precisely.
+	readCmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixBash, "-c", "cat "+shQuote(gitconfigPath))
+	if out, runErr := readCmd.CombinedOutput(); runErr == nil {
+		t.Errorf("gitconfig read succeeded WITHOUT the work-dir (subpath ...) rule.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	}
+
+	writeCmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixBash, "-c", "echo hi > "+shQuote(probe))
+	if out, runErr := writeCmd.CombinedOutput(); runErr == nil {
+		t.Errorf("work-dir write succeeded WITHOUT the work-dir (subpath ...) rule.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — work-dir access correctly denied without the subpath rule (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecSessionWorkDir_GitConfigGlobalUsable verifies the env-wiring
+// half of the #2213 AC end-to-end: a Nix-built git inside the sandbox, with
+// GIT_CONFIG_GLOBAL pointing at the work-dir gitconfig, resolves the
+// configured identity from it. The read rides the same (subpath
+// "<sessionDir>") rule negatively covered by DeniedWithoutSubpath above.
+func TestSandboxExecSessionWorkDir_GitConfigGlobalUsable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixGit := requireNixGit(t)
+
+	m := newProfileManager(t)
+	sessionDir, prepared := sessionWorkDirFixture(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	gitEnv := container.SessionWorkDirGitEnv(sessionDir, "")
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", gitEnv[0], // GIT_CONFIG_GLOBAL=<sessionDir>/gitconfig
+		nixGit, "config", "--global", "user.name")
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("git config --global user.name failed under production profile with GIT_CONFIG_GLOBAL.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s", runErr, string(out), testProfilePath)
+	}
+	// newProfileManager configures GitUserName "test-user".
+	if got := strings.TrimSpace(string(out)); got != "test-user" {
+		t.Errorf("git config --global user.name = %q, want %q (gitconfig not resolved from the work dir?)",
+			got, "test-user")
+	}
+}
+
+// knownHostsFixture returns the real ~/.ssh/known_hosts path. It skips when
+// the file does not exist or is itself a symlink (an SBPL literal grant on a
+// symlink path is inert — policy evaluates the resolved target at open time
+// — so the rule under test would not be load-bearing on such a host).
+func knownHostsFixture(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	knownHosts := filepath.Join(home, ".ssh", "known_hosts")
+	info, err := os.Lstat(knownHosts)
+	if err != nil {
+		t.Skipf("~/.ssh/known_hosts not present on this host: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Skipf("~/.ssh/known_hosts is a symlink on this host — the literal grant under test is not load-bearing")
+	}
+	return knownHosts
+}
+
+// TestSandboxExecKnownHosts_ReadableViaLiteral is the positive test for the
+// explicit read-only (literal "~/.ssh/known_hosts") grant (#2213): ssh's
+// default UserKnownHostsFile resolves against the real home (getpwuid →
+// pw_dir), so the real file must be readable in-sandbox without the
+// staging-HOME symlink walk.
+//
+// Uses the BareRoot variant so the ancestor block grants file-read-metadata
+// on (subpath HOME) for path traversal — but NOT file-read-data, which is
+// what keeps the paired negative test meaningful.
+func TestSandboxExecKnownHosts_ReadableViaLiteral(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	knownHosts := knownHostsFixture(t)
+
+	m := newProfileManagerWithBareRoot(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	if want := "(literal " + sbplQuoteForTest(knownHosts) + ")"; !strings.Contains(prepared.content, want) {
+		t.Fatalf("generated profile missing the known_hosts literal %q.\nProfile:\n%s", want, prepared.content)
+	}
+	// The profile must never grant (subpath "<HOME>/.ssh") — it would cover
+	// non-sops private keys (e.g. the daily-driver key).
+	if forbidden := "(subpath " + sbplQuoteForTest(filepath.Dir(knownHosts)) + ")"; strings.Contains(prepared.content, forbidden) {
+		t.Fatalf("generated profile contains forbidden rule %q.\nProfile:\n%s", forbidden, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "cat "+shQuote(knownHosts)+" > /dev/null")
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("read of real ~/.ssh/known_hosts failed under production profile.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s", runErr, string(out), testProfilePath)
+	}
+}
+
+// TestSandboxExecKnownHosts_DeniedWithoutLiteral is the paired negative
+// test. It re-targets every rule referencing the known_hosts path (the
+// explicit #2213 literal AND the per-symlink literal that
+// collectStagingHomeSymlinkTargets emits for the staging .ssh/known_hosts
+// symlink — on a host where known_hosts is a regular file both quote to the
+// same string) at a non-existent path, then asserts the read fails.
+//
+// Re-targeting (ReplaceAll on the quoted path) rather than line deletion
+// keeps the SBPL valid regardless of each rule's position in its block.
+func TestSandboxExecKnownHosts_DeniedWithoutLiteral(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	knownHosts := knownHostsFixture(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p,
+			sbplQuoteForTest(knownHosts),
+			sbplQuoteForTest(knownHosts+".prism-2213-disabled"))
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixBash, "-c", "cat "+shQuote(knownHosts)+" > /dev/null")
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read of ~/.ssh/known_hosts succeeded WITHOUT its (literal ...) allow.\n"+
+			"The negative test is not catching the regression — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — known_hosts read correctly denied without the literal allow (exit: %v)", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_staging_home_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_staging_home_darwin_test.go
@@ -26,9 +26,12 @@ import (
 )
 
 // TestSandboxExecProfile_StagingHomeWritable is the positive integration
-// test for the staging-HOME write allow. It generates the production
-// profile, prepares the staging HOME, and runs `bash -c 'echo hi > $HOME/foo'`
-// inside the sandbox. Asserts the file is created (exit 0).
+// test for the staging-HOME write coverage. Post issue #2213 the profile's
+// RW rule is (subpath "<sessionDir>") — the per-session work dir — which
+// covers the staging HOME nested under it at <sessionDir>/home/. The test
+// generates the production profile, prepares the staging HOME, and runs
+// `bash -c 'echo hi > $HOME/foo'` inside the sandbox. Asserts the file is
+// created (exit 0).
 func TestSandboxExecProfile_StagingHomeWritable(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -66,23 +69,25 @@ func TestSandboxExecProfile_StagingHomeWritable(t *testing.T) {
 }
 
 // TestSandboxExecProfile_StagingHomeWriteDenied is the paired negative test.
-// It removes the single (subpath "<stagingHome>") line from the
-// staging-HOME write allow block and asserts the same write operation
-// fails with a non-zero exit.
+// It removes the single (subpath "<sessionDir>") line — the per-session
+// work dir rule that covers the staging HOME nested under it (issue #2213)
+// — from the RW allow block and asserts the same write operation fails with
+// a non-zero exit.
 //
 // Mutation strategy: targeted single-line ReplaceAll on the indented
-// `  (subpath "<stagingHome>")\n` form. This leaves the rest of the
+// `  (subpath "<sessionDir>")\n` form. This leaves the rest of the
 // (allow file-read* file-write* ...) block intact (worktree, bare repo,
 // host-API socket dir, agent shared dirs) so the profile remains
 // syntactically valid SBPL — the only behaviour change is that the
-// staging-HOME path itself is no longer covered by the write allow,
-// which is exactly the rule we are testing. Removing the entire block
-// would make the profile malformed (orphaned subpath lines from the
-// trailing entries in the block) and sandbox-exec would reject the
-// profile at parse time, making the test pass for the wrong reason.
+// session dir (and therefore the staging HOME under it) is no longer
+// covered by the write allow, which is exactly the rule we are testing.
+// Removing the entire block would make the profile malformed (orphaned
+// subpath lines from the trailing entries in the block) and sandbox-exec
+// would reject the profile at parse time, making the test pass for the
+// wrong reason.
 //
 // This proves StagingHomeWritable is not green by accident — the staging
-// HOME is writable specifically because of the (subpath "<stagingHome>")
+// HOME is writable specifically because of the (subpath "<sessionDir>")
 // entry in the write allow block, not because of some unrelated rule.
 func TestSandboxExecProfile_StagingHomeWriteDenied(t *testing.T) {
 	if runtime.GOOS != "darwin" {
@@ -99,9 +104,13 @@ func TestSandboxExecProfile_StagingHomeWriteDenied(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	stagingHomeRule := "  (subpath " + sbplQuoteForTest(stagingHome) + ")\n"
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+	sessionDirRule := "  (subpath " + sbplQuoteForTest(sessionDir) + ")\n"
 	mutatedPath := withMutatedProfile(t, m, func(p string) string {
-		return strings.ReplaceAll(p, stagingHomeRule, "")
+		return strings.ReplaceAll(p, sessionDirRule, "")
 	})
 
 	// Belt-and-suspenders check on top of withMutatedProfile's no-op


### PR DESCRIPTION
Step 2 of the #2132 staging-HOME elimination train (see §4 Step 2 of the design doc).

Refs #2132
Closes #2213

## What

Introduces the per-session **work dir** at `~/.local/state/prism/sessions/<instance_id>/` (the staging HOME's parent — no symlinks, just generated regular files) and decouples the generated git/ssh configs from the staging HOME:

- **Generators** (`internal/container/session_work_dir.go`): `ssh-config`, `gitconfig`, and `allowed_signers` are emitted into `<sessionDir>`. The canonical gitconfig writer is parameterised (`writeGitconfigArtefacts`) so the bwrap mode-based writer and the new work-dir writer share one body.
- **Stable key paths**: embedded paths are the stable sops symlink paths — `~/.ssh/<SshAccessKeyName>` (ssh `IdentityFile`) and `~/.ssh/<SshSigningKeyName>.pub` (`user.signingKey`) — never `EvalSymlinks`-resolved `secrets.d/<N>` paths (#1410/#1573) and never staging-HOME paths. The in-sandbox read of resolved key content rides the existing `/private/var/folders` allow, so a sops rotation after spawn keeps ssh auth and signing working.
- **Env layer** (`cmd/agent_run_sandbox_exec_darwin.go`): injects `GIT_CONFIG_GLOBAL=<sessionDir>/gitconfig` and `GIT_SSH_COMMAND="<cfg.SshBin> -F <sessionDir>/ssh-config"` (replacing the staging-path `-F`).
- **SBPL** (`generateProfile`): the RW `(subpath <stagingHome>)` entry becomes `(subpath <sessionDir>)` — the staging HOME is nested at `<sessionDir>/home/`, so one rule covers both until Step 5 deletes the staging mechanism. New §5c read-only `(literal ~/.ssh/known_hosts)` grant (openssh resolves its default `UserKnownHostsFile` via `getpwuid → pw_dir`, not `$HOME`). **Never `(subpath ~/.ssh)`** — asserted in unit + integration tests.
- **Staging HOME**: keeps its `.ssh/*` symlinks (unused-but-present, deleted in Step 5) but no longer receives generated config files. The #1960 missing-git-identity hard error moves to `PrepareSessionWorkDir`, still failing at `Prepare` before any session launch (pinned by `TestSandboxExecPrepare_EmptyIdentityAborts`).
- **Cleanup**: `cmd/cleanup.go` (all four teardown sites), `Manager.EnsureRemoved`, and `Manager.Shutdown` remove the work dir tree so generated configs don't accumulate.
- Fix-in-passing per the issue: stale `bwrap.go:NNN` line-number citations in `sandbox_exec_home.go` comments replaced with stable function/file references.

## Bwrap decision (implementer's call, per issue)

**Bwrap keeps its existing gitconfig bind-mount path unchanged.** Rationale: converging bwrap on the work dir would churn `bwrap.go`/`bwrap_test.go`, which worker #2212 is actively touching this round — the issue explicitly biases toward avoiding that. The mode-based `writeGitconfig(isolationBwrap)` call path and its generic-name layout are untouched; only the shared generator body was extracted (zero behavioural change for bwrap, verified by the unchanged bwrap test suite). Bwrap convergence remains available to a later step of #2132.

The "uniform generic key-path layout across isolation modes" property dies here, deliberately (called out in the design doc).

## Testing

Per `docs/sandbox-exec-testing.md` (this changes `generateProfile`, `PrepareSandboxExec`, and `PrepareSandboxExecHome`):

- **Darwin integration** (`internal/integration/sandbox_exec_session_work_dir_darwin_test.go`, real `/usr/bin/sandbox-exec`, #2207 capability-probe gating kept):
  - Positive: work-dir gitconfig readable + work dir writable in-sandbox; `git config --global user.name` resolves from `GIT_CONFIG_GLOBAL` using Nix-built git; real `~/.ssh/known_hosts` readable via the literal grant (profile asserted to contain no `(subpath ~/.ssh)`).
  - Negative (profile-mutation, proving the positives are not no-ops): re-target `(subpath <sessionDir>)` → read **and** write denied; re-target the known_hosts literal(s) → read denied. Mutations use quoted-path `ReplaceAll` (not line deletion) so the SBPL stays syntactically valid.
  - Updated `TestSandboxExecProfile_StagingHomeWriteDenied` to mutate the new `(subpath <sessionDir>)` rule (the old `(subpath <stagingHome>)` line no longer exists).
- **Unit** (`internal/container/session_work_dir_test.go`): path layout + staging-HOME nesting invariant; generated content embeds only stable `~/.ssh/<keyname>` and work-dir paths (explicit negative assertions on staging-HOME and `secrets.d` substrings); **sops-rotation survival** (two-hop chain rotated `secrets.d/1 → 2` after generation, embedded path still resolves); custom key names; env-var pairs; profile contains `(subpath <sessionDir>)` + read-only known_hosts literal + no `(subpath ~/.ssh)`; idempotency; removal; #1960 hard error at both `PrepareSessionWorkDir` and `sandboxExecIsolator.Prepare`.

Ran: `go build ./...`, `go test ./... -race` (CI parity) — green, re-verified after each rebase (over #2215/#2216, then #2223/#2224 — one `cmd/cleanup.go` conflict with #2223's archive-then-sever restructure resolved by keeping main's structure and re-adding the `RemoveSessionWorkDir` calls — then #2225). The Darwin sandbox-exec integration tests skip inside this worker's sandbox (nested `sandbox_apply` is not permitted — the #2207 probe handles this) and will execute on an unsandboxed host.

## Review status

All five review perspectives passed with zero blocking issues: review-goal / review-code / review-qa / review-context passed in round 1 of `prism review`. The **review-security agent never started** across four attempts (recurring infrastructure fault, tracked as #2228), so the security review was **coordinator-delegated per #2228** to a dedicated session (`nixos-config@security-review-pr-2221`), which posted its full findings and **PASS** verdict as a comment on this PR against HEAD `a13ad0d6`. Its three non-blocking observations were deliberately not actioned (one is forward guidance for #2132 Steps 3/5; one is a pre-existing shared-helper mode choice the reviewer itself scoped to a separate hygiene change; one was a verification note).

**Local `nix build .#prism` could not run in this sandbox**: the flake CLI fails on the pre-#2201 `trusted-settings.json` read (`Operation not permitted` — this sandbox pre-dates the fix's deployment). The sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` passes; the authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).

## Live-session ACs (verify post-merge on the host)

The functional ACs "git commit (signed) / git push / git log --show-signature from inside a session", "rotation mid-session", and "nix flake metadata in-sandbox" need a live sandbox-exec session on the host; the unit + integration suites above cover their mechanics (stable-path embedding, profile rules, GIT_CONFIG_GLOBAL resolution, rotation property).

## Parallel-work awareness

No files owned by #2210 (`pi_invocation.go`, `harness/pi/archive.go`) or #2212 (`env.go`, `default.nix`, `bwrap_test.go`) are touched.

