### PR TITLE
prism: isolate cmd test suite from the live host tmux server (#2214)

### DIFF
--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -60,6 +60,14 @@ import (
 //     any test that creates real sessions in the live environment. The guard
 //     uses the DB path that was live at suite start (before any test overrides
 //     XDG_STATE_HOME), so it reliably reads the production database.
+//
+//  4. Tmux isolation (#2214): after taking the leak-guard before-snapshots,
+//     clears $TMUX and redirects $TMUX_TMPDIR to an empty directory so no
+//     code under test can reach the live host tmux server via the
+//     default-socket fallback (tmux.CurrentSession et al.). See
+//     tmux_isolation_test.go for the full rationale. The original
+//     environment is restored after m.Run() so the leak-guard
+//     after-snapshots consult the same live server as the before-snapshots.
 func TestMain(m *testing.M) {
 	if os.Getenv("PRISM_CMD_TEST_STUB") == "1" {
 		time.Sleep(60 * time.Second)
@@ -86,7 +94,13 @@ func TestMain(m *testing.M) {
 	beforeSessionsRows := snapshotSessionsRows(liveDBPath)
 	beforeWorktrees := snapshotWorktreeDirs()
 
+	// Tmux isolation (#2214): applied after the before-snapshots above (they
+	// must see the real live server), undone before the after-snapshots below.
+	restoreTmuxEnv := isolateSuiteFromHostTmux()
+
 	code := m.Run()
+
+	restoreTmuxEnv()
 
 	// Leak guard: assert no new sessions or DB rows were created in the live
 	// environment. We skip the check if the suite failed — a failing test may

--- a/modules/programs/prism/prism/cmd/tmux_isolation_test.go
+++ b/modules/programs/prism/prism/cmd/tmux_isolation_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+// Suite-wide tmux isolation for the cmd package (#2214).
+//
+// Several production code paths in cmd/ fall back to querying the live tmux
+// server when no explicit session is provided:
+//
+//   - review.LookupParentSession() → tmux.CurrentSession() when
+//     PRISM_SESSION_NAME is empty (resolveCoordinatorSession,
+//     rejectIfCoordinator, runReview, runMerge, runMergesList/runMergesCancel,
+//     runProfileUse)
+//   - tmux.CurrentSession() directly (close, cleanup, nav, dashboard)
+//   - tmux.HasSession / tmux.ListWindows / window-option helpers
+//     (cleanup, escalate idempotency)
+//
+// Crucially, `tmux display-message -p '#{session_name}'` reaches the live
+// host server even when $TMUX is unset or empty: the tmux client falls back
+// to the default socket ($TMUX_TMPDIR/tmux-<uid>/default, /tmp/tmux-<uid>/
+// default when TMUX_TMPDIR is unset). When invoked outside any pane, the
+// server resolves the "current" session via its most-recently-used
+// heuristics — i.e. whatever session the developer happens to be attached
+// to. Five cmd/ tests failed nondeterministically on developer hosts because
+// of exactly this (#2214): three independent sessions observed three
+// different leaked names ("actions-runner@main", "staging-db-refresh@main",
+// "aws-identity@main"), each the host's most-recently-used live session.
+//
+// t.Setenv("TMUX", "") is therefore NOT sufficient isolation on its own.
+// The suite-wide neutralisation below, applied by TestMain before m.Run():
+//
+//   1. clears $TMUX, so a socket path inherited from an enclosing live pane
+//      is never used; and
+//   2. points $TMUX_TMPDIR at a fresh, empty directory, so the
+//      default-socket fallback cannot reach the host server either.
+//
+// Every tmux client invocation made by code under test then fails fast with
+// "error connecting to ..." — indistinguishable from a host with no tmux
+// server running, which is what CI sees. This neutralises the live-server
+// leak for every current and future test in the package without per-test
+// boilerplate (the same philosophy as sidecartest.NewIsolated, #1608).
+//
+// The redirected directory must have a SHORT path: tmux sockets are Unix
+// domain sockets and sun_path is ~104 bytes on Darwin. os.MkdirTemp("", ...)
+// on macOS yields /var/folders/... paths that overflow it once tmux appends
+// tmux-<uid>/<socket-name>, which would break the tests that intentionally
+// run real isolated tmux servers via -L (cleanup, dashboard, restore,
+// switch, event). Hence /tmp first, with the generic temp dir as fallback.
+//
+// Tests that intentionally exercise a real tmux server keep working: they
+// use unique `-L prism-cmd-test-…` socket names, which simply resolve under
+// the redirected $TMUX_TMPDIR. Tests that set their own $TMUX (e.g. the nav
+// tests' "/tmp/tmux-test,1234,0" guard-satisfier) override the cleared value
+// via t.Setenv and point at sockets that do not exist — never the live
+// server.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// isolateSuiteFromHostTmux applies the suite-wide tmux neutralisation
+// described above and returns a restore function that puts the original
+// environment back. TestMain calls restore after m.Run() so the #1180 leak
+// guard's after-snapshots consult the same live server as its
+// before-snapshots.
+func isolateSuiteFromHostTmux() (restore func()) {
+	origTmux, hadTmux := os.LookupEnv("TMUX")
+	origTmpdir, hadTmpdir := os.LookupEnv("TMUX_TMPDIR")
+
+	isoDir, err := os.MkdirTemp("/tmp", "ptm-")
+	if err != nil {
+		// /tmp unwritable (e.g. restrictive build sandboxes). Fall back to
+		// the default temp dir: the resulting socket paths may exceed
+		// sun_path, which only makes tmux fail faster — isolation is
+		// preserved either way (such hosts have no live tmux server for the
+		// -L tests anyway).
+		isoDir, err = os.MkdirTemp("", "ptm-")
+	}
+	if err != nil {
+		// Last resort: a path guaranteed not to contain a live socket.
+		// Isolation trumps the real-tmux -L tests' ability to run.
+		isoDir = "/nonexistent/prism-cmd-test-tmux"
+	}
+
+	os.Setenv("TMUX", "")
+	os.Setenv("TMUX_TMPDIR", isoDir)
+
+	return func() {
+		if hadTmux {
+			os.Setenv("TMUX", origTmux)
+		} else {
+			os.Unsetenv("TMUX")
+		}
+		if hadTmpdir {
+			os.Setenv("TMUX_TMPDIR", origTmpdir)
+		} else {
+			os.Unsetenv("TMUX_TMPDIR")
+		}
+		os.RemoveAll(isoDir)
+	}
+}
+
+// TestSuiteTmuxIsolation_HostServerUnreachable is the regression guard for
+// the #2214 leak class. It asserts that, under the TestMain-level
+// neutralisation, the live host tmux server is unreachable from code under
+// test:
+//
+//   - tmux.CurrentSession() must fail (no default-socket fallback to the
+//     host server), and
+//   - review.LookupParentSession() must return "" when PRISM_SESSION_NAME is
+//     empty (the exact fallback chain that leaked into
+//     resolveCoordinatorSession and rejectIfCoordinator).
+//
+// On a host with no tmux server (CI) this passes trivially. On a developer
+// host with a live server it fails if — and only if — the suite isolation is
+// removed, which is precisely the regression it exists to catch. Verified
+// non-vacuous by disabling the isolateSuiteFromHostTmux call in TestMain and
+// observing this test fail against a live server.
+func TestSuiteTmuxIsolation_HostServerUnreachable(t *testing.T) {
+	if s, err := tmux.CurrentSession(); err == nil && s != "" {
+		t.Errorf("tmux.CurrentSession() = %q, want error — the cmd suite must be isolated from the live host tmux server (#2214); check TestMain's isolateSuiteFromHostTmux", s)
+	}
+
+	t.Setenv("PRISM_SESSION_NAME", "")
+	if got := review.LookupParentSession(); got != "" {
+		t.Errorf("review.LookupParentSession() = %q, want \"\" — host tmux state is leaking into cmd tests (#2214)", got)
+	}
+}


### PR DESCRIPTION
Closes #2214

## Root cause — pinned empirically before fixing

The issue carried two conflicting hypotheses (the `$TMUX` fallback vs. a live `prism.db` read). Both were investigated before choosing the fix:

- **Confirmed leak path:** `review.LookupParentSession()` → `tmux.CurrentSession()` → `tmux display-message -p '#{session_name}'`. The tmux client reaches the **live host server even when `$TMUX` is unset or empty**, by falling back to the default socket (`$TMUX_TMPDIR/tmux-<uid>/default`, `/tmp/tmux-<uid>/default` otherwise). Invoked outside any pane, the server resolves the "current" session via its most-recently-used heuristics — i.e. *whatever session the human is attached to*. This explains why three independent workers saw three different leaked names (`actions-runner@main`, `staging-db-refresh@main`, `aws-identity@main` in my sandbox — and `komaru-hou@eks-pipeline` during the no-op check), none of them the worker's own pane session. The 5 tests flap: they fail only while the host's MRU session happens to be `*@main`-shaped.
- **`t.Setenv("TMUX", "")` is provably insufficient:** my sandbox already had `$TMUX` empty and the leak still occurred (the failing `TestRejectIfCoordinator_NoSession_NoError` already set it).
- **Live-DB hypothesis disproven for these tests:** `resolveCoordinatorSession` only consults the injected fixture `*db.DB`, and `rejectIfCoordinator`'s tests use `openReviewTestDB(t)` → `SetTestDBPath`. The "leaked name is not my pane session" observation that motivated the DB hypothesis is fully explained by the MRU resolution above.

## Fix — suite-wide isolation in `TestMain` (no production code changes)

`cmd/tmux_isolation_test.go` adds `isolateSuiteFromHostTmux()`, applied by the existing `TestMain` (killsidecar_test.go) before `m.Run()`:

1. clears `$TMUX` (an inherited live-pane socket path is never used), and
2. redirects `$TMUX_TMPDIR` to a fresh empty directory (the default-socket fallback cannot reach the host server).

Every tmux client call made by code under test then fails fast — indistinguishable from a host with no tmux server, which is what CI sees. This covers every current and future test in the package without per-test boilerplate (same philosophy as `sidecartest.NewIsolated`, #1608). The directory must be **short-pathed** (`/tmp` first): Darwin's `sun_path` ≈104-byte limit otherwise breaks the tests that intentionally run real isolated `-L` tmux servers (discovered empirically — a long `/var/folders/...` redirect failed 35 such tests with `File name too long`).

The #1180 leak guard is preserved: isolation is applied **after** its before-snapshots and restored **before** its after-snapshots, so both consult the same live server.

`TestSuiteTmuxIsolation_HostServerUnreachable` is the regression guard: it fails on any host where the live server is still reachable from code under test. **Verified non-vacuous:** with the `isolateSuiteFromHostTmux()` call no-opped, it fails against the live server (`tmux.CurrentSession() = "komaru-hou@eks-pipeline", want error`) while the 5 named tests happened to pass at that moment (host MRU session was not `*@main`-shaped) — exactly the nondeterminism this guard pins down deterministically.

## Acceptance criteria

- **[functional] pass inside a live `*@main` pane** — simulated with `TMUX="/tmp/tmux-502/default,99999,0" go test ./cmd/` (the live default socket, sessions incl. `*@main` present): **green**. `TestMain` clears `$TMUX` before any test runs.
- **[functional] pass outside tmux entirely** — `TMUX= TMUX_TMPDIR=$(mktemp -d) go test ./cmd/`: **green**. The neutralisation never assumes tmux presence (a missing binary or absent socket both yield the same "" fallback).
- **[edge-case] production fallback unchanged** — zero production code changes; `cmd/profile.go`, `internal/review/run.go`, `internal/tmux/` untouched. Only test files changed.
- **[functional] audit** — see below.
- Also green in a worker sandbox (this one — the environment where both reporting workers reproduced the failure), and the full module passes CI's invocation `go test ./... -race`.

## Audit — cmd/ call sites that can reach the live tmux server (AC 4)

All are now neutralised suite-wide by the `TestMain` redirect; an empirical PATH-shim spy run was used to enumerate actual tmux invocations during the suite, in addition to the static walk:

Via `review.LookupParentSession()` (fires when `PRISM_SESSION_NAME` is empty):

| Call site | Function |
|---|---|
| `cmd/profile.go:344` | `runProfileUse` (session scope) |
| `cmd/profile.go:433` | `resolveCoordinatorSession` |
| `cmd/review.go:180` | `runReview` |
| `cmd/review.go:528` | `rejectIfCoordinator` |
| `cmd/merge.go:156` | `runMerge` |
| `cmd/merges.go:117,241` | `runMergesList` / `runMergesCancel` |

Direct `tmux.CurrentSession()`:

| Call site | Notes |
|---|---|
| `cmd/close.go:138` | behind a `$TMUX` guard (close.go:115) |
| `cmd/cleanup.go:393` | reached when `--session` absent |
| `cmd/nav.go:63` | behind a `$TMUX` guard |
| `cmd/dashboard.go:46` | behind an `inTmux` guard |

Other live-server surfaces observed in the spy run (also covered by the redirect): `tmux.HasSession` (escalate idempotency tests), `tmux.ListWindows`/window-option helpers (cleanup/close/checkin paths), `tmux.ListSessions`.

Existing isolation patterns checked and left intact: `withNoopTmux`/`withSpyTmux`/`withNavSpy` (TmuxBin redirects — dashboard, nav, hostapi), private `-L prism-cmd-test-*` real servers (cleanup, dashboard, restore, switch, event) — all verified still working under the redirect (full suite green in all three scenarios above).

**Residual exposure noted, out of scope:** tests that don't `t.Setenv` `PRISM_SESSION_NAME`/`PRISM_HOST_API` inherit them from the environment (unset on CI, set inside worker sandboxes). Not tmux state; the tests that matter already control them. Flagging for completeness rather than fixing here.

## Verification

- `go build ./...`, `go vet ./cmd/` — clean
- `go test ./cmd/` in 3 scenarios (sandbox w/ live server reachable; `$TMUX` set to live socket; no server) — green ×3
- `go test ./... -race` (CI's invocation) — green, whole module
- No-op check on the new regression test — fails with isolation disabled, passes with it
- `nix build .#prism`: **not run to completion** — this sandbox pre-dates the #2201 trusted-settings fix (`error: opening file ".../trusted-settings.json": Operation not permitted`). Used the sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — evaluates clean. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`); note this change is test-files-only and `os.MkdirTemp("/tmp", …)` has an explicit fallback chain for restrictive sandboxes (documented in the helper).

Known pre-existing failures out of scope per the spawn prompt: `TestProbePRStateExec_*` (#2217) — these passed/skipped in my runs regardless.
