### PR TITLE
prism: deterministic gh-probe tests + suite-wide PRISM_* env isolation in cmd/ (#2217)

### DIFF
--- a/modules/programs/prism/prism/cmd/close.go
+++ b/modules/programs/prism/prism/cmd/close.go
@@ -41,11 +41,35 @@ import (
 // ghProbeTimeout caps the `gh pr list` probe so a hung GitHub API never
 // wedges the tmux popup (issue #2179, AC: performance ≤ 5s). On timeout the
 // command fails safe to a soft close.
-const ghProbeTimeout = 5 * time.Second
+//
+// A var, not a const: tests shrink it so the timeout→fail-safe path is
+// covered without a real 5-second wall-clock wait (issue #2217).
+var ghProbeTimeout = 5 * time.Second
 
 // prProbe is the indirection used by decideClose to query PR state for a
 // branch. Replaced in tests with a fake that returns canned responses.
 var prProbe = probePRStateExec
+
+// ghExecOutput is the exec seam used by probePRStateExec to run the gh CLI
+// (issue #2217). Production points at ghExecOutputReal, which shells out to
+// `gh` on $PATH. Tests replace it with a stub returning canned stdout so the
+// probe's argv construction, JSON parsing, and state reduction run
+// in-process — no subprocess, no $PATH lookup, and no network. PATH-injected
+// fake binaries proved environment-fragile (the probe reached the real gh in
+// some worker sandboxes and hit its 5s network timeout), which is why the
+// seam sits at the exec boundary rather than on $PATH.
+var ghExecOutput = ghExecOutputReal
+
+// ghExecOutputReal runs `gh` with the given argv in workdir (empty = caller
+// cwd), returning its stdout. The context bounds the subprocess lifetime:
+// exec.CommandContext kills it when the deadline fires.
+func ghExecOutputReal(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	return cmd.Output()
+}
 
 // closeCmd is the public `prism close` cobra command.
 var closeCmd = &cobra.Command{
@@ -297,15 +321,11 @@ func probePRStateExec(workdir, branch string) (string, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), ghProbeTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+	out, err := ghExecOutput(ctx, workdir, "pr", "list",
 		"--head", branch,
 		"--state", "all",
 		"--json", "state,number",
 		"--limit", "10")
-	if workdir != "" {
-		cmd.Dir = workdir
-	}
-	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}

--- a/modules/programs/prism/prism/cmd/close_test.go
+++ b/modules/programs/prism/prism/cmd/close_test.go
@@ -3,9 +3,10 @@
 // The tests fall into three groups:
 //
 //  1. decideClose — pure decision-tree tests that swap prProbe for a stub.
-//  2. probePRStateExec — exercises the production gh shell-out via a PATH-
-//     injected `gh` stub, so we test the JSON-parse branches without depending
-//     on a real network call.
+//  2. probePRStateExec — exercises the probe against the ghExecOutput exec
+//     seam with canned outputs (issue #2217), so the JSON-parse and
+//     state-reduction branches run in-process with no subprocess, no $PATH
+//     dependence, and no network.
 //  3. runCloseCmd — flag validation (mutually-exclusive force flags, --json
 //     requires --yes, unknown --session) and the integration with the
 //     existing cleanup-soft / cleanup-hard paths.
@@ -18,11 +19,13 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -225,41 +228,46 @@ func TestDecideClose_WorkerUnknownState(t *testing.T) {
 }
 
 // ── probePRStateExec ─────────────────────────────────────────────────────────
-
-// withFakeGhInPath writes a fake `gh` to a tempdir, prepends it to $PATH, and
-// returns the tempdir so the test can also inspect what gh was invoked with.
 //
-// The fake gh writes the contents of $FAKE_GH_STDOUT to stdout, the contents
-// of $FAKE_GH_STDERR to stderr, and exits with $FAKE_GH_EXIT (default 0). It
-// also records its argv to $FAKE_GH_ARGV_FILE if that env var is set.
-func withFakeGhInPath(t *testing.T) string {
+// These tests inject the gh exec seam (ghExecOutput, issue #2217) with canned
+// outputs so the probe's argv construction, JSON parsing, and state reduction
+// are exercised in-process: no subprocess, no $PATH lookup, no network, and
+// no dependence on a gh binary existing in the environment. The previous
+// PATH-injected fake-gh fixture proved environment-fragile — in some worker
+// sandboxes the probe reached the real gh and failed at its 5s network
+// timeout (issue #2217).
+
+// withGhExecStub swaps the ghExecOutput exec seam for the duration of the
+// test.
+func withGhExecStub(t *testing.T, fn func(ctx context.Context, workdir string, args ...string) ([]byte, error)) {
 	t.Helper()
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "gh")
-	script := `#!/bin/sh
-if [ -n "$FAKE_GH_ARGV_FILE" ]; then
-  echo "$@" >> "$FAKE_GH_ARGV_FILE"
-fi
-if [ -n "$FAKE_GH_STDOUT" ]; then
-  printf '%s' "$FAKE_GH_STDOUT"
-fi
-if [ -n "$FAKE_GH_STDERR" ]; then
-  printf '%s' "$FAKE_GH_STDERR" >&2
-fi
-exit "${FAKE_GH_EXIT:-0}"
-`
-	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake gh: %v", err)
-	}
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
-	return dir
+	orig := ghExecOutput
+	ghExecOutput = fn
+	t.Cleanup(func() { ghExecOutput = orig })
+}
+
+// cannedGhOutput stubs the gh exec seam to return the given stdout with a
+// zero exit.
+func cannedGhOutput(t *testing.T, stdout string) {
+	t.Helper()
+	withGhExecStub(t, func(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+		return []byte(stdout), nil
+	})
+}
+
+// withGhProbeTimeout shrinks the probe's context deadline for the duration of
+// the test, so timeout behaviour is covered without the production 5-second
+// wall-clock wait (issue #2217 AC: edge-case).
+func withGhProbeTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := ghProbeTimeout
+	ghProbeTimeout = d
+	t.Cleanup(func() { ghProbeTimeout = orig })
 }
 
 // TestProbePRStateExec_OpenPR verifies the happy path: a single OPEN PR.
 func TestProbePRStateExec_OpenPR(t *testing.T) {
-	withFakeGhInPath(t)
-	t.Setenv("FAKE_GH_STDOUT", `[{"number":42,"state":"OPEN"}]`)
+	cannedGhOutput(t, `[{"number":42,"state":"OPEN"}]`)
 
 	state, err := probePRStateExec("", "feature-foo")
 	if err != nil {
@@ -272,8 +280,7 @@ func TestProbePRStateExec_OpenPR(t *testing.T) {
 
 // TestProbePRStateExec_MergedPR verifies a single MERGED PR returns MERGED.
 func TestProbePRStateExec_MergedPR(t *testing.T) {
-	withFakeGhInPath(t)
-	t.Setenv("FAKE_GH_STDOUT", `[{"number":42,"state":"MERGED"}]`)
+	cannedGhOutput(t, `[{"number":42,"state":"MERGED"}]`)
 
 	state, err := probePRStateExec("", "feature-merged")
 	if err != nil {
@@ -287,8 +294,7 @@ func TestProbePRStateExec_MergedPR(t *testing.T) {
 // TestProbePRStateExec_NoPR verifies an empty result returns ("", nil), which
 // the caller treats as "no PR found → hard cleanup".
 func TestProbePRStateExec_NoPR(t *testing.T) {
-	withFakeGhInPath(t)
-	t.Setenv("FAKE_GH_STDOUT", `[]`)
+	cannedGhOutput(t, `[]`)
 
 	state, err := probePRStateExec("", "orphan-branch")
 	if err != nil {
@@ -302,9 +308,8 @@ func TestProbePRStateExec_NoPR(t *testing.T) {
 // TestProbePRStateExec_MultiPROpenWins verifies the AC: when multiple PRs
 // exist for the same head branch and any is OPEN, the probe returns OPEN.
 func TestProbePRStateExec_MultiPROpenWins(t *testing.T) {
-	withFakeGhInPath(t)
 	// Two PRs: one MERGED, one OPEN. OPEN must win regardless of order.
-	t.Setenv("FAKE_GH_STDOUT", `[{"number":1,"state":"MERGED"},{"number":2,"state":"OPEN"}]`)
+	cannedGhOutput(t, `[{"number":1,"state":"MERGED"},{"number":2,"state":"OPEN"}]`)
 
 	state, err := probePRStateExec("", "branch-with-multiple-prs")
 	if err != nil {
@@ -315,12 +320,13 @@ func TestProbePRStateExec_MultiPROpenWins(t *testing.T) {
 	}
 }
 
-// TestProbePRStateExec_GhExitsNonZero verifies an error exit propagates,
-// so decideClose can fail-safe to soft close.
+// TestProbePRStateExec_GhExitsNonZero verifies an error from the gh runner
+// (e.g. a non-zero exit from an unauthenticated gh) propagates, so
+// decideClose can fail-safe to soft close.
 func TestProbePRStateExec_GhExitsNonZero(t *testing.T) {
-	withFakeGhInPath(t)
-	t.Setenv("FAKE_GH_EXIT", "1")
-	t.Setenv("FAKE_GH_STDERR", "gh: not authenticated\n")
+	withGhExecStub(t, func(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1: gh: not authenticated")
+	})
 
 	state, err := probePRStateExec("", "some-branch")
 	if err == nil {
@@ -328,9 +334,23 @@ func TestProbePRStateExec_GhExitsNonZero(t *testing.T) {
 	}
 }
 
-// TestProbePRStateExec_GhMissing verifies the probe returns an error when gh
-// is not on $PATH. PATH is set to an empty tempdir to guarantee no gh on
-// PATH for this test, decoupled from the test runner's environment.
+// TestProbePRStateExec_MalformedJSON verifies that gh stdout which fails to
+// parse propagates as an error (caller fails safe to soft close).
+func TestProbePRStateExec_MalformedJSON(t *testing.T) {
+	cannedGhOutput(t, `{not json`)
+
+	state, err := probePRStateExec("", "some-branch")
+	if err == nil {
+		t.Errorf("expected non-nil error for malformed gh output; got state=%q", state)
+	}
+}
+
+// TestProbePRStateExec_GhMissing verifies the production runner
+// (ghExecOutputReal, reached through the default seam) returns an error when
+// gh is not on $PATH. PATH is set to an empty tempdir to guarantee no gh on
+// PATH for this test, decoupled from the test runner's environment. The
+// exec.LookPath failure is immediate — no subprocess is spawned and no
+// network is touched.
 func TestProbePRStateExec_GhMissing(t *testing.T) {
 	emptyDir := t.TempDir()
 	t.Setenv("PATH", emptyDir)
@@ -342,71 +362,136 @@ func TestProbePRStateExec_GhMissing(t *testing.T) {
 }
 
 // TestProbePRStateExec_EmptyBranch verifies the early-return on an empty
-// branch (defensive guard).
+// branch (defensive guard) — the gh runner must never be invoked.
 func TestProbePRStateExec_EmptyBranch(t *testing.T) {
-	withFakeGhInPath(t)
+	withGhExecStub(t, func(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+		t.Error("gh runner should not be invoked for an empty branch")
+		return nil, fmt.Errorf("unreachable")
+	})
 	if state, err := probePRStateExec("", ""); err == nil {
 		t.Errorf("expected error for empty branch; got state=%q", state)
 	}
 }
 
-// TestProbePRStateExec_PassesArgv verifies the exact argv shape sent to gh:
-// `gh pr list --head <branch> --state all --json state,number --limit 10`.
-// This is a regression guard on the AC: multi-PR support requires
-// `gh pr list --head`, not `gh pr view`.
+// TestProbePRStateExec_PassesArgv verifies the exact argv shape handed to the
+// gh runner: `pr list --head <branch> --state all --json state,number
+// --limit 10`, plus workdir passthrough. This is a regression guard on the
+// AC: multi-PR support requires `gh pr list --head`, not `gh pr view`.
 func TestProbePRStateExec_PassesArgv(t *testing.T) {
-	dir := withFakeGhInPath(t)
-	argvFile := filepath.Join(dir, "argv.log")
-	t.Setenv("FAKE_GH_STDOUT", `[]`)
-	t.Setenv("FAKE_GH_ARGV_FILE", argvFile)
+	var gotWorkdir string
+	var gotArgs []string
+	withGhExecStub(t, func(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+		gotWorkdir = workdir
+		gotArgs = args
+		return []byte(`[]`), nil
+	})
 
-	if _, err := probePRStateExec("", "my-branch"); err != nil {
+	if _, err := probePRStateExec("/some/workdir", "my-branch"); err != nil {
 		t.Fatalf("probePRStateExec: %v", err)
 	}
 
-	data, err := os.ReadFile(argvFile)
-	if err != nil {
-		t.Fatalf("read argv: %v", err)
+	if gotWorkdir != "/some/workdir" {
+		t.Errorf("workdir = %q, want /some/workdir", gotWorkdir)
 	}
-	argv := strings.TrimSpace(string(data))
-	wantSubstrings := []string{
-		"pr list",
-		"--head my-branch",
-		"--state all",
-		"--json state,number",
-		"--limit 10",
-	}
-	for _, want := range wantSubstrings {
-		if !strings.Contains(argv, want) {
-			t.Errorf("argv %q missing %q", argv, want)
-		}
+	wantArgs := []string{"pr", "list", "--head", "my-branch", "--state", "all", "--json", "state,number", "--limit", "10"}
+	if !slices.Equal(gotArgs, wantArgs) {
+		t.Errorf("argv = %q, want %q", gotArgs, wantArgs)
 	}
 }
 
-// TestProbePRStateExec_HangingProbeRespectsTimeout verifies the 5s context
-// timeout. The fake gh execs sleep so SIGKILL on context cancellation tears
-// down the actual sleep process (a wrapping shell would leave the sleep
-// child holding the stdout pipe open, hanging cmd.Output past the deadline).
-func TestProbePRStateExec_HangingProbeRespectsTimeout(t *testing.T) {
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "gh")
-	// `exec sleep` replaces the shell with sleep so SIGKILL hits sleep
-	// directly, closing the stdout pipe and unblocking probePRStateExec.
-	script := "#!/bin/sh\nexec sleep 30\n"
-	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
-		t.Fatalf("write hanging gh: %v", err)
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+// TestProbePRStateExec_TimeoutFailsSafe verifies the probe applies the
+// ghProbeTimeout deadline to the context it hands the gh runner and
+// propagates the cancellation error — the input decideClose relies on for its
+// fail-safe-to-soft-close path (#2179). The deadline is shrunk to 50ms via
+// the ghProbeTimeout seam so real cancellation behaviour is asserted without
+// the production 5-second wall-clock wait (issue #2217 AC: edge-case).
+func TestProbePRStateExec_TimeoutFailsSafe(t *testing.T) {
+	withGhProbeTimeout(t, 50*time.Millisecond)
+	withGhExecStub(t, func(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Error("probe context has no deadline — ghProbeTimeout not applied")
+		}
+		// Simulate a hung gh that only returns when the context is cancelled.
+		// The bounded escape hatch keeps the failure mode crisp (a named
+		// error within 3s, not a suite hang) if the deadline is ever dropped.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(3 * time.Second):
+			return nil, fmt.Errorf("probe context was never cancelled")
+		}
+	})
 
 	start := time.Now()
-	_, err := probePRStateExec("", "stuck-branch")
+	state, err := probePRStateExec("", "stuck-branch")
 	elapsed := time.Since(start)
 
 	if err == nil {
-		t.Errorf("expected error from hanging gh probe; got nil after %v", elapsed)
+		t.Errorf("expected error from hung probe; got state=%q", state)
 	}
-	if elapsed > ghProbeTimeout+2*time.Second {
-		t.Errorf("probe took %v, want < %v (timeout not enforced)", elapsed, ghProbeTimeout+2*time.Second)
+	if elapsed > 2*time.Second {
+		t.Errorf("probe returned after %v, want ~50ms (deadline not enforced)", elapsed)
+	}
+}
+
+// TestProbePRStateExec_HangingSubprocessKilledAtDeadline exercises the
+// production runner (ghExecOutputReal) end to end against a hanging fake gh,
+// proving exec.CommandContext actually kills the subprocess at the deadline
+// and cmd.Output returns promptly. The deadline is shrunk to 250ms so there
+// is no 5-second wall-clock wait, and $PATH is set to ONLY the fake's dir so
+// the real gh is unreachable in every environment — if the fake cannot be
+// executed at all, exec fails fast instead, and either way the probe must
+// return an error well inside the bound (issue #2217).
+//
+// The fake holds the stdout pipe itself (a shell busy-loop, no children) so
+// SIGKILL on the process closes the pipe and unblocks cmd.Output; it needs
+// no external binaries (`sleep` is not guaranteed on PATH inside the nix
+// build sandbox).
+func TestProbePRStateExec_HangingSubprocessKilledAtDeadline(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "gh")
+	script := "#!/bin/sh\nwhile :; do :; done\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatalf("write hanging gh: %v", err)
+	}
+	t.Setenv("PATH", dir) // fake-only PATH: the real gh must be unreachable
+
+	withGhProbeTimeout(t, 250*time.Millisecond)
+
+	start := time.Now()
+	state, err := probePRStateExec("", "stuck-branch")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Errorf("expected error from hanging gh probe; got state=%q after %v", state, elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("probe took %v, want ≲250ms (timeout not enforced)", elapsed)
+	}
+}
+
+// TestDecideClose_ProbeTimeoutFailsSafeToSoftClose wires the real
+// probePRStateExec (hung runner, shrunk deadline) into decideClose and
+// asserts the probe timeout routes to soft close — the #2179 fail-safe —
+// without any wall-clock wait near the production 5s (issue #2217 AC:
+// edge-case).
+func TestDecideClose_ProbeTimeoutFailsSafeToSoftClose(t *testing.T) {
+	// Empty DB — no coordinator rows; decideClose must consult the probe.
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, _ := db.Open(dbFile)
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	withGhProbeTimeout(t, 50*time.Millisecond)
+	withGhExecStub(t, func(ctx context.Context, workdir string, args ...string) ([]byte, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	soft, hard := decideClose("myrepo@stuck-branch", false, false)
+	if !soft || hard {
+		t.Errorf("decideClose(probe timeout) = (soft=%v, hard=%v), want (true, false) — fail-safe", soft, hard)
 	}
 }
 

--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -68,6 +68,12 @@ import (
 //     tmux_isolation_test.go for the full rationale. The original
 //     environment is restored after m.Run() so the leak-guard
 //     after-snapshots consult the same live server as the before-snapshots.
+//
+//  5. Sandbox-env isolation (#2217): unsets the PRISM_* variables the
+//     sidecar injects into agent sessions (PRISM_SESSION_NAME,
+//     PRISM_HOST_API, …) so tests see the same environment surface on CI,
+//     developer hosts, and inside prism worker sandboxes. See
+//     sandbox_env_isolation_test.go for the full rationale.
 func TestMain(m *testing.M) {
 	if os.Getenv("PRISM_CMD_TEST_STUB") == "1" {
 		time.Sleep(60 * time.Second)
@@ -97,9 +103,13 @@ func TestMain(m *testing.M) {
 	// Tmux isolation (#2214): applied after the before-snapshots above (they
 	// must see the real live server), undone before the after-snapshots below.
 	restoreTmuxEnv := isolateSuiteFromHostTmux()
+	// Sandbox-env isolation (#2217): unset the sidecar-injected PRISM_* vars
+	// so the suite controls its full environment surface.
+	restoreSandboxEnv := isolateSuiteFromSandboxEnv()
 
 	code := m.Run()
 
+	restoreSandboxEnv()
 	restoreTmuxEnv()
 
 	// Leak guard: assert no new sessions or DB rows were created in the live

--- a/modules/programs/prism/prism/cmd/sandbox_env_isolation_test.go
+++ b/modules/programs/prism/prism/cmd/sandbox_env_isolation_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+// Suite-wide sandbox-env isolation for the cmd package (issue #2217).
+//
+// The prism sidecar injects a set of PRISM_* environment variables into every
+// agent session it spawns (see cmd/agent_run_sandbox_exec_darwin.go and
+// internal/container/container.go). Those variables are UNSET on CI and on a
+// developer host shell, but SET inside prism worker sandboxes — so any test
+// that exercises a code path consulting them behaves differently across the
+// two environments unless it pins them with t.Setenv. Production code in
+// cmd/ reads several of them:
+//
+//   - PRISM_HOST_API   → the proxy-to-host branch in ~20 commands (checkin,
+//     cleanup, close, db, escalate, feedback, investigate, list-sessions,
+//     logs, merge, pr, prompt, review, spawn, stats, switch, …). Inherited
+//     from a sandbox, it points at the LIVE host API socket — a test that
+//     reaches the proxy branch unpinned would talk to the real sidecar.
+//   - PRISM_SESSION_NAME → session auto-detection (escalate, feedback,
+//     investigate, mute, profile, sessions; review.LookupParentSession).
+//   - PRISM_SPAWN_PATH / PRISM_BARE_ROOT → cwd/repo fallbacks (checkin
+//     --list, list-sessions, spawn).
+//   - PRISM_HARNESS_PIPE → not read by Go code today; cleared so the suite
+//     controls the full surface the sidecar injects.
+//
+// As with the tmux isolation (#2214), per-test t.Setenv is not a structural
+// fix: it protects only the tests that remembered it. The suite-wide
+// neutralisation below, applied by TestMain before m.Run(), unsets the whole
+// injected set so the suite sees the same environment on CI, developer
+// hosts, and inside worker sandboxes. Tests that need a specific value
+// (e.g. pointing PRISM_HOST_API at a mock unix server) still override it
+// per-test with t.Setenv, which takes precedence and is restored
+// automatically.
+//
+// An empirical poison-run before this isolation (all five variables set to
+// unreachable/poisoned values) showed no currently-failing test — the
+// exposure today is latent, not active. The TestMain pin closes the class
+// structurally rather than relying on each future test remembering the
+// boilerplate.
+
+import (
+	"os"
+	"testing"
+)
+
+// sandboxInjectedPrismEnvVars is the set of PRISM_* variables the sidecar
+// injects into agent sessions. Source of truth: the env assembly in
+// cmd/agent_run_sandbox_exec_darwin.go (sandbox-exec path) and
+// internal/container/container.go (bwrap path).
+var sandboxInjectedPrismEnvVars = []string{
+	"PRISM_SESSION_NAME",
+	"PRISM_HOST_API",
+	"PRISM_SPAWN_PATH",
+	"PRISM_BARE_ROOT",
+	"PRISM_HARNESS_PIPE",
+}
+
+// isolateSuiteFromSandboxEnv unsets the sidecar-injected PRISM_* variables
+// (matching CI, where they are unset) and returns a restore function that
+// puts the original environment back. TestMain calls restore after m.Run()
+// for symmetry with the tmux isolation (#2214).
+func isolateSuiteFromSandboxEnv() (restore func()) {
+	type saved struct {
+		val string
+		had bool
+	}
+	origs := make(map[string]saved, len(sandboxInjectedPrismEnvVars))
+	for _, k := range sandboxInjectedPrismEnvVars {
+		v, ok := os.LookupEnv(k)
+		origs[k] = saved{val: v, had: ok}
+		os.Unsetenv(k)
+	}
+	return func() {
+		for k, s := range origs {
+			if s.had {
+				os.Setenv(k, s.val)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}
+}
+
+// TestSuiteSandboxEnvIsolation_NotInherited is the regression guard for the
+// #2217 env-inheritance class. Under the TestMain-level neutralisation, none
+// of the sidecar-injected PRISM_* variables may be visible to tests that do
+// not set them explicitly.
+//
+// On CI and developer hosts (variables unset) this passes trivially. Inside
+// a prism worker sandbox (variables set by the sidecar) it fails if — and
+// only if — the suite isolation is removed, which is precisely the
+// regression it exists to catch. Verified non-vacuous by disabling the
+// isolateSuiteFromSandboxEnv call in TestMain and observing this test fail
+// inside a worker sandbox.
+func TestSuiteSandboxEnvIsolation_NotInherited(t *testing.T) {
+	for _, k := range sandboxInjectedPrismEnvVars {
+		if v, ok := os.LookupEnv(k); ok {
+			t.Errorf("%s=%q leaked into the cmd test suite — sidecar-injected env must be neutralised suite-wide (#2217); check TestMain's isolateSuiteFromSandboxEnv", k, v)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2217

## What

### 1. gh exec seam for the PR-state probe (`cmd/close.go`, `cmd/close_test.go`)

`probePRStateExec` now runs `gh` through an injectable exec seam (`ghExecOutput`, production impl `ghExecOutputReal`), and `ghProbeTimeout` is a var so tests can shrink the deadline. The `TestProbePRStateExec_*` tests no longer use a PATH-injected fake-gh script — every scenario (merged / no PR / multi-PR-open-wins / non-zero exit / malformed JSON / argv shape) runs against canned outputs **in-process**: no subprocess, no `$PATH` lookup, no network, no gh binary required.

Timeout coverage without the 5-second wall-clock wait (AC: edge-case):
- `TestProbePRStateExec_TimeoutFailsSafe` — 50ms shrunk deadline, runner stub blocks until `ctx.Done()`; asserts the deadline is applied and the cancellation error propagates (~50ms, bounded 3s escape hatch if the deadline is ever dropped).
- `TestProbePRStateExec_HangingSubprocessKilledAtDeadline` — keeps end-to-end coverage of the production runner: a hanging fake gh (shell busy-loop, no children, no external binaries) with a 250ms deadline proves `exec.CommandContext` kills the subprocess and `cmd.Output` returns. `$PATH` is set to *only* the fake's dir so the real gh is unreachable in every environment.
- `TestDecideClose_ProbeTimeoutFailsSafeToSoftClose` — wires the real probe (hung runner, shrunk deadline) through `decideClose` and asserts the timeout routes to **soft close** (#2179 fail-safe).

**No live-gh integration variant kept**: a live probe adds flake risk and no signal beyond the argv-shape regression guard, so there is nothing to gate behind the #2207-style env flag.

AC check: `go test ./cmd/ -race -run TestProbePRStateExec` → passes in **1.7s** total with no network and no gh on PATH (previously 5.00s+ spent in the hanging-probe test alone).

### 2. Suite-wide PRISM_* env neutralisation (`cmd/sandbox_env_isolation_test.go`, `cmd/killsidecar_test.go`)

Per the issue comment: `TestMain` now unsets the five sidecar-injected variables (`PRISM_SESSION_NAME`, `PRISM_HOST_API`, `PRISM_SPAWN_PATH`, `PRISM_BARE_ROOT`, `PRISM_HARNESS_PIPE`) before `m.Run()` and restores them after — the #2224 `isolateSuiteFromHostTmux` pattern. `TestSuiteSandboxEnvIsolation_NotInherited` is the regression guard (trivially green on CI; fails inside a worker sandbox iff the isolation is removed — verified non-vacuously, see below).

## Env-inheritance sweep findings

Method: audited every `os.Getenv`/`LookupEnv` of `PRISM_*` in cmd/ production code against the sidecar's injected set (source: `cmd/agent_run_sandbox_exec_darwin.go`, `internal/container/container.go`), then ran the full cmd suite with all five vars **poisoned** (`PRISM_HOST_API=unix:///nonexistent/poison.sock`, etc.).

- **Poison run: zero failures.** No current test fails from uncontrolled inheritance — the exposure is latent, not active. The TestMain pin closes the class structurally instead of relying on per-test boilerplate.
- ~30 test files pin `PRISM_HOST_API` per-test and 7 pin `PRISM_SESSION_NAME` per-test; protection was ad-hoc. Existing pins are left in place (redundant but harmless).
- Latent cases found: `close_test.go` `TestCloseCmd_MutuallyExclusiveFlags` / `TestCloseCmd_JSONRequiresYes` call `runCloseCmd` unpinned — safe today only because flag validation happens to precede the `PRISM_HOST_API` proxy branch (ordering-fragile). `escalate_idempotency_test.go` exercises `runEscalateForSessionOpts` below the proxy branch; a future test of the full RunE would proxy to the **live host API** inside a sandbox if unpinned. `PRISM_SPAWN_PATH` cwd fallbacks (`checkin --list`, `list-sessions`, `spawn`) were pinned only where individual tests remembered.
- **`cmd/cleanup_test.go` (issue #2219 worker's footprint — not touched):** no changes needed there; it already pins `PRISM_HOST_API` 17× per-test and the suite-wide neutralisation now covers it regardless. Its per-test pins are redundant-but-harmless; removing them is optional follow-up hygiene for whoever owns that file next.

## Reproduction note

I could **not** reproduce the issue's 5.00s probe failures in this worker sandbox — the old PATH-fake tests passed here in 0.08s. The seam removes the entire PATH/subprocess/network surface regardless of the leak mechanism in the original environment, and the suite no longer contains any test that can reach the real gh.

## Verified non-vacuous (mutation checks)

- Multi-PR loop mutated to return the first PR's state → `TestProbePRStateExec_MultiPROpenWins` FAILS (`state = "MERGED", want OPEN`).
- `context.WithTimeout` → `WithCancel` (deadline dropped) → `TestProbePRStateExec_TimeoutFailsSafe` FAILS on both assertions (no deadline; returned after 3s escape, not ~50ms).
- TestMain isolation call disabled → `TestSuiteSandboxEnvIsolation_NotInherited` FAILS inside this worker sandbox, reporting all five leaked vars.

## Workflow checks

- `go build ./...` — clean; `go vet ./cmd/` — clean.
- `go test ./... -race` (CI's invocation) — full suite green.
- `nix build .#prism` could not run locally: this sandbox pre-dates the #2201 trusted-settings read allowance (`error: opening file ".../trusted-settings.json": Operation not permitted`). Per AGENTS.md I used the sanctioned non-flake fallback — `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — which evaluates clean. CI's `nix-build-prism-checked` job is the authoritative homeless-shelter gate.
