### PR TITLE
prism reset: scope transcript removal to the DB resume pointers being reset (#2220)

### DIFF
--- a/modules/programs/prism/prism/cmd/reset.go
+++ b/modules/programs/prism/prism/cmd/reset.go
@@ -12,10 +12,13 @@ package cmd
 //     clear the per-session pi conversation resume pointer
 //     (agent_status.harness_session_id) on every row, so the next switch into
 //     a previously-active project starts pi with a fresh conversation
-//     (issue #1947).
+//     (issue #1947). The (worktree, harness_session_id) pairs are
+//     snapshotted BEFORE the clear so step 4b can scope its transcript
+//     removal to exactly the sessions being reset (issue #2220).
 //  4. Kill all sidecar processes and remove stale run files (PID, ready)
-//     from ~/.local/state/prism/run/, and remove the per-session pi-agent
-//     transcript JSONL subtree (issue #1947).
+//     from ~/.local/state/prism/run/, and delete exactly the pi transcript
+//     JSONLs belonging to the snapshotted resume pointers from the shared
+//     host pi sessions root (issues #1947, #2220).
 //  5. (Unless --no-launch) invoke `prism launch` to restart the server.
 //
 // Flags:
@@ -53,7 +56,8 @@ Steps (each attempted independently):
   3. Mark all non-ended rows in agent_status as ended and clear the pi
      conversation resume pointer (harness_session_id) on every row.
   4. Terminate all sidecar processes (reads PID files from
-     ~/.local/state/prism/run/) and remove pi-agent transcript JSONLs.
+     ~/.local/state/prism/run/) and remove the pi transcript JSONLs
+     belonging to the reset sessions from the shared pi sessions root.
   5. Invoke prism launch to restart (skipped with --no-launch).`,
 	Args: cobra.NoArgs,
 	RunE: runReset,
@@ -108,8 +112,11 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	}
 
 	// ── Step 3: Mark all agent_status rows as ended ───────────────────────────
+	// Also snapshots the pi resume pointers (worktree + harness_session_id)
+	// before clearing them, so step 4b can scope its transcript removal.
 	fmt.Println("Marking all sessions as ended in DB...")
-	if err := resetMarkDBEnded(); err != nil {
+	resumePointers, err := resetMarkDBEnded()
+	if err != nil {
 		proglog.Warnf("[prism reset] DB cleanup: %v (continuing)\n", err)
 	}
 
@@ -120,12 +127,12 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	}
 
 	// ── Step 4b: Remove pi-agent transcript JSONLs ────────────────────────────
-	// Reset means forget: drop the on-disk pi session JSONLs so that even if
-	// a stale harness_session_id somehow survived (e.g. an external writer),
-	// piResolveResumeSession returns false and pi starts a fresh chat.
-	// See issue #1947.
+	// Reset means forget: drop the on-disk pi session JSONLs for the
+	// snapshotted resume pointers so that even if a stale harness_session_id
+	// somehow survived (e.g. an external writer), piResolveResumeSession
+	// returns false and pi starts a fresh chat. See issues #1947 and #2220.
 	fmt.Println("Removing pi-agent transcript JSONLs...")
-	if err := resetClearPiTranscripts(); err != nil {
+	if err := resetClearPiTranscripts(resumePointers); err != nil {
 		proglog.Warnf("[prism reset] transcript cleanup: %v (continuing)\n", err)
 	}
 
@@ -180,22 +187,66 @@ func resetIsolators() error {
 	return firstErr
 }
 
+// piResumePointer is the snapshot of one agent_status row's pi resume
+// linkage — captured by resetMarkDBEnded immediately BEFORE
+// ClearAllResumePointers nulls the harness_session_id column. The FS half of
+// the reset (resetClearPiTranscripts) consumes the snapshot to delete exactly
+// the transcript JSONLs belonging to the sessions being reset, mirroring
+// cleanup's capture-before-clear pattern in severPiResumeLinkage
+// (cmd/cleanup.go).
+type piResumePointer struct {
+	sessionName      string
+	worktree         string
+	harnessSessionID string
+}
+
 // resetMarkDBEnded opens the prism DB, calls MarkAllEnded to update all
 // non-ended agent_status rows, then calls ClearAllResumePointers to wipe the
 // per-session pi conversation resume pointer (harness_session_id) on every
 // row. The two operations are independent (different columns) but conceptually
 // paired by `prism reset`: end every session, then forget the resume pointer
 // (issue #1947).
-func resetMarkDBEnded() error {
+//
+// Before the clear, the (worktree, harness_session_id) pairs of every row
+// carrying a resume pointer are snapshotted and returned so the FS half of
+// the reset (resetClearPiTranscripts) can delete exactly those transcript
+// JSONLs (issue #2220). The snapshot deliberately covers ended rows too —
+// ClearAllResumePointers wipes the column on every row, and the FS half must
+// match that scope. A snapshot failure is logged and degrades the FS half to
+// a no-op; the DB-side clears (the load-bearing half) still run.
+//
+// The returned slice is valid even when err is non-nil, so the caller can
+// still hand whatever was captured to resetClearPiTranscripts — each reset
+// step is best-effort and attempted independently.
+func resetMarkDBEnded() ([]piResumePointer, error) {
 	d, err := openDB()
 	if err != nil {
-		return fmt.Errorf("open DB: %w", err)
+		return nil, fmt.Errorf("open DB: %w", err)
 	}
 	defer d.Close()
 
+	// Snapshot resume pointers BEFORE ClearAllResumePointers nulls the
+	// column. AllStatusesWithPrefix("") returns every agent_status row,
+	// active and ended.
+	var pointers []piResumePointer
+	statuses, err := d.AllStatusesWithPrefix("")
+	if err != nil {
+		proglog.Warnf("[prism reset] snapshot resume pointers: %v (transcript removal will be skipped)\n", err)
+	}
+	for _, s := range statuses {
+		if s.HarnessSessionID == nil || *s.HarnessSessionID == "" || s.Worktree == "" {
+			continue
+		}
+		pointers = append(pointers, piResumePointer{
+			sessionName:      s.SessionName,
+			worktree:         s.Worktree,
+			harnessSessionID: *s.HarnessSessionID,
+		})
+	}
+
 	n, err := d.MarkAllEnded()
 	if err != nil {
-		return err
+		return pointers, err
 	}
 	if n == 0 {
 		fmt.Println("  no active sessions in DB.")
@@ -208,12 +259,12 @@ func resetMarkDBEnded() error {
 	// resetClearPiTranscripts.
 	cleared, err := d.ClearAllResumePointers()
 	if err != nil {
-		return err
+		return pointers, err
 	}
 	if cleared > 0 {
 		fmt.Printf("  cleared pi resume pointer on %d row(s).\n", cleared)
 	}
-	return nil
+	return pointers, nil
 }
 
 // resetKillSidecars scans ~/.local/state/prism/run/ for *-sidecar.pid files,
@@ -275,98 +326,66 @@ func resetKillSidecars() error {
 	return nil
 }
 
-// resetClearPiTranscripts removes the per-session pi-agent transcript JSONL
-// subtree under each per-session run directory, and the sandbox-exec staging
-// HOME equivalent. This is the filesystem-side half of the issue #1947 fix
-// (the DB-side half is ClearAllResumePointers, called from resetMarkDBEnded).
+// resetClearPiTranscripts deletes the on-disk pi transcript JSONLs belonging
+// to the sessions being reset. This is the filesystem-side half of the issue
+// #1947 fix (the DB-side half is ClearAllResumePointers, called from
+// resetMarkDBEnded), re-scoped by issue #2220 to the shared host pi sessions
+// root where pi actually writes transcripts in EVERY isolation mode
+// (post #2186/#2210):
 //
-// Layouts walked (all defensively skipped when missing):
+//	$PI_CODING_AGENT_DIR/sessions/--<encoded-cwd>--/<ts>_<uuid>.jsonl
+//	(or ~/.pi/agent/sessions/... when the env var is unset)
 //
-//   bwrap:
-//     $XDG_STATE_HOME/prism/run/<sessionDirHash>/pi-agent/sessions/
+// That root is shared across all repos, sessions, and non-prism pi
+// invocations on the host, so it must NEVER be swept wholesale. Instead the
+// removal is keyed off the DB rows being reset: for each snapshotted
+// (worktree, harness_session_id) pair, exactly the *_<id>.jsonl files in that
+// worktree's encoded-cwd directory are deleted — the same per-file
+// granularity as cleanup's severPiResumeLinkage, via the same
+// container.RemovePiResumeJSONL(Count) mechanism. Conversations the DB does
+// not know about (other repos' sessions, non-prism pi chats, sessions whose
+// linkage was already severed) are untouched.
 //
-//   sandbox-exec (Darwin):
-//     $XDG_STATE_HOME/prism/sessions/<instanceID>/home/.pi/agent/sessions/
+// Unlike `prism cleanup` (which archives the transcript before severing —
+// see archiveThenSeverPiResume, issue #2219), reset deletes WITHOUT
+// archiving: reset is the destructive "forget everything" surface
+// (issue #1947: "Reset means forget"); cleanup is the lifecycle path that
+// preserves history.
 //
-//   host:
-//     $PI_CODING_AGENT_DIR/sessions/ (when set) or ~/.pi/agent/sessions/
-//     — NOT touched here. Host mode is already safe because
-//     `prism switch` leaves opts.HarnessSessionID empty (see
-//     internal/session/session.go ~line 181-182), so the host-mode
-//     buildDirectAgentCmd never appends --session even if a transcript
-//     remains on disk. Wiping the host PI sessions root would also touch
-//     state belonging to non-prism pi invocations — strictly out of scope.
-//     The host-mode resolution path now honours PI_CODING_AGENT_DIR (see
-//     internal/harness/pi/archive.go::piSessionsRoot) but is unchanged here:
-//     reset still skips host mode entirely.
+// The pre-#2220 implementation instead swept two dead layouts — the
+// pre-#1985 bwrap run-dir layout ($XDG_STATE_HOME/prism/run/<hash>/pi-agent/
+// sessions/) and the sandbox-exec staging HOME ($XDG_STATE_HOME/prism/
+// sessions/<instanceID>/home/.pi/agent/sessions/, which pi never wrote to) —
+// and was therefore a silent no-op in every current isolation mode.
 //
-// In every layout only the inner `.../sessions/` subtree is removed; the
-// enclosing per-session directory (`<sessionDirHash>` or `<instanceID>/home`)
-// is preserved because other state may live alongside the transcripts.
-//
-// All path joins are anchored at $XDG_STATE_HOME/prism/{run,sessions}/, so
-// the walk never traverses outside the prism state root.
-func resetClearPiTranscripts() error {
-	stateHome := os.Getenv("XDG_STATE_HOME")
-	if stateHome == "" {
-		home, err := os.UserHomeDir()
+// Best-effort: a per-pointer removal failure is logged and the remaining
+// pointers are still processed; the first error is returned so the caller
+// can emit its aggregate warning without aborting the reset pipeline.
+func resetClearPiTranscripts(pointers []piResumePointer) error {
+	if len(pointers) == 0 {
+		fmt.Println("  no pi resume pointers recorded — nothing to remove.")
+		return nil
+	}
+	removed := 0
+	var firstErr error
+	for _, p := range pointers {
+		n, err := container.RemovePiResumeJSONLCount(container.Config{
+			SessionName:      p.sessionName,
+			Worktree:         p.worktree,
+			HarnessSessionID: p.harnessSessionID,
+		})
+		removed += n
 		if err != nil {
-			return fmt.Errorf("resolve home dir: %w", err)
+			proglog.Warnf("[prism reset] remove pi transcript for %s: %v (continuing)\n", p.sessionName, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
-		stateHome = filepath.Join(home, ".local", "state")
 	}
-	prismRoot := filepath.Join(stateHome, "prism")
-
-	removed := 0
-	// Bwrap layout: prism/run/<sessionDirHash>/pi-agent/sessions/
-	removed += removePiSessionsSubtree(filepath.Join(prismRoot, "run"), "pi-agent", "sessions")
-
-	// Sandbox-exec layout: prism/sessions/<instanceID>/home/.pi/agent/sessions/
-	removed += removePiSessionsSubtree(filepath.Join(prismRoot, "sessions"), "home", ".pi", "agent", "sessions")
-
 	if removed == 0 {
-		fmt.Println("  no pi-agent transcript subtrees found.")
+		fmt.Println("  no matching pi transcript JSONLs found.")
 	} else {
-		fmt.Printf("  removed %d pi-agent transcript subtree(s).\n", removed)
+		fmt.Printf("  removed %d pi transcript JSONL(s) for %d resume pointer(s).\n", removed, len(pointers))
 	}
-	return nil
-}
-
-// removePiSessionsSubtree iterates over the immediate children of parent (each
-// expected to be a per-session directory like `<sessionDirHash>` or
-// `<instanceID>`) and removes the `subPath...` subtree under each child. The
-// child directory itself is preserved; only the inner subtree goes.
-//
-// Missing parent / missing subtree / non-dir child are silent no-ops — reset
-// is best-effort and must never abort the rest of the pipeline.
-//
-// Returns the number of child directories under which a subtree was actually
-// removed (i.e. the subtree existed before the call).
-func removePiSessionsSubtree(parent string, subPath ...string) int {
-	entries, err := os.ReadDir(parent)
-	if err != nil {
-		return 0 // parent missing — nothing to do
-	}
-	removed := 0
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		child := filepath.Join(parent, entry.Name())
-		target := filepath.Join(append([]string{child}, subPath...)...)
-		// Confirm the target is inside the parent root — belt-and-braces
-		// against a malformed entry name like "..". filepath.Join cleans
-		// the path so any traversal would surface here.
-		rel, err := filepath.Rel(parent, target)
-		if err != nil || rel == "" || rel == "." || strings.HasPrefix(rel, "..") {
-			continue
-		}
-		if _, err := os.Stat(target); err != nil {
-			continue // subtree absent under this child
-		}
-		if err := os.RemoveAll(target); err == nil {
-			removed++
-		}
-	}
-	return removed
+	return firstErr
 }

--- a/modules/programs/prism/prism/cmd/reset_resume_e2e_test.go
+++ b/modules/programs/prism/prism/cmd/reset_resume_e2e_test.go
@@ -1,31 +1,34 @@
 package cmd
 
-// End-to-end seam test for the issue #1947 fix, updated for #1985.
+// End-to-end seam test for the issue #1947 fix, updated for #1985 and #2220.
 //
 // Pins the post-reset invariant: given a DB row with a non-empty
 // harness_session_id AND a transcript JSONL on disk, after the
 // `prism reset` DB + FS code paths run, the `--session <id>` injection
-// trigger in pi_invocation.go no longer fires — via the DB-side guard alone.
+// trigger in pi_invocation.go no longer fires — on BOTH surfaces.
 //
-// Post-#1985 update: bwrap pi sessions now write into the host's global
-// ~/.pi/agent/sessions/ tree (the per-prism-session staging dir was removed
-// to restore cross-session per-cwd history). `resetClearPiTranscripts` does
-// NOT touch that global tree — same intentional skip as host mode, because
-// the dir holds state belonging to non-prism pi invocations too. The FS
-// transcript therefore survives the reset; the DB-side `HarnessSessionID =
-// nil` clear is what prevents the resume.
+// Post-#2220 update: since #2186/#2210 pi writes its transcripts to the
+// shared host sessions root (~/.pi/agent/sessions/--<encoded-cwd>--/, or
+// $PI_CODING_AGENT_DIR/sessions/...) in every isolation mode. `prism reset`
+// snapshots the (worktree, harness_session_id) pairs from the DB before
+// clearing them and deletes exactly those *_<id>.jsonl files from the shared
+// root — per-file, never a wholesale sweep.
 //
 // Invariants pinned here:
 //
 //   (1) DB:  CurrentStatus.HarnessSessionID is nil (so cmd/agent_run.go feeds
 //       the empty string into container.Config.HarnessSessionID).
-//   (2) FS:  the transcript JSONL survives by design (matches host mode).
+//   (2) FS:  the transcript JSONL for the reset session is REMOVED from the
+//       shared root ("reset means forget"); transcripts the DB does not know
+//       about — sibling ids on the same worktree, other cwd roots — survive.
 //   (3) PIInvocation: with HarnessSessionID="" the helper short-circuits and
-//       does not append --session at all (issue #1838 contract) — this is
-//       the load-bearing half of the reset guard now.
+//       does not append --session (issue #1838 contract); and even with a
+//       stale id, ResolvePIResumeSession finds no transcript, so the flag is
+//       not emitted either — the reset guard is now double-layered.
 //
-// Host-mode behaviour has not changed and is pinned separately by
-// TestReset_E2E_HostModeUnchanged below.
+// Transcripts with no corresponding DB resume pointer (e.g. non-prism pi
+// conversations) are pinned separately by
+// TestReset_E2E_UntrackedTranscriptsSurvive below.
 
 import (
 	"os"
@@ -37,21 +40,25 @@ import (
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 )
 
-// TestReset_E2E_NoSessionFlagAfterReset is the AC8 end-to-end invariant:
-// reset \u2192 (DB cleared + FS cleared) \u2192 PIInvocation does NOT emit --session.
+// TestReset_E2E_NoSessionFlagAfterReset is the end-to-end invariant:
+// reset → (DB cleared + targeted FS removal) → PIInvocation does NOT emit
+// --session.
 func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 	clearPICodingAgentDir(t)
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
-	// Some downstream helpers (piResumeSessionsRoot host fallback,
-	// SandboxExecStagingHomePath) consult $HOME via os.UserHomeDir(). Pin
-	// it to a tempdir too so we never touch the real home.
+	// Downstream helpers (piResumeSessionsRoot host fallback) consult $HOME
+	// via os.UserHomeDir(). Pin it to a tempdir so we never touch the real
+	// home.
 	t.Setenv("HOME", t.TempDir())
 
 	const (
 		sessionName      = "myrepo@feature"
 		worktree         = "/home/user/code/myrepo/feature"
 		harnessSessionID = "019e00ed-aaaa-bbbb-cccc-deadbeef1947"
+		siblingSessionID = "019e00ed-1111-2222-3333-aaaabbbbcccc"
+		otherWorktree    = "/home/user/code/otherrepo/main"
+		otherSessionID   = "019e00ed-4444-5555-6666-777788889999"
 	)
 
 	// ---- Seed DB ----
@@ -73,23 +80,20 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 	}
 	d.Close()
 
-	// ---- Seed FS (post-#1985 bwrap layout: host-global ~/.pi/agent/sessions/) ----
-	// Pi inside the bwrap sandbox writes to $PI_CODING_AGENT_DIR/sessions/,
-	// which is overlay-bound to the host's ~/.pi/agent/sessions/. So the
-	// host-side transcript path matches host mode.
+	// ---- Seed FS (shared host root: ~/.pi/agent/sessions/) ----
 	home := os.Getenv("HOME")
-	transcriptDir := filepath.Join(home, ".pi", "agent", "sessions",
-		"--home-user-code-myrepo-feature--")
-	if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
-		t.Fatalf("mkdir transcriptDir: %v", err)
-	}
-	transcript := filepath.Join(transcriptDir, "2026-05-22T03-04-05-000Z_"+harnessSessionID+".jsonl")
-	if err := os.WriteFile(transcript, []byte(`{"type":"session"}`), 0o600); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
-	// Plant a sibling file under the legacy per-prism-session hash dir that
-	// must survive the reset — the run/<hash>/ subtree still holds
-	// agent-run.log, hostapi.sock, sidecar.pid etc.
+	// The transcript belonging to the session being reset — must be removed.
+	transcript := writeFakePiResumeJSONL(t, home, worktree, harnessSessionID)
+	// A sibling transcript in the SAME encoded-cwd dir with a different id
+	// (no DB row) — must survive: removal is per-file, not per-directory.
+	sibling := writeFakePiResumeJSONL(t, home, worktree, siblingSessionID)
+	// A transcript under a DIFFERENT cwd root with no DB row — must survive.
+	otherRoot := writeFakePiResumeJSONL(t, home, otherWorktree, otherSessionID)
+
+	// Plant a sibling file under the per-prism-session hash dir that must
+	// survive the reset — the run/<hash>/ subtree holds agent-run.log,
+	// hostapi.sock, sidecar.pid etc., and reset's transcript step no longer
+	// walks the prism state root at all.
 	hash := prismSession.SessionDirName(sessionName)
 	hashDir := filepath.Join(stateHome, "prism", "run", hash)
 	if err := os.MkdirAll(hashDir, 0o700); err != nil {
@@ -115,10 +119,11 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 	// ---- Run the reset code paths ----
 	SetTestDBPath(dbFile)
 	t.Cleanup(func() { SetTestDBPath("") })
-	if err := resetMarkDBEnded(); err != nil {
+	pointers, err := resetMarkDBEnded()
+	if err != nil {
 		t.Fatalf("resetMarkDBEnded: %v", err)
 	}
-	if err := resetClearPiTranscripts(); err != nil {
+	if err := resetClearPiTranscripts(pointers); err != nil {
 		t.Fatalf("resetClearPiTranscripts: %v", err)
 	}
 
@@ -143,13 +148,17 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 		t.Errorf("post-reset DB EndedAt = nil, want non-nil")
 	}
 
-	// (2) FS: post-#1985, the transcript JSONL SURVIVES the reset by design
-	//     (it lives in the user's global ~/.pi/agent/sessions/, which holds
-	//     state belonging to non-prism pi invocations too — same intentional
-	//     skip as host mode). The hashDir and its sibling files are also
-	//     preserved.
-	if _, err := os.Stat(transcript); err != nil {
-		t.Errorf("transcript was removed by reset; post-#1985 bwrap transcripts must survive: %v", err)
+	// (2) FS: the reset session's transcript is REMOVED from the shared root
+	//     (issue #2220: reset means forget, scoped per-id). Transcripts the
+	//     DB does not know about survive, as do the run/<hash>/ files.
+	if _, err := os.Stat(transcript); !os.IsNotExist(err) {
+		t.Errorf("reset session's transcript was not removed (stat err=%v)", err)
+	}
+	if _, err := os.Stat(sibling); err != nil {
+		t.Errorf("sibling transcript (different id, same cwd) was removed but must survive: %v", err)
+	}
+	if _, err := os.Stat(otherRoot); err != nil {
+		t.Errorf("other-root transcript was removed but must survive: %v", err)
 	}
 	if _, err := os.Stat(hashDir); err != nil {
 		t.Errorf("hashDir removed: %v", err)
@@ -158,17 +167,22 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 		t.Errorf("sibling file removed: %v", err)
 	}
 
-	// (3) container.ResolvePIResumeSession still returns true post-reset
-	//     when invoked with the stale UUID — the transcript is still there.
-	//     This is intentional: the reset guard is now the DB-side clear, not
-	//     the FS-side clear. The realistic path (next assertion) proves the
-	//     full chain is safe.
-	if !container.ResolvePIResumeSession(preCfg) {
-		t.Errorf("post-reset: ResolvePIResumeSession = false, want true " +
-			"(transcript intentionally survives reset; DB-side clear is the guard)")
+	// (3) Even a caller holding the STALE id can no longer resume: the
+	//     transcript is gone, so ResolvePIResumeSession returns false and
+	//     PIInvocation omits --session. This is the FS-side guard the
+	//     pre-#2220 sweep never actually provided.
+	if container.ResolvePIResumeSession(preCfg) {
+		t.Errorf("post-reset: ResolvePIResumeSession = true, want false (transcript must be gone)")
+	}
+	staleCfg := preCfg
+	staleCfg.InitialPrompt = "hello after reset"
+	for i, a := range container.PIInvocation(staleCfg) {
+		if a == "--session" {
+			t.Errorf("PIInvocation with stale SID emitted --session at args[%d] post-reset", i)
+		}
 	}
 
-	// (4) The realistic post-reset path \u2014 cmd/agent_run.go feeds
+	// (4) The realistic post-reset path — cmd/agent_run.go feeds
 	//     status.HarnessSessionID into container.Config. With the DB row now
 	//     carrying nil, that lowers to "". PIInvocation must NOT contain
 	//     --session in its args.
@@ -192,17 +206,18 @@ func TestReset_E2E_NoSessionFlagAfterReset(t *testing.T) {
 	}
 }
 
-// TestReset_E2E_HostModeUnchanged pins AC4: host mode is incidentally safe.
-// It does not rely on the reset code path because `prism switch` already
-// leaves opts.HarnessSessionID empty for host mode (see
-// internal/session/session.go:181-182). The test mirrors that contract by
-// constructing a host-mode container.Config (no PIAgentConfig* dirs, no
-// InstanceID) and verifying PIInvocation does not emit --session even when
-// transcripts and a DB SID still exist on disk.
+// TestReset_E2E_UntrackedTranscriptsSurvive pins the shared-root safety
+// property of the #2220 design: transcripts with NO corresponding resume
+// pointer in prism's DB — non-prism pi conversations, other repos' sessions,
+// sessions whose linkage was already severed at cleanup — survive a reset
+// untouched. The removal is keyed off DB rows, so an empty DB means zero FS
+// deletions.
 //
-// In other words: the reset fix changes bwrap / sandbox-exec behaviour; it
-// does NOT regress host mode, which was already correct.
-func TestReset_E2E_HostModeUnchanged(t *testing.T) {
+// It also pins the #1838 resume regression guard: because the untracked
+// transcript survives, a caller that (re)acquires the id can still resume —
+// reset must not break the legitimate resume path for conversations it does
+// not own.
+func TestReset_E2E_UntrackedTranscriptsSurvive(t *testing.T) {
 	clearPICodingAgentDir(t)
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
@@ -214,58 +229,49 @@ func TestReset_E2E_HostModeUnchanged(t *testing.T) {
 		harnessSessionID = "019e00ed-1111-2222-3333-444444444444"
 	)
 
-	// Plant a host-mode transcript at ~/.pi/agent/sessions/<encoded-cwd>/...
-	// (resetClearPiTranscripts intentionally does NOT touch this.)
+	// Plant a transcript at the shared root with NO DB row referencing it
+	// (e.g. a pi conversation started outside prism).
 	home := os.Getenv("HOME")
-	hostTranscriptDir := filepath.Join(home, ".pi", "agent", "sessions", "--home-user-host-repo-main--")
-	if err := os.MkdirAll(hostTranscriptDir, 0o700); err != nil {
-		t.Fatalf("mkdir host transcript: %v", err)
-	}
-	hostTranscript := filepath.Join(hostTranscriptDir, "2026-05-22_"+harnessSessionID+".jsonl")
-	if err := os.WriteFile(hostTranscript, []byte(`{}`), 0o600); err != nil {
-		t.Fatalf("write host transcript: %v", err)
-	}
+	untracked := writeFakePiResumeJSONL(t, home, worktree, harnessSessionID)
 
-	// Run the FS-side reset.
-	if err := resetClearPiTranscripts(); err != nil {
+	// Run both reset halves against an empty DB: the snapshot is empty, so
+	// the FS half must be a no-op.
+	dbFile := filepath.Join(stateHome, "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	d.Close()
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	pointers, err := resetMarkDBEnded()
+	if err != nil {
+		t.Fatalf("resetMarkDBEnded: %v", err)
+	}
+	if len(pointers) != 0 {
+		t.Fatalf("snapshot from empty DB has %d pointer(s), want 0: %+v", len(pointers), pointers)
+	}
+	if err := resetClearPiTranscripts(pointers); err != nil {
 		t.Fatalf("resetClearPiTranscripts: %v", err)
 	}
 
-	// AC4(a): the host-mode transcript is preserved (out of scope).
-	if _, err := os.Stat(hostTranscript); err != nil {
-		t.Errorf("host-mode transcript was removed by reset; reset must not touch ~/.pi/agent/sessions/: %v", err)
+	// The untracked transcript is preserved.
+	if _, err := os.Stat(untracked); err != nil {
+		t.Errorf("untracked transcript was removed by reset; reset must only delete transcripts it has resume pointers for: %v", err)
 	}
 
-	// AC4(b): the host-mode invocation path that cmd does not feed
-	// HarnessSessionID into (mirrors internal/session.buildDirectAgentCmd's
-	// opts.HarnessSessionID="" contract). PIInvocation should not emit
-	// --session for a Config with empty HarnessSessionID regardless of
-	// what is on disk.
-	hostCfg := container.Config{
-		SessionName: sessionName,
-		Worktree:    worktree,
-		// HarnessSessionID intentionally empty \u2014 host-mode switch/spawn path.
-	}
-	args := container.PIInvocation(hostCfg)
-	for i, a := range args {
-		if a == "--session" {
-			t.Errorf("PIInvocation host-mode emitted --session at args[%d]; full args=%v", i, args)
-		}
-	}
-	// Even if a caller did populate the host config with a SID, host mode
-	// resolves to ~/.pi/agent/sessions/, so the transcript is still there and
-	// resume WOULD succeed (intentional \u2014 the host-mode resume path is the
-	// regression guard described in AC5 / #1838).
-	hostCfgWithSID := container.Config{
+	// #1838 regression guard: the surviving transcript is still resumable by
+	// a caller that holds the id — PIInvocation appends --session for it.
+	cfgWithSID := container.Config{
 		SessionName:      sessionName,
 		Worktree:         worktree,
 		HarnessSessionID: harnessSessionID,
 	}
-	if !container.ResolvePIResumeSession(hostCfgWithSID) {
-		t.Errorf("AC5 regression: host-mode resume should still work after reset (the transcript survives, the host path doesn't auto-fetch the SID from the DB)")
+	if !container.ResolvePIResumeSession(cfgWithSID) {
+		t.Errorf("resume should still work for an untracked transcript after reset")
 	}
-	// And if it does get the SID, PIInvocation appends --session per #1838.
-	argsWithSID := container.PIInvocation(hostCfgWithSID)
+	argsWithSID := container.PIInvocation(cfgWithSID)
 	foundSession := false
 	for i, a := range argsWithSID {
 		if a == "--session" && i+1 < len(argsWithSID) && argsWithSID[i+1] == harnessSessionID {
@@ -274,7 +280,19 @@ func TestReset_E2E_HostModeUnchanged(t *testing.T) {
 		}
 	}
 	if !foundSession {
-		t.Errorf("AC5 regression: PIInvocation should append --session %s when host-mode transcript exists; got %v",
+		t.Errorf("PIInvocation should append --session %s when the transcript exists; got %v",
 			harnessSessionID, argsWithSID)
+	}
+
+	// And the empty-HarnessSessionID path (what `prism switch` produces for
+	// host mode) still never emits --session regardless of what is on disk.
+	hostCfg := container.Config{
+		SessionName: sessionName,
+		Worktree:    worktree,
+	}
+	for i, a := range container.PIInvocation(hostCfg) {
+		if a == "--session" {
+			t.Errorf("PIInvocation with empty HarnessSessionID emitted --session at args[%d]", i)
+		}
 	}
 }

--- a/modules/programs/prism/prism/cmd/reset_test.go
+++ b/modules/programs/prism/prism/cmd/reset_test.go
@@ -42,7 +42,7 @@ func TestResetMarkDBEnded_MarksAllNonEndedRows(t *testing.T) {
 	t.Cleanup(func() { SetTestDBPath("") })
 
 	// Run the DB cleanup step.
-	if err := resetMarkDBEnded(); err != nil {
+	if _, err := resetMarkDBEnded(); err != nil {
 		t.Fatalf("resetMarkDBEnded returned error: %v", err)
 	}
 
@@ -99,7 +99,7 @@ func TestResetMarkDBEnded_NoActiveRows(t *testing.T) {
 	t.Cleanup(func() { SetTestDBPath("") })
 
 	// Should succeed even with nothing to update.
-	if err := resetMarkDBEnded(); err != nil {
+	if _, err := resetMarkDBEnded(); err != nil {
 		t.Fatalf("resetMarkDBEnded returned error on empty active set: %v", err)
 	}
 }
@@ -117,7 +117,7 @@ func TestResetMarkDBEnded_EmptyDB(t *testing.T) {
 	SetTestDBPath(dbFile)
 	t.Cleanup(func() { SetTestDBPath("") })
 
-	if err := resetMarkDBEnded(); err != nil {
+	if _, err := resetMarkDBEnded(); err != nil {
 		t.Fatalf("resetMarkDBEnded returned error on empty DB: %v", err)
 	}
 }
@@ -155,7 +155,7 @@ func TestResetMarkDBEnded_AlreadyEndedRowsUntouched(t *testing.T) {
 	SetTestDBPath(dbFile)
 	t.Cleanup(func() { SetTestDBPath("") })
 
-	if err := resetMarkDBEnded(); err != nil {
+	if _, err := resetMarkDBEnded(); err != nil {
 		t.Fatalf("resetMarkDBEnded: %v", err)
 	}
 
@@ -185,5 +185,79 @@ func TestResetMarkDBEnded_AlreadyEndedRowsUntouched(t *testing.T) {
 	if ended.EndedAt.UnixMilli() != origEndedAt {
 		t.Errorf("ended session %q ended_at changed: got %d, want %d",
 			endedSession, ended.EndedAt.UnixMilli(), origEndedAt)
+	}
+}
+
+// TestResetMarkDBEnded_SnapshotsResumePointersBeforeClear verifies the issue
+// #2220 capture-before-clear contract: resetMarkDBEnded returns the
+// (sessionName, worktree, harness_session_id) snapshot of every row that
+// carried a resume pointer — including already-ended rows, since
+// ClearAllResumePointers wipes the column on every row — and the DB column is
+// NULL afterwards. Rows with no harness_session_id are excluded from the
+// snapshot.
+func TestResetMarkDBEnded_SnapshotsResumePointersBeforeClear(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Active row with a resume pointer.
+	if err := d.UpsertStatus("repo@active", "repo", "/wt/active", "running", nil, strPtr("sid-active")); err != nil {
+		t.Fatalf("UpsertStatus active: %v", err)
+	}
+	// Already-ended row with a resume pointer — must still be snapshotted.
+	if err := d.UpsertStatus("repo@ended", "repo", "/wt/ended", "idle", nil, strPtr("sid-ended")); err != nil {
+		t.Fatalf("UpsertStatus ended: %v", err)
+	}
+	if err := d.SetEnded("repo@ended"); err != nil {
+		t.Fatalf("SetEnded: %v", err)
+	}
+	// Row with no resume pointer — must be excluded from the snapshot.
+	if err := d.UpsertStatus("repo@nosid", "repo", "/wt/nosid", "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus nosid: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	pointers, err := resetMarkDBEnded()
+	if err != nil {
+		t.Fatalf("resetMarkDBEnded: %v", err)
+	}
+
+	got := map[string]piResumePointer{}
+	for _, p := range pointers {
+		got[p.sessionName] = p
+	}
+	if len(got) != 2 {
+		t.Fatalf("snapshot has %d pointer(s), want 2: %+v", len(got), pointers)
+	}
+	if p := got["repo@active"]; p.worktree != "/wt/active" || p.harnessSessionID != "sid-active" {
+		t.Errorf("repo@active pointer = %+v, want worktree=/wt/active sid=sid-active", p)
+	}
+	if p := got["repo@ended"]; p.worktree != "/wt/ended" || p.harnessSessionID != "sid-ended" {
+		t.Errorf("repo@ended pointer = %+v, want worktree=/wt/ended sid=sid-ended", p)
+	}
+	if _, ok := got["repo@nosid"]; ok {
+		t.Errorf("repo@nosid must not appear in the snapshot (no resume pointer): %+v", pointers)
+	}
+
+	// And the DB-side pointers are cleared AFTER the snapshot was taken.
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+	for _, name := range []string{"repo@active", "repo@ended"} {
+		st, err := d2.CurrentStatus(name)
+		if err != nil || st == nil {
+			t.Fatalf("CurrentStatus %q: %v", name, err)
+		}
+		if st.HarnessSessionID != nil {
+			t.Errorf("session %q: harness_session_id = %q, want NULL after reset",
+				name, *st.HarnessSessionID)
+		}
 	}
 }

--- a/modules/programs/prism/prism/cmd/reset_transcripts_test.go
+++ b/modules/programs/prism/prism/cmd/reset_transcripts_test.go
@@ -1,11 +1,19 @@
 package cmd
 
-// Tests for the issue #1947 reset transcript-wipe code path.
+// Tests for the `prism reset` transcript-removal code path (issue #2220,
+// superseding the dead-layout sweep from issue #1947).
 //
-// resetClearPiTranscripts removes the per-session pi-agent transcript JSONL
-// subtree under each per-session run directory (bwrap layout) and under each
-// sandbox-exec instance staging HOME. The enclosing per-session directory
-// must be preserved \u2014 only the inner `.../sessions/` subtree is removed.
+// resetClearPiTranscripts deletes exactly the *_<harness_session_id>.jsonl
+// files belonging to the snapshotted resume pointers from the shared host pi
+// sessions root (~/.pi/agent/sessions/--<encoded-cwd>--/, or
+// $PI_CODING_AGENT_DIR/sessions/... when the env var is set). The shared
+// root is NEVER swept wholesale: transcripts the DB does not know about —
+// other repos' sessions, non-prism pi conversations, sibling sessions on the
+// same worktree — must survive a reset untouched.
+//
+// Test helpers (clearPICodingAgentDir, piEncodeCWD, writeFakePiResumeJSONL)
+// are shared with the cleanup-side severance tests in
+// cleanup_pi_resume_test.go.
 
 import (
 	"os"
@@ -13,187 +21,207 @@ import (
 	"testing"
 )
 
-// TestResetClearPiTranscripts_RemovesBwrapSubtreePreservesParent is the
-// primary AC2 test for the bwrap layout:
-//
-//   <stateHome>/prism/run/<sessionDirHash>/pi-agent/sessions/...
-//
-// After resetClearPiTranscripts, the inner `pi-agent/sessions/` subtree is
-// gone, but the enclosing <sessionDirHash>/ directory is preserved (other
-// state like agent-run.log, *-sidecar.pid, hostapi.sock may live there).
-func TestResetClearPiTranscripts_RemovesBwrapSubtreePreservesParent(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+// TestResetClearPiTranscripts_RemovesExactlyTargetedJSONLs is the primary
+// issue #2220 AC test: transcripts are planted for two distinct cwd roots,
+// the reset covers only one of them, and the other root is untouched. A
+// sibling transcript with a different harness_session_id in the SAME
+// encoded-cwd directory must also survive — the removal is per-file, not
+// per-directory (matching cleanup's sever granularity).
+func TestResetClearPiTranscripts_RemovesExactlyTargetedJSONLs(t *testing.T) {
+	clearPICodingAgentDir(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	// Synthesise two per-session dirs under prism/run/ with the canonical layout:
-	//   <hash>/pi-agent/sessions/--<encoded-cwd>--/<ts>_<uuid>.jsonl
-	// and one sibling file under <hash>/ that must be preserved.
-	hashes := []string{"abc123def456", "feedfacecafe"}
-	for _, h := range hashes {
-		hashDir := filepath.Join(stateHome, "prism", "run", h)
-		// Plant a sibling file that MUST be preserved.
-		if err := os.MkdirAll(hashDir, 0o700); err != nil {
-			t.Fatalf("mkdir %s: %v", hashDir, err)
-		}
-		sibling := filepath.Join(hashDir, "agent-run.log")
-		if err := os.WriteFile(sibling, []byte("log content"), 0o600); err != nil {
-			t.Fatalf("write sibling: %v", err)
-		}
-		// Plant the transcript subtree to be removed.
-		transcriptDir := filepath.Join(hashDir, "pi-agent", "sessions", "--home-u-repo--")
-		if err := os.MkdirAll(transcriptDir, 0o700); err != nil {
-			t.Fatalf("mkdir transcripts %s: %v", transcriptDir, err)
-		}
-		transcript := filepath.Join(transcriptDir, "2026-05-22_019e00ed-1234.jsonl")
-		if err := os.WriteFile(transcript, []byte(`{"type":"session"}`), 0o600); err != nil {
-			t.Fatalf("write transcript: %v", err)
-		}
+	const (
+		wtA      = "/home/user/code/repo-a/feature"
+		wtB      = "/home/user/code/repo-b/main"
+		sidA     = "019e00ed-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		sidB     = "019e00ed-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+		sidOther = "019e00ed-cccc-cccc-cccc-cccccccccccc"
+	)
+	target := writeFakePiResumeJSONL(t, home, wtA, sidA)
+	siblingSameCwd := writeFakePiResumeJSONL(t, home, wtA, sidOther)
+	otherRoot := writeFakePiResumeJSONL(t, home, wtB, sidB)
+
+	pointers := []piResumePointer{
+		{sessionName: "repo-a@feature", worktree: wtA, harnessSessionID: sidA},
 	}
-
-	if err := resetClearPiTranscripts(); err != nil {
+	if err := resetClearPiTranscripts(pointers); err != nil {
 		t.Fatalf("resetClearPiTranscripts: %v", err)
 	}
 
-	for _, h := range hashes {
-		hashDir := filepath.Join(stateHome, "prism", "run", h)
+	// The targeted transcript is gone.
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("targeted transcript %s was not removed (stat err=%v)", target, err)
+	}
+	// The sibling transcript in the same cwd dir (different id) survives.
+	if _, err := os.Stat(siblingSameCwd); err != nil {
+		t.Errorf("sibling transcript %s was removed but must survive: %v", siblingSameCwd, err)
+	}
+	// The other cwd root is untouched.
+	if _, err := os.Stat(otherRoot); err != nil {
+		t.Errorf("other-root transcript %s was removed but must survive: %v", otherRoot, err)
+	}
+}
 
-		// (a) The hashDir itself MUST still exist (other state may live here).
-		if _, err := os.Stat(hashDir); err != nil {
-			t.Errorf("sessionDirHash %q was removed but must be preserved: %v", h, err)
-		}
+// TestResetClearPiTranscripts_MultiplePointersAllRemoved verifies that every
+// snapshotted pointer is processed: transcripts across two distinct cwd
+// roots are both removed when both sessions are being reset.
+func TestResetClearPiTranscripts_MultiplePointersAllRemoved(t *testing.T) {
+	clearPICodingAgentDir(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-		// (b) The sibling file under hashDir MUST still exist.
-		sibling := filepath.Join(hashDir, "agent-run.log")
-		if _, err := os.Stat(sibling); err != nil {
-			t.Errorf("sibling file %s under %q was removed: %v", sibling, h, err)
-		}
+	const (
+		wtA  = "/home/user/code/repo-a/feature"
+		wtB  = "/home/user/code/repo-b/main"
+		sidA = "019e00ed-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+		sidB = "019e00ed-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	)
+	transcriptA := writeFakePiResumeJSONL(t, home, wtA, sidA)
+	transcriptB := writeFakePiResumeJSONL(t, home, wtB, sidB)
 
-		// (c) The pi-agent/sessions/ subtree MUST be gone.
-		subtree := filepath.Join(hashDir, "pi-agent", "sessions")
-		if _, err := os.Stat(subtree); !os.IsNotExist(err) {
-			t.Errorf("pi-agent/sessions/ subtree under %q was not removed (stat err=%v)", h, err)
+	pointers := []piResumePointer{
+		{sessionName: "repo-a@feature", worktree: wtA, harnessSessionID: sidA},
+		{sessionName: "repo-b@main", worktree: wtB, harnessSessionID: sidB},
+	}
+	if err := resetClearPiTranscripts(pointers); err != nil {
+		t.Fatalf("resetClearPiTranscripts: %v", err)
+	}
+
+	for _, p := range []string{transcriptA, transcriptB} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("transcript %s was not removed (stat err=%v)", p, err)
 		}
 	}
 }
 
-// TestResetClearPiTranscripts_RemovesSandboxExecSubtree exercises the
-// sandbox-exec layout:
-//
-//   <stateHome>/prism/sessions/<instanceID>/home/.pi/agent/sessions/...
-//
-// The `<instanceID>/home/` directory is preserved (the staging HOME root); only
-// the `.pi/agent/sessions/` subtree under it is removed.
-func TestResetClearPiTranscripts_RemovesSandboxExecSubtree(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+// TestResetClearPiTranscripts_NoTranscriptsNoError is the issue #2220
+// edge-case AC: `prism reset` on a host with no transcripts completes
+// without error, and the sessions root is not materialised as a side
+// effect.
+func TestResetClearPiTranscripts_NoTranscriptsNoError(t *testing.T) {
+	clearPICodingAgentDir(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	const instanceID = "11111111-2222-3333-4444-555555555555"
-	homeDir := filepath.Join(stateHome, "prism", "sessions", instanceID, "home")
-	sessionsDir := filepath.Join(homeDir, ".pi", "agent", "sessions", "--home-u-repo--")
-	if err := os.MkdirAll(sessionsDir, 0o700); err != nil {
-		t.Fatalf("mkdir sessionsDir: %v", err)
+	pointers := []piResumePointer{
+		{sessionName: "repo@gone", worktree: "/wt/gone", harnessSessionID: "019e00ed-dddd"},
 	}
-	transcript := filepath.Join(sessionsDir, "2026-05-22_uuid.jsonl")
-	if err := os.WriteFile(transcript, []byte(`{}`), 0o600); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
-	// Plant a sibling file in the staging HOME that MUST be preserved.
-	sibling := filepath.Join(homeDir, ".gitconfig")
-	if err := os.WriteFile(sibling, []byte("[user]"), 0o600); err != nil {
-		t.Fatalf("write sibling: %v", err)
+	if err := resetClearPiTranscripts(pointers); err != nil {
+		t.Fatalf("resetClearPiTranscripts with no transcripts on disk: %v", err)
 	}
 
-	if err := resetClearPiTranscripts(); err != nil {
-		t.Fatalf("resetClearPiTranscripts: %v", err)
-	}
-
-	// The staging HOME root must remain.
-	if _, err := os.Stat(homeDir); err != nil {
-		t.Errorf("staging HOME %s removed but must be preserved: %v", homeDir, err)
-	}
-	// The sibling file must remain.
-	if _, err := os.Stat(sibling); err != nil {
-		t.Errorf("sibling .gitconfig removed: %v", err)
-	}
-	// The .pi/agent/sessions subtree must be gone.
-	wiped := filepath.Join(homeDir, ".pi", "agent", "sessions")
-	if _, err := os.Stat(wiped); !os.IsNotExist(err) {
-		t.Errorf(".pi/agent/sessions/ not removed (stat err=%v)", err)
+	if _, err := os.Stat(filepath.Join(home, ".pi")); !os.IsNotExist(err) {
+		t.Errorf("~/.pi materialised by resetClearPiTranscripts (stat err=%v)", err)
 	}
 }
 
-// TestResetClearPiTranscripts_MissingDirsAreNoOp verifies the defensive
-// no-op contract: when neither prism/run/ nor prism/sessions/ exists,
-// resetClearPiTranscripts returns nil and does not create them.
-func TestResetClearPiTranscripts_MissingDirsAreNoOp(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+// TestResetClearPiTranscripts_EmptyPointerListIsNoOp verifies that with no
+// resume pointers recorded in the DB, the FS half does nothing: no error,
+// and existing transcripts on the shared root are untouched.
+func TestResetClearPiTranscripts_EmptyPointerListIsNoOp(t *testing.T) {
+	clearPICodingAgentDir(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	if err := resetClearPiTranscripts(); err != nil {
-		t.Fatalf("resetClearPiTranscripts on empty stateHome: %v", err)
+	untracked := writeFakePiResumeJSONL(t, home, "/wt/untracked", "019e00ed-eeee")
+
+	if err := resetClearPiTranscripts(nil); err != nil {
+		t.Fatalf("resetClearPiTranscripts(nil): %v", err)
 	}
 
-	// Neither directory should have been created as a side effect.
-	for _, d := range []string{
-		filepath.Join(stateHome, "prism", "run"),
-		filepath.Join(stateHome, "prism", "sessions"),
-	} {
-		if _, err := os.Stat(d); !os.IsNotExist(err) {
-			t.Errorf("directory %s materialised by resetClearPiTranscripts (err=%v)", d, err)
-		}
+	if _, err := os.Stat(untracked); err != nil {
+		t.Errorf("untracked transcript %s was removed by an empty-pointer reset: %v", untracked, err)
 	}
 }
 
-// TestResetClearPiTranscripts_NoSubtreeUnderHashIsNoOp verifies that a
-// <sessionDirHash> directory without a pi-agent/sessions/ subtree (e.g. a
-// host-mode session, or a fresh dir with only agent-run.log) is left alone
-// without error.
-func TestResetClearPiTranscripts_NoSubtreeUnderHashIsNoOp(t *testing.T) {
-	stateHome := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateHome)
+// TestResetClearPiTranscripts_BlankPointerFieldsSkipped is defence-in-depth
+// for the container.RemovePiResumeJSONL caller contract: pointers with an
+// empty worktree or empty harness_session_id are silently skipped (nothing
+// to scope to), without error and without touching unrelated transcripts.
+// resetMarkDBEnded filters such rows out of the snapshot, so this guards the
+// underlying helper's behaviour should that filter ever regress.
+func TestResetClearPiTranscripts_BlankPointerFieldsSkipped(t *testing.T) {
+	clearPICodingAgentDir(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	hashDir := filepath.Join(stateHome, "prism", "run", "deadbeefcafe")
-	if err := os.MkdirAll(hashDir, 0o700); err != nil {
-		t.Fatalf("mkdir hashDir: %v", err)
+	bystander := writeFakePiResumeJSONL(t, home, "/wt/bystander", "019e00ed-ffff")
+
+	pointers := []piResumePointer{
+		{sessionName: "repo@no-worktree", worktree: "", harnessSessionID: "019e00ed-1111"},
+		{sessionName: "repo@no-sid", worktree: "/wt/bystander", harnessSessionID: ""},
 	}
-	keep := filepath.Join(hashDir, "agent-run.log")
-	if err := os.WriteFile(keep, []byte("log"), 0o600); err != nil {
-		t.Fatalf("write keep: %v", err)
+	if err := resetClearPiTranscripts(pointers); err != nil {
+		t.Fatalf("resetClearPiTranscripts with blank-field pointers: %v", err)
 	}
 
-	if err := resetClearPiTranscripts(); err != nil {
-		t.Fatalf("resetClearPiTranscripts: %v", err)
-	}
-
-	if _, err := os.Stat(hashDir); err != nil {
-		t.Errorf("hashDir removed: %v", err)
-	}
-	if _, err := os.Stat(keep); err != nil {
-		t.Errorf("keep file removed: %v", err)
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("bystander transcript %s was removed: %v", bystander, err)
 	}
 }
 
-// TestResetClearPiTranscripts_NonDirChildIsSkipped guards against a stray
-// regular file under prism/run/ being interpreted as a session dir. The
-// helper must filepath.Join(parent, ...) → stat → skip without erroring.
-func TestResetClearPiTranscripts_NonDirChildIsSkipped(t *testing.T) {
+// TestResetClearPiTranscripts_DeadLayoutsNotSwept pins the removal of the
+// pre-#2220 dead-layout sweeps. The old implementation deleted
+// $XDG_STATE_HOME/prism/run/<hash>/pi-agent/sessions/ (pre-#1985 bwrap
+// layout) and $XDG_STATE_HOME/prism/sessions/<instanceID>/home/.pi/agent/
+// sessions/ (sandbox-exec staging HOME). Both trees are planted here and
+// must survive a reset that DOES remove a targeted shared-root transcript —
+// proving the test is not vacuous and that reset no longer walks the prism
+// state root at all.
+func TestResetClearPiTranscripts_DeadLayoutsNotSwept(t *testing.T) {
+	clearPICodingAgentDir(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)
 
-	runDir := filepath.Join(stateHome, "prism", "run")
-	if err := os.MkdirAll(runDir, 0o700); err != nil {
-		t.Fatalf("mkdir runDir: %v", err)
+	// Dead layout 1: pre-#1985 bwrap run-dir layout.
+	bwrapLegacy := filepath.Join(stateHome, "prism", "run", "abc123def456", "pi-agent", "sessions", "--wt--")
+	if err := os.MkdirAll(bwrapLegacy, 0o700); err != nil {
+		t.Fatalf("mkdir bwrap legacy: %v", err)
 	}
-	stray := filepath.Join(runDir, "stray-file.txt")
-	if err := os.WriteFile(stray, []byte("oops"), 0o600); err != nil {
-		t.Fatalf("write stray: %v", err)
+	bwrapLegacyFile := filepath.Join(bwrapLegacy, "2026-01-02_legacy.jsonl")
+	if err := os.WriteFile(bwrapLegacyFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write bwrap legacy: %v", err)
 	}
 
-	if err := resetClearPiTranscripts(); err != nil {
+	// Dead layout 2: sandbox-exec staging HOME.
+	stagingLegacy := filepath.Join(stateHome, "prism", "sessions", "11111111-2222-3333-4444-555555555555",
+		"home", ".pi", "agent", "sessions", "--wt--")
+	if err := os.MkdirAll(stagingLegacy, 0o700); err != nil {
+		t.Fatalf("mkdir staging legacy: %v", err)
+	}
+	stagingLegacyFile := filepath.Join(stagingLegacy, "2026-01-02_legacy.jsonl")
+	if err := os.WriteFile(stagingLegacyFile, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write staging legacy: %v", err)
+	}
+
+	// A live shared-root transcript targeted by the reset (non-vacuity
+	// anchor: the function must do real work in this run).
+	const (
+		wt  = "/home/user/code/repo/main"
+		sid = "019e00ed-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	)
+	target := writeFakePiResumeJSONL(t, home, wt, sid)
+
+	pointers := []piResumePointer{
+		{sessionName: "repo@main", worktree: wt, harnessSessionID: sid},
+	}
+	if err := resetClearPiTranscripts(pointers); err != nil {
 		t.Fatalf("resetClearPiTranscripts: %v", err)
 	}
 
-	if _, err := os.Stat(stray); err != nil {
-		t.Errorf("stray file removed unexpectedly: %v", err)
+	// The shared-root target is gone (the function ran for real)…
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Errorf("targeted transcript %s was not removed (stat err=%v)", target, err)
+	}
+	// …and both dead-layout trees are untouched.
+	if _, err := os.Stat(bwrapLegacyFile); err != nil {
+		t.Errorf("pre-#1985 bwrap layout was swept but the sweep should be gone: %v", err)
+	}
+	if _, err := os.Stat(stagingLegacyFile); err != nil {
+		t.Errorf("sandbox-exec staging HOME layout was swept but the sweep should be gone: %v", err)
 	}
 }

--- a/modules/programs/prism/prism/internal/container/pi_invocation.go
+++ b/modules/programs/prism/prism/internal/container/pi_invocation.go
@@ -296,31 +296,52 @@ func piResumeHostSessionsRoot() (string, bool) {
 // the same worktree path (e.g. the legitimate-resume case in #1838 where a
 // still-active session is being restarted) must not be touched.
 func RemovePiResumeJSONL(cfg Config) error {
+	_, err := RemovePiResumeJSONLCount(cfg)
+	return err
+}
+
+// RemovePiResumeJSONLCount is RemovePiResumeJSONL additionally reporting the
+// number of transcript files actually removed. The error semantics, scoping
+// and best-effort contract are identical to RemovePiResumeJSONL (which is a
+// thin wrapper over this function) — see its doc comment for the full
+// reference.
+//
+// The count exists for callers that aggregate removals across many sessions
+// and want honest summary output: `prism reset` (issue #2220) snapshots every
+// (worktree, harness_session_id) pair being reset and removes exactly those
+// transcripts from the shared host sessions root, reporting the total. The
+// per-session cleanup paths keep using the error-only wrapper.
+func RemovePiResumeJSONLCount(cfg Config) (int, error) {
 	if cfg.HarnessSessionID == "" || cfg.Worktree == "" {
-		return nil
+		return 0, nil
 	}
 	root, ok := piResumeSessionsRoot(cfg)
 	if !ok {
-		return nil
+		return 0, nil
 	}
 	cwdDir := filepath.Join(root, encodePiCWD(cfg.Worktree))
 	entries, err := os.ReadDir(cwdDir)
 	if err != nil {
 		// Missing dir / unreadable — nothing to do. Cleanup is best-effort.
-		return nil
+		return 0, nil
 	}
 	suffix := "_" + cfg.HarnessSessionID + ".jsonl"
+	removed := 0
 	var firstErr error
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), suffix) {
 			continue
 		}
 		path := filepath.Join(cwdDir, e.Name())
-		if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) && firstErr == nil {
-			firstErr = fmt.Errorf("remove pi resume jsonl %s: %w", path, rmErr)
+		if rmErr := os.Remove(path); rmErr != nil {
+			if !os.IsNotExist(rmErr) && firstErr == nil {
+				firstErr = fmt.Errorf("remove pi resume jsonl %s: %w", path, rmErr)
+			}
+			continue
 		}
+		removed++
 	}
-	return firstErr
+	return removed, firstErr
 }
 
 // encodePiCWD mirrors internal/harness/pi.EncodePiCWD: pi's session-dir naming


### PR DESCRIPTION
Closes #2220

## Design decision: option 3 (per-id deletion keyed off DB rows)

Per the issue's directive, `prism reset`'s FS half now enumerates the resume pointers being reset from the DB and deletes exactly those `*_<harness_session_id>.jsonl` files from the shared host pi sessions root — the same per-file granularity as cleanup's sever (`severPiResumeLinkage`), via the same `container.RemovePiResumeJSONL` mechanism.

**Contract check (gate from the spawn prompt):** no documented promise contradicts option 3.
- The `--help`/`Long` text promised "remove pi-agent transcript JSONLs" — option 3 still honours that, precisely scoped (wording updated to match).
- #1947's documented decision is "Reset means forget … both the DB resume-pointer and the on-disk transcripts go away for every ended session" — option 3 matches "for every ended session" exactly. #1947's ACs named the `$XDG_STATE_HOME/prism/run/...` layout, which is the dead layout #2220 supersedes.
- No `docs/` reference documents a reset transcript contract.

**Reset deletes WITHOUT archiving — reasoning (per spawn prompt):** #1947's documented intent is "reset means forget", a destructive surface; no archiving is promised anywhere. Cleanup remains the lifecycle path that preserves history (archive-then-sever, #2219). This split is now stated explicitly in `resetClearPiTranscripts`'s doc comment. No archiving scope added.

**Mode note:** the snapshot is mode-agnostic — any row with a non-empty `harness_session_id` + worktree is covered (the DB half, `ClearAllResumePointers`, was already mode-agnostic; the FS half now matches its scope, ended rows included). Non-prism pi conversations have no DB row and are untouched, preserving the original "don't touch state belonging to non-prism pi invocations" concern that ruled out a wholesale sweep.

## Changes

- **`cmd/reset.go`**
  - `resetMarkDBEnded` now snapshots `(sessionName, worktree, harness_session_id)` from every `agent_status` row (via `AllStatusesWithPrefix("")`, active + ended) BEFORE `ClearAllResumePointers` nulls the column — mirroring cleanup's capture-before-clear pattern — and returns the snapshot.
  - `resetClearPiTranscripts(pointers)` deletes exactly the snapshotted ids from the shared root via `container.RemovePiResumeJSONLCount`; per-pointer failures are logged and the rest still run.
  - The dead-layout sweeps (`removePiSessionsSubtree`, pre-#1985 bwrap run-dir + sandbox-exec staging HOME) are **removed** — they were a silent no-op for every current isolation mode.
  - Top-of-file doc, `--help` Long text, and step comments updated.
- **`internal/container/pi_invocation.go`** (sanctioned generalisation, this file only): `RemovePiResumeJSONL` is now a thin wrapper over a new `RemovePiResumeJSONLCount` which additionally reports how many files were removed, so reset can emit honest aggregate output. Identical scoping/error semantics; cleanup call sites unchanged.
- **Tests**
  - `cmd/reset_transcripts_test.go` rewritten: exact-targeting (two cwd roots + sibling-id survival), multi-pointer removal, no-transcripts-no-error (root not materialised), empty-pointer no-op, blank-field defence, and a dead-layouts-not-swept pin (non-vacuous: anchored on a real shared-root deletion in the same run).
  - `cmd/reset_resume_e2e_test.go` updated to the new contract: the reset session's transcript is now REMOVED (the old test pinned survival of the pre-#2220 skip), `--session` is suppressed on both surfaces (DB nil AND stale-id-with-missing-file), untracked transcripts survive, and the #1838 resume regression guard is retained (`TestReset_E2E_UntrackedTranscriptsSurvive`).
  - `cmd/reset_test.go`: call sites updated for the new signature + new `TestResetMarkDBEnded_SnapshotsResumePointersBeforeClear` (snapshot covers ended rows, excludes pointer-less rows, column NULL afterwards).

## Acceptance criteria (finalised in the issue)

- ✅ [functional] Reset snapshots resume pointers before the DB clear and deletes exactly those `*_<id>.jsonl` files from the shared root — `TestResetClearPiTranscripts_RemovesExactlyTargetedJSONLs` plants two distinct cwd roots and asserts the other root (and a sibling id in the same root) is untouched.
- ✅ [functional] Transcripts with no DB resume pointer survive — `TestReset_E2E_UntrackedTranscriptsSurvive`, `TestResetClearPiTranscripts_EmptyPointerListIsNoOp`.
- ✅ [functional] Dead-layout sweeps removed — code deleted; pinned by `TestResetClearPiTranscripts_DeadLayoutsNotSwept`.
- ✅ [edge-case] No transcripts on host → no error, sessions root not materialised — `TestResetClearPiTranscripts_NoTranscriptsNoError`.
- ✅ [functional] Design choice + rationale recorded (this description).

## Verification

- `go build ./...` and `go vet` — clean. My files are `gofmt`-clean (a number of pre-existing files repo-wide are flagged by my local gofmt version; untouched).
- `go test ./... -race` (CI's invocation) — fully green on 5 of 6 full runs (plus repeated targeted `-race` runs of `./cmd/` and `./internal/container/`). The intermittent failures were identified as two **pre-existing live-host isolation tripwires**, escalated informationally to the coordinator: the cmd suite LEAK GUARD (#2214) flagging a tmux session created by a *parallel worker's live review agent* mid-run, and `internal/sidecar` `TestNotifyInvestigatorCompletion_NoHostBusLeak` racing against live sidecars writing the real `prism.db`. Neither file intersects this diff, and neither fires on CI runners (no live tmux server / sidecars). Rebased onto `39d7ca3e` (#2225) and re-verified green.
- Non-vacuity check: temporarily neutered `resetClearPiTranscripts` to simulate the pre-#2220 silent no-op → `TestReset_E2E_NoSessionFlagAfterReset`, `RemovesExactlyTargetedJSONLs`, `MultiplePointersAllRemoved`, `DeadLayoutsNotSwept` all FAIL; restored the fix → all PASS.
- Pre-PR nix check: this sandbox pre-dates #2201, so `nix build .#prism` fails on `trusted-settings.json` (`Operation not permitted`). Ran the sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — evaluates cleanly. CI's `nix-build-prism-checked` is the authoritative homeless-shelter gate.

## Scope notes (parallel-work awareness)

Footprint: `cmd/reset.go` + its three test files, plus the sanctioned `RemovePiResumeJSONLCount` generalisation confined to `internal/container/pi_invocation.go`. `cmd/cleanup.go`, `cmd/tmux_isolation_test.go`, `internal/container/sandbox_exec_home.go`, and `internal/container/container.go` untouched. No TestMain-level isolation changes were needed — the reset tests pin `HOME`/`XDG_STATE_HOME`/`PI_CODING_AGENT_DIR` per-test via `t.Setenv`.

