### PR TITLE
prism: fix isolation tripwires that false-positive on live-host activity (#2227)

### DIFF
--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -62,16 +62,21 @@ import (
 //     overrides XDG_STATE_HOME), so it reliably reads the production
 //     database. The guard's original live-tmux-server session diff was
 //     dropped in #2227: since the suite-wide tmux isolation (#2214/#2224)
-//     the code under test cannot reach the live server by construction, so
-//     a live-server diff could only ever observe concurrent host activity
-//     (e.g. a parallel worker's review agents spawning mid-suite) and
-//     misattribute it to the suite — a false positive at ~1-in-6 full-suite
-//     runs on a multi-worker host. Isolation regressions are instead caught
-//     deterministically by TestSuiteTmuxIsolation_HostServerUnreachable
-//     (tmux_isolation_test.go). The DB-row and worktree diffs are retained
-//     because no equivalent by-construction isolation exists for them
-//     (tests opt in per-test via XDG_STATE_HOME / SetTestDBPath /
-//     PRISM_SPAWN_PATH overrides).
+//     THIS package's code under test cannot reach the live server by
+//     construction, so for cmd/ a live-server diff could only observe
+//     concurrent host activity (e.g. a parallel worker's review agents
+//     spawning mid-suite) and misattribute it to the suite — a false
+//     positive at ~1-in-6 full-suite runs on a multi-worker host. cmd/
+//     isolation regressions are instead caught deterministically by
+//     TestSuiteTmuxIsolation_HostServerUnreachable (tmux_isolation_test.go).
+//     One residual: the diff had also incidentally caught a CROSS-package
+//     leak (#1732, internal/review) via parallel `go test ./...` window
+//     overlap; that signal was indistinguishable from the false-positive
+//     class (both are live `*~review-N-review-*` sessions) and is gone —
+//     #2230 tracks #2224-style suite-wide isolation for internal/review.
+//     The DB-row and worktree diffs are retained because no equivalent
+//     by-construction isolation exists for them (tests opt in per-test via
+//     XDG_STATE_HOME / SetTestDBPath / PRISM_SPAWN_PATH overrides).
 //
 //  4. Tmux isolation (#2214): clears $TMUX and redirects $TMUX_TMPDIR to an
 //     empty directory so no code under test can reach the live host tmux

--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -54,20 +54,30 @@ import (
 //     test binary mid-run — t.Cleanup will not fire in that case, but the
 //     SIGTERM handler will.
 //
-//  3. Leak guard (#1180): snapshots the live tmux server's session list and
-//     the live agent_status and sessions tables before running tests, then
-//     asserts no new entries appear after the suite completes. This catches
-//     any test that creates real sessions in the live environment. The guard
-//     uses the DB path that was live at suite start (before any test overrides
-//     XDG_STATE_HOME), so it reliably reads the production database.
+//  3. Leak guard (#1180): snapshots the live agent_status and sessions
+//     tables and the live worktree root before running tests, then asserts
+//     no new entries appear after the suite completes. This catches any test
+//     that creates real DB rows or worktrees in the live environment. The
+//     guard uses the DB path that was live at suite start (before any test
+//     overrides XDG_STATE_HOME), so it reliably reads the production
+//     database. The guard's original live-tmux-server session diff was
+//     dropped in #2227: since the suite-wide tmux isolation (#2214/#2224)
+//     the code under test cannot reach the live server by construction, so
+//     a live-server diff could only ever observe concurrent host activity
+//     (e.g. a parallel worker's review agents spawning mid-suite) and
+//     misattribute it to the suite — a false positive at ~1-in-6 full-suite
+//     runs on a multi-worker host. Isolation regressions are instead caught
+//     deterministically by TestSuiteTmuxIsolation_HostServerUnreachable
+//     (tmux_isolation_test.go). The DB-row and worktree diffs are retained
+//     because no equivalent by-construction isolation exists for them
+//     (tests opt in per-test via XDG_STATE_HOME / SetTestDBPath /
+//     PRISM_SPAWN_PATH overrides).
 //
-//  4. Tmux isolation (#2214): after taking the leak-guard before-snapshots,
-//     clears $TMUX and redirects $TMUX_TMPDIR to an empty directory so no
-//     code under test can reach the live host tmux server via the
-//     default-socket fallback (tmux.CurrentSession et al.). See
-//     tmux_isolation_test.go for the full rationale. The original
-//     environment is restored after m.Run() so the leak-guard
-//     after-snapshots consult the same live server as the before-snapshots.
+//  4. Tmux isolation (#2214): clears $TMUX and redirects $TMUX_TMPDIR to an
+//     empty directory so no code under test can reach the live host tmux
+//     server via the default-socket fallback (tmux.CurrentSession et al.).
+//     See tmux_isolation_test.go for the full rationale. The original
+//     environment is restored after m.Run().
 //
 //  5. Sandbox-env isolation (#2217): unsets the PRISM_* variables the
 //     sidecar injects into agent sessions (PRISM_SESSION_NAME,
@@ -95,13 +105,11 @@ func TestMain(m *testing.M) {
 	// Leak guard: snapshot live environment before tests.
 	// Capture the DB path now, before any test overrides XDG_STATE_HOME.
 	liveDBPath := dbPath()
-	beforeSessions := snapshotTmuxSessions()
 	beforeAgentStatusRows := snapshotAgentStatusRows(liveDBPath)
 	beforeSessionsRows := snapshotSessionsRows(liveDBPath)
 	beforeWorktrees := snapshotWorktreeDirs()
 
-	// Tmux isolation (#2214): applied after the before-snapshots above (they
-	// must see the real live server), undone before the after-snapshots below.
+	// Tmux isolation (#2214).
 	restoreTmuxEnv := isolateSuiteFromHostTmux()
 	// Sandbox-env isolation (#2217): unset the sidecar-injected PRISM_* vars
 	// so the suite controls its full environment surface.
@@ -117,20 +125,9 @@ func TestMain(m *testing.M) {
 	// have left intentional state, and we don't want to obscure the primary
 	// failure with a secondary leak report.
 	if code == 0 {
-		afterSessions := snapshotTmuxSessions()
 		afterAgentStatusRows := snapshotAgentStatusRows(liveDBPath)
 		afterSessionsRows := snapshotSessionsRows(liveDBPath)
 		afterWorktrees := snapshotWorktreeDirs()
-		if leaked := setDiff(afterSessions, beforeSessions); len(leaked) > 0 {
-			fmt.Fprintf(os.Stderr,
-				"\n[LEAK GUARD] cmd test suite created %d new live tmux session(s):\n",
-				len(leaked))
-			for _, s := range leaked {
-				fmt.Fprintf(os.Stderr, "  - %s\n", s)
-			}
-			fmt.Fprintln(os.Stderr, "Fix: ensure tests use withNoopTmux() or an isolated test server.")
-			code = 1
-		}
 		if leaked := setDiff(afterAgentStatusRows, beforeAgentStatusRows); len(leaked) > 0 {
 			fmt.Fprintf(os.Stderr,
 				"\n[LEAK GUARD] cmd test suite created %d new live agent_status row(s):\n",
@@ -164,23 +161,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
-}
-
-// snapshotTmuxSessions returns the sorted list of session names in the live
-// tmux server, or nil if tmux is not running.
-func snapshotTmuxSessions() []string {
-	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
-	if err != nil {
-		return nil // tmux server not running — treat as empty
-	}
-	var names []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line != "" {
-			names = append(names, line)
-		}
-	}
-	sort.Strings(names)
-	return names
 }
 
 // snapshotAgentStatusRows returns the sorted list of session_names in

--- a/modules/programs/prism/prism/cmd/tmux_isolation_test.go
+++ b/modules/programs/prism/prism/cmd/tmux_isolation_test.go
@@ -62,9 +62,16 @@ import (
 
 // isolateSuiteFromHostTmux applies the suite-wide tmux neutralisation
 // described above and returns a restore function that puts the original
-// environment back. TestMain calls restore after m.Run() so the #1180 leak
-// guard's after-snapshots consult the same live server as its
-// before-snapshots.
+// environment back. TestMain calls restore after m.Run() so the test
+// process leaves the environment as it found it.
+//
+// Because this isolation makes the live host server unreachable from code
+// under test by construction, the #1180 leak guard's live-tmux-server
+// before/after session diff was dropped (#2227): it could no longer catch a
+// suite leak — only misattribute concurrent host activity (parallel
+// workers' spawns and review rounds) to the suite. The deterministic
+// regression guard for this isolation is
+// TestSuiteTmuxIsolation_HostServerUnreachable below.
 func isolateSuiteFromHostTmux() (restore func()) {
 	origTmux, hadTmux := os.LookupEnv("TMUX")
 	origTmpdir, hadTmpdir := os.LookupEnv("TMUX_TMPDIR")

--- a/modules/programs/prism/prism/cmd/tmux_isolation_test.go
+++ b/modules/programs/prism/prism/cmd/tmux_isolation_test.go
@@ -65,12 +65,15 @@ import (
 // environment back. TestMain calls restore after m.Run() so the test
 // process leaves the environment as it found it.
 //
-// Because this isolation makes the live host server unreachable from code
-// under test by construction, the #1180 leak guard's live-tmux-server
-// before/after session diff was dropped (#2227): it could no longer catch a
-// suite leak — only misattribute concurrent host activity (parallel
-// workers' spawns and review rounds) to the suite. The deterministic
-// regression guard for this isolation is
+// Because this isolation makes the live host server unreachable from this
+// package's code under test by construction, the #1180 leak guard's
+// live-tmux-server before/after session diff was dropped (#2227): it could
+// no longer catch a leak from THIS package — only misattribute concurrent
+// host activity (parallel workers' spawns and review rounds) to the suite,
+// or incidentally observe another package's leak during parallel
+// `go test ./...` window overlap (#1732 — a class now tracked by #2230,
+// which proposes this same isolation pattern for internal/review). The
+// deterministic regression guard for this package's isolation is
 // TestSuiteTmuxIsolation_HostServerUnreachable below.
 func isolateSuiteFromHostTmux() (restore func()) {
 	origTmux, hadTmux := os.LookupEnv("TMUX")

--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2145,9 +2145,13 @@ func TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort(t *testing.T) {
 	// default tmux server. Without this, SpawnSession's tmux-new-session
 	// call lands on the live tmux server and the post-readiness-gate
 	// cleanup (`tmux.KillSession`, best-effort) can leak the 5 review-agent
-	// sessions under parallel `go test ./...` scheduling — picked up by the
-	// cmd/-package TestMain leak guard as `nixos-config@require-slot-ok~
-	// review-1-review-{role}` (#1732, regression introduced by #1728).
+	// sessions — exactly what happened in #1732 (regression introduced by
+	// #1728), back then caught incidentally by the cmd/-package leak guard
+	// under parallel `go test ./...` scheduling. That guard's live-tmux
+	// session diff was dropped in #2227 (it false-positived on concurrent
+	// host activity), so this per-test stub is now the ONLY line of defence
+	// against this leak class — there is no cross-package backstop. #2230
+	// tracks adding #2224-style suite-wide tmux isolation to this package.
 	//
 	// Uses spawnSpyTmuxBin from spawn_prompt_file_test.go — the canonical
 	// tmux-isolation pattern in this package. Must NOT call t.Parallel:

--- a/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/notify_investigate_test.go
@@ -14,8 +14,8 @@
 package sidecar
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -450,37 +450,32 @@ func TestInvestigatorNoIntermediatePings(t *testing.T) {
 // TestNotifyInvestigatorCompletion_NoHostBusLeak asserts that constructing a
 // sidecar with a session name that looks like a real coordinator
 // ("nixos-config@main~investigate-leakcheck") against an isolated DB + bus
-// does NOT write any file under the process-default $XDG_STATE_HOME/prism/
-// path (i.e. the path that would be used if the test had NOT set the env var).
+// cannot touch the real host prism state, and that the delivery lands on the
+// isolated httptest.Server.
 //
 // This is the "defence in depth" test for issue #1608: it verifies that the
 // isolation invariants hold even when the test session name collides with a
 // live coordinator slug.
+//
+// Isolation is asserted BY CONSTRUCTION — every path the sidecar can write
+// through (resolved DB path, host-API socket path, $XDG_STATE_HOME-derived
+// resolution) must reside under the test-scoped XDG_STATE_HOME tempdir and
+// must not reside under the real host state dir. Earlier versions of this
+// test instead observed host quiescence (snapshotting the real prism/run/
+// directory and probing the real prism.db mtime before/after the test). On a
+// multi-worker host those probes raced live sidecars: any concurrent session
+// writing the real prism.db during the test window tripped the mtime check,
+// a false positive that asserted "the host is quiet", not "this test is
+// isolated" (issue #2227). Path-comparison assertions are race-free and hold
+// regardless of concurrent host activity.
 func TestNotifyInvestigatorCompletion_NoHostBusLeak(t *testing.T) {
-	// Capture the real XDG_STATE_HOME *before* NewIsolated redirects it.
-	// We need to record this now so we can verify it's untouched after the test.
-	//
-	// Unlike the other tests in this file, this one *intentionally* references
-	// the real host path: its whole purpose is to prove that NewIsolated
-	// prevents writes from leaking to ~/.local/state/prism/ on the developer's
-	// host (the exact failure mode of issue #1608). Refactoring this to
-	// t.TempDir() would degenerate the test into "an empty temp dir stays
-	// empty", which proves nothing about the host-leak invariant.
-	//
-	// In sandboxed environments where XDG_STATE_HOME is unset (notably the
-	// nix-build sandbox where HOME=/homeless-shelter), there is no meaningful
-	// host path to protect — skip rather than fall back to UserHomeDir, which
-	// would resolve to /homeless-shelter/.local/state and reintroduce the
-	// inconsistency this test was meant to guard against (see issue #1857).
+	// Capture the real XDG_STATE_HOME *before* NewIsolated redirects it, so we
+	// can assert nothing resolves under it. It may legitimately be unset (CI,
+	// nix sandbox where HOME=/homeless-shelter — issue #1857); the
+	// by-construction assertions below don't need a real host path to exist,
+	// so the real-path comparisons are simply skipped in that case rather than
+	// falling back to UserHomeDir.
 	realXDGStateHome := os.Getenv("XDG_STATE_HOME")
-	if realXDGStateHome == "" {
-		t.Skip("test requires XDG_STATE_HOME to be set; it verifies that NewIsolated does not leak writes to the real host state directory, which is only meaningful when a real host path exists")
-	}
-	realPrismDir := realXDGStateHome + "/prism"
-
-	// Record the current state of the real prism/ directory before the test.
-	beforeSnapshot := snapshotDirNames(realPrismDir + "/run")
-	beforeDBMtime := fileModTime(realPrismDir + "/prism.db")
 
 	// Use a session name that matches a real coordinator slug — this is the
 	// exact scenario that caused the observed leak in issue #1608. The
@@ -509,25 +504,48 @@ func TestNotifyInvestigatorCompletion_NoHostBusLeak(t *testing.T) {
 	}
 	s := New(cfg)
 
+	// ── Isolation by construction (#2227) ──────────────────────────────────
+
+	// The env redirect must be in effect: any code that resolves prism paths
+	// from $XDG_STATE_HOME during this test lands in the tempdir.
+	if got := os.Getenv("XDG_STATE_HOME"); got != bus.XDGStateHome {
+		t.Fatalf("XDG_STATE_HOME = %q, want test-scoped %q — NewIsolated env redirect not in effect", got, bus.XDGStateHome)
+	}
+	if realXDGStateHome != "" && bus.XDGStateHome == realXDGStateHome {
+		t.Fatalf("test-scoped XDG_STATE_HOME equals the real host value %q — no isolation", realXDGStateHome)
+	}
+
+	// The sidecar's resolved DB path must reside under the test-scoped
+	// XDG_STATE_HOME. This is the by-construction replacement for the old
+	// real-prism.db mtime probe.
+	if dbPath := cfg.DB.Path(); !pathWithin(dbPath, bus.XDGStateHome) {
+		t.Errorf("test sidecar DB path %q resolves outside the test-scoped XDG_STATE_HOME %q — DB isolation breach", dbPath, bus.XDGStateHome)
+	} else if realXDGStateHome != "" && pathWithin(dbPath, realXDGStateHome) {
+		t.Errorf("test sidecar DB path %q resolves under the real host XDG_STATE_HOME %q — DB isolation breach", dbPath, realXDGStateHome)
+	}
+
+	// The host-API socket the bus listens on (the socket-pipe delivery path)
+	// must also reside under the test-scoped XDG_STATE_HOME — the
+	// by-construction replacement for the old real prism/run/ snapshot.
+	if !pathWithin(bus.SockPath, bus.XDGStateHome) {
+		t.Errorf("host-API socket path %q resolves outside the test-scoped XDG_STATE_HOME %q — socket isolation breach", bus.SockPath, bus.XDGStateHome)
+	} else if realXDGStateHome != "" && pathWithin(bus.SockPath, realXDGStateHome) {
+		t.Errorf("host-API socket path %q resolves under the real host XDG_STATE_HOME %q — socket isolation breach", bus.SockPath, realXDGStateHome)
+	}
+
+	// ── Delivery routing ────────────────────────────────────────────────────
+
 	s.notifyInvestigatorCompletion(agent.StateFinished, "leakcheck findings")
-
-	// Give async delivery a moment to settle.
-	time.Sleep(200 * time.Millisecond)
-
-	// Assert: the real prism/run/ directory is unchanged (no socket files created).
-	afterSnapshot := snapshotDirNames(realPrismDir + "/run")
-	if beforeSnapshot != afterSnapshot {
-		t.Errorf("real $XDG_STATE_HOME/prism/run/ changed during test:\nbefore: %q\nafter:  %q\nThis indicates isolation breach — test wrote to host prism state.", beforeSnapshot, afterSnapshot)
-	}
-
-	// Assert: the real prism.db mtime is unchanged (no writes to the real DB).
-	afterDBMtime := fileModTime(realPrismDir + "/prism.db")
-	if beforeDBMtime != afterDBMtime {
-		t.Errorf("real prism.db mtime changed during test (before=%d after=%d) — DB isolation breach", beforeDBMtime, afterDBMtime)
-	}
 
 	// Assert: all HTTP traffic went to the isolated httptest.Server.
 	// The delivery must have been captured — not dropped silently.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(bus.CopyBodies()) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	bodies := bus.CopyBodies()
 	if len(bodies) == 0 {
 		t.Error("expected delivery to be captured by the isolated httptest.Server, got none — delivery was either dropped or escaped to host")
@@ -569,27 +587,13 @@ func seedEndedSessionInvestigate(t *testing.T, database *db.DB, sessionName, rep
 
 // ── OS helpers ────────────────────────────────────────────────────────────────
 
-// snapshotDirNames returns a sorted string of all filenames in dir (non-recursive,
-// first level only). Returns "" if the directory does not exist or cannot be read.
-func snapshotDirNames(dir string) string {
-	entries, err := os.ReadDir(dir)
+// pathWithin reports whether path resides inside dir (or equals it). Pure
+// lexical comparison — no filesystem access, so it cannot race concurrent
+// host activity (#2227).
+func pathWithin(path, dir string) bool {
+	rel, err := filepath.Rel(dir, path)
 	if err != nil {
-		// Directory doesn't exist — return empty (no files to change).
-		return ""
+		return false
 	}
-	var names []string
-	for _, e := range entries {
-		names = append(names, fmt.Sprintf("%s:%v", e.Name(), e.IsDir()))
-	}
-	return strings.Join(names, ",")
-}
-
-// fileModTime returns the modification time of path as Unix nanoseconds.
-// Returns 0 if the file does not exist.
-func fileModTime(path string) int64 {
-	info, err := os.Stat(path)
-	if err != nil {
-		return 0
-	}
-	return info.ModTime().UnixNano()
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/modules/programs/prism/prism/internal/sidecar/sidecartest/sidecartest.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecartest/sidecartest.go
@@ -98,7 +98,9 @@ func (b *Bus) CopyBodies() []string {
 //     redirected to the tempdir.
 //   - Sets PRISM_TEST_MODE_RESTRICT_HOSTAPI=1 so deliverViaSidecarSocket
 //     refuses to dial sockets outside the tempdir.
-//   - Opens an isolated SQLite DB under a private os.MkdirTemp() directory.
+//   - Opens an isolated SQLite DB at $XDG_STATE_HOME/prism/prism.db (the
+//     production-resolved path under the redirected tempdir), so tests can
+//     assert DB isolation by construction via Bus.DB.Path().
 //   - Starts an httptest.Server that records received prompt bodies.
 //   - Starts a Unix-socket listener at the test-session hostapi.sock path so
 //     that the socket-pipe delivery path is also exercised in-process.
@@ -126,21 +128,21 @@ func NewIsolated(t *testing.T, invokerSession string) *Bus {
 	//    dial sockets outside the tempdir.
 	t.Setenv(EnvRestrictHostAPI, "1")
 
-	// 3. Open an isolated DB.
-	dbDir, err := os.MkdirTemp("", "sidecartest-db-")
-	if err != nil {
-		t.Fatalf("sidecartest: create DB temp dir: %v", err)
+	// 3. Open an isolated DB at the exact path production resolution would
+	//    compute under the redirected $XDG_STATE_HOME
+	//    ($XDG_STATE_HOME/prism/prism.db). Keeping the DB inside the
+	//    test-scoped XDG tempdir makes the isolation assertable by
+	//    construction: a test can verify Bus.DB.Path() resides under
+	//    Bus.XDGStateHome instead of probing live host state (#2227).
+	prismDir := filepath.Join(xdgTmp, "prism")
+	if err := os.MkdirAll(prismDir, 0o700); err != nil {
+		t.Fatalf("sidecartest: create prism state dir: %v", err)
 	}
-	dbPath := filepath.Join(dbDir, "test.db")
-	d, err := db.Open(dbPath)
+	d, err := db.Open(filepath.Join(prismDir, "prism.db"))
 	if err != nil {
-		_ = os.RemoveAll(dbDir)
 		t.Fatalf("sidecartest: open test DB: %v", err)
 	}
-	t.Cleanup(func() {
-		d.Close()
-		_ = os.RemoveAll(dbDir)
-	})
+	t.Cleanup(func() { d.Close() })
 
 	bus := &Bus{
 		DB:           d,


### PR DESCRIPTION
Closes #2227

Two isolation tripwires false-positived on live-host activity at ~1-in-6 full-suite runs on a multi-worker host. Both asserted "the host is quiet" instead of "this suite is isolated". This PR makes both assert isolation by construction.

## Part 1 — cmd suite: drop the live-tmux-server LEAK GUARD diff (option a)

**Chosen option: (a) drop the before/after live-server session diff entirely**, relying on the #2224 regression guard (`TestSuiteTmuxIsolation_HostServerUnreachable`).

Justification: since #2224, `TestMain` clears `$TMUX` and redirects `$TMUX_TMPDIR` before `m.Run()`, so **this package's** code under test **cannot reach the live server by construction** — the suite's intentional real servers use private `-L prism-cmd-test-*` sockets under the redirected tmpdir. For cmd-package leaks the diff therefore has zero remaining signal; what it can observe is (i) concurrent host activity (a parallel worker's spawns/review rounds), which it misattributes to the suite, and (ii) historically, a **cross-package** leak from `internal/review` during parallel `go test ./...` window overlap (#1732) — a signal that is inherently indistinguishable from the false-positive class (both manifest as live `*~review-N-review-*` sessions), so no diff variant can keep it without keeping the flake. Option (b) (filter by suite naming patterns) was rejected because cmd tests use dozens of session-name shapes (`prism-test@*`, `testrepo@*`, `myrepo@*`, even fixture names like `actions-runner@main`) — no reliable filter exists, and any filter would still be guarding a surface that is unreachable by construction. Option (c) (non-fatal warning) keeps the noise without the signal.

**Retained:** the agent_status-row, sessions-row, and worktree-dir diffs. Unlike tmux, there is no suite-wide by-construction isolation for the live DB or the worktree root (tests opt in per-test via `XDG_STATE_HOME` / `SetTestDBPath` / `PRISM_SPAWN_PATH`), so those diffs still carry real leak signal.

## Part 2 — sidecar: assert DB isolation by construction

`TestNotifyInvestigatorCompletion_NoHostBusLeak` no longer probes the real `prism.db` mtime or snapshots the real `prism/run/` dir (both raced live sidecars). It now asserts, race-free:

- the `XDG_STATE_HOME` env redirect is in effect and differs from the real host value;
- the test sidecar's **resolved DB path** (`cfg.DB.Path()`) resides under the test-scoped `XDG_STATE_HOME` and not under the real one;
- the host-API **socket path** resides under the test-scoped `XDG_STATE_HOME` and not under the real one;
- the delivery still lands on the isolated `httptest.Server` (kept, now with a poll loop instead of a fixed sleep).

To make the DB assertion possible, `sidecartest.NewIsolated` now opens the test DB at the production-resolved path under the redirected tempdir (`$XDG_STATE_HOME/prism/prism.db`) instead of a sibling `MkdirTemp` dir — making the issue text "NewIsolated already guarantees this" actually true. No other test depended on the old location.

Bonus: the test no longer skips when `XDG_STATE_HOME` is unset (CI / nix `homeless-shelter` sandbox, #1857) — the by-construction assertions hold there too, so the nix-sandbox build now exercises this test instead of skipping it.

## AC verification

- **[functional] Full `go test ./... -race` passes under concurrent host activity** — 3 full-suite runs passed while live sessions (incl. a parallel worker's review round) were active. Plus a direct reproduction: ran the **old** cmd suite while a new live tmux session was created mid-run — the old guard FAILed, misattributing both my probe session *and* a real parallel worker's 5-agent review round (`staging-db-refresh@fix-restore-fixtures-db-leak~review-1-*`) to the suite. Same scenario against the **new** code: PASS.
- **[functional] cmd suite still fails if suite tmux isolation genuinely breaks** — mutation: replaced `isolateSuiteFromHostTmux()` with a no-op → `TestSuiteTmuxIsolation_HostServerUnreachable` FAILed against the live server (leaked `komaru-hou@eks-pipeline`). Restored → PASS.
- **[functional] sidecar test fails if DB path resolves outside test-scoped XDG_STATE_HOME** — mutation: reverted `NewIsolated` to open the DB in a sibling tempdir → test FAILed with "DB isolation breach". Second mutation: disabled the env redirect → test FAILed. Restored → PASS.
- **[edge-case] both pass in CI shape** — cmd suite passed with `TMUX=` + `TMUX_TMPDIR=<empty dir>` (no reachable server); sidecar test passed with `XDG_STATE_HOME` unset.

## Pre-PR self-check

- `go build ./...` ✅, `go test ./... -race` ✅ (×3 under live host activity)
- `nix build .#prism` could **not** run locally: this worker sandbox pre-dates #2201 (`trusted-settings.json: Operation not permitted`). Used the sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` ✅. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).

## Known residuals (out of scope, noted for the record)

1. **Retained DB-row / worktree-dir diffs can still race host-mode runs.** They can in principle misattribute a concurrent `prism spawn` to the suite — but only on host-mode runs where the live `prism.db` / worktree root are visible to the test process. In worker sandboxes the prism state dir is overlaid per-session (the DB snapshots return nil), which is why only the tmux diff was observed firing. Fixing that class properly needs suite-wide DB isolation (a #2224-style premise inversion for the DB), which issue #2227 explicitly scoped out of Part 1.
2. **Cross-package tmux-leak backstop is gone.** The dropped diff once incidentally caught an `internal/review` leak (#1732) via parallel `go test ./...` window overlap. `internal/review` / `internal/session` rely on per-test opt-in tmux stubs (`spawnSpyTmuxBin`) with no package-wide isolation; after this PR nothing detects that leak class. The stale comment in `review_test.go` that promised the cmd-guard backstop has been corrected, and **follow-up issue #2230** tracks applying the #2224 pattern (suite-wide `TestMain` isolation + deterministic regression guard) to those packages.
