### PR TITLE
prism: per-process temp paths for container test suite (#2222)

### DIFF
--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -420,10 +420,22 @@ func New(cfg Config) *Manager {
 // Name returns the container name.
 func (m *Manager) Name() string { return m.name }
 
+// tempDir returns the directory under which per-session temp artefact files
+// are created. It is a test seam: production code never reassigns it, so
+// every real binary uses the prior default, os.TempDir. The container test
+// suite replaces it once in TestMain (container_test.go) with a per-process
+// directory — fixture session names (e.g. "repo@feat") repeat across the
+// suite, so without per-process namespacing two concurrent `go test`
+// processes in different worktrees on the same host would read/write the
+// same /tmp/prism-gitconfig-prism-repo-feat file (issue #2222).
+var tempDir = os.TempDir
+
 // sessionTempPath is the package-level building block for per-session temp
 // file paths. All per-session artefact files follow the shape:
 //
-//	<os.TempDir()>/prism-<stem>-<session_name><suffix>
+//	<tempDir()>/prism-<stem>-<session_name><suffix>
+//
+// where tempDir() is os.TempDir() outside tests (see the tempDir seam).
 //
 // stem identifies the artefact (e.g. "gitdir", "ssh-config"); suffix is ""
 // for most artefacts and ".sb" for the sandbox-exec SBPL profile.
@@ -431,7 +443,7 @@ func (m *Manager) Name() string { return m.name }
 // It is a free function so that exported helpers like HarnessConfigFilePath
 // can share the same path logic without requiring a Manager receiver.
 func sessionTempPath(stem, suffix, name string) string {
-	return filepath.Join(os.TempDir(), "prism-"+stem+"-"+name+suffix)
+	return filepath.Join(tempDir(), "prism-"+stem+"-"+name+suffix)
 }
 
 // tempPath returns the host path for a temporary per-session artefact file.

--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -13,6 +13,28 @@ import (
 	"time"
 )
 
+// TestMain points the package temp-path seam (tempDir, container.go) at a
+// directory unique to this test process for the entire suite. Per-session
+// temp artefacts (gitconfig, ssh-config, sandbox-exec profile, …) are named
+// after slugified fixture session names like "repo@feat" that repeat across
+// the suite, so two concurrent `go test` processes in different worktrees on
+// the same host would otherwise collide on shared /tmp filenames — observed
+// as TestWriteGitconfig_AllModes_EmptyIdentityRefused flaking on a file
+// written by a sibling worker's test process (issue #2222). The directory is
+// removed after the run, so the suite also stops accumulating stale
+// prism-* files under the host temp dir.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "prism-container-test-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "container: TestMain: MkdirTemp: %v\n", err)
+		os.Exit(1)
+	}
+	tempDir = func() string { return dir }
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
 // ── containerName tests ──────────────────────────────────────────────────────
 
 func TestContainerName_ReplacesAt(t *testing.T) {
@@ -805,10 +827,13 @@ func TestHarnessConfigFilePath_Deterministic(t *testing.T) {
 }
 
 func TestHarnessConfigFilePath_Format(t *testing.T) {
-	// The path must equal filepath.Join(os.TempDir(), "prism-harness-config-"+sessionName).
+	// The path must equal filepath.Join(tempDir(), "prism-harness-config-"+sessionName).
+	// tempDir() rather than os.TempDir(): TestMain points the package
+	// temp-path seam at a per-process directory for the whole suite
+	// (issue #2222); outside tests tempDir() is os.TempDir().
 	const sessionName = "my-repo@branch"
 	got := HarnessConfigFilePath(sessionName)
-	want := filepath.Join(os.TempDir(), "prism-harness-config-"+sessionName)
+	want := filepath.Join(tempDir(), "prism-harness-config-"+sessionName)
 	if got != want {
 		t.Errorf("HarnessConfigFilePath(%q) = %q, want %q", sessionName, got, want)
 	}
@@ -968,6 +993,15 @@ func TestWriteGitconfig_AllModes_EmptyIdentityRefused(t *testing.T) {
 					GitUserName:   c.name,
 					GitUserEmail:  c.email,
 				})
+				// Own the precondition: the "must not exist after refusal"
+				// assertion below is about THIS call's behaviour, so any
+				// stale file at the path (e.g. left by a crashed earlier
+				// run) must be cleared before the call under test. The
+				// TestMain seam already namespaces the path per-process;
+				// this guards the within-process stale-file case on top
+				// (issue #2222).
+				_ = os.Remove(m.gitconfigFilePath())
+
 				err := m.writeGitconfig(mode.mode)
 				if err == nil {
 					t.Fatalf("mode=%s name=%q email=%q: writeGitconfig returned nil, want error",


### PR DESCRIPTION
Closes #2222

## Problem

`Manager` temp artefact paths (`/tmp/prism-gitconfig-prism-repo-feat`, ...) derive from slugified **fixture session names** that repeat across the suite, so concurrent `go test ./internal/container/` processes in different worktrees on this multi-worker host collide on shared `/tmp` filenames. Observed flake: `TestWriteGitconfig_AllModes_EmptyIdentityRefused` failing its "must not exist after refusal" assertion on a file written by a sibling worker's test process.

## Fix

- **`container.go`** — `tempDir` seam (`var tempDir = os.TempDir`) consumed by `sessionTempPath`. Production code never reassigns it, so all real binaries keep the prior `os.TempDir()` behaviour (pure seam, prior default).
- **`container_test.go`** — `TestMain` points the seam at a per-process `os.MkdirTemp` dir for the entire suite and removes it after the run. Suite-wide and opt-out-free: every existing and future test in the package is namespaced per-process, and no `prism-*` files accumulate in the shared temp dir.
- **`EmptyIdentityRefused`** owns its precondition: removes any stale file at the gitconfig path before the call under test, guarding the within-process stale-file case on top of the seam.
- **`TestHarnessConfigFilePath_Format`** asserts the path format against the seam dir (its old `os.TempDir()` expectation would otherwise be the one false failure under the seam).

`session_work_dir_test.go` needs no changes — its paths derive from `t.Setenv("HOME", t.TempDir())`, not `sessionTempPath`.

## AC verification

- **Flake reproduced pre-fix, gone post-fix (test-is-not-a-no-op check):** with an isolated `TMPDIR` (to avoid planting collision files for sibling workers), `touch $TMPDIR/prism-gitconfig-prism-repo-feat` then `go test -run EmptyIdentityRefused ./internal/container/` → **FAIL** pre-fix with the exact issue symptom; **PASS** post-fix with the stale file left untouched (the suite no longer reads the shared namespace at all).
- **Concurrent processes:** two overlapping `go test -count=1 ./internal/container/` invocations on this host (while two other prism workers were also active) → both pass. Audited the package for remaining shared-temp writes: all other test writes are `t.TempDir()`/fake-HOME rooted; the only `MkdirTemp("", ...)` uses are uniquely suffixed.
- **No accumulation:** snapshot of `prism-*` entries in `/tmp` and `$DARWIN_USER_TEMP_DIR` before/after a full package run → zero new entries.
- **Stability:** 16 consecutive `go test -count=1 ./internal/container/` runs green; full `go test ./... -race` green (29 packages).

## Notes

- One package run during verification exited 1 with output discarded (`>/dev/null`, my mistake); unreproducible across 16 subsequent runs + concurrent pairs, and the failing window coincided with sibling workers running pre-fix suites. No log, no test name — noting for transparency rather than filing an unactionable issue.
- `gofmt -l` flags pre-existing cosmetic nits (missing blank lines) in `internal/container/bwrap_test.go` and `sandbox_exec_test.go` on main — untouched here, outside footprint.
- Local `nix build .#prism` could not run: this sandbox pre-dates the #2201 trusted-settings allowance (`trusted-settings.json: Operation not permitted`). Ran the sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` → clean. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).
