### PR TITLE
prism (sandbox-exec): deny sops secrets.d in-sandbox with named, rotation-safe re-allow exceptions (#2211)

### DIFF
--- a/modules/programs/prism/prism/docs/sandbox-exec-testing.md
+++ b/modules/programs/prism/prism/docs/sandbox-exec-testing.md
@@ -154,6 +154,13 @@ integration test coverage exists for:
   need when the target flake declares a `nixConfig` block (issue #2201).
 - **Explicit denies** — `~/.aws`, `/private/etc/wireguard`,
   `/private/etc/wpa_supplicant`, `/private/etc/ssh` are blocked.
+- **sops secrets.d narrowing** — the secrets.d subtree deny (read + write)
+  with named require-not exceptions (issue #2211): real-tree denial of
+  `github_token` and the daily-driver RSA key, allowlisted stable-chain
+  reads (`~/.ssh/<key>`, `~/.config/aws/readonly-config`,
+  `~/.config/kube/agents-config`), and a fake-tree counter-rotation
+  simulation proving the exceptions are counter-independent (#1410/#1573).
+  See `sandbox_exec_secrets_deny_darwin_test.go`.
 - **Network egress** — `(allow network*)` permits outbound TCP.
 
 Each positive case has a paired negative case that mutates the profile to

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -102,6 +102,8 @@ func (s *sandboxExecIsolator) BuildRunArgs() []string {
 //   - /tmp read-write for xcrun and transient files
 //   - Deny of sensitive /private/etc subtrees (wireguard, wpa_supplicant, ssh),
 //     both /etc/... and /private/etc/... forms (symlink non-transparency)
+//   - sops secrets.d deny (read + write) with named re-allow exceptions for
+//     exactly the inventoried agent-needed secret names (issue #2211)
 //   - Host ~/.aws deny (only staged entries accessible)
 //   - Literal RO grant for the real ~/.ssh/known_hosts — never (subpath ~/.ssh)
 //     (issue #2213)
@@ -257,6 +259,69 @@ func generateProfile(m *Manager) string {
 		sb.WriteString(")\n")
 		sb.WriteString("\n")
 	}
+
+	// ── 3c. sops secrets.d deny + named re-allow exceptions (issue #2211) ─
+	// The broad /private/var/folders allows above (sections 2 and 3b) expose
+	// the entire home-manager sops-nix secrets tree
+	// (~/.config/sops-nix/secrets → /var/folders/<…>/T/secrets.d/<N>/) to the
+	// sandbox: the daily-driver GitHub PAT, full-power AWS config, admin kube
+	// configs, gitlab/hass/notion/syncthing keys, the non-prism SSH keys, and
+	// the secrets.d/age-keys.txt copy. None of those are read in-sandbox —
+	// GITHUB_TOKEN, OPENROUTER_API_KEY, etc. are resolved host-side by
+	// agent-run (credentialEnvVars, including the #2029 GitHubTokenPath file
+	// fallback) and injected into the sandbox env as VALUES before
+	// sandbox-exec starts.
+	//
+	// Shape:
+	//   1. deny file-write* on the secrets.d subtree, no exceptions — nothing
+	//      in-sandbox ever writes a secret; this also protects the allowlisted
+	//      names from in-sandbox tampering.
+	//   2. deny file-read* on the secrets.d subtree, with require-not
+	//      exceptions for exactly the inventoried agent-needed secret NAMES
+	//      (collectSecretsDAllowlistNames: ssh access key + .pub, signing key
+	//      + .pub, aws readonly-config, aws credentials, kube agents-config —
+	//      each derived from its stable host source path, so a source that is
+	//      absent or not sops-backed simply produces no exception).
+	//
+	// The exceptions live inside the deny rule itself (require-all +
+	// require-not) rather than as separate (allow ...) rules emitted after
+	// the deny, so the narrowing does not depend on inter-rule precedence
+	// between a regex allow and a regex deny: an allowlisted path simply does
+	// not match this deny and falls through to the broad allow above. The
+	// deny-after-broader-allow precedence this rule does rely on is the same
+	// proven shape as the /private/etc/ssh denies in section 4 (integration
+	// tested by sandbox_exec_denies_darwin_test.go).
+	//
+	// Rotation safety (#1410/#1573): sops rotates secrets.d/<N> → <N+1> on
+	// every activation, but secret NAMES are stable. The exception regexes
+	// match any counter ([0-9]+), so allowlisted reads survive a rotation
+	// mid-session and denied reads stay denied — by construction. The deny
+	// prefixes are static regexes covering both the /var and /private/var
+	// symlink forms (same dual-form pattern as 3b) and do not depend on
+	// os.TempDir(), so an unset or odd TMPDIR cannot silently re-expose the
+	// real tree.
+	//
+	// Accepted residual: file-test-existence on the subtree stays allowed
+	// (via the section-2 allow), so an in-sandbox process can probe which
+	// secret NAMES exist — but cannot read or write their content.
+	const (
+		secretsDDenyRegexVarForm     = `^/var/folders/.*/secrets\.d/`
+		secretsDDenyRegexPrivateForm = `^/private/var/folders/.*/secrets\.d/`
+	)
+	sb.WriteString("(deny file-write*\n")
+	sb.WriteString("  (regex #\"" + secretsDDenyRegexVarForm + "\")\n")
+	sb.WriteString("  (regex #\"" + secretsDDenyRegexPrivateForm + "\"))\n")
+	sb.WriteString("\n")
+	sb.WriteString("(deny file-read*\n")
+	sb.WriteString("  (require-all\n")
+	sb.WriteString("    (require-any\n")
+	sb.WriteString("      (regex #\"" + secretsDDenyRegexVarForm + "\")\n")
+	sb.WriteString("      (regex #\"" + secretsDDenyRegexPrivateForm + "\"))\n")
+	for _, name := range collectSecretsDAllowlistNames(m, home) {
+		sb.WriteString("    (require-not (regex #\"/secrets\\.d/[0-9]+/" + regexQuotePath(name) + "$\"))\n")
+	}
+	sb.WriteString("))\n")
+	sb.WriteString("\n")
 
 	// ── 4. Sensitive /etc subtree denies ──────────────────────────────────
 	// These deny rules must follow the broad /etc and /private/etc allows
@@ -731,6 +796,117 @@ func generateProfile(m *Manager) string {
 	sb.WriteString("(allow user-preference-read)\n")
 
 	return sb.String()
+}
+
+// collectSecretsDAllowlistNames returns the secrets.d-relative names of the
+// agent-needed secrets, derived from the stable host source paths the
+// sandbox legitimately reads through (issue #2211):
+//
+//	~/.ssh/<SshAccessKeyName>            — ssh auth (generated ssh-config IdentityFile)
+//	~/.ssh/<SshAccessKeyName>.pub        — openssh public-half probe
+//	~/.ssh/<SshSigningKeyName>           — commit signing (ssh-keygen -Y sign)
+//	~/.ssh/<SshSigningKeyName>.pub       — gitconfig user.signingKey
+//	~/.config/aws/readonly-config        — staged at <stagingHome>/.aws/config
+//	~/.config/aws/credentials            — staged at <stagingHome>/.aws/credentials
+//	~/.config/kube/agents-config         — staged at <stagingHome>/.kube/config
+//
+// Each source is resolved via filepath.EvalSymlinks; when the resolved
+// target is a sops secrets.d path (…/secrets.d/<N>/<name>), <name> is
+// returned. Sources that are absent, unresolvable, or not sops-backed are
+// skipped — they need no exception because the secrets.d deny never covers
+// them. The returned names are deduplicated and keep source order so the
+// emitted profile is deterministic.
+//
+// This list is the enforcement half of the inventory in issue #2211: every
+// other name under secrets.d/<N>/ (github_token, the role PATs, aws-config,
+// workkube, gitlab_token, …) stays denied. Do NOT add a source here merely
+// because a secret exists — only because an in-sandbox consumer reads it.
+func collectSecretsDAllowlistNames(m *Manager, home string) []string {
+	if home == "" {
+		return nil
+	}
+	accessKeyName := m.cfg.SshAccessKeyName
+	if accessKeyName == "" {
+		accessKeyName = "prismatic-koi-ed25519"
+	}
+	signingKeyName := m.cfg.SshSigningKeyName
+	if signingKeyName == "" {
+		signingKeyName = "prismatic-koi-ed25519-signingkey"
+	}
+	sources := []string{
+		filepath.Join(home, ".ssh", accessKeyName),
+		filepath.Join(home, ".ssh", accessKeyName+".pub"),
+		filepath.Join(home, ".ssh", signingKeyName),
+		filepath.Join(home, ".ssh", signingKeyName+".pub"),
+		filepath.Join(home, ".config", "aws", "readonly-config"),
+		filepath.Join(home, ".config", "aws", "credentials"),
+		filepath.Join(home, ".config", "kube", "agents-config"),
+	}
+	seen := map[string]bool{}
+	var names []string
+	for _, src := range sources {
+		resolved, err := filepath.EvalSymlinks(src)
+		if err != nil {
+			continue // absent on host — no exception needed (mirrors symlinkIfExists)
+		}
+		name, ok := secretsDRelativeName(resolved)
+		if !ok || seen[name] {
+			continue
+		}
+		if strings.Contains(name, `"`) {
+			// A double-quote cannot be safely embedded in the SBPL #"…"
+			// regex literal. No real sops secret name contains one; skip
+			// defensively rather than emit a malformed profile.
+			log.Printf("container: sandbox-exec: skipping secrets.d allowlist name with embedded quote: %q", name)
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+// secretsDRelativeName extracts the secrets.d-relative secret name from a
+// resolved sops target path of the form …/secrets.d/<N>/<name…> where <N>
+// is the all-digits generation counter. Returns ("", false) when the path
+// is not a sops secrets.d path.
+func secretsDRelativeName(resolved string) (string, bool) {
+	const marker = "/secrets.d/"
+	idx := strings.Index(resolved, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := resolved[idx+len(marker):] // "<N>/<name…>"
+	slash := strings.IndexByte(rest, '/')
+	if slash <= 0 {
+		return "", false
+	}
+	for _, c := range rest[:slash] {
+		if c < '0' || c > '9' {
+			return "", false
+		}
+	}
+	name := rest[slash+1:]
+	if name == "" || strings.HasSuffix(name, "/") {
+		return "", false
+	}
+	return name, true
+}
+
+// regexQuotePath escapes the AppleMatch/POSIX-ERE metacharacters in s so it
+// matches literally inside an SBPL (regex #"…") filter. Only basic escapes
+// are used (backslash before the metacharacter) — no perl-style \Q…\E,
+// which Apple's regex engine does not support.
+func regexQuotePath(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case '\\', '.', '+', '*', '?', '(', ')', '[', ']', '{', '}', '|', '^', '$':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // quoteSBPL returns the path quoted for inclusion in an SBPL expression.

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -2261,3 +2261,209 @@ func firstNChars(s string, n int) string {
 func containerPortString() string {
 	return fmt.Sprintf("%d", ContainerPort)
 }
+
+// ── sops secrets.d deny + named re-allow exceptions (issue #2211) ────────────
+
+// secretsDDenyReadHeader is the verbatim opening of the secrets.d read-deny
+// rule as emitted by generateProfile. Kept as a constant so the assertions
+// below stay in lockstep with the generator.
+const secretsDDenyReadHeader = "(deny file-read*\n" +
+	"  (require-all\n" +
+	"    (require-any\n" +
+	"      (regex #\"^/var/folders/.*/secrets\\.d/\")\n" +
+	"      (regex #\"^/private/var/folders/.*/secrets\\.d/\"))\n"
+
+// secretsDDenyWriteRule is the verbatim secrets.d write-deny rule.
+const secretsDDenyWriteRule = "(deny file-write*\n" +
+	"  (regex #\"^/var/folders/.*/secrets\\.d/\")\n" +
+	"  (regex #\"^/private/var/folders/.*/secrets\\.d/\"))\n"
+
+// TestGenerateProfile_SecretsDDenyBlocksPresent verifies that the profile
+// contains the secrets.d write-deny and read-deny rules covering both the
+// /var and /private/var symlink forms, and that the read-deny appears AFTER
+// the broad /private/var/folders allow it narrows (the deny-after-broader-
+// allow precedence shape, issue #2211).
+func TestGenerateProfile_SecretsDDenyBlocksPresent(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	if !strings.Contains(profile, secretsDDenyWriteRule) {
+		t.Errorf("profile missing the secrets.d write-deny rule:\n%s\nfull profile:\n%s",
+			secretsDDenyWriteRule, profile)
+	}
+	if !strings.Contains(profile, secretsDDenyReadHeader) {
+		t.Errorf("profile missing the secrets.d read-deny rule header:\n%s\nfull profile:\n%s",
+			secretsDDenyReadHeader, profile)
+	}
+
+	broadAllow := "  (subpath \"/private/var/folders\")\n"
+	broadIdx := strings.Index(profile, broadAllow)
+	denyIdx := strings.Index(profile, secretsDDenyReadHeader)
+	if broadIdx < 0 {
+		t.Fatalf("profile missing the broad /private/var/folders allow; full profile:\n%s", profile)
+	}
+	if denyIdx < broadIdx {
+		t.Errorf("secrets.d read-deny (index %d) must appear after the broad /private/var/folders allow (index %d) — SBPL deny-after-broader-allow shape; full profile:\n%s",
+			denyIdx, broadIdx, profile)
+	}
+}
+
+// fakeSopsChain replaces the plain-file credential sources in a newFakeHome
+// tree with sops-style symlink chains:
+//
+//	<fakeHome>/<sourceRel>  →  <secretsRoot>/secrets.d/<counter>/<secretName>
+//
+// creating the concrete secret file with dummy content. Returns the secrets.d
+// base dir (the parent of the counter dir).
+func fakeSopsChain(t *testing.T, fakeHome, secretsBase, counter string, entries map[string]string) {
+	t.Helper()
+	for sourceRel, secretName := range entries {
+		concrete := filepath.Join(secretsBase, counter, filepath.FromSlash(secretName))
+		if err := os.MkdirAll(filepath.Dir(concrete), 0o700); err != nil {
+			t.Fatalf("create fake secrets dir for %s: %v", secretName, err)
+		}
+		if err := os.WriteFile(concrete, []byte("dummy-secret"), 0o600); err != nil {
+			t.Fatalf("write fake secret %s: %v", secretName, err)
+		}
+		source := filepath.Join(fakeHome, filepath.FromSlash(sourceRel))
+		_ = os.Remove(source) // replace the plain file newFakeHome created
+		if err := os.Symlink(concrete, source); err != nil {
+			t.Fatalf("symlink fake sops chain %s → %s: %v", source, concrete, err)
+		}
+	}
+}
+
+// TestGenerateProfile_SecretsDAllowlistDerivedFromStableSources verifies
+// that, when the stable host sources resolve into a sops secrets.d tree,
+// generateProfile emits a require-not exception for exactly each derived
+// secret name — counter-independent ([0-9]+) and $-anchored — and nothing
+// else (no wildcard matching future secrets, issue #2211 AC).
+func TestGenerateProfile_SecretsDAllowlistDerivedFromStableSources(t *testing.T) {
+	fakeHome := newFakeHome(t)
+	secretsBase := filepath.Join(t.TempDir(), "secrets.d")
+	fakeSopsChain(t, fakeHome, secretsBase, "389", map[string]string{
+		".ssh/prismatic-koi-ed25519":                "ssh/prismatic-koi-ed25519",
+		".ssh/prismatic-koi-ed25519.pub":            "ssh/prismatic-koi-ed25519.pub",
+		".ssh/prismatic-koi-ed25519-signingkey":     "ssh/prismatic-koi-ed25519-signingkey",
+		".ssh/prismatic-koi-ed25519-signingkey.pub": "ssh/prismatic-koi-ed25519-signingkey.pub",
+		".config/aws/readonly-config":               "aws-readonly-config",
+		".config/kube/agents-config":                "workreadonlykube",
+	})
+	// ~/.config/aws/credentials stays the plain file newFakeHome created —
+	// it resolves to itself (not a secrets.d path) and must produce no
+	// exception. Remove it entirely to also cover the absent-source path
+	// (currently absent on the real host).
+	if err := os.Remove(filepath.Join(fakeHome, ".config", "aws", "credentials")); err != nil {
+		t.Fatalf("remove fake aws credentials: %v", err)
+	}
+
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	expected := []string{
+		`    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519$"))` + "\n",
+		`    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519\.pub$"))` + "\n",
+		`    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519-signingkey$"))` + "\n",
+		`    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519-signingkey\.pub$"))` + "\n",
+		`    (require-not (regex #"/secrets\.d/[0-9]+/aws-readonly-config$"))` + "\n",
+		`    (require-not (regex #"/secrets\.d/[0-9]+/workreadonlykube$"))` + "\n",
+	}
+	for _, exp := range expected {
+		if !strings.Contains(profile, exp) {
+			t.Errorf("profile missing expected secrets.d allowlist exception:\n%s\nfull profile:\n%s", exp, profile)
+		}
+	}
+
+	// Exactly the six inventoried exceptions — nothing else. A higher count
+	// would mean a wildcard or an un-inventoried name slipped in.
+	if got := strings.Count(profile, "(require-not "); got != len(expected) {
+		t.Errorf("expected exactly %d require-not exceptions, got %d; full profile:\n%s",
+			len(expected), got, profile)
+	}
+	// The concrete counter must never be baked into an exception — that
+	// would break the #1410/#1573 rotation property.
+	if strings.Contains(profile, `/secrets\.d/389/`) {
+		t.Errorf("profile bakes the concrete secrets.d counter into a regex (must use [0-9]+); full profile:\n%s", profile)
+	}
+}
+
+// TestGenerateProfile_SecretsDAllowlistEmptyWithoutSopsChains verifies that
+// on a host whose credential sources are plain files (no sops), the secrets.d
+// deny rules are still emitted but carry zero exceptions.
+func TestGenerateProfile_SecretsDAllowlistEmptyWithoutSopsChains(t *testing.T) {
+	_ = newFakeHome(t) // plain files only — nothing resolves into secrets.d
+
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	if !strings.Contains(profile, secretsDDenyWriteRule) || !strings.Contains(profile, secretsDDenyReadHeader) {
+		t.Fatalf("secrets.d deny rules must be emitted even with no allowlist sources; full profile:\n%s", profile)
+	}
+	if got := strings.Count(profile, "(require-not "); got != 0 {
+		t.Errorf("expected zero require-not exceptions on a non-sops host, got %d; full profile:\n%s", got, profile)
+	}
+}
+
+// TestGenerateProfile_SecretsDAllowlistEscapesRegexMeta verifies that regex
+// metacharacters in a derived secret name are escaped so the emitted
+// exception matches the name literally.
+func TestGenerateProfile_SecretsDAllowlistEscapesRegexMeta(t *testing.T) {
+	fakeHome := newFakeHome(t)
+	secretsBase := filepath.Join(t.TempDir(), "secrets.d")
+	fakeSopsChain(t, fakeHome, secretsBase, "7", map[string]string{
+		".ssh/we.ird+key": "ssh/we.ird+key",
+	})
+
+	m := newSandboxExecManager(Config{
+		SessionName:      "repo@main",
+		SshAccessKeyName: "we.ird+key",
+	})
+	profile := generateProfile(m)
+
+	exp := `    (require-not (regex #"/secrets\.d/[0-9]+/ssh/we\.ird\+key$"))` + "\n"
+	if !strings.Contains(profile, exp) {
+		t.Errorf("profile missing escaped exception %q; full profile:\n%s", exp, profile)
+	}
+}
+
+// TestSecretsDRelativeName covers the resolved-path → secret-name extraction.
+func TestSecretsDRelativeName(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantOK   bool
+	}{
+		{"/private/var/folders/hr/x/T/secrets.d/389/github_token", "github_token", true},
+		{"/private/var/folders/hr/x/T/secrets.d/389/ssh/prismatic-koi-ed25519", "ssh/prismatic-koi-ed25519", true},
+		{"/var/folders/hr/x/T/secrets.d/1/a", "a", true},
+		{"/private/var/folders/hr/x/T/secrets.d/age-keys.txt", "", false}, // no counter dir
+		{"/private/var/folders/hr/x/T/secrets.d/v389/name", "", false},    // non-numeric counter
+		{"/private/var/folders/hr/x/T/secrets.d/389/", "", false},         // empty name
+		{"/home/user/.ssh/plain-key", "", false},                          // not a secrets.d path
+		{"/private/var/folders/hr/x/T/secrets.d/389", "", false},          // counter only, no name
+	}
+	for _, tc := range cases {
+		gotName, gotOK := secretsDRelativeName(tc.in)
+		if gotName != tc.wantName || gotOK != tc.wantOK {
+			t.Errorf("secretsDRelativeName(%q) = (%q, %v); want (%q, %v)",
+				tc.in, gotName, gotOK, tc.wantName, tc.wantOK)
+		}
+	}
+}
+
+// TestRegexQuotePath covers the AppleMatch metacharacter escaping helper.
+func TestRegexQuotePath(t *testing.T) {
+	cases := map[string]string{
+		"plain-name":      "plain-name",
+		"ssh/key.pub":     `ssh/key\.pub`,
+		"we.ird+key":      `we\.ird\+key`,
+		`back\slash`:      `back\\slash`,
+		"a(b)[c]{d}|e^f$": `a\(b\)\[c\]\{d\}\|e\^f\$`,
+		"q?u*e":           `q\?u\*e`,
+	}
+	for in, want := range cases {
+		if got := regexQuotePath(in); got != want {
+			t.Errorf("regexQuotePath(%q) = %q; want %q", in, got, want)
+		}
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_secrets_deny_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_secrets_deny_darwin_test.go
@@ -1,0 +1,479 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_secrets_deny_darwin_test.go — integration coverage for the
+// sops secrets.d narrowing (issue #2211):
+//
+//	(deny file-write* (regex #"^/var/folders/.*/secrets\.d/") …)
+//	(deny file-read*  (require-all (require-any (regex …)) (require-not …)…))
+//
+// The broad (subpath "/private/var/folders") allow exposes the entire
+// home-manager sops-nix secrets tree to the sandbox. The narrowing denies the
+// secrets.d subtree and carves out require-not exceptions for exactly the
+// inventoried agent-needed secret NAMES, counter-independent ([0-9]+) so the
+// #1410/#1573 rotation property is preserved.
+//
+// Coverage:
+//
+//  1. TestSandboxExecSecretsDeny_DeniedNamesUnreadable — reading the real
+//     non-allowlisted secrets (github_token, the daily-driver RSA key) inside
+//     the sandbox fails with EPERM.
+//  2. TestSandboxExecSecretsDeny_NegationAllowsReads — the paired negative:
+//     a profile mutation disabling the secrets.d deny regexes makes the same
+//     reads succeed, proving the deny is the load-bearing rule (not
+//     deny-default or POSIX permissions).
+//  3. TestSandboxExecSecretsDeny_AllowlistedStableChainsReadable — reads
+//     through the stable host symlink chains (~/.ssh/<key>,
+//     ~/.config/aws/readonly-config, ~/.config/kube/agents-config) still
+//     succeed under the production profile.
+//  4. TestSandboxExecSecretsDeny_RotationSimulation — a fake secrets.d tree
+//     under the per-user TMPDIR proves allowlisted reads survive a counter
+//     rotation (100 → 101) and denied reads stay denied at both counters.
+//     Unlike (3), the fake counters have no per-symlink (literal …) allows in
+//     the profile, so this test isolates the require-not exceptions as the
+//     only mechanism that can permit the read.
+//  5. TestSandboxExecSecretsDeny_RotationSimulation_ExceptionsLoadBearing —
+//     the paired negative for (4): stripping the require-not exceptions makes
+//     the allowlisted-name read fail.
+//
+// Secret hygiene: tests never print secret file content. In-sandbox reads of
+// real secrets redirect stdout to /dev/null and assert on exit status and
+// stderr only. Only the fake rotation tree uses readable sentinel content.
+//
+// See docs/sandbox-exec-testing.md for the convention (#1192).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// secretsDeniedCandidates are the secrets.d-relative names the issue #2211
+// ACs name explicitly: the daily-driver GitHub PAT and the daily-driver
+// (non-prism) SSH private key. Neither may ever appear in the allowlist.
+var secretsDeniedCandidates = []string{
+	"github_token",
+	"ssh/prismatic-koi-rsa",
+}
+
+// realSecretsDRoot returns the host sops secrets.d root derived from the
+// per-user TMPDIR (the same base sops-nix uses on Darwin), skipping the test
+// when the tree does not exist on this host.
+func realSecretsDRoot(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(os.TempDir(), "secrets.d")
+	fi, err := os.Stat(root)
+	if err != nil || !fi.IsDir() {
+		t.Skipf("no sops secrets.d tree at %s on this host: %v", root, err)
+	}
+	return root
+}
+
+// currentSecretsCounterDir returns the path of the highest numeric
+// generation dir under the secrets.d root, skipping when none is found or
+// the root is unreadable (e.g. the test process itself is already inside a
+// post-#2211 sandbox).
+func currentSecretsCounterDir(t *testing.T, root string) string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Skipf("cannot enumerate %s from the test process (already sandboxed?): %v", root, err)
+	}
+	best := -1
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if n, convErr := strconv.Atoi(e.Name()); convErr == nil && n > best {
+			best = n
+		}
+	}
+	if best < 0 {
+		t.Skipf("no numeric generation dir under %s", root)
+	}
+	return filepath.Join(root, strconv.Itoa(best))
+}
+
+// secretsDExceptionRe matches a require-not exception line emitted by
+// generateProfile and captures the (regex-escaped) secret name.
+var secretsDExceptionRe = regexp.MustCompile(`\(require-not \(regex #"/secrets\\\.d/\[0-9\]\+/(.+)\$"\)\)`)
+
+// parseSecretsDAllowlist extracts the allowlisted secrets.d-relative names
+// from the generated profile content, undoing the regex-metacharacter
+// escaping applied by the generator. Parsing the emitted rules (rather than
+// re-deriving from the host) means the tests exercise exactly what the
+// profile enforces.
+func parseSecretsDAllowlist(profile string) []string {
+	var names []string
+	for _, m := range secretsDExceptionRe.FindAllStringSubmatch(profile, -1) {
+		names = append(names, unescapeRegexQuote(m[1]))
+	}
+	return names
+}
+
+// unescapeRegexQuote reverses the generator's regexQuotePath escaping:
+// every backslash-prefixed character is replaced by the character itself.
+func unescapeRegexQuote(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			i++
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// sandboxCatDiscard runs `cat <path> > /dev/null` inside sandbox-exec under
+// the given profile and returns the run error and combined output (stderr
+// only — stdout is discarded inside the sandbox so secret content never
+// reaches the test log).
+func sandboxCatDiscard(profilePath, nixBash, path string) (error, string) {
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(path)+" > /dev/null")
+	out, err := cmd.CombinedOutput()
+	return err, string(out)
+}
+
+// TestSandboxExecSecretsDeny_DeniedNamesUnreadable asserts that reading the
+// real non-allowlisted secrets (github_token and the daily-driver RSA key)
+// inside the sandbox fails with EPERM under the production profile
+// (issue #2211 AC #1).
+func TestSandboxExecSecretsDeny_DeniedNamesUnreadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	root := realSecretsDRoot(t)
+	counterDir := currentSecretsCounterDir(t, root)
+
+	m := newProfileManager(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Guard: the AC-named denied candidates must never be allowlisted.
+	allowNames := parseSecretsDAllowlist(prepared.content)
+	for _, denied := range secretsDeniedCandidates {
+		for _, allowed := range allowNames {
+			if denied == allowed {
+				t.Fatalf("denied candidate %q appears in the profile allowlist — inventory violation (issue #2211 AC #2)", denied)
+			}
+		}
+	}
+
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	tested := 0
+	for _, rel := range secretsDeniedCandidates {
+		target := filepath.Join(counterDir, filepath.FromSlash(rel))
+		// Precondition: the file exists and is readable from the
+		// (unsandboxed) test process — so an in-sandbox failure can only be
+		// sandbox-caused, not ENOENT or POSIX permissions.
+		f, openErr := os.Open(target)
+		if openErr != nil {
+			t.Logf("skipping %s: not present/readable on host: %v", rel, openErr)
+			continue
+		}
+		_ = f.Close()
+		tested++
+
+		runErr, out := sandboxCatDiscard(profilePath, nixBash, target)
+		if runErr == nil {
+			t.Errorf("in-sandbox read of denied secret %q SUCCEEDED under the production profile — the secrets.d deny is not effective (issue #2211)", rel)
+			continue
+		}
+		if !strings.Contains(out, "Operation not permitted") {
+			t.Errorf("in-sandbox read of %q failed, but not with EPERM (want \"Operation not permitted\").\nExit: %v\nStderr: %s",
+				rel, runErr, out)
+		} else {
+			t.Logf("ka pai — %s correctly unreadable in-sandbox (exit: %v)", rel, runErr)
+		}
+	}
+	if tested == 0 {
+		t.Skipf("none of the denied candidate secrets exist on this host: %v", secretsDeniedCandidates)
+	}
+}
+
+// disableSecretsDDeny rewrites the secrets.d deny regex token so the deny
+// (and its exceptions) no longer match any real path. Used by the paired
+// negative test to prove the deny rules are load-bearing.
+func disableSecretsDDeny(p string) string {
+	return strings.ReplaceAll(p, `secrets\.d/`, `prism-2211-disabled\.d/`)
+}
+
+// TestSandboxExecSecretsDeny_NegationAllowsReads is the paired negative test
+// demanded by the issue #2211 ACs: a profile mutation that removes the
+// secrets.d deny must make the denied reads succeed — proving
+// TestSandboxExecSecretsDeny_DeniedNamesUnreadable is not green by accident
+// (the broad /private/var/folders allow would otherwise permit the read).
+func TestSandboxExecSecretsDeny_NegationAllowsReads(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	root := realSecretsDRoot(t)
+	counterDir := currentSecretsCounterDir(t, root)
+
+	m := newProfileManager(t)
+	mutatedPath := withMutatedProfile(t, m, disableSecretsDDeny)
+
+	tested := 0
+	for _, rel := range secretsDeniedCandidates {
+		target := filepath.Join(counterDir, filepath.FromSlash(rel))
+		f, openErr := os.Open(target)
+		if openErr != nil {
+			t.Logf("skipping %s: not present/readable on host: %v", rel, openErr)
+			continue
+		}
+		_ = f.Close()
+		tested++
+
+		runErr, out := sandboxCatDiscard(mutatedPath, nixBash, target)
+		if runErr != nil {
+			t.Errorf("in-sandbox read of %q still fails with the secrets.d deny disabled.\n"+
+				"The negative test is not isolating the deny — something else blocks the read.\n"+
+				"Exit: %v\nStderr: %s", rel, runErr, out)
+		} else {
+			t.Logf("ka pai — %s readable once the deny is disabled (deny is load-bearing)", rel)
+		}
+	}
+	if tested == 0 {
+		t.Skipf("none of the denied candidate secrets exist on this host: %v", secretsDeniedCandidates)
+	}
+}
+
+// TestSandboxExecSecretsDeny_AllowlistedStableChainsReadable asserts that
+// the agent-needed secrets remain readable through their stable host symlink
+// chains under the production profile (issue #2211 functional AC). The
+// stable paths are the ones embedded in the generated ssh-config/gitconfig
+// and staged into the sandbox HOME.
+func TestSandboxExecSecretsDeny_AllowlistedStableChainsReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	// The inventoried stable sources (mirrors collectSecretsDAllowlistNames
+	// with the default key names).
+	stableSources := []string{
+		filepath.Join(home, ".ssh", "prismatic-koi-ed25519"),
+		filepath.Join(home, ".ssh", "prismatic-koi-ed25519.pub"),
+		filepath.Join(home, ".ssh", "prismatic-koi-ed25519-signingkey"),
+		filepath.Join(home, ".ssh", "prismatic-koi-ed25519-signingkey.pub"),
+		filepath.Join(home, ".config", "aws", "readonly-config"),
+		filepath.Join(home, ".config", "aws", "credentials"),
+		filepath.Join(home, ".config", "kube", "agents-config"),
+	}
+
+	// BareRoot variant: following the stable symlink under the real HOME
+	// needs the ancestor block's (subpath home) metadata allow.
+	m := newProfileManagerWithBareRoot(t)
+	prepared, _ := preparePositiveProfile(t, m)
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	tested := 0
+	for _, src := range stableSources {
+		resolved, resolveErr := filepath.EvalSymlinks(src)
+		if resolveErr != nil || !strings.Contains(resolved, "/secrets.d/") {
+			t.Logf("skipping %s: absent or not sops-backed on this host", src)
+			continue
+		}
+		tested++
+
+		runErr, out := sandboxCatDiscard(profilePath, nixBash, src)
+		if runErr != nil {
+			t.Errorf("in-sandbox read of allowlisted stable chain %s failed under the production profile.\n"+
+				"The secrets.d narrowing broke an agent-needed credential read (issue #2211 functional AC).\n"+
+				"Exit: %v\nStderr: %s", src, runErr, out)
+		} else {
+			t.Logf("ka pai — %s readable in-sandbox", src)
+		}
+	}
+	if tested == 0 {
+		t.Skipf("no sops-backed stable sources on this host")
+	}
+}
+
+// setupFakeSecretsTree creates a fake sops-style secrets.d tree under the
+// per-user TMPDIR (so the production deny/exception regexes apply to it
+// without any profile mutation):
+//
+//	<base>/secrets.d/<counter>/<allowedName>   (sentinel content)
+//	<base>/secrets.d/<counter>/github_token    (fake denied secret)
+//
+// Returns the base dir. Skips when TMPDIR is not under /var/folders (the
+// deny regexes are anchored there).
+func setupFakeSecretsTree(t *testing.T, allowedName string, counters ...string) string {
+	t.Helper()
+	base, err := os.MkdirTemp("", "prism-2211-rot-")
+	if err != nil {
+		t.Fatalf("MkdirTemp for fake secrets tree: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+
+	canonical, err := filepath.EvalSymlinks(base)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", base, err)
+	}
+	if !strings.HasPrefix(canonical, "/private/var/folders/") && !strings.HasPrefix(canonical, "/var/folders/") {
+		t.Skipf("TMPDIR-derived base %s is not under /var/folders — the production secrets.d deny regexes would not apply", canonical)
+	}
+
+	for _, counter := range counters {
+		writeFakeSecretsCounter(t, base, counter, allowedName)
+	}
+	return base
+}
+
+// writeFakeSecretsCounter writes one fake generation dir (allowed + denied
+// names) under <base>/secrets.d/<counter>/.
+func writeFakeSecretsCounter(t *testing.T, base, counter, allowedName string) {
+	t.Helper()
+	counterDir := filepath.Join(base, "secrets.d", counter)
+	allowedPath := filepath.Join(counterDir, filepath.FromSlash(allowedName))
+	if err := os.MkdirAll(filepath.Dir(allowedPath), 0o700); err != nil {
+		t.Fatalf("create fake counter dir for %s: %v", allowedName, err)
+	}
+	if err := os.WriteFile(allowedPath, []byte(fakeAllowedSentinel), 0o600); err != nil {
+		t.Fatalf("write fake allowed secret: %v", err)
+	}
+	deniedPath := filepath.Join(counterDir, "github_token")
+	if err := os.WriteFile(deniedPath, []byte("ghp_fake-2211-denied"), 0o600); err != nil {
+		t.Fatalf("write fake denied secret: %v", err)
+	}
+}
+
+const fakeAllowedSentinel = "prism-2211-rotation-sentinel"
+
+// TestSandboxExecSecretsDeny_RotationSimulation proves the #1410/#1573
+// rotation property of the narrowing (issue #2211 edge-case AC): after a
+// secrets.d counter increment, allowlisted reads continue to work and denied
+// reads remain denied. The fake counters (100, 101) carry no per-symlink
+// (literal …) allows in the profile, so the require-not exceptions are the
+// only mechanism that can permit the allowlisted read — this is the
+// precision check that the exceptions are counter-independent.
+func TestSandboxExecSecretsDeny_RotationSimulation(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	allowNames := parseSecretsDAllowlist(prepared.content)
+	if len(allowNames) == 0 {
+		t.Skipf("profile carries no secrets.d allowlist exceptions on this host (no sops-backed sources)")
+	}
+	allowedName := allowNames[0]
+	for _, n := range allowNames {
+		if n == "github_token" {
+			t.Fatalf("github_token appears in the profile allowlist — inventory violation (issue #2211 AC #2)")
+		}
+	}
+
+	base := setupFakeSecretsTree(t, allowedName, "100")
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	assertCounter := func(counter string) {
+		t.Helper()
+		counterDir := filepath.Join(base, "secrets.d", counter)
+		allowedPath := filepath.Join(counterDir, filepath.FromSlash(allowedName))
+		deniedPath := filepath.Join(counterDir, "github_token")
+
+		cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+			nixBash, "-c", "cat "+shQuote(allowedPath))
+		out, runErr := cmd.CombinedOutput()
+		if runErr != nil {
+			t.Errorf("counter %s: in-sandbox read of allowlisted name %q failed — the exception is not counter-independent (#1410/#1573 regression).\nExit: %v\nOutput: %s",
+				counter, allowedName, runErr, out)
+		} else if !strings.Contains(string(out), fakeAllowedSentinel) {
+			t.Errorf("counter %s: allowlisted read exited 0 but sentinel missing.\nOutput: %s", counter, out)
+		}
+
+		runErr, errOut := sandboxCatDiscard(profilePath, nixBash, deniedPath)
+		if runErr == nil {
+			t.Errorf("counter %s: in-sandbox read of denied name github_token SUCCEEDED — the deny is not counter-independent.", counter)
+		} else if !strings.Contains(errOut, "Operation not permitted") {
+			t.Errorf("counter %s: denied read failed but not with EPERM.\nExit: %v\nStderr: %s", counter, runErr, errOut)
+		}
+	}
+
+	// Generation 100, then simulate a sops rotation: write 101, prune 100.
+	assertCounter("100")
+	writeFakeSecretsCounter(t, base, "101", allowedName)
+	if err := os.RemoveAll(filepath.Join(base, "secrets.d", "100")); err != nil {
+		t.Fatalf("prune fake counter 100: %v", err)
+	}
+	assertCounter("101")
+}
+
+// TestSandboxExecSecretsDeny_RotationSimulation_ExceptionsLoadBearing is the
+// paired negative for the rotation simulation: with the require-not
+// exceptions stripped from the profile, the allowlisted-name read at a fake
+// counter fails — proving the exceptions (not some broader rule) are what
+// permit it in the positive test.
+func TestSandboxExecSecretsDeny_RotationSimulation_ExceptionsLoadBearing(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	allowNames := parseSecretsDAllowlist(prepared.content)
+	if len(allowNames) == 0 {
+		t.Skipf("profile carries no secrets.d allowlist exceptions on this host (no sops-backed sources)")
+	}
+	allowedName := allowNames[0]
+
+	base := setupFakeSecretsTree(t, allowedName, "100")
+	allowedPath := filepath.Join(base, "secrets.d", "100", filepath.FromSlash(allowedName))
+
+	// Strip every require-not exception line (mirrors withMutatedProfile,
+	// operating on the already-prepared profile so the allowlist parse above
+	// and the mutation use the same content).
+	var kept []string
+	for _, line := range strings.Split(prepared.content, "\n") {
+		if strings.Contains(line, `(require-not (regex #"/secrets\.d/`) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	mutated := strings.Join(kept, "\n")
+	if mutated == prepared.content {
+		t.Fatalf("stripping require-not exceptions changed nothing — mutation is a no-op.\nProfile:\n%s", prepared.content)
+	}
+	augmented := augmentProfileForTest(mutated)
+	mutatedPath := prepared.path + ".integ-2211-noexc"
+	if err := os.WriteFile(mutatedPath, []byte(augmented), 0o600); err != nil {
+		t.Fatalf("write mutated profile: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(mutatedPath) })
+
+	runErr, out := sandboxCatDiscard(mutatedPath, nixBash, allowedPath)
+	if runErr == nil {
+		t.Errorf("in-sandbox read of %q succeeded WITHOUT the require-not exceptions — "+
+			"the exceptions are not load-bearing and the positive rotation test is a no-op.", allowedName)
+	} else {
+		t.Logf("ka pai — allowlisted name unreadable once exceptions are stripped (exit: %v, stderr: %s)", runErr, out)
+	}
+}


### PR DESCRIPTION
Closes #2211

## What

Narrows the sandbox-exec SBPL profile so the sops `secrets.d` tree under `/private/var/folders` is no longer readable in-sandbox, except for exactly the inventoried agent-needed secret names. The broad `(subpath "/private/var/folders")` allow stays (TMPDIR, dylib extraction, caches); two new rules follow it:

```scheme
(deny file-write*
  (regex #"^/var/folders/.*/secrets\.d/")
  (regex #"^/private/var/folders/.*/secrets\.d/"))

(deny file-read*
  (require-all
    (require-any
      (regex #"^/var/folders/.*/secrets\.d/")
      (regex #"^/private/var/folders/.*/secrets\.d/"))
    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519$"))
    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519\.pub$"))
    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519-signingkey$"))
    (require-not (regex #"/secrets\.d/[0-9]+/ssh/prismatic-koi-ed25519-signingkey\.pub$"))
    (require-not (regex #"/secrets\.d/[0-9]+/aws-readonly-config$"))
    (require-not (regex #"/secrets\.d/[0-9]+/workreadonlykube$"))
))
```

The exception names are not hard-coded: `collectSecretsDAllowlistNames` derives them at profile-generation time by `EvalSymlinks`-resolving the stable host sources (`~/.ssh/<accessKeyName>{,.pub}`, `~/.ssh/<signingKeyName>{,.pub}`, `~/.config/aws/readonly-config`, `~/.config/aws/credentials`, `~/.config/kube/agents-config`) and extracting the `secrets.d/<N>/<name>` suffix. A source that is absent or not sops-backed produces no exception.

**Rotation safety (#1410/#1573)**: secret names are stable across rotations; only the `<N>` counter changes. The exceptions match `[0-9]+`, so allowlisted reads survive a mid-session rotation and denied reads stay denied — by construction. The deny prefixes are static regexes (both `/var` and `/private/var` forms, same dual-form pattern as the TMPDIR block) with no `os.TempDir()` dependence, so an odd/unset TMPDIR cannot silently re-expose the tree.

**Why require-not instead of deny-then-re-allow**: expressing the exceptions inside the deny rule (`require-all` + `require-not`) means an allowlisted path simply never matches the deny and falls through to the existing broad allow — the narrowing does not depend on inter-rule precedence between a regex allow and a regex deny. The only precedence the rule relies on (specific deny after broader allow) is the same proven shape as the `/private/etc/ssh` denies, already integration-tested.

## Inventory (AC: recorded outcome)

Full enumeration of `secrets.d/389/` on the live host (verified 2026-06-11, from inside a pre-fix sandbox — demonstrating the exposure):

| Name | Decision | Rationale |
|---|---|---|
| `ssh/prismatic-koi-ed25519` | **allow** | The prism ssh access key (`SshAccessKeyName` default; staged at `.ssh/access-key`; embedded as IdentityFile in the generated ssh-config). Push auth requires it. |
| `ssh/prismatic-koi-ed25519.pub` | **allow** | Public half of the access key; openssh probes `<IdentityFile>.pub`. Non-secret by definition. |
| `ssh/prismatic-koi-ed25519-signingkey` | **allow** | Commit signing (`ssh-keygen -Y sign`). |
| `ssh/prismatic-koi-ed25519-signingkey.pub` | **allow** | gitconfig `user.signingKey` points at it. |
| `aws-readonly-config` | **allow** | Resolved target of `~/.config/aws/readonly-config`, staged at `.aws/config`. |
| `workreadonlykube` | **allow** | Resolved target of `~/.config/kube/agents-config`, staged at `.kube/config`. |
| *(aws credentials)* | n/a | `~/.config/aws/credentials` is currently absent on the host → no exception emitted. If it appears later as a sops secret, the derivation picks it up automatically; until then nothing matches. |
| `github_token` | **deny** | Daily-driver PAT. Not read in-sandbox — see token analysis below. AC negative-test target. |
| `github_token_prismatic_koi_{coordinator,worker}` | **deny** | Role PATs — value-injected host-side (see below). |
| `github_token_thankyou_payroll_{coordinator,worker}` | **deny** | Same. |
| `gitlab_token` | **deny** | Surfaced as `GITLAB_TOKEN` via host session vars only; `MinimalIsolatedExecEnv` does not forward it and `credentialEnvVars` does not inject it — no in-sandbox consumer ever had it via env, and none reads the file. |
| `aws-config` | **deny** | Full-power AWS config — the readonly-variant indirection exists precisely to keep this out of agent hands. |
| `kubeconfig`, `workkube` | **deny** | Admin kube configs (home + work). |
| `config/cloudflared_domain` | **deny** | Consumed by host shell session vars; in-sandbox ssh uses the generated `-F` ssh-config which has no cloudflared hosts. |
| `hass_api_key`, `hass_domain`, `notion_shopping_list_key` | **deny** | Host-only consumers (home-automation, rofi). |
| `m4mac-syncthing-cert`, `m4mac-syncthing-key` | **deny** | Syncthing service material. |
| `ssh/prismatic-koi-rsa`, `ssh/prismatic-koi-rsa.pub` | **deny** | The daily-driver (non-prism) SSH key — AC negative-test target. |
| `secrets.d/age-keys.txt` (outside `<N>/`) | **deny** (bonus) | The sops age key copy sits at the secrets.d root; the subtree deny covers it and the exceptions are anchored under `[0-9]+/`, so it can never be re-allowed. |

### Open question answered: do agents consume github/gitlab tokens from secrets.d?

**No — with evidence:**

- `credentialEnvVars()` (incl. the #2029 `GitHubTokenPath` file fallback) executes in **agent-run on the host**, before `sandboxCmd.Start()` in `cmd/agent_run_sandbox_exec_darwin.go`. The selected token **value** is injected into the sandbox env as `GITHUB_TOKEN`; no in-sandbox process reads the secrets.d file. `gh`/git in-sandbox consume the env var.
- The zsh #2029 self-heal guard (`modules/programs/zsh.nix`) is `[ -r <path> ]`-gated — when the file is unreadable it skips silently. In-sandbox shells use the staging HOME (no `.zshenv` → no `hm-session-vars.sh` sourcing) anyway.
- `OPENROUTER_API_KEY` likewise: host shell `$(cat …)` → forwarded by value through `credentialEnvVars`.

So denying every token file breaks nothing — verified by the full suite plus the allowlisted-chain integration tests, and nothing was allowlisted merely because it exists.

### bwrap side (AC: verified)

Clean — this is a Darwin-only change. `bwrap.go` mounts individually resolved files (`--ro-bind` after per-mount `EvalSymlinks`); the only `/run` entries bound are `/run/current-system` and `/run/wrappers`. There is no blanket bind of `/run/secrets.d` (the Linux sops tree), so non-mounted secrets are simply absent from the bwrap namespace.

## Tests

Per `docs/sandbox-exec-testing.md` (#1192), with the #2207 `sandboxexectest.Require` capability gating kept:

- **Unit** (`sandbox_exec_test.go`, run everywhere incl. Linux CI): deny blocks present + ordered after the broad allow; allowlist derived from fake sops chains (exact six exceptions, no wildcard, no baked-in counter); empty allowlist on non-sops hosts; regex-metacharacter escaping; `secretsDRelativeName` table.
- **Integration** (`internal/integration/sandbox_exec_secrets_deny_darwin_test.go`, Darwin + real `/usr/bin/sandbox-exec`):
  - `DeniedNamesUnreadable` — in-sandbox `cat` of the real `github_token` and `ssh/prismatic-koi-rsa` fails with `Operation not permitted` (host-readability prechecked, so failure is sandbox-caused). Stdout discarded in-sandbox — no secret content reaches test logs.
  - `NegationAllowsReads` — paired negative: disabling the deny regex token makes the same reads succeed, proving the deny is load-bearing (AC #5).
  - `AllowlistedStableChainsReadable` — reads via the stable chains still work.
  - `RotationSimulation` — fake `secrets.d/{100,101}` tree under the per-user TMPDIR (matched by the production regexes, but with no per-symlink literal allows): allowlisted name readable at both counters incl. after pruning 100; `github_token` EPERM at both (edge-case AC).
  - `RotationSimulation_ExceptionsLoadBearing` — paired negative: stripping the `require-not` lines makes the allowlisted read fail.

## Verification status

- `go build ./...` + `go test ./... -race` — green (full suite).
- The Darwin integration tests **skip in this worker session** (nested sandbox-exec is blocked — the #2207 probe fires: `sandbox_apply: Operation not permitted`); they need a host-mode run. Please run on the host before/at deploy: `go test ./internal/integration/ -run SecretsDeny -v`.
- `nix build .#prism` could not run locally — this sandbox pre-dates the #2201 trusted-settings allowance (`error: opening file ".../trusted-settings.json": Operation not permitted`). The sanctioned `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` fallback passes; the homeless-shelter build is covered by the `nix-build-prism-checked` CI job.

## Residuals / notes

- `file-test-existence` on the subtree stays allowed (section-2 broad allow), so in-sandbox processes can probe which secret **names** exist — content is unreadable/unwritable. Documented in the generator comment.
- The per-symlink `(literal …)` allows emitted by `collectStagingHomeSymlinkTargets` for the *current* counter still appear; they cover only allowlisted names (verified) and go stale on rotation, at which point the `require-not` exceptions are the only mechanism — exactly what `RotationSimulation` isolates.
- Profile changes only affect sandboxes spawned after deploy — no live-session risk.
- Related to but independent of design #2132 (per its issue text, this lands the enforcement that makes #2132's grant minimisation meaningful).
