### PR TITLE
prism: suite-wide tmux isolation for internal/review and internal/session (#2230)

### DIFF
--- a/modules/programs/prism/prism/internal/review/review_test.go
+++ b/modules/programs/prism/prism/internal/review/review_test.go
@@ -2149,9 +2149,10 @@ func TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort(t *testing.T) {
 	// #1728), back then caught incidentally by the cmd/-package leak guard
 	// under parallel `go test ./...` scheduling. That guard's live-tmux
 	// session diff was dropped in #2227 (it false-positived on concurrent
-	// host activity), so this per-test stub is now the ONLY line of defence
-	// against this leak class — there is no cross-package backstop. #2230
-	// tracks adding #2224-style suite-wide tmux isolation to this package.
+	// host activity). Since #2230 this package has suite-wide tmux
+	// isolation (TestMain in tmux_isolation_test.go), so the live server is
+	// unreachable by construction even without this stub — the stub remains
+	// as defence-in-depth and to let the test assert on recorded argv.
 	//
 	// Uses spawnSpyTmuxBin from spawn_prompt_file_test.go — the canonical
 	// tmux-isolation pattern in this package. Must NOT call t.Parallel:

--- a/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
+++ b/modules/programs/prism/prism/internal/review/spawn_prompt_file_test.go
@@ -15,8 +15,10 @@ package review_test
 //   - A fake tmux binary (shell script) that records its argv to a file is
 //     installed for the duration of each test via tmux.TmuxBin.
 //   - PRISM_TEST_SUBPROCESS=1 makes the StartSidecar call use the test binary
-//     as a stub sidecar (exits after 50ms — see TestMain in the session package
-//     which owns the PRISM_TEST_SUBPROCESS handling).
+//     as a stub sidecar (exits after 50ms — see TestMain in
+//     tmux_isolation_test.go, which owns the PRISM_TEST_SUBPROCESS handling
+//     for THIS test binary; the session package's TestMain only covers the
+//     session test binary).
 //   - XDG_STATE_HOME is redirected to a temp dir so no real state files are
 //     written to the user's home directory.
 //
@@ -107,7 +109,8 @@ func TestSpawnReviewAgent_LargePrompt_UsesPromptFile(t *testing.T) {
 	argsFile := spawnSpyTmuxBin(t)
 
 	// Stub the sidecar so StartSidecarWithOpts does not try to exec a real
-	// prism binary. The session package's TestMain handles PRISM_TEST_SUBPROCESS.
+	// prism binary. This package's TestMain (tmux_isolation_test.go) handles
+	// PRISM_TEST_SUBPROCESS.
 	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
 
 	// Route all XDG state writes to a temp dir.

--- a/modules/programs/prism/prism/internal/review/tmux_isolation_test.go
+++ b/modules/programs/prism/prism/internal/review/tmux_isolation_test.go
@@ -1,0 +1,181 @@
+package review_test
+
+// Suite-wide tmux isolation for the review package (#2230, pattern from
+// #2214/#2224).
+//
+// Several production code paths in internal/review reach the live tmux
+// server when invoked without a stub:
+//
+//   - review.LookupParentSession() → tmux.CurrentSession() when
+//     PRISM_SESSION_NAME is empty (run.go)
+//   - review.KillSessionPrefix() → tmux.Run("list-sessions", …) +
+//     tmux.KillSession (lifecycle.go)
+//   - the readiness-gate and Run/RunAsync cleanup paths → tmux.KillSession
+//     (readiness.go, run.go)
+//
+// Crucially, `tmux list-sessions` / `tmux display-message` reach the live
+// host server even when $TMUX is unset or empty: the tmux client falls back
+// to the default socket ($TMUX_TMPDIR/tmux-<uid>/default, /tmp/tmux-<uid>/
+// default when TMUX_TMPDIR is unset). Historically this package relied on
+// per-test opt-in stubs (spawnSpyTmuxBin rewriting tmux.TmuxBin) as the ONLY
+// line of defence — and #1732 is the proof it is not enough: a test that
+// forgot the stub leaked 5 real review-agent sessions onto the live server,
+// caught only incidentally by the cmd package's leak guard under parallel
+// `go test ./...` scheduling. That incidental backstop was dropped in #2227
+// (it false-positived on concurrent host activity), leaving nothing to
+// detect this leak class. The suite-wide neutralisation below, applied by
+// TestMain before m.Run():
+//
+//   1. clears $TMUX, so a socket path inherited from an enclosing live pane
+//      is never used; and
+//   2. points $TMUX_TMPDIR at a fresh, empty directory, so the
+//      default-socket fallback cannot reach the host server either.
+//
+// Every tmux client invocation made by code under test then fails fast with
+// "error connecting to ..." — indistinguishable from a host with no tmux
+// server running, which is what CI sees. The per-test spawnSpyTmuxBin stubs
+// become defence-in-depth instead of the only line of defence.
+//
+// The redirected directory must have a SHORT path: tmux sockets are Unix
+// domain sockets and sun_path is ~104 bytes on Darwin. os.MkdirTemp("", ...)
+// on macOS yields /var/folders/... paths that overflow it once tmux appends
+// tmux-<uid>/<socket-name>. No review test runs an intentional real tmux
+// server (audited for #2230: all tmux interaction goes through the
+// spawnSpyTmuxBin stub), so the short path only matters for keeping the
+// failure mode "connection refused" rather than "path too long" — but we
+// follow the cmd package's /tmp-first convention anyway so a future
+// intentional-real-server test does not trip over it.
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// isoTmuxTmpdir records the redirected $TMUX_TMPDIR applied by TestMain.
+// TestSuiteTmuxIsolation_HostServerUnreachable asserts against it so the
+// guard fails deterministically — even on hosts with no live tmux server
+// (the CI shape) — if the TestMain-level isolation is removed or reordered
+// after m.Run().
+var isoTmuxTmpdir string
+
+// TestMain serves two purposes:
+//
+//  1. Stub sidecar: code under test (review.Run → session.SpawnSession →
+//     session.StartSidecarWithOpts) re-invokes os.Executable() — THIS test
+//     binary — as a detached `sidecar --session …` process. Without
+//     interception the child would recursively run the entire review suite
+//     in the background, which itself spawns more children (observed: 93
+//     detached review.test processes after a single suite run). The
+//     spawn_prompt_file tests set PRISM_TEST_SUBPROCESS=1 expecting a
+//     TestMain to handle it (the session package's TestMain does the same
+//     for ITS binary); the argv check additionally covers call paths that
+//     reach StartSidecarWithOpts without setting the env var (e.g.
+//     TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort's 5-agent fan-out).
+//     The 50ms sleep mirrors the session package's stub: long enough for a
+//     parent to observe a live PID, short enough to be free.
+//
+//  2. Tmux isolation (#2230): clears $TMUX and redirects $TMUX_TMPDIR to an
+//     empty directory so no code under test can reach the live host tmux
+//     server via the default-socket fallback. See the package comment above
+//     for the full rationale. The original environment is restored after
+//     m.Run().
+func TestMain(m *testing.M) {
+	if os.Getenv("PRISM_TEST_SUBPROCESS") == "1" {
+		// We are the child process acting as the sidecar stub.
+		time.Sleep(50 * time.Millisecond)
+		os.Exit(0)
+	}
+	if len(os.Args) > 1 && (os.Args[1] == "sidecar" || os.Args[1] == "monitor-review") {
+		// Re-invoked as a prism subcommand without the stub env var. Exit
+		// instead of recursively running the suite. "sidecar" comes from
+		// session.StartSidecarWithOpts; "monitor-review" from
+		// review.StartMonitorProcess when a test passes prismBinary==""
+		// (RunAsync's default).
+		os.Exit(0)
+	}
+
+	restore := isolateSuiteFromHostTmux()
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
+
+// isolateSuiteFromHostTmux applies the suite-wide tmux neutralisation
+// described in the package comment and returns a restore function that puts
+// the original environment back. TestMain calls restore after m.Run() so the
+// test process leaves the environment as it found it.
+func isolateSuiteFromHostTmux() (restore func()) {
+	origTmux, hadTmux := os.LookupEnv("TMUX")
+	origTmpdir, hadTmpdir := os.LookupEnv("TMUX_TMPDIR")
+
+	isoDir, err := os.MkdirTemp("/tmp", "prv-")
+	if err != nil {
+		// /tmp unwritable (e.g. restrictive build sandboxes). Fall back to
+		// the default temp dir: the resulting socket paths may exceed
+		// sun_path, which only makes tmux fail faster — isolation is
+		// preserved either way.
+		isoDir, err = os.MkdirTemp("", "prv-")
+	}
+	if err != nil {
+		// Last resort: a path guaranteed not to contain a live socket.
+		isoDir = "/nonexistent/prism-review-test-tmux"
+	}
+
+	os.Setenv("TMUX", "")
+	os.Setenv("TMUX_TMPDIR", isoDir)
+	isoTmuxTmpdir = isoDir
+
+	return func() {
+		if hadTmux {
+			os.Setenv("TMUX", origTmux)
+		} else {
+			os.Unsetenv("TMUX")
+		}
+		if hadTmpdir {
+			os.Setenv("TMUX_TMPDIR", origTmpdir)
+		} else {
+			os.Unsetenv("TMUX_TMPDIR")
+		}
+		os.RemoveAll(isoDir)
+	}
+}
+
+// TestSuiteTmuxIsolation_HostServerUnreachable is the deterministic
+// regression guard for the #1732 leak class (#2230). It asserts that, under
+// the TestMain-level neutralisation:
+//
+//   - the env redirect is actually in effect ($TMUX cleared, $TMUX_TMPDIR
+//     pointing at the suite's private directory) — these assertions fail
+//     even on hosts with NO live tmux server (the CI shape), so removing
+//     the isolation cannot pass unnoticed anywhere; and
+//   - the live host tmux server is behaviourally unreachable:
+//     tmux.CurrentSession() must fail, and review.LookupParentSession()
+//     must return "" when PRISM_SESSION_NAME is empty — the exact fallback
+//     chain through which a forgotten stub would reach the host server.
+//
+// Verified non-vacuous by no-opping isolateSuiteFromHostTmux in TestMain and
+// observing this test fail against a live host server (see PR for #2230).
+func TestSuiteTmuxIsolation_HostServerUnreachable(t *testing.T) {
+	if isoTmuxTmpdir == "" {
+		t.Fatal("isoTmuxTmpdir is empty — TestMain did not apply isolateSuiteFromHostTmux before m.Run() (#2230)")
+	}
+	if got := os.Getenv("TMUX_TMPDIR"); got != isoTmuxTmpdir {
+		t.Errorf("TMUX_TMPDIR = %q, want the suite's private dir %q — suite-wide tmux isolation is not in effect (#2230)", got, isoTmuxTmpdir)
+	}
+	if got := os.Getenv("TMUX"); got != "" {
+		t.Errorf("TMUX = %q, want \"\" — an inherited live-pane socket path could reach the host server (#2230)", got)
+	}
+
+	if s, err := tmux.CurrentSession(); err == nil && s != "" {
+		t.Errorf("tmux.CurrentSession() = %q, want error — the review suite must be isolated from the live host tmux server (#2230); check TestMain's isolateSuiteFromHostTmux", s)
+	}
+
+	t.Setenv("PRISM_SESSION_NAME", "")
+	if got := review.LookupParentSession(); got != "" {
+		t.Errorf("review.LookupParentSession() = %q, want \"\" — host tmux state is leaking into review tests (#2230)", got)
+	}
+}

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -454,21 +453,32 @@ func TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir(t *testing.T) {
 		// blocked by the guard.
 		//
 		// The guard under test fires BEFORE any tmux invocation, so its
-		// behaviour is observable even when tmux is absent from $PATH
-		// (tmux is intentionally NOT in nativeCheckInputs in pkgs/prism.nix
-		// — see the long comment there — so the nix build sandbox runs
-		// this subtest without tmux):
+		// behaviour is observable even when tmux is unusable (tmux is
+		// intentionally NOT in nativeCheckInputs in pkgs/prism.nix — see
+		// the long comment there — so the nix build sandbox runs this
+		// subtest without tmux):
 		//
-		//   - tmux available: Create must succeed end-to-end.
-		//   - tmux absent: Create must fail at the tmux launch ("new-session"),
-		//     NOT at the PIExtensionDir guard. If the guard were wrongly
-		//     applied to LayoutBare it would reject before reaching tmux,
-		//     producing a "piExtensionDir" error in both environments — so
-		//     either branch catches the regression.
+		//   - tmux usable: Create must succeed end-to-end.
+		//   - tmux unusable: Create must fail at the tmux launch
+		//     ("new-session"), NOT at the PIExtensionDir guard. If the guard
+		//     were wrongly applied to LayoutBare it would reject before
+		//     reaching tmux, producing a "piExtensionDir" error in both
+		//     environments — so either branch catches the regression.
+		//
+		// "Usable" is decided by a functional probe, not exec.LookPath:
+		// since the suite-wide $TMUX_TMPDIR redirect (#2230) this subtest
+		// starts a fresh private tmux server instead of reusing the live
+		// host server (the old form created its session on the developer's
+		// LIVE server — exactly the leak class #2230 eliminates). Inside a
+		// prism worker sandbox the tmux binary is on $PATH but a fresh
+		// server cannot fork window processes ("fork failed: Operation not
+		// permitted"), so LookPath alone would put a sandboxed run in the
+		// wrong branch.
 		name := "unit-test-2065-bare"
-		_, tmuxErr := exec.LookPath("tmux")
-		tmuxAvailable := tmuxErr == nil
+		const probe = "unit-test-2065-probe"
+		tmuxAvailable := tmux.NewSessionDetached(probe, "/tmp") == nil
 		if tmuxAvailable {
+			_ = tmux.KillSession(probe)
 			defer tmux.KillSession(name)
 		}
 		err := Create(name, dir, Opts{

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -28,6 +28,22 @@ import (
 // When PRISM_TEST_STUB_LONG=1 the binary acts as a long-running stub that
 // sleeps for 60 seconds, interruptible by SIGTERM. This is used by tests that
 // exercise the KillSidecarAndWait wait path.
+//
+// The argv check is defence in depth for the #2230 recursion class: this
+// package's production code re-execs os.Executable() — in tests, THIS
+// binary — as `<self> sidecar …` (StartSidecarWithOpts) and `<self> event
+// tmux-session-start …` (setupFullLayout's status seed). A test that
+// reaches either path without setting the stub env var would otherwise run
+// the entire suite recursively as a detached (or, for the event seed,
+// synchronous) child. internal/review hit exactly this (93 detached
+// review.test processes after one suite run) because its tests relied on a
+// TestMain it did not have.
+//
+// Suite-wide tmux isolation (#2230): clears $TMUX and redirects
+// $TMUX_TMPDIR to an empty directory before m.Run() so no code under test
+// can reach the live host tmux server via the default-socket fallback. See
+// tmux_isolation_test.go for the full rationale and the regression guard.
+// The original environment is restored after m.Run().
 func TestMain(m *testing.M) {
 	if os.Getenv("PRISM_TEST_SUBPROCESS") == "1" {
 		// We are the child process acting as the sidecar stub.
@@ -40,7 +56,17 @@ func TestMain(m *testing.M) {
 		time.Sleep(60 * time.Second)
 		os.Exit(0)
 	}
-	os.Exit(m.Run())
+	if len(os.Args) > 1 && (os.Args[1] == "sidecar" || os.Args[1] == "event") {
+		// Re-invoked as a prism subcommand without a stub env var (#2230
+		// recursion defence — see the doc comment above). Exit instead of
+		// recursively running the suite.
+		os.Exit(0)
+	}
+
+	restoreTmuxEnv := isolateSuiteFromHostTmux()
+	code := m.Run()
+	restoreTmuxEnv()
+	os.Exit(code)
 }
 
 // ── path helper tests ────────────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/session/tmux_isolation_test.go
+++ b/modules/programs/prism/prism/internal/session/tmux_isolation_test.go
@@ -1,0 +1,136 @@
+package session
+
+// Suite-wide tmux isolation for the session package (#2230, pattern from
+// #2214/#2224).
+//
+// Production code in this package talks to tmux on nearly every path:
+// Create/setupFullLayout (NewSessionDetached, NewWindow, RenameWindow,
+// SendKeys, SelectWindow), SpawnSession (NewSessionDetached, NewWindow,
+// KillSession on the failure paths), Exists/kill helpers (HasSession,
+// KillSession), and attachOrSwitch (CurrentClient, SwitchClient).
+//
+// Crucially, every one of those reaches the LIVE host tmux server when no
+// per-test stub is installed: the tmux client falls back to the default
+// socket ($TMUX_TMPDIR/tmux-<uid>/default, /tmp/tmux-<uid>/default when
+// TMUX_TMPDIR is unset) even with $TMUX unset or empty. Historically this
+// package relied on per-test opt-in stubs (spyTmuxBin / failTmuxBin
+// rewriting tmux.TmuxBin) as the ONLY line of defence — the same posture
+// that produced the #1732 leak in internal/review (5 real review-agent
+// sessions on the live server). The suite-wide neutralisation below,
+// applied by TestMain before m.Run():
+//
+//   1. clears $TMUX, so a socket path inherited from an enclosing live pane
+//      is never used; and
+//   2. points $TMUX_TMPDIR at a fresh, empty directory, so the
+//      default-socket fallback cannot reach the host server either.
+//
+// The per-test stubs become defence-in-depth instead of the only line of
+// defence, and a test that forgets the stub fails fast with "error
+// connecting to ..." — the same shape CI (no tmux server) produces.
+//
+// One test in this package intentionally runs a REAL tmux session on the
+// default socket: TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir's
+// LayoutBare subtest (session_test.go). Before #2230 that session was
+// created on the LIVE host server; under the redirect, tmux auto-starts a
+// private throwaway server inside the redirected $TMUX_TMPDIR instead, and
+// the server exits when the subtest's KillSession removes its only session.
+// That is why the redirected directory must have a SHORT path: tmux sockets
+// are Unix domain sockets and sun_path is ~104 bytes on Darwin, and
+// os.MkdirTemp("", ...) on macOS yields /var/folders/... paths that
+// overflow it once tmux appends tmux-<uid>/default. Hence /tmp first, with
+// the generic temp dir as fallback.
+
+import (
+	"os"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/tmux"
+)
+
+// isoTmuxTmpdir records the redirected $TMUX_TMPDIR applied by TestMain
+// (sidecar_test.go). TestSuiteTmuxIsolation_HostServerUnreachable asserts
+// against it so the guard fails deterministically — even on hosts with no
+// live tmux server (the CI shape) — if the TestMain-level isolation is
+// removed or reordered after m.Run().
+var isoTmuxTmpdir string
+
+// isolateSuiteFromHostTmux applies the suite-wide tmux neutralisation
+// described in the package comment and returns a restore function that puts
+// the original environment back. TestMain (sidecar_test.go) calls restore
+// after m.Run() so the test process leaves the environment as it found it.
+func isolateSuiteFromHostTmux() (restore func()) {
+	origTmux, hadTmux := os.LookupEnv("TMUX")
+	origTmpdir, hadTmpdir := os.LookupEnv("TMUX_TMPDIR")
+
+	isoDir, err := os.MkdirTemp("/tmp", "pse-")
+	if err != nil {
+		// /tmp unwritable (e.g. restrictive build sandboxes). Fall back to
+		// the default temp dir: the resulting socket paths may exceed
+		// sun_path, which only makes tmux fail faster — isolation is
+		// preserved either way (such hosts have no tmux available for the
+		// intentional real-server subtest anyway, which skips its
+		// tmux-available branch).
+		isoDir, err = os.MkdirTemp("", "pse-")
+	}
+	if err != nil {
+		// Last resort: a path guaranteed not to contain a live socket.
+		// Isolation trumps the real-tmux subtest's ability to run.
+		isoDir = "/nonexistent/prism-session-test-tmux"
+	}
+
+	os.Setenv("TMUX", "")
+	os.Setenv("TMUX_TMPDIR", isoDir)
+	isoTmuxTmpdir = isoDir
+
+	return func() {
+		if hadTmux {
+			os.Setenv("TMUX", origTmux)
+		} else {
+			os.Unsetenv("TMUX")
+		}
+		if hadTmpdir {
+			os.Setenv("TMUX_TMPDIR", origTmpdir)
+		} else {
+			os.Unsetenv("TMUX_TMPDIR")
+		}
+		os.RemoveAll(isoDir)
+	}
+}
+
+// TestSuiteTmuxIsolation_HostServerUnreachable is the deterministic
+// regression guard for the #1732 leak class (#2230). It asserts that, under
+// the TestMain-level neutralisation:
+//
+//   - the env redirect is actually in effect ($TMUX cleared, $TMUX_TMPDIR
+//     pointing at the suite's private directory) — these assertions fail
+//     even on hosts with NO live tmux server (the CI shape), so removing
+//     the isolation cannot pass unnoticed anywhere; and
+//   - the live host tmux server is behaviourally unreachable:
+//     tmux.CurrentSession() must fail — the default-socket fallback chain
+//     through which a forgotten spyTmuxBin would reach the host server.
+//
+// The behavioural probe is deterministic with respect to this package's own
+// intentional real-server subtest (see the package comment): that subtest
+// kills its only session before returning, which makes the private server
+// exit, and the tests in this package run sequentially — so by the time
+// this guard runs there is nothing listening on the redirected default
+// socket.
+//
+// Verified non-vacuous by no-opping the isolateSuiteFromHostTmux call in
+// TestMain and observing this test fail against a live host server (see PR
+// for #2230).
+func TestSuiteTmuxIsolation_HostServerUnreachable(t *testing.T) {
+	if isoTmuxTmpdir == "" {
+		t.Fatal("isoTmuxTmpdir is empty — TestMain did not apply isolateSuiteFromHostTmux before m.Run() (#2230)")
+	}
+	if got := os.Getenv("TMUX_TMPDIR"); got != isoTmuxTmpdir {
+		t.Errorf("TMUX_TMPDIR = %q, want the suite's private dir %q — suite-wide tmux isolation is not in effect (#2230)", got, isoTmuxTmpdir)
+	}
+	if got := os.Getenv("TMUX"); got != "" {
+		t.Errorf("TMUX = %q, want \"\" — an inherited live-pane socket path could reach the host server (#2230)", got)
+	}
+
+	if s, err := tmux.CurrentSession(); err == nil && s != "" {
+		t.Errorf("tmux.CurrentSession() = %q, want error — the session suite must be isolated from the live host tmux server (#2230); check TestMain's isolateSuiteFromHostTmux", s)
+	}
+}


### PR DESCRIPTION
Closes #2230

Applies the #2224 pattern to `internal/review` and `internal/session`: suite-wide `TestMain` tmux isolation (clear `$TMUX` + redirect `$TMUX_TMPDIR` to a fresh short-pathed dir before `m.Run()`, restored after) plus a deterministic `TestSuiteTmuxIsolation_HostServerUnreachable` regression guard in each package. The per-test stubs (`spawnSpyTmuxBin` / `spyTmuxBin`) become defence-in-depth instead of the only line of defence against the #1732 leak class.

## Guard design

Each guard asserts two layers:

- **Env assertions** — `$TMUX` cleared and `$TMUX_TMPDIR` equal to the private dir recorded by the isolation helper. These fail **even on a host with no live tmux server** (the CI shape), so removing the isolation cannot pass unnoticed anywhere — strictly stronger than a probe-only guard.
- **Behavioural probes** — `tmux.CurrentSession()` must fail; for review, `review.LookupParentSession()` must return `""` with `PRISM_SESSION_NAME` empty (the exact fallback chain a forgotten stub would leak through).

Short-path discipline (#2224 sun_path lesson): `os.MkdirTemp("/tmp", …)` first, generic temp dir fallback, `/nonexistent` last resort. Audit answer to the spawn-prompt question: **no review test runs an intentional real `-L` server** — all review tmux interaction goes through stubs. internal/session has exactly one intentional real-tmux test (see below).

## Bonus fix — pre-existing re-exec recursion landmine (escalated to coordinator, agreed in scope)

The audit surfaced that `internal/review` had **no TestMain at all**, while its tests reach `session.StartSidecarWithOpts`, which re-execs `os.Executable()` — the *review test binary* — as a detached `sidecar` subprocess. The comment claiming "the session package's TestMain handles PRISM_TEST_SUBPROCESS" was wrong for this binary. Each such child ran the **entire review suite** detached, which spawned more children (`TestRun_RequireSlot_AllSlotsPresent_DoesNotAbort` spawns 5 per run with no stub env var at all; the 3 `spawn_prompt_file` tests set the env var that nothing handled). **Observed: 93 detached `review.test` processes after a single suite run on this host** — anyone seeing `pgrep` noise of `review.test sidecar --session …` processes carrying ~120KB synthetic prompts hit this. The storm self-extinguishes within ~1–2 generations only because `go test` deletes its build dir, making grandchild re-execs fail.

Fix (inseparable from the TestMain this issue requires — any TestMain added here must decide what a stub re-invocation does): both TestMains intercept stub re-invocations via env var (`PRISM_TEST_SUBPROCESS`, matching the session package's convention) **and** argv defence (`sidecar`/`monitor-review` for review; `sidecar`/`event` for session — each package's own re-exec argvs). Verified: zero stray processes after a full suite run (was 93).

## internal/session specifics

- `TestMain` (sidecar_test.go) wires the isolation around `m.Run()` (stub short-circuits unchanged, ahead of it).
- The LayoutBare subtest of `TestCreate_LayoutFull_FailsFastOnEmptyPIExtensionDir` previously created its real session **on the live host server** — exactly the leak class this issue eliminates. Under the redirect it now starts a private throwaway server. Inside a prism worker sandbox the tmux binary is on `$PATH` but a fresh server cannot fork window processes, so the subtest now uses a **functional probe** (`NewSessionDetached` + kill) instead of `exec.LookPath` to pick its branch; the guard-regression signal (no `piExtensionDir` error) is preserved in both branches.

## Mutation verification (both packages, live host server reachable from this sandbox)

- **Mutation (b) — redirect line disabled, recording kept:** guard FAILs; behavioural probes caught the live server, reporting a *parallel worker's* live session (`nixos-config@narrow-secrets-sbpl~review-2-review-context`) from `tmux.CurrentSession()` and `review.LookupParentSession()`; env assertion fired too.
- **Mutation (a) — isolation call no-opped in TestMain:** guard FAILs at `isoTmuxTmpdir is empty` — proving detection in the CI shape with no live server needed.
- Restored → both guards PASS.

## AC verification

- **[functional] review tests cannot reach the live host server even without a stub** — by construction (TestMain redirect) + mutation-verified guard (above).
- **[functional] existing tmux-exercising tests still pass** — full `go test ./... -race`: 29 packages ok, 0 fail, under live host activity.
- **[edge-case] suite passes with no tmux server** — every run now exercises exactly this shape by construction (the redirected socket dir is empty); additionally this sandbox cannot even fork a fresh server, so the "tmux unusable" branch of the LayoutBare subtest ran and passed. The tmux-binary-absent shape is exercised by CI's `nix-build-prism-checked` job.

## Audit record — other non-cmd packages with tmux call paths / re-exec paths (recorded, not touched)

| Package | Finding | Disposition |
|---|---|---|
| `internal/dashboard` | Production tmux calls exist (`list-clients`, `SwitchClientLast`, `HasSession`/`SwitchClient`), but **no test file imports `internal/tmux` or invokes any of those paths today**; no TestMain. | Out of scope: no live-server-reachable call path under test. Follow-up candidate if dashboard tests grow tmux coverage. |
| `internal/tmux` | Its own tests intentionally run real servers, but **only** via private `-L` sockets + `-f /dev/null` (`withServer`/`withTmuxServer` rewrite `TmuxBin` to inject `-L`); no default-socket use. | Out of scope: isolated by a different construction. |
| `internal/integration` | Real tmux via private `-L` sockets (`tmuxtest`); explicitly avoids `Create(LayoutFull)` *because of* the `event` re-exec (documented in-file); TestMain handles only `PRISM_FAKE_STDIO_HARNESS` — **no `sidecar`-style argv/env interception**, though no test currently reaches `StartSidecarWithOpts`. | Follow-up: add re-exec interception defence to its TestMain. |
| `internal/sidecar` | Host-API handlers re-exec `prismBinary()` which falls back to `os.Executable()`; every current test injects the `PrismBinaryPath` stub seam; **no TestMain** → a forgotten seam re-execs the sidecar test binary. | Out of footprint (forbidden dir for this worker). Follow-up: TestMain interception. |
| `cmd` | TestMain intercepts its own stubs (`PRISM_CMD_TEST_STUB`, supervise helper); spawn paths seamed (`investigateSpawnSessionFn`); `restart`'s `syscall.Exec` stubbed before exec. No current path reaches `StartSidecarWithOpts`. | Adequate today; the env/argv stub defence could be added in the same follow-up sweep. |

## Pre-PR self-check

- `go build ./...` ✅, `go vet` ✅, `go test ./... -race` ✅ (29 ok / 0 fail, with live host sessions and a parallel worker's review round active)
- `nix build .#prism` could **not** run locally: this worker sandbox pre-dates #2201 (`trusted-settings.json: Operation not permitted`). Used the sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` ✅. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).

Footprint: `internal/review` + `internal/session` test files only — no production code, no `cmd/`, no `internal/container`, no `internal/sidecar`.
