### PR TITLE
prism: re-exec stub interception for internal/integration, internal/sidecar, and cmd test binaries (#2237)

### DIFF
--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -42,7 +42,7 @@ import (
 	prismSession "github.com/prismatic-koi/prism/internal/session"
 )
 
-// TestMain serves three purposes:
+// TestMain serves several purposes:
 //
 //  1. Stub sidecar: when PRISM_CMD_TEST_STUB=1, the binary sleeps for 60
 //     seconds (simulating a long-running sidecar). The sleep is interruptible
@@ -89,6 +89,19 @@ import (
 //     PRISM_HOST_API, …) so tests see the same environment surface on CI,
 //     developer hosts, and inside prism worker sandboxes. See
 //     sandbox_env_isolation_test.go for the full rationale.
+//
+//  6. Re-exec stub interception (#2230 class, swept in #2237): production
+//     code reachable from this package re-execs os.Executable() — in tests,
+//     THIS binary — as `<self> sidecar …` / `<self> event …`
+//     (session.SpawnSession paths) and `<self> monitor-review …`
+//     (review.RunAsync → StartMonitorProcess with prismBinary=="").
+//     PRISM_TEST_SUBPROCESS=1 short-circuits an explicit stub re-invocation;
+//     the argv check covers paths reached without the env var, exiting
+//     instead of recursively running the suite. The argv check MUST stay
+//     after the PRISM_CMD_TEST_STUB check: startStubProcess re-invokes this
+//     binary with argv "sidecar --session …" and relies on the env stub's
+//     60-second sleep. (The host-API re-exec subcommands — prompt, spawn,
+//     … — are intercepted by internal/sidecar's own TestMain.)
 func TestMain(m *testing.M) {
 	if os.Getenv("PRISM_CMD_TEST_STUB") == "1" {
 		time.Sleep(60 * time.Second)
@@ -96,6 +109,16 @@ func TestMain(m *testing.M) {
 	}
 	if os.Getenv(superviseHelperEnvVar) == "1" {
 		os.Exit(runSuperviseHelper())
+	}
+	if os.Getenv("PRISM_TEST_SUBPROCESS") == "1" {
+		// Stub subprocess convention shared with the internal/review,
+		// internal/session, and internal/integration TestMains (#2237).
+		time.Sleep(50 * time.Millisecond)
+		os.Exit(0)
+	}
+	if len(os.Args) > 1 && (os.Args[1] == "sidecar" || os.Args[1] == "event" || os.Args[1] == "monitor-review") {
+		// Re-exec argv defence — see purpose 6 in the doc comment above.
+		os.Exit(0)
 	}
 
 	// Register a SIGTERM handler that cleans up orphaned tmux test servers.

--- a/modules/programs/prism/prism/internal/integration/reexec_interception_test.go
+++ b/modules/programs/prism/prism/internal/integration/reexec_interception_test.go
@@ -1,0 +1,86 @@
+package integration_test
+
+// Regression guard for TestMain's re-exec stub interception (#2237, residual
+// from #2230).
+//
+// Production code reachable from this package re-execs os.Executable() — in
+// tests, THIS test binary — as a prism subcommand: session.StartSidecarWithOpts
+// launches `<self> sidecar --session …` and setupFullLayout's status seed runs
+// `<self> event tmux-session-start …`. Without the TestMain interception
+// (testmain_test.go) such a re-invocation runs the ENTIRE test suite as a
+// detached child, which can spawn further children — the #2230 landmine class
+// (93 detached test processes observed after a single internal/review run
+// before its TestMain gained the same defence in #2236).
+//
+// This guard execs the test binary the way the production re-exec would —
+// the same argv shapes, no stub env var — and asserts it exits 0 immediately
+// with no output. A suite run instead prints test/log output and at minimum
+// a trailing "PASS"/"FAIL", so the empty-output assertion fails if the
+// interception is ever removed (verified non-vacuous against the pre-#2237
+// binary: the `event …` re-invocation ran the full suite and printed PASS).
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// reexecGuardChildEnv is a recursion brake for the mutated state only: if the
+// TestMain interception is removed, the child invocation below runs the full
+// suite — including this guard. The brake makes the child's copy of the guard
+// skip instead of spawning grandchildren, so the failure is a bounded, visible
+// guard FAIL rather than a fork storm. With the interception in place the
+// child never reaches m.Run() and the brake is inert.
+const reexecGuardChildEnv = "PRISM_REEXEC_GUARD_CHILD"
+
+func TestReExecInterception_ProductionArgvShapes(t *testing.T) {
+	if os.Getenv(reexecGuardChildEnv) == "1" {
+		t.Skip("recursion brake: running inside a guard-spawned child (see reexecGuardChildEnv)")
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		// session.StartSidecarWithOpts (internal/session/sidecar.go).
+		{"sidecar", []string{"sidecar", "--session", "prism-test@reexec-guard", "--harness-url", "http://localhost:0"}},
+		// setupFullLayout's status seed (internal/session/session.go).
+		{"event", []string{"event", "tmux-session-start", "--session", "prism-test@reexec-guard", "--worktree", "/nonexistent/prism-reexec-guard"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, self, tc.argv...)
+			// Bound Wait on lingering pipe holders if a mutated run leaves
+			// grandchildren sharing stdout/stderr.
+			cmd.WaitDelay = 5 * time.Second
+			cmd.Env = append(os.Environ(), reexecGuardChildEnv+"=1")
+			out, runErr := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("re-invoked test binary %v did not exit within 30s — TestMain re-exec interception missing (#2237); output:\n%s", tc.argv, reexecGuardTruncate(out))
+			}
+			if runErr != nil {
+				t.Fatalf("re-invoked test binary %v = %v, want immediate exit 0 from TestMain interception (#2237); output:\n%s", tc.argv, runErr, reexecGuardTruncate(out))
+			}
+			if len(out) != 0 {
+				t.Errorf("re-invoked test binary %v wrote %d bytes — the suite ran instead of TestMain intercepting (#2237):\n%s", tc.argv, len(out), reexecGuardTruncate(out))
+			}
+		})
+	}
+}
+
+// reexecGuardTruncate bounds child output in failure messages.
+func reexecGuardTruncate(b []byte) string {
+	const max = 2048
+	if len(b) > max {
+		return string(b[:max]) + "… (truncated)"
+	}
+	return string(b)
+}

--- a/modules/programs/prism/prism/internal/integration/testmain_test.go
+++ b/modules/programs/prism/prism/internal/integration/testmain_test.go
@@ -12,12 +12,16 @@ package integration_test
 //   - "silent": exits 0 immediately without writing any frames. Exercises the
 //     "pipe closed before first frame" error path in runStartupStdio.
 //
-// When PRISM_FAKE_STDIO_HARNESS is unset, TestMain runs the normal test suite.
+// TestMain also intercepts re-exec stub invocations of this test binary
+// (#2237, residual from #2230) — see the env and argv checks below.
+//
+// When no interception applies, TestMain runs the normal test suite.
 
 import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -29,6 +33,34 @@ func TestMain(m *testing.M) {
 		// Exit immediately without writing any frames.
 		os.Exit(0)
 	}
+
+	if os.Getenv("PRISM_TEST_SUBPROCESS") == "1" {
+		// We are a child process acting as a stub subprocess — the
+		// convention shared by the internal/review, internal/session, and
+		// cmd TestMains. Sleep briefly so a parent can observe a live PID,
+		// then exit instead of running the suite.
+		time.Sleep(50 * time.Millisecond)
+		os.Exit(0)
+	}
+	if len(os.Args) > 1 && (os.Args[1] == "sidecar" || os.Args[1] == "event") {
+		// Re-invoked as a prism subcommand without the stub env var (#2230
+		// recursion class, swept in #2237). This package's reachable re-exec
+		// paths both exec os.Executable() — in tests, THIS binary:
+		//
+		//   - session.StartSidecarWithOpts → `<self> sidecar --session …`
+		//   - session.setupFullLayout's status seed →
+		//     `<self> event tmux-session-start --session … --worktree …`
+		//
+		// No current test reaches either path (Create(LayoutFull) is
+		// deliberately avoided — see TestTmuxHarness_ThreeWindowLayout), so
+		// this is a defence against a future test or forgotten stub
+		// recursively running the entire suite as a detached child
+		// (observed in internal/review: 93 detached test processes after a
+		// single run). Exit instead of running the suite — see
+		// reexec_interception_test.go for the regression guard.
+		os.Exit(0)
+	}
+
 	// Default: run the test suite.
 	os.Exit(m.Run())
 }

--- a/modules/programs/prism/prism/internal/sidecar/reexec_interception_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/reexec_interception_test.go
@@ -1,0 +1,83 @@
+package sidecar
+
+// Regression guard for TestMain's re-exec stub interception (#2237, residual
+// from #2230).
+//
+// The host-API handlers re-exec prismBinary() — which falls back to
+// os.Executable(), i.e. THIS test binary — with the subcommand argv shapes
+// below (the exec.CommandContext sites in host_api.go). Without the TestMain
+// interception (testmain_test.go) such a re-invocation runs the ENTIRE test
+// suite as a detached child — verified against the pre-#2237 binary:
+// `<self> prompt prism-test@reexec-guard --prompt hi` ran the full suite for
+// 47 seconds and wrote 2.9 MB of output ending in PASS.
+//
+// This guard execs the test binary the way the production re-exec would —
+// the same argv shapes prismBinary() callers build, no stub env var — and
+// asserts it exits 0 immediately with no output. A suite run instead prints
+// test/log output and at minimum a trailing "PASS"/"FAIL", so the
+// empty-output assertion fails if the interception is ever removed.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// reexecGuardChildEnv is a recursion brake for the mutated state only: if the
+// TestMain interception is removed, the child invocation below runs the full
+// suite — including this guard. The brake makes the child's copy of the guard
+// skip instead of spawning grandchildren, so the failure is a bounded, visible
+// guard FAIL rather than a fork storm. With the interception in place the
+// child never reaches m.Run() and the brake is inert.
+const reexecGuardChildEnv = "PRISM_REEXEC_GUARD_CHILD"
+
+func TestReExecInterception_ProductionArgvShapes(t *testing.T) {
+	if os.Getenv(reexecGuardChildEnv) == "1" {
+		t.Skip("recursion brake: running inside a guard-spawned child (see reexecGuardChildEnv)")
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	// One case per host_api.go re-exec site, mirroring the production
+	// `args := []string{…}` literals. Keep in sync with
+	// hostAPIReExecSubcommands (testmain_test.go).
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		{"prompt", []string{"prompt", "prism-test@reexec-guard", "--prompt", "guard"}},
+		{"spawn", []string{"spawn", "--branch", "prism-test-reexec-guard"}},
+		{"review", []string{"review", "0"}},
+		{"cleanup", []string{"cleanup", "--session", "prism-test@reexec-guard"}},
+		{"close", []string{"close", "--session", "prism-test@reexec-guard"}},
+		{"switch", []string{"switch", "--path", "/nonexistent/prism-reexec-guard"}},
+		{"event", []string{"event", "guard-event", "--session", "prism-test@reexec-guard"}},
+		{"escalate", []string{"escalate", "--prompt", "guard"}},
+		{"investigate", []string{"investigate", "--prompt", "guard"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, self, tc.argv...)
+			// Bound Wait on lingering pipe holders if a mutated run leaves
+			// grandchildren sharing stdout/stderr.
+			cmd.WaitDelay = 5 * time.Second
+			cmd.Env = append(os.Environ(), reexecGuardChildEnv+"=1")
+			out, runErr := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("re-invoked test binary %v did not exit within 30s — TestMain re-exec interception missing (#2237); output:\n%s", tc.argv, truncateBytes(out, 2048))
+			}
+			if runErr != nil {
+				t.Fatalf("re-invoked test binary %v = %v, want immediate exit 0 from TestMain interception (#2237); output:\n%s", tc.argv, runErr, truncateBytes(out, 2048))
+			}
+			if len(out) != 0 {
+				t.Errorf("re-invoked test binary %v wrote %d bytes — the suite ran instead of TestMain intercepting (#2237):\n%s", tc.argv, len(out), truncateBytes(out, 2048))
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/testmain_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/testmain_test.go
@@ -1,0 +1,64 @@
+package sidecar
+
+// TestMain re-exec stub interception (#2237, residual from #2230).
+//
+// The host-API handlers in this package re-exec prismBinary() (host_api.go),
+// which falls back to os.Executable() — in tests, THIS test binary — when
+// Config.PrismBinaryPath is unset. Every current test injects the
+// PrismBinaryPath seam, so no test reaches the fallback today; but one
+// forgotten seam would re-exec the sidecar test binary as a full detached
+// suite run — the #2230 landmine class (93 detached test processes observed
+// after a single internal/review run before its TestMain gained the same
+// defence in #2236; this package's binary demonstrably did the same when
+// invoked as `<self> prompt …`: a 47-second full suite run).
+//
+// Interception, per the convention shared by internal/review,
+// internal/session, internal/integration, and cmd:
+//
+//  1. PRISM_TEST_SUBPROCESS=1 — explicit stub re-invocation: sleep briefly
+//     (so a parent can observe a live PID) and exit 0.
+//  2. argv defence — re-invoked with one of this package's own re-exec argv
+//     shapes (the host-API subcommands below) without the stub env var:
+//     exit 0 instead of recursively running the suite. See
+//     reexec_interception_test.go for the regression guard.
+//
+// The fake stdio harness re-invocation (PRISM_FAKE_STDIO_HARNESS) is handled
+// by an init() in sidecar_stdio_test.go, which runs before TestMain and
+// exits — the two interceptions compose.
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// hostAPIReExecSubcommands lists every argv[1] this package's production code
+// passes to prismBinary() (the exec.CommandContext sites in host_api.go).
+// Keep in sync with the `args := []string{…}` literals there.
+var hostAPIReExecSubcommands = map[string]bool{
+	"prompt":      true,
+	"spawn":       true,
+	"review":      true,
+	"cleanup":     true,
+	"close":       true,
+	"switch":      true,
+	"event":       true,
+	"escalate":    true,
+	"investigate": true,
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("PRISM_TEST_SUBPROCESS") == "1" {
+		// We are a child process acting as a stub subprocess.
+		time.Sleep(50 * time.Millisecond)
+		os.Exit(0)
+	}
+	if len(os.Args) > 1 && hostAPIReExecSubcommands[os.Args[1]] {
+		// Re-invoked as a prism subcommand without the stub env var (#2230
+		// recursion class, swept in #2237). Exit instead of recursively
+		// running the suite.
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Closes #2237

Applies the re-exec stub interception convention established for `internal/review` and `internal/session` in #2236 — `PRISM_TEST_SUBPROCESS` env stub + per-package argv defence in `TestMain` — to the two packages PR #2236's audit table left exposed by construction, so a forgotten seam or a future test reaching a re-exec path cannot fork-bomb the suite (the #2230 landmine class: 93 detached test processes from one run).

## What changed (pure test files — no production code)

### internal/integration (`testmain_test.go`)

TestMain now intercepts, ahead of `m.Run()` and after the existing `PRISM_FAKE_STDIO_HARNESS` handling:

- `PRISM_TEST_SUBPROCESS=1` → 50 ms sleep + exit 0 (shared stub convention).
- argv `sidecar` / `event` → exit 0. These are this package's reachable re-exec shapes per #2236's audit: `session.StartSidecarWithOpts` (`<self> sidecar --session …`) and `setupFullLayout`'s status seed (`<self> event tmux-session-start …`). Exposure was latent — no current test reaches either path — which is exactly why the defence goes in now.

### internal/sidecar (new `testmain_test.go`)

The package previously had **no TestMain**; host-API handlers re-exec `prismBinary()` with an `os.Executable()` fallback, and every current test relies on injecting the `Config.PrismBinaryPath` seam. New TestMain intercepts:

- `PRISM_TEST_SUBPROCESS=1` → 50 ms sleep + exit 0.
- argv defence covering **all nine** host-API re-exec subcommands from `host_api.go`: `prompt`, `spawn`, `review`, `cleanup`, `close`, `switch`, `event`, `escalate`, `investigate`.

The fake stdio harness re-invocation (`PRISM_FAKE_STDIO_HARNESS`) is handled by an existing `init()` in `sidecar_stdio_test.go` which runs before TestMain — the two interceptions compose.

**Landmine demonstrated pre-fix:** `sidecar.test prompt prism-test@reexec-guard --prompt hi` ran the **entire sidecar suite for 47 s, writing 2.9 MB of output ending in PASS**; `integration.test event tmux-session-start …` likewise ran its full suite to PASS. Both recorded before any changes were made.

### Regression guards (AC: a test that execs the binary the way the production re-exec would)

New `reexec_interception_test.go` in each package: `TestReExecInterception_ProductionArgvShapes` execs `os.Executable()` with the production argv shapes (mirroring the `args := []string{…}` literals — 2 shapes for integration, all 9 for sidecar), no stub env var, and asserts **immediate exit 0 with zero output**. A suite run prints at minimum a trailing `PASS`/`FAIL`, so the empty-output assertion fails if the interception is removed. A `PRISM_REEXEC_GUARD_CHILD` recursion brake makes the mutated state fail as a bounded guard FAIL instead of a fork storm; `cmd.WaitDelay` bounds Wait against lingering pipe holders.

### cmd (optional hardening, in passing per the issue)

Same env + argv defence (`sidecar` / `event` / `monitor-review` — cmd's own production reach: `session.SpawnSession` paths and `review.RunAsync` → `StartMonitorProcess(prismBinary="")`), placed **after** the `PRISM_CMD_TEST_STUB` check that `startStubProcess`'s argv-matching stub (`<self> sidecar --session stub-session` + 60 s sleep) relies on. Doc comment gains purpose 6 recording the ordering constraint.

## Mutation verification (guards are not no-ops)

Disabled the argv defence (`if false && …`) in each TestMain, re-ran only the guards:

- **integration**: FAIL — child wrote 711 bytes ending in `PASS` (the suite ran).
- **sidecar**: FAIL — child still running at the 30 s deadline (`FAIL … 30.301s`).
- Restored → both guards PASS (also green inside the full suite run below).

## AC verification

- **[functional] re-invoked binaries exit immediately without running the suite** — by construction (TestMain) + the guard tests above, mutation-verified.
- **[edge-case] zero stray detached test-binary processes after a full suite run** — `go test ./... -race` (full module, 29 ok / 0 fail), then `pgrep -lx` for `sidecar.test`, `integration.test`, `cmd.test`, `review.test`, `session.test` plus a `go-build.*\.test` cmdline sweep: all clean. (One pgrep methodology note: an unescaped-dot `pgrep -f 'sidecar.test'` false-positives on live host prism sidecars whose cmdlines contain review prompts — the recorded check uses `-lx` exact process-name matching.)
- **[functional] no production code changes** — diff touches `*_test.go` files only.

## Pre-PR self-check

- `go build ./...` ✅, `go vet` (changed packages) ✅, `go test ./... -race` ✅ (full module green), gofmt clean on all touched files.
- `nix build .#prism` could **not** run locally: this worker sandbox pre-dates the #2201 trusted-settings allowance (`error: opening file ".../trusted-settings.json": Operation not permitted` — the real build was attempted first, per instructions). Used the sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` ✅. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).

Footprint: `internal/integration/{testmain_test.go,reexec_interception_test.go}`, `internal/sidecar/{testmain_test.go,reexec_interception_test.go}`, `cmd/killsidecar_test.go`. No overlap with the #2234 worker's files (`sandbox_exec_aws_*_darwin_test.go`, `internal/container/*`) and `internal/review` untouched.
