### PR TITLE
prism: drop staging kube symlink — KUBECONFIG env + KUBECACHEDIR work-dir cache (Step 3b of #2132)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -347,8 +347,19 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	// GIT_CONFIG_GLOBAL; they fall back to $HOME-derived config, which does
 	// not exist — benign for read-only operations (e.g. nix flake metadata),
 	// which need no git identity.
+	//
+	// KUBECACHEDIR: redirect kubectl's discovery/http cache into the session
+	// work dir (issue #2235, Step 3b of #2132). kubectl defaults to
+	// $HOME/.kube/cache, which exists on the host and would EPERM under the
+	// deny-default profile now that the staging .kube symlink is gone. The
+	// kube config itself arrives via KUBECONFIG from agent.envVars (injected
+	// by AppendSandboxEnvVarsKV above); only the cache dir is session-derived.
+	// The (subpath <sessionDir>) RW allow in the SBPL profile covers kubectl's
+	// MkdirAll of the cache dir — no extra profile rule is needed — and the
+	// per-session ephemeral semantics match the former staging-HOME behaviour.
 	if sessionDir, workDirErr := m.SessionWorkDir(); workDirErr == nil && sessionDir != "" {
 		env = append(env, container.SessionWorkDirGitEnv(sessionDir, ctrCfg.SshBin)...)
+		env = append(env, container.SessionWorkDirKubeEnv(sessionDir)...)
 	}
 
 	// argv[0] is "sandbox-exec" (from BuildArgs); the well-known binary path

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -76,6 +76,11 @@ func (b *bwrapIsolator) BuildRunArgs() []string {
 	return nil
 }
 
+// bwrapKubeCacheDir is the in-sandbox KUBECACHEDIR value for bwrap sessions:
+// kubectl's cache lands on the per-session /tmp tmpfs (ephemeral, never
+// host-visible). See the KUBECACHEDIR comment in BuildArgs (issue #2235).
+const bwrapKubeCacheDir = "/tmp/kube-cache"
+
 // fallbackPATH returns the PATH value used when os.Getenv("PATH") is empty.
 // It covers the per-user home-manager profile (when USER is set), the NixOS
 // system profile, and standard POSIX paths.
@@ -462,6 +467,19 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 
 	// NIX_CONFIG: tell nix to use the host daemon for store operations.
 	args = append(args, "--setenv", "NIX_CONFIG", "store = daemon")
+
+	// KUBECACHEDIR: redirect kubectl's discovery/http cache to the sandbox's
+	// private /tmp tmpfs (issue #2235, Step 3b of #2132). With the canonical
+	// $HOME/.kube/config bind gone, no kube path exists in-namespace and
+	// kubectl's default $HOME/.kube/cache would land wherever the root tmpfs
+	// happens to permit. /tmp is an explicit per-session tmpfs (--tmpfs /tmp
+	// in the baseline flags), so the cache is guaranteed writable, ephemeral,
+	// and never written through to the host — the bwrap equivalent of
+	// sandbox-exec's <sessionDir>/kube-cache redirect (the session work dir
+	// is a sandbox-exec mechanism; bwrap deliberately does not materialise
+	// host-side per-session state for a throwaway cache). kubectl MkdirAll's
+	// the directory on first use.
+	args = append(args, "--setenv", "KUBECACHEDIR", bwrapKubeCacheDir)
 
 	// TERM: pass through the host's TERM so that the sandbox sees the same
 	// terminal type as the tmux pane (e.g. tmux-256color). In bwrap mode the

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -612,7 +612,13 @@ func TestBwrapBuildArgs_AWSXDGPathROBound(t *testing.T) {
 	}
 }
 
-func TestBwrapBuildArgs_KubeAgentsConfigROBound(t *testing.T) {
+func TestBwrapBuildArgs_KubeAgentsConfigXDGPathROBound(t *testing.T) {
+	// Issue #2235: the env-var route needs the kube config content delivered
+	// INTO the bwrap namespace — bwrap builds its filesystem additively from
+	// an empty root, so KUBECONFIG pointing at an unbound path would resolve
+	// to nothing in-sandbox. The XDG host path is bound Dst==Src so
+	// KUBECONFIG (which carries exactly this path) resolves to a readable
+	// file. The former canonical-path ($HOME/.kube/config) remap is gone.
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -623,12 +629,60 @@ func TestBwrapBuildArgs_KubeAgentsConfigROBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// SRC: host ~/.config/kube/agents-config (XDG-compliant, managed by sops-nix)
-	// DST: sandbox $HOME/.kube/config (canonical path kubectl reads by default)
+	// SRC: resolved host file (EvalSymlinks pins the sops target inode).
+	// DST: the same XDG path — the value KUBECONFIG carries.
 	kubeSrc := filepath.Join(fakeHome, ".config", "kube", "agents-config")
-	kubeDst := filepath.Join(fakeHome, ".kube", "config")
-	if !hasROBindSrcDst(args, kubeSrc, kubeDst) {
-		t.Errorf("kube agents-config: want --ro-bind %q %q in args: %v", kubeSrc, kubeDst, args)
+	if !hasROBindSrcDst(args, kubeSrc, kubeSrc) {
+		t.Errorf("kube agents-config: want --ro-bind %q %q (Dst==Src XDG delivery for the env-var route, #2235) in args: %v",
+			kubeSrc, kubeSrc, args)
+	}
+
+	// The canonical-path remap must be gone (issue #2235, bwrap convergence
+	// per #2132 design decision §5.1).
+	kubeCanonicalDst := filepath.Join(fakeHome, ".kube", "config")
+	for i, arg := range args {
+		if arg != "--ro-bind" && arg != "--bind" {
+			continue
+		}
+		if i+2 >= len(args) {
+			continue
+		}
+		if args[i+1] == kubeCanonicalDst || args[i+2] == kubeCanonicalDst {
+			t.Errorf("kube canonical-path bind found (%s %q %q) — dropped in #2235 (env-var route); args: %v",
+				arg, args[i+1], args[i+2], args)
+		}
+	}
+}
+
+// TestBwrapBuildArgs_KubeCacheDirEnvInjected verifies the bwrap equivalent
+// of the sandbox-exec KUBECACHEDIR redirect (issue #2235): kubectl's cache
+// is pointed at /tmp/kube-cache on the per-session tmpfs (--tmpfs /tmp), so
+// cache writes are ephemeral and never reach the host. The injection is
+// unconditional — it must not depend on the kube config existing on the
+// host (kubectl creates the dir on first use).
+func TestBwrapBuildArgs_KubeCacheDirEnvInjected(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	// Remove the kube config to prove the env injection is unconditional.
+	if err := os.Remove(filepath.Join(fakeHome, ".config", "kube", "agents-config")); err != nil {
+		t.Fatalf("Remove kube agents-config: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasSetenv(args, "KUBECACHEDIR", bwrapKubeCacheDir) {
+		t.Errorf("--setenv KUBECACHEDIR %s not found in args: %v", bwrapKubeCacheDir, args)
+	}
+
+	// The value must live on the per-session /tmp tmpfs — never a host path.
+	if !strings.HasPrefix(bwrapKubeCacheDir, "/tmp/") {
+		t.Errorf("bwrapKubeCacheDir = %q, want a /tmp/ tmpfs path (ephemeral, never host-visible)", bwrapKubeCacheDir)
 	}
 }
 
@@ -1148,13 +1202,13 @@ func TestBwrapBuildArgs_ColortermOmittedWhenUnset(t *testing.T) {
 
 // ── AgentEnvVars (--setenv K V) ───────────────────────────────────────────────
 
-// TestBwrapBuildArgs_AgentEnvVarsInjected verifies that plain entries in
-// Config.AgentEnvVars (e.g. GIT_EDITOR) are emitted as --setenv K V in the
-// bwrap arg list. KUBECONFIG is suppressed because the kube config is still
-// bind-mounted at its canonical default path (un-suppression is Step 3b of
-// #2132); AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE flow through since
-// issue #2234 (Step 3a) — their canonical-path bind-mounts were dropped and
-// the aws CLI resolves the files via these env vars at the host XDG paths.
+// TestBwrapBuildArgs_AgentEnvVarsInjected verifies that every entry in
+// Config.AgentEnvVars is emitted as --setenv K V in the bwrap arg list.
+// KUBECONFIG flows through since issue #2235 (Step 3b of #2132) — the
+// canonical-path ($HOME/.kube/config) kube bind was dropped and kubectl
+// resolves the config via KUBECONFIG at the host XDG path. AWS_CONFIG_FILE
+// and AWS_SHARED_CREDENTIALS_FILE flow through since issue #2234 (Step 3a)
+// on the same pattern.
 func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
 	m, _, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
@@ -1187,19 +1241,22 @@ func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
 		t.Errorf("--setenv AWS_SHARED_CREDENTIALS_FILE not found in args (must flow since #2234): %v", args)
 	}
 
-	// KUBECONFIG must NOT be injected — the kube config is still bind-mounted
-	// at its canonical default path inside the sandbox (Step 3b scope).
-	for i, arg := range args {
-		if arg == "--setenv" && i+1 < len(args) && args[i+1] == "KUBECONFIG" {
-			t.Errorf("KUBECONFIG must not be injected in bwrap mode; found in args: %v", args)
-		}
+	// KUBECONFIG MUST be injected (issue #2235) — the canonical-path kube
+	// bind is gone and kubectl resolves the config via this env var at the
+	// host XDG path.
+	if !hasSetenv(args, "KUBECONFIG", "/home/ben/.config/kube/agents-config") {
+		t.Errorf("--setenv KUBECONFIG not found in args (must flow since #2235): %v", args)
 	}
 }
 
-// TestBwrapBuildArgs_KubeconfigNotInjectedWhenAbsent verifies that KUBECONFIG
-// is suppressed even when ~/.config/kube/agents-config does not exist (mount
-// is skipped but the host path is still wrong inside the sandbox).
-func TestBwrapBuildArgs_KubeconfigNotInjectedWhenAbsent(t *testing.T) {
+// TestBwrapBuildArgs_KubeconfigInjectedEvenWhenFileAbsent verifies that
+// KUBECONFIG is injected even when ~/.config/kube/agents-config does not
+// exist on the host, and that the absent file produces no bind args (the
+// XDG Dst==Src mount is EvalSymlinks-conditional). The env layer is a plain
+// value pass-through (issue #2235); kubectl tolerates a missing config file,
+// so injection must not depend on file existence — mirrors the AWS shape
+// from #2234.
+func TestBwrapBuildArgs_KubeconfigInjectedEvenWhenFileAbsent(t *testing.T) {
 	fakeHome := t.TempDir()
 	// Do NOT create kube dir — file absent.
 	origHome := os.Getenv("HOME")
@@ -1249,10 +1306,14 @@ func TestBwrapBuildArgs_KubeconfigNotInjectedWhenAbsent(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	for i, arg := range args {
-		if arg == "--setenv" && i+1 < len(args) && args[i+1] == "KUBECONFIG" {
-			t.Errorf("KUBECONFIG must not be injected even when kube file is absent; found in args: %v", args)
-		}
+	if !hasSetenv(args, "KUBECONFIG", "/home/ben/.config/kube/agents-config") {
+		t.Errorf("--setenv KUBECONFIG must be injected even when the host file is absent (#2235); args: %v", args)
+	}
+
+	// Absent file → no XDG bind emitted (EvalSymlinks silent skip).
+	kubeSrc := filepath.Join(fakeHome, ".config", "kube", "agents-config")
+	if hasROBindSrcDst(args, kubeSrc, kubeSrc) {
+		t.Errorf("absent kube file %q must not produce a bind; args: %v", kubeSrc, args)
 	}
 }
 
@@ -1445,9 +1506,10 @@ func TestBwrapBuildArgs_ChdirIsNotSlashWorkspace(t *testing.T) {
 func TestBwrapBuildArgs_MissingMountOmitted(t *testing.T) {
 	// Create a fixture with all the standard paths present, then remove the
 	// kube agents-config to verify it is omitted from the arg list.
-	// (The vehicle was the AWS readonly-config until #2234 dropped its mount
-	// unconditionally — kube exercises the same EvalSymlinks silent-skip
-	// semantics in StandardSandboxMounts.)
+	// (The vehicle was the AWS readonly-config until #2234 dropped its
+	// canonical mount — kube exercises the same EvalSymlinks silent-skip
+	// semantics in StandardSandboxMounts, now on the Dst==Src XDG bind
+	// from #2235.)
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -1464,10 +1526,14 @@ func TestBwrapBuildArgs_MissingMountOmitted(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// Neither the src (old Dst==Src form) nor the remapped dst should appear.
-	kubeDst := filepath.Join(fakeHome, ".kube", "config")
-	if hasROBindSrcDst(args, kubeSrc, kubeDst) {
-		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind %q %q in args: %v", kubeSrc, kubeDst, args)
+	// Neither the Dst==Src XDG form (#2235) nor the old canonical remap
+	// should appear.
+	if hasROBindSrcDst(args, kubeSrc, kubeSrc) {
+		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind %q %q in args: %v", kubeSrc, kubeSrc, args)
+	}
+	kubeCanonicalDst := filepath.Join(fakeHome, ".kube", "config")
+	if hasROBindSrcDst(args, kubeSrc, kubeCanonicalDst) {
+		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind %q %q in args: %v", kubeSrc, kubeCanonicalDst, args)
 	}
 }
 
@@ -1563,10 +1629,14 @@ func TestBwrapBuildArgs_MissingKubeConfigOmitted(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// Neither the src nor the remapped dst should appear.
-	kubeDst := filepath.Join(fakeHome, ".kube", "config")
-	if hasROBindSrcDst(args, kubeSrc, kubeDst) {
-		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind %q %q in args: %v", kubeSrc, kubeDst, args)
+	// Neither the Dst==Src XDG form (#2235) nor the old canonical remap
+	// should appear.
+	if hasROBindSrcDst(args, kubeSrc, kubeSrc) {
+		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind %q %q in args: %v", kubeSrc, kubeSrc, args)
+	}
+	kubeCanonicalDst := filepath.Join(fakeHome, ".kube", "config")
+	if hasROBindSrcDst(args, kubeSrc, kubeCanonicalDst) {
+		t.Errorf("missing kube agents-config should be omitted but found as --ro-bind %q %q in args: %v", kubeSrc, kubeCanonicalDst, args)
 	}
 }
 
@@ -1624,9 +1694,11 @@ func TestBwrapBuildArgs_AllRemapsHaveCorrectDestinations(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	// Note (#2234): the AWS readonly-config and credentials remaps are gone
-	// — the aws CLI reads both files via env vars at the host XDG paths. See
-	// TestBwrapBuildArgs_AWSConfigCanonicalBindsGone for the negative
+	// Note (#2234/#2235): the AWS readonly-config, AWS credentials, and kube
+	// agents-config remaps are gone — the CLIs read those files via env vars
+	// at the host XDG paths (bound Dst==Src). See
+	// TestBwrapBuildArgs_AWSConfigCanonicalBindsGone and
+	// TestBwrapBuildArgs_KubeAgentsConfigXDGPathROBound for the negative
 	// assertions.
 	cases := []struct {
 		name string
@@ -1642,11 +1714,6 @@ func TestBwrapBuildArgs_AllRemapsHaveCorrectDestinations(t *testing.T) {
 			name: "generated gitconfig → $HOME/.gitconfig",
 			src:  m.gitconfigFilePath(),
 			dst:  filepath.Join(fakeHome, ".gitconfig"),
-		},
-		{
-			name: "kube agents-config → $HOME/.kube/config",
-			src:  filepath.Join(fakeHome, ".config", "kube", "agents-config"),
-			dst:  filepath.Join(fakeHome, ".kube", "config"),
 		},
 	}
 
@@ -1851,20 +1918,30 @@ func TestBwrapBuildArgs_FullFixture(t *testing.T) {
 		t.Errorf("expected --extension flag near end (before --agent), got %q at [n-5]", args[n-5])
 	}
 
-	// Kube ro-bind present with the correct remapped destination. The AWS
-	// readonly-config remap is gone since #2234 (env-var route) — assert it
-	// stays gone.
+	// The canonical-path remaps are gone: AWS readonly-config since #2234,
+	// kube agents-config since #2235 (env-var route) — assert both stay
+	// gone, and that the kube XDG Dst==Src bind is present instead.
 	if hasROBindSrcDst(args,
 		filepath.Join(fakeHome, ".config", "aws", "readonly-config"),
 		filepath.Join(fakeHome, ".aws", "config"),
 	) {
 		t.Errorf("AWS readonly-config: --ro-bind src $HOME/.aws/config must NOT be emitted (env-var route since #2234)")
 	}
-	if !hasROBindSrcDst(args,
+	if hasROBindSrcDst(args,
 		filepath.Join(fakeHome, ".config", "kube", "agents-config"),
 		filepath.Join(fakeHome, ".kube", "config"),
 	) {
-		t.Errorf("kube agents-config: want --ro-bind src $HOME/.kube/config")
+		t.Errorf("kube agents-config: --ro-bind src $HOME/.kube/config must NOT be emitted (env-var route since #2235)")
+	}
+	kubeXDG := filepath.Join(fakeHome, ".config", "kube", "agents-config")
+	if !hasROBindSrcDst(args, kubeXDG, kubeXDG) {
+		t.Errorf("kube agents-config: want --ro-bind %q %q (Dst==Src XDG delivery, #2235)", kubeXDG, kubeXDG)
+	}
+
+	// KUBECACHEDIR redirects kubectl's cache to the per-session /tmp tmpfs
+	// (issue #2235).
+	if !hasSetenv(args, "KUBECACHEDIR", bwrapKubeCacheDir) {
+		t.Errorf("--setenv KUBECACHEDIR %s not found in args", bwrapKubeCacheDir)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/env.go
+++ b/modules/programs/prism/prism/internal/container/env.go
@@ -14,35 +14,26 @@ type EnvAppender func(args []string, k, v string) []string
 // slice. It handles two sources:
 //
 //  1. cfg.AgentEnvVars — profile-level vars (e.g. GIT_EDITOR=true) emitted
-//     in sorted key order for determinism. KUBECONFIG is suppressed because
-//     the kube config is still bind-mounted at its canonical default path
-//     inside the sandbox and the host XDG path held in AgentEnvVars would
-//     only override the correctly-mounted location (un-suppression is
-//     Step 3b of #2132). AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE
-//     are NOT suppressed (issue #2234, Step 3a of #2132): the canonical-path
-//     ($HOME/.aws/*) delivery for the aws config/credentials was dropped
-//     from both isolators, and the aws CLI resolves them via these env vars
-//     at the host XDG paths instead (bwrap binds those XDG paths Dst==Src —
-//     see StandardSandboxMounts; sandbox-exec reads ride the #2211
-//     allowlist).
+//     in sorted key order for determinism. Every key flows through: the
+//     former sandboxMountedByDefault suppression map is gone (issue #2235,
+//     Step 3b of #2132 — its last entry, KUBECONFIG, was un-suppressed when
+//     the canonical-path ($HOME/.kube/config) kube delivery was dropped
+//     from both isolators; the AWS pair was un-suppressed in #2234). kubectl
+//     resolves the kube config via KUBECONFIG at the host XDG path (bwrap
+//     binds that path Dst==Src — see StandardSandboxMounts; sandbox-exec
+//     reads ride the #2211 secrets.d allowlist).
 //
 //  2. cfg.RuntimeEnv — harness-specific runtime vars (e.g. the bash-tool
 //     timeout) emitted as-is.
 //
 // The caller is responsible for any additional env vars that are
-// mode-specific (e.g. NIX_CONFIG, TERM, COLORTERM, PRISM_* context vars).
+// mode-specific (e.g. NIX_CONFIG, TERM, COLORTERM, KUBECACHEDIR, PRISM_*
+// context vars).
 func AppendStandardEnv(args []string, cfg Config, appender EnvAppender) []string {
-	// Suppress keys that are already provided via bind-mounts.
-	sandboxMountedByDefault := map[string]bool{
-		"KUBECONFIG": true,
-	}
-
 	if len(cfg.AgentEnvVars) > 0 {
 		keys := make([]string, 0, len(cfg.AgentEnvVars))
 		for k := range cfg.AgentEnvVars {
-			if !sandboxMountedByDefault[k] {
-				keys = append(keys, k)
-			}
+			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
@@ -59,23 +50,18 @@ func AppendStandardEnv(args []string, cfg Config, appender EnvAppender) []string
 
 // AppendSandboxEnvVarsKV appends K=V pairs from cfg.AgentEnvVars and
 // cfg.RuntimeEnv to env (a []string slice for use as a syscall.Exec env).
-// It applies the same suppression logic as AppendStandardEnv (KUBECONFIG is
-// omitted because the kube config is still delivered at its canonical path
-// inside the sandbox; the AWS file vars flow through — issue #2234).
+// Like AppendStandardEnv, every AgentEnvVars key flows through — the former
+// sandboxMountedByDefault suppression map is gone (KUBECONFIG was its last
+// entry, un-suppressed in issue #2235 when the staging .kube/config symlink
+// was dropped; the kube config is read via KUBECONFIG at the host XDG path).
 //
 // This is used by the sandbox-exec dispatch path in cmd/agent_run.go where
 // the env is a plain K=V slice (not a bwrap-style argument list).
 func AppendSandboxEnvVarsKV(env []string, cfg Config) []string {
-	sandboxMountedByDefault := map[string]bool{
-		"KUBECONFIG": true,
-	}
-
 	if len(cfg.AgentEnvVars) > 0 {
 		keys := make([]string, 0, len(cfg.AgentEnvVars))
 		for k := range cfg.AgentEnvVars {
-			if !sandboxMountedByDefault[k] {
-				keys = append(keys, k)
-			}
+			keys = append(keys, k)
 		}
 		sort.Strings(keys)
 		for _, k := range keys {

--- a/modules/programs/prism/prism/internal/container/env_test.go
+++ b/modules/programs/prism/prism/internal/container/env_test.go
@@ -1,14 +1,15 @@
 package container
 
-// env_test.go — unit coverage for the sandboxMountedByDefault suppression
-// maps in AppendStandardEnv and AppendSandboxEnvVarsKV (issue #2234, Step 3a
-// of #2132): AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE must flow into
-// both isolators' env (the canonical-path delivery was dropped — the aws CLI
-// resolves the files via these env vars at the host XDG paths), while
-// KUBECONFIG remains suppressed until Step 3b.
+// env_test.go — unit coverage for the AgentEnvVars emission in
+// AppendStandardEnv and AppendSandboxEnvVarsKV. The former
+// sandboxMountedByDefault suppression maps are gone (issue #2235, Step 3b of
+// #2132): KUBECONFIG — their last entry — now flows into both isolators'
+// env alongside the AWS pair (un-suppressed in #2234, Step 3a). kubectl
+// resolves the kube config via KUBECONFIG at the host XDG path; the
+// canonical-path ($HOME/.kube/config) delivery was dropped from both
+// isolators.
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -23,9 +24,19 @@ func envSuppressionFixtureVars() map[string]string {
 	}
 }
 
-// TestAppendStandardEnv_AWSEnvVarsFlow_KubeconfigSuppressed verifies the
-// suppression-map shape used by the bwrap arg builder.
-func TestAppendStandardEnv_AWSEnvVarsFlow_KubeconfigSuppressed(t *testing.T) {
+// envFixtureWantPairs is the full K=V emission expected from the fixture —
+// every AgentEnvVars key flows through, including the historically
+// suppressed KUBECONFIG (#2235) and AWS pair (#2234).
+var envFixtureWantPairs = []string{
+	"AWS_CONFIG_FILE=/home/ben/.config/aws/readonly-config",
+	"AWS_SHARED_CREDENTIALS_FILE=/home/ben/.config/aws/credentials",
+	"GIT_EDITOR=true",
+	"KUBECONFIG=/home/ben/.config/kube/agents-config",
+}
+
+// TestAppendStandardEnv_AllAgentEnvVarsFlow verifies the bwrap arg builder
+// emits every AgentEnvVars key — no suppression map remains (issue #2235).
+func TestAppendStandardEnv_AllAgentEnvVarsFlow(t *testing.T) {
 	cfg := Config{AgentEnvVars: envSuppressionFixtureVars()}
 
 	var got []string
@@ -34,12 +45,7 @@ func TestAppendStandardEnv_AWSEnvVarsFlow_KubeconfigSuppressed(t *testing.T) {
 		return args
 	})
 
-	want := []string{
-		"AWS_CONFIG_FILE=/home/ben/.config/aws/readonly-config",
-		"AWS_SHARED_CREDENTIALS_FILE=/home/ben/.config/aws/credentials",
-		"GIT_EDITOR=true",
-	}
-	for _, w := range want {
+	for _, w := range envFixtureWantPairs {
 		found := false
 		for _, kv := range got {
 			if kv == w {
@@ -47,29 +53,22 @@ func TestAppendStandardEnv_AWSEnvVarsFlow_KubeconfigSuppressed(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("AppendStandardEnv must emit %q (AWS vars flow since #2234); got: %v", w, got)
+			t.Errorf("AppendStandardEnv must emit %q (all AgentEnvVars flow since #2235); got: %v", w, got)
 		}
 	}
-	for _, kv := range got {
-		if strings.HasPrefix(kv, "KUBECONFIG=") {
-			t.Errorf("AppendStandardEnv must suppress KUBECONFIG (canonical-path delivery until Step 3b of #2132); got: %v", got)
-		}
+	if len(got) != len(envFixtureWantPairs) {
+		t.Errorf("AppendStandardEnv emitted %d vars, want exactly %d: %v", len(got), len(envFixtureWantPairs), got)
 	}
 }
 
-// TestAppendSandboxEnvVarsKV_AWSEnvVarsFlow_KubeconfigSuppressed verifies the
-// same shape for the sandbox-exec K=V dispatch path.
-func TestAppendSandboxEnvVarsKV_AWSEnvVarsFlow_KubeconfigSuppressed(t *testing.T) {
+// TestAppendSandboxEnvVarsKV_AllAgentEnvVarsFlow verifies the same shape for
+// the sandbox-exec K=V dispatch path.
+func TestAppendSandboxEnvVarsKV_AllAgentEnvVarsFlow(t *testing.T) {
 	cfg := Config{AgentEnvVars: envSuppressionFixtureVars()}
 
 	env := AppendSandboxEnvVarsKV(nil, cfg)
 
-	want := []string{
-		"AWS_CONFIG_FILE=/home/ben/.config/aws/readonly-config",
-		"AWS_SHARED_CREDENTIALS_FILE=/home/ben/.config/aws/credentials",
-		"GIT_EDITOR=true",
-	}
-	for _, w := range want {
+	for _, w := range envFixtureWantPairs {
 		found := false
 		for _, kv := range env {
 			if kv == w {
@@ -77,12 +76,10 @@ func TestAppendSandboxEnvVarsKV_AWSEnvVarsFlow_KubeconfigSuppressed(t *testing.T
 			}
 		}
 		if !found {
-			t.Errorf("AppendSandboxEnvVarsKV must emit %q (AWS vars flow since #2234); got: %v", w, env)
+			t.Errorf("AppendSandboxEnvVarsKV must emit %q (all AgentEnvVars flow since #2235); got: %v", w, env)
 		}
 	}
-	for _, kv := range env {
-		if strings.HasPrefix(kv, "KUBECONFIG=") {
-			t.Errorf("AppendSandboxEnvVarsKV must suppress KUBECONFIG (canonical-path delivery until Step 3b of #2132); got: %v", env)
-		}
+	if len(env) != len(envFixtureWantPairs) {
+		t.Errorf("AppendSandboxEnvVarsKV emitted %d vars, want exactly %d: %v", len(env), len(envFixtureWantPairs), env)
 	}
 }

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -255,12 +255,32 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 			OptionalIfMissing: true,
 		},
 
-		// ── Kube agents config (RO, EvalSymlinks) ────────────────────────
-		// Host: ~/.config/kube/agents-config (XDG, sops-managed symlink).
-		// Sandbox: $HOME/.kube/config (canonical kubectl default path).
+		// ── Kube agents config (RO, EvalSymlinks, Dst==Src at XDG path) ─
+		// kubectl resolves its config via the KUBECONFIG env var at the host
+		// XDG path (~/.config/kube/agents-config, declared in agent.envVars
+		// by the nix module). The former RO bind-mount at the canonical
+		// $HOME/.kube/config path was dropped in issue #2235 (Step 3b of
+		// #2132, bwrap convergence per design decision §5.1) — see env.go for
+		// the matching un-suppression.
+		//
+		// Same shape as the AWS XDG binds above (#2234): the bwrap mount
+		// namespace is additive from an empty root, so the env-var route
+		// still needs the file content delivered INTO the namespace — bind
+		// the XDG path Dst==Src so KUBECONFIG resolves to a readable file
+		// in-sandbox. EvalSymlinks pins the sops-resolved target inode (same
+		// rotation semantics as the previous canonical bind); resolution
+		// failure (file absent on host) silently skips the mount while the
+		// env var still flows.
+		//
+		// kubectl's cache is redirected via KUBECACHEDIR (see BuildArgs in
+		// bwrap.go) so no writable kube path is needed in-namespace.
+		//
+		// sandbox-exec does not walk this slice (see the package comment):
+		// there the real host paths are visible modulo SBPL and the read
+		// rides the #2211 secrets.d allowlist.
 		{
 			HostPath:     filepath.Join(hostHome, ".config", "kube", "agents-config"),
-			SandboxPath:  filepath.Join(sandboxHomeDir, ".kube", "config"),
+			SandboxPath:  filepath.Join(sandboxHomeDir, ".config", "kube", "agents-config"),
 			ReadOnly:     true,
 			EvalSymlinks: true,
 		},

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -559,7 +559,7 @@ func generateProfile(m *Manager) string {
 	//   - File targets → (literal ...) to allow the specific file.
 	//   - Writable targets (cache dirs, write-through credential dirs) →
 	//     file-read* file-write* file-test-existence. Mirrors bwrap --bind (RW).
-	//   - RO targets (.ssh, .aws entries, .kube, .config/opencode) →
+	//   - RO targets (.ssh, .config/opencode) →
 	//     file-read* only. Mirrors bwrap --ro-bind.
 	//
 	// Targets that fall under the denied ~HOME/.aws subtree are excluded from
@@ -810,7 +810,7 @@ func generateProfile(m *Manager) string {
 //	~/.ssh/<SshSigningKeyName>.pub       — gitconfig user.signingKey
 //	~/.config/aws/readonly-config        — read via AWS_CONFIG_FILE env (#2234)
 //	~/.config/aws/credentials            — read via AWS_SHARED_CREDENTIALS_FILE env (#2234)
-//	~/.config/kube/agents-config         — staged at <stagingHome>/.kube/config
+//	~/.config/kube/agents-config         — read via KUBECONFIG env (#2235)
 //
 // Each source is resolved via filepath.EvalSymlinks; when the resolved
 // target is a sops secrets.d path (…/secrets.d/<N>/<name>), <name> is

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -107,7 +107,6 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		stagingHome,
 		filepath.Join(stagingHome, ".ssh"),
 		filepath.Join(stagingHome, ".aws"),
-		filepath.Join(stagingHome, ".kube"),
 		filepath.Join(stagingHome, ".cache"),
 		filepath.Join(stagingHome, ".pi"),
 		filepath.Join(stagingHome, ".config", "prism"),
@@ -238,10 +237,17 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	)
 
 	// ── Kube ──────────────────────────────────────────────────────────────────
-	// Use symlinkIfExists (not symlinkIfResolvable) so the staging symlink
-	// points at the stable intermediate (~/.config/kube/agents-config) rather
-	// than the fully-resolved sops concrete path that rotates on each
-	// darwin-rebuild switch (issue #1573).
+	// Note (#2235, Step 3b of #2132): the .kube/config staging symlink is no
+	// longer created (and no .kube/ staging dir exists). kubectl resolves the
+	// config via the KUBECONFIG env var at the host XDG path
+	// (~/.config/kube/agents-config); the in-sandbox read of the resolved sops
+	// target rides the broad (subpath "/private/var/folders") allow narrowed
+	// by the #2211 secrets.d allowlist (collectSecretsDAllowlistNames derives
+	// the exception from the same stable XDG source path, so the read survives
+	// sops rotations — #1410/#1573). kubectl's discovery/http cache is
+	// redirected to <sessionDir>/kube-cache via KUBECACHEDIR (see
+	// SessionWorkDirKubeEnv in session_work_dir.go).
+
 	// ── prism agent role prompts (issue #2032) ─────────────────────────
 	// Symlink ~/.config/prism/agents (deployed by pi.nix) into the staging
 	// HOME at the canonical XDG path so the prism PI extension can read
@@ -253,11 +259,6 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	symlinkIfExists(
 		filepath.Join(home, ".config", "prism", "agents"),
 		filepath.Join(stagingHome, ".config", "prism", "agents"),
-	)
-
-	symlinkIfExists(
-		filepath.Join(home, ".config", "kube", "agents-config"),
-		filepath.Join(stagingHome, ".kube", "config"),
 	)
 
 	// ── Library/Application Support/Google + Library/Caches/Google (issue #2021) ─
@@ -501,7 +502,7 @@ type StagingSymlinkTarget struct {
 	// (RW) vs --ro-bind (RO) distinction:
 	//   RW: .cache/opencode, .cache/bun, .cache/nix,
 	//       .claude (write-through for credentials), .mcp-auth
-	//   RO: .ssh keys, .kube/config, .config/opencode/*,
+	//   RO: .ssh keys, .config/opencode/*,
 	//       .config/prism/agents (role prompts; issue #2032),
 	//       .cache/prism/clipboard (read-only; mirrors bwrap.go --ro-bind)
 	Writable bool
@@ -527,7 +528,7 @@ type StagingSymlinkTarget struct {
 //   - .claude          — write-through for .credentials.json on Darwin
 //   - .mcp-auth        — MCP auth token writes
 //
-// All other targets (.ssh, .kube, .config/opencode, .cache/prism/clipboard)
+// All other targets (.ssh, .config/opencode, .cache/prism/clipboard)
 // are read-only. .cache/prism/clipboard mirrors bwrap.go's --ro-bind treatment —
 // the agent only reads image files staged there by `prism clipboard paste-image`.
 //
@@ -672,7 +673,7 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 	// Scan the top-level staging HOME and all immediate subdirectories that
 	// the staging HOME builder creates (one level deep).
 	scanDir("")
-	subDirs := []string{".ssh", ".aws", ".kube", ".cache", ".pi"}
+	subDirs := []string{".ssh", ".aws", ".cache", ".pi"}
 	for _, sub := range subDirs {
 		scanDir(sub)
 	}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -1272,15 +1272,16 @@ func TestPrepareSandboxExecHome_AccessKeyUsesIntermediatePath(t *testing.T) {
 }
 
 // TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks verifies that the
-// remaining sops-backed staging-HOME symlinks — access-key and .kube/config
-// (issue #1573) — survive a sops secrets.d/<N> → secrets.d/<N+1> rotation
-// after PrepareSandboxExecHome has already run.
+// remaining sops-backed staging-HOME symlink — access-key (issue #1573) —
+// survives a sops secrets.d/<N> → secrets.d/<N+1> rotation after
+// PrepareSandboxExecHome has already run.
 //
 // The .aws/config and .aws/credentials staging symlinks were removed in
-// issue #2234 (Step 3a of #2132): the aws CLI reads those files via the
-// AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE env vars at the host XDG
-// paths, and rotation safety for those reads rides the name-based #2211
-// secrets.d allowlist (counter-independent regexes — see
+// issue #2234 (Step 3a of #2132) and the .kube/config staging symlink in
+// issue #2235 (Step 3b): those files are read via the AWS_CONFIG_FILE /
+// AWS_SHARED_CREDENTIALS_FILE / KUBECONFIG env vars at the host XDG paths,
+// and rotation safety for those reads rides the name-based #2211 secrets.d
+// allowlist (counter-independent regexes — see
 // TestGenerateProfile_SecretsDAllowlistDerivedFromStableSources and the
 // rotation-simulation integration tests).
 //
@@ -1298,13 +1299,12 @@ func TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks(t *testing.T) {
 
 	// ── set up v1 concrete files ───────────────────────────────────────
 	sopsDir1 := filepath.Join(fakeHome, "sops-dir-1")
-	if err := os.MkdirAll(filepath.Join(sopsDir1, "kube"), 0o700); err != nil {
-		t.Fatalf("create sops-dir-1/kube: %v", err)
+	if err := os.MkdirAll(sopsDir1, 0o700); err != nil {
+		t.Fatalf("create sops-dir-1: %v", err)
 	}
 
 	v1Files := map[string]string{
 		"ssh/access-key": "access-key-v1",
-		"kube/config":    "kube-config-v1",
 	}
 	for rel, content := range v1Files {
 		path := filepath.Join(sopsDir1, rel)
@@ -1320,8 +1320,7 @@ func TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks(t *testing.T) {
 	// Each intermediate simulates the path that sops-nix keeps stable across
 	// rotations: e.g. ~/.ssh/prismatic-koi-ed25519 → secrets.d/<N>/...
 	intermediates := map[string]string{
-		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"):    filepath.Join(sopsDir1, "ssh", "access-key"),
-		filepath.Join(fakeHome, ".config", "kube", "agents-config"): filepath.Join(sopsDir1, "kube", "config"),
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"): filepath.Join(sopsDir1, "ssh", "access-key"),
 	}
 	for intermediate, target := range intermediates {
 		_ = os.Remove(intermediate) // remove plain file from newFakeHome
@@ -1351,19 +1350,19 @@ func TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks(t *testing.T) {
 			link:         filepath.Join(stagingHome, ".ssh", "access-key"),
 			intermediate: filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"),
 		},
-		{
-			link:         filepath.Join(stagingHome, ".kube", "config"),
-			intermediate: filepath.Join(fakeHome, ".config", "kube", "agents-config"),
-		},
 	}
 
-	// The AWS staging symlinks must NOT have been created (issue #2234).
+	// The AWS staging symlinks must NOT have been created (issue #2234),
+	// and neither the kube staging symlink nor its .kube parent dir
+	// (issue #2235).
 	for _, gone := range []string{
 		filepath.Join(stagingHome, ".aws", "config"),
 		filepath.Join(stagingHome, ".aws", "credentials"),
+		filepath.Join(stagingHome, ".kube", "config"),
+		filepath.Join(stagingHome, ".kube"),
 	} {
 		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
-			t.Errorf("staging symlink %s should NOT exist (removed in #2234), but it does", gone)
+			t.Errorf("staging entry %s should NOT exist (removed in #2234/#2235), but it does", gone)
 		}
 	}
 	for _, e := range entries {
@@ -1384,7 +1383,6 @@ func TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks(t *testing.T) {
 	sopsDir2 := filepath.Join(fakeHome, "sops-dir-2")
 	v2Files := map[string]string{
 		"ssh/access-key": "access-key-v2",
-		"kube/config":    "kube-config-v2",
 	}
 	for rel, content := range v2Files {
 		path := filepath.Join(sopsDir2, rel)
@@ -1396,8 +1394,7 @@ func TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks(t *testing.T) {
 		}
 	}
 	v2Targets := map[string]string{
-		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"):    filepath.Join(sopsDir2, "ssh", "access-key"),
-		filepath.Join(fakeHome, ".config", "kube", "agents-config"): filepath.Join(sopsDir2, "kube", "config"),
+		filepath.Join(fakeHome, ".ssh", "prismatic-koi-ed25519"): filepath.Join(sopsDir2, "ssh", "access-key"),
 	}
 	for intermediate, newTarget := range v2Targets {
 		_ = os.Remove(intermediate)
@@ -1410,7 +1407,6 @@ func TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks(t *testing.T) {
 	// ── verify reads through staging HOME still succeed after rotation ──────
 	v2Contents := map[string]string{
 		filepath.Join(stagingHome, ".ssh", "access-key"): "access-key-v2",
-		filepath.Join(stagingHome, ".kube", "config"):    "kube-config-v2",
 	}
 	for link, wantContent := range v2Contents {
 		content, readErr := os.ReadFile(link)
@@ -2161,6 +2157,58 @@ func TestPrepareSandboxExecHome_NoAWSConfigCredentialsSymlinks(t *testing.T) {
 	for _, target := range targets {
 		if target.ResolvedPath == resolvedCfg {
 			t.Errorf("collectStagingHomeSymlinkTargets emitted the aws readonly-config target %q — the .aws/config staging symlink should be gone (#2234)", resolvedCfg)
+		}
+	}
+}
+
+// TestPrepareSandboxExecHome_NoKubeConfigSymlink is the unit-level AC test
+// for issue #2235 (Step 3b of #2132): after PrepareSandboxExecHome, the
+// staging HOME contains no .kube/config symlink (nor a .kube directory at
+// all) even though the host XDG source exists, and
+// collectStagingHomeSymlinkTargets no longer emits its resolved target.
+// kubectl reads the config via KUBECONFIG at the host XDG path instead;
+// the in-sandbox read rides the #2211 secrets.d allowlist (see
+// TestGenerateProfile_SecretsDAllowlistDerivedFromStableSources — the kube
+// agents-config exception derives from the stable XDG source path, not
+// from any staging symlink, so it is unaffected by this removal).
+func TestPrepareSandboxExecHome_NoKubeConfigSymlink(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Resolve the XDG source before staging so we can assert its absence
+	// from the collector output below. newFakeHome writes a real file at
+	// ~/.config/kube/agents-config, so the source-present path is exercised.
+	resolvedKube, err := filepath.EvalSymlinks(filepath.Join(fakeHome, ".config", "kube", "agents-config"))
+	if err != nil {
+		t.Fatalf("fixture: EvalSymlinks kube agents-config: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "no-kube-symlink-test",
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	for _, gone := range []string{
+		filepath.Join(stagingHome, ".kube", "config"),
+		filepath.Join(stagingHome, ".kube"),
+	} {
+		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
+			t.Errorf("staging HOME has %s entry — removed in #2235 (env-var route), must not be recreated", gone)
+		}
+	}
+
+	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
+	if err != nil {
+		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
+	}
+	for _, target := range targets {
+		if target.ResolvedPath == resolvedKube {
+			t.Errorf("collectStagingHomeSymlinkTargets emitted the kube agents-config target %q — the .kube/config staging symlink should be gone (#2235)", resolvedKube)
 		}
 	}
 }

--- a/modules/programs/prism/prism/internal/container/session_work_dir.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir.go
@@ -99,6 +99,40 @@ func SessionWorkDirAllowedSignersPath(sessionDir string) string {
 	return filepath.Join(sessionDir, "allowed_signers")
 }
 
+// SessionWorkDirKubeCacheDirPath returns the kubectl cache directory inside
+// the given session work dir (issue #2235, Step 3b of #2132):
+//
+//	<sessionDir>/kube-cache
+//
+// kubectl writes its discovery/http cache to $HOME/.kube/cache by default,
+// which exists on the host and would EPERM under the deny-default SBPL
+// profile once the staging .kube symlink is gone. KUBECACHEDIR (supported
+// since kubectl ≈ 1.26) redirects the cache here instead. The directory is
+// not pre-created — kubectl MkdirAll's it on first use, which the SBPL
+// profile's (subpath <sessionDir>) RW allow already covers; per-session
+// ephemeral semantics match the former staging-HOME behaviour (the work dir
+// is removed by RemoveSessionWorkDir on cleanup).
+func SessionWorkDirKubeCacheDirPath(sessionDir string) string {
+	return filepath.Join(sessionDir, "kube-cache")
+}
+
+// SessionWorkDirKubeEnv returns the env var pair (K=V form) that redirects
+// kubectl's cache inside the sandbox at the session work dir:
+//
+//	KUBECACHEDIR=<sessionDir>/kube-cache
+//
+// Injected by the sandbox-exec dispatcher
+// (cmd/agent_run_sandbox_exec_darwin.go) alongside SessionWorkDirGitEnv.
+// The kube config itself is delivered via KUBECONFIG from agent.envVars
+// (issue #2235); only the cache redirect is session-derived and therefore
+// injected here. The bwrap equivalent lives in bwrap.go BuildArgs
+// (KUBECACHEDIR=/tmp/kube-cache — the per-session tmpfs).
+func SessionWorkDirKubeEnv(sessionDir string) []string {
+	return []string{
+		"KUBECACHEDIR=" + SessionWorkDirKubeCacheDirPath(sessionDir),
+	}
+}
+
 // SessionWorkDirGitEnv returns the env var pairs (K=V form) that point git
 // and ssh inside the sandbox at the generated work-dir configs:
 //

--- a/modules/programs/prism/prism/internal/container/session_work_dir_test.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir_test.go
@@ -391,6 +391,30 @@ func TestSessionWorkDirGitEnv(t *testing.T) {
 	}
 }
 
+// TestSessionWorkDirKubeEnv verifies the kubectl cache redirect the
+// dispatcher injects (issue #2235, Step 3b of #2132): the sandbox env
+// carries KUBECACHEDIR=<sessionDir>/kube-cache so kubectl's discovery/http
+// cache lands inside the session work dir (already RW-granted in the SBPL
+// profile) instead of the host's ~/.kube/cache.
+func TestSessionWorkDirKubeEnv(t *testing.T) {
+	const dir = "/Users/u/.local/state/prism/sessions/abc"
+
+	got := SessionWorkDirKubeEnv(dir)
+	want := []string{"KUBECACHEDIR=" + dir + "/kube-cache"}
+	if len(got) != len(want) {
+		t.Fatalf("SessionWorkDirKubeEnv returned %d vars, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("SessionWorkDirKubeEnv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	if p := SessionWorkDirKubeCacheDirPath(dir); p != dir+"/kube-cache" {
+		t.Errorf("SessionWorkDirKubeCacheDirPath = %q, want %q", p, dir+"/kube-cache")
+	}
+}
+
 // TestGenerateProfile_SessionWorkDirAndKnownHostsRules pins the SBPL profile
 // AC: the profile contains (subpath "<sessionDir>") and a read-only literal
 // for ~/.ssh/known_hosts, and contains no (subpath "<HOME>/.ssh") — the

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_kube_config_envvar_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_kube_config_envvar_darwin_test.go
@@ -1,0 +1,533 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_kube_config_envvar_darwin_test.go — integration coverage for
+// the env-var delivery of the kube config (issue #2235, Step 3b of #2132).
+//
+// The staging-HOME .kube/config symlink is gone. kubectl resolves the config
+// via KUBECONFIG pointing at the host XDG path
+// (~/.config/kube/agents-config) and writes its discovery/http cache to
+// <sessionDir>/kube-cache via KUBECACHEDIR (kubectl defaults to
+// $HOME/.kube/cache, which exists on the host and would EPERM under
+// deny-default post-removal). Per the #2132 §2 mechanism note, no literal
+// SBPL grant exists on the XDG symlink path (it would be inert — SBPL
+// evaluates resolved targets): the in-sandbox read of the resolved sops
+// target rides the broad (subpath "/private/var/folders") allow narrowed by
+// the #2211 secrets.d allowlist, whose kube agents-config exception is
+// derived from the same stable XDG source path.
+//
+// This file tests:
+//
+//  1. Shape: after PrepareSandboxExecHome, the staging HOME contains no
+//     .kube/config symlink and no .kube directory at all (issue #2235 AC).
+//
+//  2. Positive: a real config-resolving kubectl invocation —
+//     `kubectl config view` with KUBECONFIG at the host XDG path — exits 0
+//     inside sandbox-exec AND its output carries the current-context name
+//     parsed from the host config. kubectl prints an EMPTY config (exit 0)
+//     when the env var is ignored or the file is absent, and fails non-zero
+//     when the file is unreadable, so the combined exit-0 + named-context
+//     assertion proves a real config read in-sandbox. (The config's
+//     exec-plugin auth — aws eks get-token — is NOT exercised: config view
+//     performs no auth, and a live EKS probe would be non-hermetic. The
+//     exec-plugin env propagation (AWS_CONFIG_FILE et al., Step 3a pair) is
+//     covered at unit level by env_test.go and the dispatcher tests.)
+//
+//  3. Negative: stripping the kube agents-config require-not exception from
+//     the #2211 secrets.d deny makes the same invocation fail — proving the
+//     allowlist exception is the load-bearing grant for the env-var route
+//     (sandbox-exec testing convention, #1192).
+//
+//  4. Cache: a discovery round-trip against a test-local fake API server
+//     (`kubectl api-resources` with KUBECACHEDIR=<sessionDir>/kube-cache)
+//     lands cache files under <sessionDir>/kube-cache and writes NOTHING
+//     under the host ~/.kube/cache; the paired negative strips the
+//     (subpath <sessionDir>) grant and asserts no cache files land.
+//
+// The kube-specific sops-rotation coverage lives in
+// sandbox_exec_sops_rotation_darwin_test.go (the fake-secrets-tree entries).
+// Capability-probe gating (#2207) applies via requireSandboxExec. Shared
+// helpers live in sandbox_exec_helpers_darwin_test.go; the allowlist parse
+// helpers live in sandbox_exec_secrets_deny_darwin_test.go and
+// sandbox_exec_aws_config_envvar_darwin_test.go.
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// requireNixKubectl resolves the kubectl binary via PATH → symlink chain and
+// returns the PATH-resolved path. Skips the test when kubectl is not found
+// or does not resolve into /nix/store (an Apple-signed or homebrew binary
+// would SIGABRT or skew the signal under the deny-default profile — same
+// rationale as requireNixBash, #1190).
+func requireNixKubectl(t *testing.T) string {
+	t.Helper()
+
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		t.Skipf("kubectl not found in PATH: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(kubectlPath)
+	if err != nil {
+		t.Skipf("EvalSymlinks(%q): %v", kubectlPath, err)
+	}
+	if !strings.HasPrefix(resolved, "/nix/store/") {
+		t.Skipf("kubectl resolves to %q which is not a /nix/store/ path — cannot use as test binary under the deny-default sandbox", resolved)
+	}
+	return kubectlPath
+}
+
+// kubeCurrentContextRe matches the current-context line of a kubeconfig
+// (and of `kubectl config view` output). The value may be YAML-quoted.
+var kubeCurrentContextRe = regexp.MustCompile(`(?m)^current-context:\s*(\S+)`)
+
+// kubeHostConfigForTest locates the host XDG kube config
+// (~/.config/kube/agents-config), requires it to be sops-backed (resolving
+// into a secrets.d/<N>/ path — the mechanism under test), and parses the
+// current-context name from it. Skips when any precondition is missing.
+//
+// Returns (configPath, currentContext). configPath is the stable XDG
+// symlink path (what KUBECONFIG carries in production).
+func kubeHostConfigForTest(t *testing.T) (configPath, currentContext string) {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	configPath = filepath.Join(home, ".config", "kube", "agents-config")
+
+	resolved, err := filepath.EvalSymlinks(configPath)
+	if err != nil {
+		t.Skipf("host kube config %s absent or unresolvable: %v", configPath, err)
+	}
+	if !strings.Contains(resolved, "/secrets.d/") {
+		t.Skipf("host kube config resolves to %q which is not sops-backed — the #2211 allowlist mechanism under test does not apply", resolved)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Skipf("cannot read host kube config from the test process: %v", err)
+	}
+	match := kubeCurrentContextRe.FindSubmatch(content)
+	if match == nil {
+		t.Skipf("host kube config has no current-context line — cannot distinguish a real config read from kubectl's empty-config default output")
+	}
+	currentContext = strings.Trim(string(match[1]), `"'`)
+	if currentContext == "" {
+		t.Skipf("host kube config current-context is empty — cannot distinguish a real config read from kubectl's empty-config default output")
+	}
+	return configPath, currentContext
+}
+
+// kubectlConfigViewCmd builds the in-sandbox `kubectl config view`
+// invocation with the production env-var shape: HOME at the staging HOME
+// (still present until Step 5 of #2132), KUBECONFIG at the host XDG path,
+// KUBECACHEDIR at the session work dir, and the Step 3a AWS pair at the
+// host XDG paths (production parity — config view does not invoke the
+// exec plugin, so the pair is inert here).
+func kubectlConfigViewCmd(profilePath, stagingHome, sessionDir, kubectlBin, nixBash, configPath string) *exec.Cmd {
+	home, _ := os.UserHomeDir()
+	script := shQuote(kubectlBin) + " config view"
+	return exec.Command(sandboxExecPath, "-f", profilePath,
+		"/usr/bin/env",
+		"HOME="+stagingHome,
+		"KUBECONFIG="+configPath,
+		"KUBECACHEDIR="+container.SessionWorkDirKubeCacheDirPath(sessionDir),
+		"AWS_CONFIG_FILE="+filepath.Join(home, ".config", "aws", "readonly-config"),
+		"AWS_SHARED_CREDENTIALS_FILE="+filepath.Join(home, ".config", "aws", "credentials"),
+		nixBash, "-c", script)
+}
+
+// TestSandboxExecKubeConfig_StagingSymlinkGone asserts the issue #2235 shape
+// of the staging HOME on the real host: PrepareSandboxExecHome creates no
+// .kube/config symlink and no .kube directory at all.
+func TestSandboxExecKubeConfig_StagingSymlinkGone(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+
+	m := newProfileManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	for _, rel := range []string{".kube/config", ".kube"} {
+		staged := filepath.Join(stagingHome, filepath.FromSlash(rel))
+		if _, lstatErr := os.Lstat(staged); lstatErr == nil {
+			t.Errorf("staging HOME has %s entry — removed in #2235 (env-var route), must not be recreated", rel)
+		}
+	}
+}
+
+// TestSandboxExecKubeConfig_EnvVarResolution is the positive integration
+// test for the env-var delivery route (issue #2235 functional AC). It runs
+// a real config-resolving kubectl invocation inside sandbox-exec under the
+// production profile, with KUBECONFIG pointing at the host XDG path, and
+// asserts the current-context from the host config appears in the output
+// (exit 0 alone is not enough — kubectl prints an empty config with exit 0
+// when the file is simply absent).
+func TestSandboxExecKubeConfig_EnvVarResolution(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	kubectlBin := requireNixKubectl(t)
+
+	configPath, currentContext := kubeHostConfigForTest(t)
+
+	// BareRoot variant: traversing the XDG symlink under the real HOME needs
+	// the ancestor block's file-read-metadata allow (same as the #2211
+	// stable-chain tests and the aws env-var tests).
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Shape check inside the real flow: the staging kube entries are gone.
+	for _, rel := range []string{".kube/config", ".kube"} {
+		if _, lstatErr := os.Lstat(filepath.Join(stagingHome, filepath.FromSlash(rel))); lstatErr == nil {
+			t.Fatalf("staging HOME has %s entry — removed in #2235, must not be recreated", rel)
+		}
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The profile must carry the kube agents-config allowlist exception —
+	// the grant the env-var route rides on (issue #2211 / #2235).
+	resolvedName := secretsDNameForTest(t, configPath)
+	found := false
+	for _, name := range parseSecretsDAllowlist(prepared.content) {
+		if name == resolvedName {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("profile allowlist does not carry the kube config exception %q — collectSecretsDAllowlistNames regressed (issue #2235).\nProfile:\n%s",
+			resolvedName, prepared.content)
+	}
+
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := kubectlConfigViewCmd(testProfilePath, stagingHome, sessionDir, kubectlBin, nixBash, configPath)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("kubectl config view failed in-sandbox under the production profile.\n"+
+			"kubectl could not resolve the config via KUBECONFIG=%s (issue #2235 AC).\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			configPath, runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), currentContext) {
+		t.Fatalf("kubectl config view exited 0 but the output does not contain the host config's current-context %q — "+
+			"the config was not actually read (kubectl prints an empty config when KUBECONFIG is absent/ignored).\nOutput: %s",
+			currentContext, string(out))
+	}
+	t.Logf("ka pai — kubectl resolved current-context %q from %s in-sandbox via KUBECONFIG", currentContext, configPath)
+}
+
+// TestSandboxExecKubeConfig_EnvVarResolutionDeniedWithoutAllowlistException
+// is the paired negative test (sandbox-exec testing convention, #1192). It
+// strips the kube agents-config require-not exception from the #2211
+// secrets.d deny and asserts the same kubectl invocation fails — proving
+// the positive is not green by accident: the allowlist exception is the
+// load-bearing grant for the env-var config read.
+func TestSandboxExecKubeConfig_EnvVarResolutionDeniedWithoutAllowlistException(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	kubectlBin := requireNixKubectl(t)
+
+	configPath, _ := kubeHostConfigForTest(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	resolvedName := secretsDNameForTest(t, configPath)
+
+	// Remove the require-not exception line for the kube config name,
+	// mirroring the generator's emission format exactly (generateProfile +
+	// regexQuotePath).
+	exceptionLine := `    (require-not (regex #"/secrets\.d/[0-9]+/` + regexQuoteForTest(resolvedName) + `$"))` + "\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, exceptionLine, "")
+	})
+
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+
+	cmd := kubectlConfigViewCmd(mutatedPath, stagingHome, sessionDir, kubectlBin, nixBash, configPath)
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("kubectl config view succeeded WITHOUT the %q allowlist exception.\n"+
+			"The exception is not the load-bearing grant — investigate.\n"+
+			"Output: %s\nMutated profile: %s", resolvedName, string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — kube config read correctly denied without the allowlist exception (exit: %v)", runErr)
+	}
+}
+
+// fakeKubeAPIServer starts a minimal unauthenticated fake Kubernetes API
+// server on the host loopback (the test process is unsandboxed; the
+// sandboxed kubectl connects out — (allow network*) covers it). It serves
+// just enough legacy discovery for `kubectl api-resources` to complete a
+// round-trip and write its discovery cache. Returns the server URL.
+func fakeKubeAPIServer(t *testing.T) *url.URL {
+	t.Helper()
+	mux := http.NewServeMux()
+	writeJSON := func(w http.ResponseWriter, body string) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, `{"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"`+r.Host+`"}]}`)
+	})
+	mux.HandleFunc("/api/v1", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","list"]}]}`)
+	})
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"kind":"APIGroupList","apiVersion":"v1","groups":[]}`)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"kind":"Status","apiVersion":"v1","status":"Failure","reason":"NotFound","code":404}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse fake API server URL %q: %v", srv.URL, err)
+	}
+	return u
+}
+
+// writeFakeKubeconfig writes a minimal kubeconfig pointing at the fake API
+// server into dir and returns its path. The file lives under a t.TempDir()
+// (i.e. /var/folders on Darwin), so the broad system-paths allow covers the
+// in-sandbox read regardless of the mutation under test — the kubeconfig
+// read is deliberately NOT the grant being exercised by the cache tests.
+func writeFakeKubeconfig(t *testing.T, dir string, server *url.URL) string {
+	t.Helper()
+	kubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: ` + server.String() + `
+  name: prism-2235-fake
+contexts:
+- context:
+    cluster: prism-2235-fake
+    user: prism-2235-anon
+  name: prism-2235-fake
+current-context: prism-2235-fake
+users:
+- name: prism-2235-anon
+  user: {}
+`
+	path := filepath.Join(dir, "prism-2235-kubeconfig")
+	if err := os.WriteFile(path, []byte(kubeconfig), 0o600); err != nil {
+		t.Fatalf("write fake kubeconfig: %v", err)
+	}
+	return path
+}
+
+// kubectlAPIResourcesCmd builds the in-sandbox `kubectl api-resources`
+// invocation against the fake API server with the production KUBECACHEDIR
+// shape.
+func kubectlAPIResourcesCmd(profilePath, stagingHome, sessionDir, kubectlBin, nixBash, kubeconfigPath string) *exec.Cmd {
+	script := shQuote(kubectlBin) + " api-resources --request-timeout=10s"
+	return exec.Command(sandboxExecPath, "-f", profilePath,
+		"/usr/bin/env",
+		"HOME="+stagingHome,
+		"KUBECONFIG="+kubeconfigPath,
+		"KUBECACHEDIR="+container.SessionWorkDirKubeCacheDirPath(sessionDir),
+		nixBash, "-c", script)
+}
+
+// countRegularFilesUnder returns the number of regular files under root
+// (0 when root does not exist).
+func countRegularFilesUnder(t *testing.T, root string) int {
+	t.Helper()
+	count := 0
+	err := filepath.WalkDir(root, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil // unreadable subtree — count what we can
+		}
+		if d.Type().IsRegular() {
+			count++
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Logf("walk %s: %v", root, err)
+	}
+	return count
+}
+
+// TestSandboxExecKubeConfig_CacheWritesLandInSessionWorkDir is the cache AC
+// for issue #2235: a kubectl discovery round-trip (against a test-local
+// fake API server) writes its cache under <sessionDir>/kube-cache — the
+// KUBECACHEDIR redirect riding the existing (subpath <sessionDir>) RW grant
+// — and writes NOTHING under the host ~/.kube/cache.
+func TestSandboxExecKubeConfig_CacheWritesLandInSessionWorkDir(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	kubectlBin := requireNixKubectl(t)
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+
+	server := fakeKubeAPIServer(t)
+	kubeconfigPath := writeFakeKubeconfig(t, t.TempDir(), server)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+	kubeCacheDir := container.SessionWorkDirKubeCacheDirPath(sessionDir)
+
+	// The discovery cache is keyed by host_port (e.g. 127.0.0.1_55555) —
+	// attributable to this test's fake server, so the host-side negative
+	// assertion below cannot be confused by unrelated host cache content.
+	hostPortKey := strings.ReplaceAll(server.Host, ":", "_")
+
+	cmd := kubectlAPIResourcesCmd(testProfilePath, stagingHome, sessionDir, kubectlBin, nixBash, kubeconfigPath)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("kubectl api-resources against the fake API server failed in-sandbox.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s", runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), "pods") {
+		t.Fatalf("kubectl api-resources exited 0 but did not list the fake server's pods resource — no real discovery round-trip happened.\nOutput: %s", string(out))
+	}
+
+	// Cache files must have landed under <sessionDir>/kube-cache.
+	if got := countRegularFilesUnder(t, kubeCacheDir); got == 0 {
+		t.Errorf("no cache files under %s after a successful discovery round-trip — KUBECACHEDIR redirect not effective (issue #2235 AC)", kubeCacheDir)
+	} else {
+		t.Logf("ka pai — %d cache file(s) under %s", got, kubeCacheDir)
+	}
+
+	// And NOT under the host ~/.kube/cache: no entry attributable to the
+	// fake server's host_port may appear anywhere under it.
+	hostKubeCache := filepath.Join(home, ".kube", "cache")
+	if _, statErr := os.Stat(hostKubeCache); statErr == nil {
+		walkErr := filepath.WalkDir(hostKubeCache, func(path string, _ fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			if strings.Contains(filepath.Base(path), hostPortKey) {
+				t.Errorf("host kube cache entry %s attributable to the fake server (%s) — cache writes leaked to the host (issue #2235 AC)", path, hostPortKey)
+			}
+			return nil
+		})
+		if walkErr != nil {
+			t.Logf("walk %s: %v", hostKubeCache, walkErr)
+		}
+	}
+}
+
+// TestSandboxExecKubeConfig_CacheWriteDeniedWithoutSessionWorkDirGrant is
+// the paired negative for the cache AC (sandbox-exec testing convention,
+// #1192): with the (subpath <sessionDir>) line stripped from the profile,
+// the same discovery round-trip lands no cache files under
+// <sessionDir>/kube-cache — proving the session-work-dir grant is what
+// permits the cache writes in the positive test. kubectl treats cache-write
+// failures as non-fatal, so the assertion is on the filesystem, not on the
+// exit code.
+func TestSandboxExecKubeConfig_CacheWriteDeniedWithoutSessionWorkDirGrant(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	kubectlBin := requireNixKubectl(t)
+
+	server := fakeKubeAPIServer(t)
+	kubeconfigPath := writeFakeKubeconfig(t, t.TempDir(), server)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+	kubeCacheDir := container.SessionWorkDirKubeCacheDirPath(sessionDir)
+
+	// Strip the session-work-dir subpath line (the grant under test). The
+	// kubeconfig itself lives under /var/folders (broad allow), so its read
+	// is unaffected — the mutation isolates the cache-write grant.
+	sessionDirLine := "  (subpath " + sbplQuoteForTest(sessionDir) + ")\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, sessionDirLine, "")
+	})
+
+	cmd := kubectlAPIResourcesCmd(mutatedPath, stagingHome, sessionDir, kubectlBin, nixBash, kubeconfigPath)
+	out, runErr := cmd.CombinedOutput()
+	t.Logf("kubectl api-resources without the session-work-dir grant: exit=%v", runErr)
+	_ = out
+
+	if got := countRegularFilesUnder(t, kubeCacheDir); got != 0 {
+		t.Errorf("%d cache file(s) landed under %s WITHOUT the (subpath <sessionDir>) grant — "+
+			"the positive cache test is not exercising that grant.\nMutated profile: %s",
+			got, kubeCacheDir, mutatedPath)
+	} else {
+		t.Logf("ka pai — no cache files land without the session-work-dir grant (grant is load-bearing)")
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_sops_rotation_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_sops_rotation_darwin_test.go
@@ -20,7 +20,7 @@ package integration_test
 // secrets.d allowlist (see TestSandboxExecSecretsDeny_RotationSimulation and
 // the aws env-var tests in sandbox_exec_aws_config_envvar_darwin_test.go).
 //
-// Mechanism note — why this only covers .ssh/access-key in this PR:
+// Mechanism note — why the staging-chain tests only cover .ssh/access-key:
 // PrepareSandboxExec re-runs PrepareSandboxExecHome internally (lifecycle_
 // dispatch.go:233), which idempotently recreates the default staging
 // symlinks via symlinkIfExists. When the canonical source path on the host
@@ -29,12 +29,22 @@ package integration_test
 // the default chain instead of the test-fabricated one. The .aws/credentials
 // vehicle worked on previous hosts only because credentials is absent
 // (symlinkIfExists short-circuits when SOURCE is missing). For .ssh the
-// test now sets SshAccessKeyName to a unique non-existent name so the same
-// short-circuit fires and the test's replacement survives. .kube/config has
-// no equivalent Config knob, and its staging symlink is itself on the
-// chopping block in #2235 (Step 3b), so this PR omits the kube entry from
-// the rotation suite. #2235's footprint covers the kube rotation guarantee
-// either via its own test or by removing the entry entirely.
+// test sets SshAccessKeyName to a unique non-existent name so the same
+// short-circuit fires and the test's replacement survives.
+//
+// Kube (issue #2235, Step 3b of #2132): the .kube/config staging symlink no
+// longer exists at all — kubectl reads the config via KUBECONFIG at the
+// host XDG path (~/.config/kube/agents-config), and rotation safety rides
+// the counter-independent #2211 secrets.d allowlist exception derived from
+// that same stable source. The kube rotation entries below
+// (TestSandboxExecSopsRotation_KubeConfigAllowlistCounterIndependent and
+// its paired negative) therefore do not touch the staging HOME: they derive
+// the kube secret NAME from the real host source, plant a fake secrets.d
+// tree under the per-user TMPDIR (where the production deny/exception
+// regexes apply with no profile mutation and no host-state writes), and
+// prove reads of that name survive a counter rotation. This sidesteps the
+// idempotent-re-run clobbering entirely — there is no staging symlink to
+// clobber and no Config knob is needed.
 //
 // Test design
 // ───────────
@@ -101,6 +111,156 @@ var sopsRotationEntries = []sopsRotationEntry{
 		intermediateRelPath: ".ssh/prismatic-koi-ed25519",
 		sentinel:            "ssh-ed25519 AAAA1573-access-key-sentinel",
 	},
+}
+
+// kubeRotationHostSource returns the stable host XDG path of the kube
+// agents config and its secrets.d-relative name, skipping when the source
+// is absent or not sops-backed on this host (the #2211 allowlist mechanism
+// under test does not apply then). This is the guard for the kube rotation
+// tests' indirection invariant: the secret NAME is derived from the same
+// stable source that feeds collectSecretsDAllowlistNames, so the fake-tree
+// reads below exercise exactly the exception the production profile carries
+// for the kube config.
+func kubeRotationHostSource(t *testing.T) (configPath, secretName string) {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	configPath = filepath.Join(home, ".config", "kube", "agents-config")
+	secretName = secretsDNameForTest(t, configPath)
+	return configPath, secretName
+}
+
+// assertNoStagingKubeEntry hard-fails when the staging HOME carries a
+// .kube/config entry (or a .kube dir at all). The kube rotation tests'
+// premise is that the env-var route — not a staging symlink — delivers the
+// kube config (issue #2235); if the staging symlink reappears, the
+// fake-tree mechanism below would no longer be testing the production read
+// path and the regression must surface loudly, not silently.
+func assertNoStagingKubeEntry(t *testing.T, stagingHome string) {
+	t.Helper()
+	for _, gone := range []string{
+		filepath.Join(stagingHome, ".kube", "config"),
+		filepath.Join(stagingHome, ".kube"),
+	} {
+		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
+			t.Fatalf("staging HOME has %s entry — removed in #2235; the kube rotation test premise (env-var route) is violated", gone)
+		}
+	}
+}
+
+// TestSandboxExecSopsRotation_KubeConfigAllowlistCounterIndependent is the
+// kube positive rotation entry (issue #2235 edge-case AC: a sops rotation
+// after spawn does not break kube config reads). The kube config rides the
+// #2211 allowlist: KUBECONFIG points at the stable XDG symlink, and the
+// in-sandbox read of the resolved secrets.d target is permitted by the
+// counter-independent ([0-9]+) require-not exception for the kube secret
+// name. The test derives that name from the real host source, plants a
+// fake secrets.d tree at counters 100 → 101, and asserts reads of the
+// kube-named secret succeed at both counters under the production profile
+// — the fake counters carry no per-symlink (literal …) allows, so the
+// exception is the only mechanism that can permit the read.
+func TestSandboxExecSopsRotation_KubeConfigAllowlistCounterIndependent(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, kubeName := kubeRotationHostSource(t)
+
+	m := newProfileManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+	assertNoStagingKubeEntry(t, stagingHome)
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The profile must carry the kube exception — the grant the env-var
+	// route rides on (issue #2211 / #2235).
+	found := false
+	for _, name := range parseSecretsDAllowlist(prepared.content) {
+		if name == kubeName {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("profile allowlist does not carry the kube config exception %q — collectSecretsDAllowlistNames regressed (issue #2235).\nProfile:\n%s",
+			kubeName, prepared.content)
+	}
+
+	base := setupFakeSecretsTree(t, kubeName, "100")
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	readAtCounter := func(counter string) {
+		t.Helper()
+		target := filepath.Join(base, "secrets.d", counter, filepath.FromSlash(kubeName))
+		cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+			nixBash, "-c", "cat "+shQuote(target))
+		out, runErr := cmd.CombinedOutput()
+		if runErr != nil {
+			t.Errorf("counter %s: in-sandbox read of kube secret name %q failed — the kube exception is not counter-independent (#1410/#1573 regression via #2235).\nExit: %v\nOutput: %s",
+				counter, kubeName, runErr, out)
+			return
+		}
+		if !strings.Contains(string(out), fakeAllowedSentinel) {
+			t.Errorf("counter %s: kube secret read exited 0 but sentinel missing.\nOutput: %s", counter, out)
+		}
+	}
+
+	// Generation 100, then simulate a sops rotation: write 101, prune 100.
+	readAtCounter("100")
+	writeFakeSecretsCounter(t, base, "101", kubeName)
+	if err := os.RemoveAll(filepath.Join(base, "secrets.d", "100")); err != nil {
+		t.Fatalf("prune fake counter 100: %v", err)
+	}
+	readAtCounter("101")
+}
+
+// TestSandboxExecSopsRotation_KubeConfigExceptionLoadBearing is the paired
+// negative for the kube rotation entry (sandbox-exec testing convention,
+// #1192): with the kube require-not exception stripped from the profile,
+// the same fake-counter read fails — proving the exception (not some
+// broader rule) is what permits the kube config read in the positive test.
+func TestSandboxExecSopsRotation_KubeConfigExceptionLoadBearing(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, kubeName := kubeRotationHostSource(t)
+
+	m := newProfileManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+	assertNoStagingKubeEntry(t, stagingHome)
+
+	base := setupFakeSecretsTree(t, kubeName, "100")
+	target := filepath.Join(base, "secrets.d", "100", filepath.FromSlash(kubeName))
+
+	exceptionLine := `    (require-not (regex #"/secrets\.d/[0-9]+/` + regexQuoteForTest(kubeName) + `$"))` + "\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, exceptionLine, "")
+	})
+
+	runErr, out := sandboxCatDiscard(mutatedPath, nixBash, target)
+	if runErr == nil {
+		t.Errorf("in-sandbox read of kube secret name %q succeeded WITHOUT the allowlist exception.\n"+
+			"The exception is not the load-bearing grant — the positive rotation test is a no-op.\n"+
+			"Mutated profile: %s", kubeName, mutatedPath)
+	} else {
+		t.Logf("ka pai — kube secret read correctly denied without the exception (exit: %v, stderr: %s)", runErr, out)
+	}
 }
 
 // rotationTestAccessKeyName is the unique-per-test-run SshAccessKeyName


### PR DESCRIPTION
Step 3b of the #2132 staging-HOME elimination train.

Refs #2132
Closes #2235

## #2211 allowlist coverage (verified as first step)

`collectSecretsDAllowlistNames` derives the kube exception directly from the stable XDG source path (`~/.config/kube/agents-config`) — **not** from the staging symlink — so removing the symlink does not change what feeds the allowlist (only its godoc changed). The new positive integration test additionally asserts the emitted profile carries the kube exception before running the kubectl invocation. Rotation safety is inherited from the allowlist's counter-independent `[0-9]+` regexes (#1410/#1573 property).

## What

- **Staging symlink dropped** — `PrepareSandboxExecHome` no longer creates `.kube/config` (the `.kube/` staging dir is gone entirely); `collectStagingHomeSymlinkTargets` no longer scans `.kube` and consequently no longer emits the resolved target.
- **`KUBECONFIG` un-suppressed from both maps** — and since it was the **last** entry, the `sandboxMountedByDefault` suppression maps are removed entirely from `AppendStandardEnv` (bwrap) and `AppendSandboxEnvVarsKV` (sandbox-exec dispatch), per the #2132 §3 end state ("empty or removed"). The value declared at the host XDG path by the nix module (`agent.envVars`, `$HOME` expanded at build time) now flows into both isolators.
- **`KUBECACHEDIR` added to both env layers** — kubectl writes its discovery/http cache to `$HOME/.kube/cache` by default, which exists on the host and would EPERM under deny-default post-removal.
  - **sandbox-exec**: the dispatcher injects `KUBECACHEDIR=<sessionDir>/kube-cache` (new `SessionWorkDirKubeEnv` / `SessionWorkDirKubeCacheDirPath` helpers) alongside the #2213 git env. The dir lives inside the already-granted `(subpath <sessionDir>)` RW allow — **no new SBPL rule**; ephemeral per-session semantics preserved (work dir is removed on cleanup). kubectl `MkdirAll`s it on first use, so it is not pre-created.
  - **bwrap**: `--setenv KUBECACHEDIR /tmp/kube-cache` — **deliberate divergence from the sandbox-exec value, called out per the issue's "bwrap equivalent" wording**: the session work dir is a sandbox-exec mechanism (bwrap never creates host-side per-session state), and `/tmp` is already an explicit per-session tmpfs (`--tmpfs /tmp`), so the cache is guaranteed writable, ephemeral, and never host-visible with zero new mounts. Pointing bwrap at `<sessionDir>/kube-cache` instead would either require a new RW bind of host-side state created solely for a throwaway cache, or land in the implicit root tmpfs with the risk of silently writing through to the host if a future bind ever covers that path.
- **Bwrap convergence (design decision §5.1)** — the canonical-path (`$HOME/.kube/config`) RO bind is dropped from `StandardSandboxMounts` (`mounts.go`). Because the bwrap namespace is additive from an empty root, the XDG path is bound **Dst==Src** (RO, EvalSymlinks — same sops-target inode semantics as the previous canonical bind; silent skip when absent) so `KUBECONFIG` resolves to a readable file in-namespace — the exact 3a pattern. `bwrap_test.go` updated.
- **No literal SBPL grants added** on the XDG symlink path, per the #2132 §2 mechanism note (inert — SBPL evaluates resolved targets). The in-sandbox read of the resolved sops target rides the #2211 allowlist.

## Sops-rotation suite: kube entry + chosen indirection mechanism

PR #2238 removed `.kube/config` from the rotation suite because the staging-chain vehicle needs a Config-knob indirection (`SshAccessKeyName`-style) to survive `iso.Prepare`'s idempotent staging re-run, and kube had no knob. **This PR's chosen mechanism sidesteps that problem instead of inventing a knob**: post-3b there is no kube staging symlink to clobber, so the kube rotation entries (`TestSandboxExecSopsRotation_KubeConfigAllowlistCounterIndependent` + paired `…ExceptionLoadBearing` negative in `sandbox_exec_sops_rotation_darwin_test.go`) derive the kube secret NAME from the real host source (same derivation as `collectSecretsDAllowlistNames`), plant a fake `secrets.d/{100→101}` tree under the per-user TMPDIR (where the production deny/exception regexes apply with **no profile mutation and no host-state writes**), and prove reads of that name survive a counter rotation under the production profile.

**Trade-off, documented**: a `KubeConfigName` Config knob would have let the test fabricate the whole chain, but (a) a unique non-existent name makes `EvalSymlinks` fail → no exception emitted → nothing to test; (b) a knob pointing at a test symlink would require writing into the real `~/.config/kube/` on the host; and (c) it adds a production Config field whose only consumer is a test. The fake-tree approach tests the exact production exception with zero production-code surface. What it does NOT exercise is a fabricated end-to-end `KUBECONFIG → stable symlink → rotated target` chain — but the stable-chain read at the current counter is covered by `TestSandboxExecSecretsDeny_AllowlistedStableChainsReadable` and the new `TestSandboxExecKubeConfig_EnvVarResolution`, and counter-independence is exactly what the fake tree isolates.

**Guard skip / indirection invariant** (matching the `.ssh` guard pattern): `kubeRotationHostSource` skips when the host source is absent or not sops-backed, and `assertNoStagingKubeEntry` hard-fails both rotation tests if a `.kube` staging entry ever reappears — the tests' premise (env-var route, not staging symlink) must break loudly, not silently.

## Acceptance criteria mapping

- **sandbox-exec env-var resolution (`kubectl config view`)** — `TestSandboxExecKubeConfig_EnvVarResolution` runs `kubectl config view` in-sandbox with `KUBECONFIG` at the host XDG path; exit 0 alone is not enough (kubectl prints an empty config with exit 0 when the file is absent/ignored), so the test also asserts the output carries the `current-context` parsed from the host config — proving a real config read. The exec-plugin probe (`aws eks get-token`) is **not** run live (non-hermetic: real STS/EKS network + credentials); per the AC's fallback, exec-plugin env propagation is covered at unit level (`env_test.go` asserts the AWS pair + KUBECONFIG all flow through `AppendSandboxEnvVarsKV`/`AppendStandardEnv`), and the integration invocation carries the production env shape including the 3a AWS pair.
- **cache writes land in `<sessionDir>/kube-cache`, not host `~/.kube/cache`** — `TestSandboxExecKubeConfig_CacheWritesLandInSessionWorkDir` triggers a real discovery cache write via `kubectl api-resources` against a test-local fake API server (loopback `httptest` server serving legacy discovery JSON; `(allow network*)` covers the connect), then asserts cache files exist under `<sessionDir>/kube-cache` AND that no entry attributable to the fake server's `host_port` discovery key appears under host `~/.kube/cache`.
- **bwrap env-var resolution + canonical bind gone** — `TestBwrapBuildArgs_AgentEnvVarsInjected` / `TestBwrapBuildArgs_KubeconfigInjectedEvenWhenFileAbsent` (setenv present; absent file → no bind), `TestBwrapBuildArgs_KubeAgentsConfigXDGPathROBound` (Dst==Src XDG bind present + canonical dst unbound), `TestBwrapBuildArgs_KubeCacheDirEnvInjected`, `TestBwrapBuildArgs_FullFixture`, plus appender-level `env_test.go`. All verified load-bearing by revert-and-fail (see Testing).
- **staging HOME shape + collector** — `TestPrepareSandboxExecHome_NoKubeConfigSymlink`, the updated `TestPrepareSandboxExecHome_SopsRotation_StagingSymlinks` (unit), and `TestSandboxExecKubeConfig_StagingSymlinkGone` (integration; also re-asserted inside the positive env-var flow).
- **sops rotation after spawn** — the kube rotation entries described above.
- **suppression maps** — maps deleted; `env_test.go` asserts exact full emission (KUBECONFIG + AWS pair + GIT_EDITOR, nothing suppressed).

Profile-mutation negatives (sandbox-exec testing convention, #1192): `TestSandboxExecKubeConfig_EnvVarResolutionDeniedWithoutAllowlistException` (strips the kube `require-not` exception → config read fails), `TestSandboxExecKubeConfig_CacheWriteDeniedWithoutSessionWorkDirGrant` (strips `(subpath <sessionDir>)` → no cache files land; filesystem-asserted because kubectl treats cache-write failures as non-fatal; the test kubeconfig deliberately lives under `/var/folders` so its read is NOT the grant under test), and `TestSandboxExecSopsRotation_KubeConfigExceptionLoadBearing`. #2207 capability-probe gating (`sandboxexectest.Require`) retained throughout.

## Testing

- `go build ./...` — pass
- `go test ./... -race` — pass (full suite)
- **Vacuous-pass check (revert-and-fail)**: selectively restored each of `env.go`, `sandbox_exec_home.go`, `mounts.go`, and the bwrap `KUBECACHEDIR` setenv to their pre-change state and confirmed the corresponding new tests FAIL, then restored and confirmed green.
- `nix build .#prism` — **could not run locally**: this worker sandbox pre-dates the #2201 trusted-settings read allowance (`error: opening file ".../trusted-settings.json": Operation not permitted`). Per AGENTS.md I ran the sanctioned non-flake eval fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — pass. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).
- ⚠️ **The Darwin kube/rotation integration tests SKIP in this worker sandbox** (nested sandbox-exec refuses to apply profiles; additionally the new tests require a nix-built `kubectl` on PATH and a sops-backed `~/.config/kube/agents-config` with a `current-context`). Please arrange a host-side run before merge, as was done for PR #2238:

  ```
  go test ./internal/integration/ -run 'TestSandboxExecKubeConfig|TestSandboxExecSopsRotation' -v
  ```

## Out of scope (untouched)

- `.aws/sso` / `.aws/cli` RW symlinks, `~/.aws` deny carve-outs (Step 3e)
- claude relocation (3c), pi-oauth (3d), caches (3e), RO trio (3f), chromium (Step 4)
- Pre-existing gofmt drift in `internal/integration/sandbox_exec_helpers_darwin_test.go` and `sandbox_exec_profile_darwin_test.go` (go 1.26 gofmt vs older formatting; neither file is modified here — all files touched by this PR are gofmt-clean)
