### PR TITLE
prism + home: relocate claude config to XDG via CLAUDE_CONFIG_DIR — drop .claude staging symlink (Step 3c of #2132)

### DIFF
--- a/modules/programs/prism/claude-code.nix
+++ b/modules/programs/prism/claude-code.nix
@@ -20,54 +20,109 @@
       envPrefix = lib.concatStringsSep " " (
         lib.mapAttrsToList (name: value: "${name}=${value}") claudeCodeEnvVars
       );
-    in
-    {
-      home-manager.users.${config.nx.username} = {
-        programs.zsh.shellAliases = {
-          # set environment variables for claude-code
-          claude-code = "${envPrefix} claude-code";
-        };
-        # programs.neovim.extraLuaConfig =
-        #   lib.mkAfter
-        #     # lua
-        #     ''
-        #       -- open current project in new kitty window with claude-code
-        #       vim.keymap.set(
-        #         "n",
-        #         "<leader>ca",
-        #         ":!kitty -d $(pwd) env ${envPrefix} claude-code . &<CR><CR>",
-        #         { silent = true, desc = "[C]laude code with [A]I agent" }
-        #       )
-        #     '';
-        programs.claude-code = {
-          enable = true;
-          settings = {
-            permissions = {
-              defaultMode = "acceptEdits";
-              allow = [
-                # Kubernetes tools
-                "Bash(flux:*)"
-                "Bash(helm:*)"
-                "Bash(kubectl:*)"
-                # nix commands
-                "Bash(nix build:*)"
-                "Bash(nixfmt:*)"
-              ];
-            };
-          };
-        };
-        home.persistence."/persist" = {
-          directories = [
-            ".claude"
-            ".config/claude"
-            ".local/share/claude"
-            ".local/state/claude"
-          ];
-          files = [
-            ".claude.json"
+      jsonFormat = pkgs.formats.json { };
+      # claude-code settings, rendered to the XDG config dir below
+      # (~/.config/claude/settings.json — NOT the upstream home-manager
+      # module's hardcoded ~/.claude/settings.json target; see the
+      # CLAUDE_CONFIG_DIR note further down). The $schema key mirrors what
+      # programs.claude-code.settings would have emitted.
+      claudeSettings = {
+        "$schema" = "https://json.schemastore.org/claude-code-settings.json";
+        permissions = {
+          defaultMode = "acceptEdits";
+          allow = [
+            # Kubernetes tools
+            "Bash(flux:*)"
+            "Bash(helm:*)"
+            "Bash(kubectl:*)"
+            # nix commands
+            "Bash(nix build:*)"
+            "Bash(nixfmt:*)"
           ];
         };
       };
+    in
+    {
+      home-manager.users.${config.nx.username} =
+        { lib, ... }:
+        {
+          programs.zsh.shellAliases = {
+            # set environment variables for claude-code
+            claude-code = "${envPrefix} claude-code";
+          };
+          # programs.neovim.extraLuaConfig =
+          #   lib.mkAfter
+          #     # lua
+          #     ''
+          #       -- open current project in new kitty window with claude-code
+          #       vim.keymap.set(
+          #         "n",
+          #         "<leader>ca",
+          #         ":!kitty -d $(pwd) env ${envPrefix} claude-code . &<CR><CR>",
+          #         { silent = true, desc = "[C]laude code with [A]I agent" }
+          #       )
+          #     '';
+
+          # CLAUDE_CONFIG_DIR relocates claude-code's config dir AND
+          # ~/.claude.json to the XDG path (verified effective in claude-code
+          # 2.1.161). Set host-wide here and delivered into prism sandboxes
+          # via nx.programs.prism.agent.envVars (issue #2243, Step 3c of the
+          # #2132 staging-HOME elimination design).
+          #
+          # Residual risk, accepted by design (#2132 §4 Step 3c): a claude
+          # launch that does not source the home-manager session vars (e.g. a
+          # bare login shell without hm integration, or a GUI process) falls
+          # back to ~/.claude and forks its state from the migrated copy.
+          # CLI-only usage on these machines makes this low — documented, not
+          # engineered around.
+          home.sessionVariables.CLAUDE_CONFIG_DIR = "$HOME/.config/claude";
+
+          programs.claude-code = {
+            # Installs the claude-code package only. Settings deliberately NOT
+            # set via programs.claude-code.settings: the upstream home-manager
+            # module hardcodes its settings.json target to ~/.claude/, which
+            # CLAUDE_CONFIG_DIR has relocated away from. The settings file is
+            # rendered at the XDG path via xdg.configFile below instead.
+            enable = true;
+          };
+          xdg.configFile."claude/settings.json".source =
+            jsonFormat.generate "claude-code-settings.json" claudeSettings;
+
+          # One-time idempotent migration of pre-#2243 claude state
+          # (~/.claude/{history.jsonl,projects,plugins,telemetry,backups} and
+          # ~/.claude.json) to ~/.config/claude. Runs in the same activation
+          # generation that delivers CLAUDE_CONFIG_DIR, so the flip is atomic
+          # at switch time. Absent sources and already-migrated state are
+          # no-ops; pre-existing destination entries are skipped with a
+          # warning, never overwritten. Logic lives in claude-xdg-migrate.sh
+          # (covered by claude_xdg_migration_script_test.go in the prism Go
+          # tree). `run` honours home-manager's dry-run mode.
+          home.activation.claudeXdgMigrate = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+            run ${pkgs.bash}/bin/bash ${./claude-xdg-migrate.sh} \
+              "$HOME/.claude" "$HOME/.claude.json" "$HOME/.config/claude"
+          '';
+
+          home.persistence."/persist" = {
+            directories = [
+              # ~/.claude stays persisted post-#2243: it is the migration
+              # source on first activation after the flip, and live sessions
+              # spawned pre-switch (plus no-session-vars fallback launches)
+              # may still write stale state there.
+              ".claude"
+              ".config/claude"
+              ".local/share/claude"
+              ".local/state/claude"
+            ];
+            files = [
+              # Kept post-#2243 for the same reason as ~/.claude above. On
+              # impermanence hosts this entry is a symlink into /persist; the
+              # migration moves the symlink (content stays in /persist, shared
+              # by both paths), and the recreated link is then skipped by the
+              # idempotent migration on later activations.
+              ".claude.json"
+            ];
+          };
+        };
     }
   );
 }

--- a/modules/programs/prism/claude-code.nix
+++ b/modules/programs/prism/claude-code.nix
@@ -20,31 +20,10 @@
       envPrefix = lib.concatStringsSep " " (
         lib.mapAttrsToList (name: value: "${name}=${value}") claudeCodeEnvVars
       );
-      jsonFormat = pkgs.formats.json { };
-      # claude-code settings, rendered to the XDG config dir below
-      # (~/.config/claude/settings.json — NOT the upstream home-manager
-      # module's hardcoded ~/.claude/settings.json target; see the
-      # CLAUDE_CONFIG_DIR note further down). The $schema key mirrors what
-      # programs.claude-code.settings would have emitted.
-      claudeSettings = {
-        "$schema" = "https://json.schemastore.org/claude-code-settings.json";
-        permissions = {
-          defaultMode = "acceptEdits";
-          allow = [
-            # Kubernetes tools
-            "Bash(flux:*)"
-            "Bash(helm:*)"
-            "Bash(kubectl:*)"
-            # nix commands
-            "Bash(nix build:*)"
-            "Bash(nixfmt:*)"
-          ];
-        };
-      };
     in
     {
       home-manager.users.${config.nx.username} =
-        { lib, ... }:
+        { lib, config, ... }:
         {
           programs.zsh.shellAliases = {
             # set environment variables for claude-code
@@ -63,30 +42,42 @@
           #       )
           #     '';
 
-          # CLAUDE_CONFIG_DIR relocates claude-code's config dir AND
-          # ~/.claude.json to the XDG path (verified effective in claude-code
-          # 2.1.161). Set host-wide here and delivered into prism sandboxes
-          # via nx.programs.prism.agent.envVars (issue #2243, Step 3c of the
-          # #2132 staging-HOME elimination design).
-          #
-          # Residual risk, accepted by design (#2132 §4 Step 3c): a claude
-          # launch that does not source the home-manager session vars (e.g. a
-          # bare login shell without hm integration, or a GUI process) falls
-          # back to ~/.claude and forks its state from the migrated copy.
-          # CLI-only usage on these machines makes this low — documented, not
-          # engineered around.
-          home.sessionVariables.CLAUDE_CONFIG_DIR = "$HOME/.config/claude";
-
           programs.claude-code = {
-            # Installs the claude-code package only. Settings deliberately NOT
-            # set via programs.claude-code.settings: the upstream home-manager
-            # module hardcodes its settings.json target to ~/.claude/, which
-            # CLAUDE_CONFIG_DIR has relocated away from. The settings file is
-            # rendered at the XDG path via xdg.configFile below instead.
             enable = true;
+            # Relocates claude-code's config dir AND ~/.claude.json to the XDG
+            # path (verified effective in claude-code 2.1.161). The upstream
+            # home-manager module renders settings.json into this dir and
+            # auto-exports CLAUDE_CONFIG_DIR via home.sessionVariables
+            # whenever it differs from the ~/.claude default — no hand-rolled
+            # env var or settings-file emission needed here. The value is
+            # delivered into prism sandboxes via nx.programs.prism.agent.envVars
+            # (issue #2243, Step 3c of the #2132 staging-HOME elimination
+            # design); keep this literal path in agreement with agent.envVars
+            # (default.nix), the prism SBPL grant / bwrap mount, and the
+            # migration destination below.
+            #
+            # Residual risk, accepted by design (#2132 §4 Step 3c): a claude
+            # launch that does not source the home-manager session vars (e.g.
+            # a bare login shell without hm integration, or a GUI process)
+            # falls back to ~/.claude and forks its state from the migrated
+            # copy. CLI-only usage on these machines makes this low —
+            # documented, not engineered around.
+            configDir = "${config.home.homeDirectory}/.config/claude";
+            settings = {
+              permissions = {
+                defaultMode = "acceptEdits";
+                allow = [
+                  # Kubernetes tools
+                  "Bash(flux:*)"
+                  "Bash(helm:*)"
+                  "Bash(kubectl:*)"
+                  # nix commands
+                  "Bash(nix build:*)"
+                  "Bash(nixfmt:*)"
+                ];
+              };
+            };
           };
-          xdg.configFile."claude/settings.json".source =
-            jsonFormat.generate "claude-code-settings.json" claudeSettings;
 
           # One-time idempotent migration of pre-#2243 claude state
           # (~/.claude/{history.jsonl,projects,plugins,telemetry,backups} and

--- a/modules/programs/prism/claude-xdg-migrate.sh
+++ b/modules/programs/prism/claude-xdg-migrate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# claude-xdg-migrate.sh — one-time idempotent migration of claude-code state
+# from the old canonical locations (~/.claude/ and ~/.claude.json) to the XDG
+# config dir reached via CLAUDE_CONFIG_DIR (~/.config/claude).
+#
+# Issue #2243 (Step 3c of #2132). Invoked from the home-manager activation
+# script in modules/programs/prism/claude-code.nix; takes explicit paths so
+# the logic is unit-testable without touching a real $HOME (see
+# internal/integration/claude_xdg_migration_script_test.go in the prism Go
+# tree).
+#
+# Usage: claude-xdg-migrate.sh <src-dir> <src-json> <dst-dir>
+#   e.g. claude-xdg-migrate.sh "$HOME/.claude" "$HOME/.claude.json" "$HOME/.config/claude"
+#
+# Behaviour (all idempotent):
+#   - Moves history.jsonl, projects/, plugins/, telemetry/, backups/ from
+#     <src-dir> into <dst-dir>, and <src-json> to <dst-dir>/.claude.json.
+#   - No source state at all → exit 0 without creating <dst-dir>.
+#   - A source entry that is absent (e.g. already migrated) → skipped.
+#   - A destination entry that already exists → skip-and-warn, NEVER
+#     overwritten; the source entry is left in place.
+#   - Entries are moved one by one (never the <src-dir> itself — it may be a
+#     mount point under impermanence). mv falls back to copy+remove across
+#     filesystems (EXDEV), which covers persisted bind mounts.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <src-dir> <src-json> <dst-dir>" >&2
+  exit 64
+fi
+
+src_dir=$1
+src_json=$2
+dst_dir=$3
+
+entries=(history.jsonl projects plugins telemetry backups)
+
+# exists: true for any filesystem entry, including dangling symlinks
+# (-e follows symlinks and reports false for dangling ones; -L catches those).
+exists() {
+  [ -e "$1" ] || [ -L "$1" ]
+}
+
+# Nothing to migrate when no source state exists — exit before creating the
+# destination so an absent ~/.claude stays a strict no-op.
+have_source=false
+if exists "$src_json"; then
+  have_source=true
+elif [ -d "$src_dir" ]; then
+  for entry in "${entries[@]}"; do
+    if exists "$src_dir/$entry"; then
+      have_source=true
+      break
+    fi
+  done
+fi
+if [ "$have_source" = false ]; then
+  exit 0
+fi
+
+mkdir -p "$dst_dir"
+
+# migrate <src> <dst>: move one entry, skipping (with a warning) when the
+# destination already exists. Never overwrites.
+migrate() {
+  local src=$1 dst=$2
+  if ! exists "$src"; then
+    return 0 # absent or already migrated — no-op
+  fi
+  if exists "$dst"; then
+    echo "claude-xdg-migrate: SKIP $src -> $dst (destination already exists; not overwritten)" >&2
+    return 0
+  fi
+  mv "$src" "$dst"
+  echo "claude-xdg-migrate: moved $src -> $dst" >&2
+}
+
+if [ -d "$src_dir" ]; then
+  for entry in "${entries[@]}"; do
+    migrate "$src_dir/$entry" "$dst_dir/$entry"
+  done
+fi
+
+migrate "$src_json" "$dst_dir/.claude.json"

--- a/modules/programs/prism/default.nix
+++ b/modules/programs/prism/default.nix
@@ -19,6 +19,13 @@
             KUBECONFIG = "$HOME/.config/kube/agents-config";
             AWS_CONFIG_FILE = "$HOME/.config/aws/readonly-config";
             AWS_SHARED_CREDENTIALS_FILE = "$HOME/.config/aws/credentials";
+            # Relocates claude-code's config dir (and .claude.json) to the
+            # XDG path — matches the host-wide home.sessionVariables value in
+            # claude-code.nix (issue #2243, Step 3c of #2132). Both isolators
+            # deliver the value as-is; the in-sandbox capability is the RW
+            # SBPL (subpath ~/.config/claude) grant (sandbox-exec) / the
+            # Dst==Src RW bind (bwrap).
+            CLAUDE_CONFIG_DIR = "$HOME/.config/claude";
             GIT_EDITOR = "true";
           };
           description = "Environment variables to set for the AI agent (pi)";

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -312,12 +312,12 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 
 	// ── Standard sandbox mounts via the shared spec walk ─────────────────
 	// StandardSandboxMounts (mounts.go, A2.M1) returns the mode-agnostic
-	// mount set for ~/.claude, ~/.mcp-auth, ~/.cache/nix, AWS config, AWS
+	// mount set for ~/.config/claude, ~/.mcp-auth, ~/.cache/nix, AWS config, AWS
 	// credentials, AWS SSO/CLI cache, kube config, and the clipboard
 	// staging dir. The bwrap appendBind appender (mounts.go) translates
 	// each MountSpec into the correct --bind / --ro-bind triple.
 	//
-	// Note on ordering: StandardSandboxMounts emits ~/.claude, ~/.mcp-auth,
+	// Note on ordering: StandardSandboxMounts emits ~/.config/claude, ~/.mcp-auth,
 	// ~/.cache/nix, AWS config, AWS credentials, AWS SSO, AWS CLI, kube
 	// config, clipboard-staging. The pre-A2.M1 bwrap order interleaved the
 	// AWS group with the SSH/known_hosts/SSH-config group; the new order

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -97,8 +97,10 @@ func bwrapFixture(t *testing.T, cfg Config) (m *Manager, fakeHome string, cleanu
 	}
 
 	// Pre-create directories that BuildArgs expects unconditionally.
+	// ~/.config/claude is conditional (OptionalIfMissing) but pre-created
+	// here so the fixture exercises the bound path (issue #2243).
 	dirs := []string{
-		filepath.Join(fakeHome, ".claude"),
+		filepath.Join(fakeHome, ".config", "claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
 		filepath.Join(fakeHome, ".npm"),
 		filepath.Join(fakeHome, ".cache", "nix"),
@@ -376,7 +378,13 @@ func TestBwrapBuildArgs_WorktreeBound(t *testing.T) {
 	}
 }
 
-func TestBwrapBuildArgs_ClaudeDirBound(t *testing.T) {
+// TestBwrapBuildArgs_ClaudeConfigXDGDirBound verifies the claude config dir
+// is RW-bound Dst==Src at the host XDG path (~/.config/claude) and that the
+// former canonical ~/.claude bind is gone (issue #2243, Step 3c of #2132).
+// claude-code reaches the dir via the CLAUDE_CONFIG_DIR env var; the bwrap
+// namespace is additive from an empty root, so the Dst==Src bind delivers
+// the host directory at the path the env var carries.
+func TestBwrapBuildArgs_ClaudeConfigXDGDirBound(t *testing.T) {
 	m, fakeHome, cleanup := bwrapFixture(t, Config{
 		SessionName:   "repo@main",
 		Worktree:      t.TempDir(),
@@ -387,9 +395,45 @@ func TestBwrapBuildArgs_ClaudeDirBound(t *testing.T) {
 	b := &bwrapIsolator{name: m.name}
 	args := b.BuildArgs(m)
 
-	claudeDir := filepath.Join(fakeHome, ".claude")
-	if !hasBind(args, claudeDir) {
-		t.Errorf("~/.claude %q not found as --bind SRC SRC in args: %v", claudeDir, args)
+	claudeXDGDir := filepath.Join(fakeHome, ".config", "claude")
+	if !hasBind(args, claudeXDGDir) {
+		t.Errorf("~/.config/claude %q not found as --bind SRC SRC in args: %v", claudeXDGDir, args)
+	}
+
+	// The canonical ~/.claude path must not appear anywhere in the args —
+	// neither as a bind source nor as a destination (env-var route, #2243).
+	canonical := filepath.Join(fakeHome, ".claude")
+	if hasArg(args, canonical) {
+		t.Errorf("canonical ~/.claude %q must not appear in args (XDG relocation, #2243): %v", canonical, args)
+	}
+}
+
+// TestBwrapBuildArgs_ClaudeConfigDirAbsentNoBind verifies the claude XDG
+// mount is OptionalIfMissing: a host without ~/.config/claude produces no
+// bind args for it (bwrap aborts on missing --bind sources), and no
+// canonical ~/.claude bind reappears (issue #2243).
+func TestBwrapBuildArgs_ClaudeConfigDirAbsentNoBind(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	// Remove the fixture's pre-created ~/.config/claude.
+	claudeXDGDir := filepath.Join(fakeHome, ".config", "claude")
+	if err := os.RemoveAll(claudeXDGDir); err != nil {
+		t.Fatalf("RemoveAll %q: %v", claudeXDGDir, err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasArg(args, claudeXDGDir) {
+		t.Errorf("absent ~/.config/claude %q must not be referenced in args (OptionalIfMissing): %v", claudeXDGDir, args)
+	}
+	if hasArg(args, filepath.Join(fakeHome, ".claude")) {
+		t.Errorf("canonical ~/.claude must not appear in args (XDG relocation, #2243): %v", args)
 	}
 }
 
@@ -1219,6 +1263,7 @@ func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
 			"KUBECONFIG":                  "/home/ben/.config/kube/agents-config",
 			"AWS_CONFIG_FILE":             "/home/ben/.config/aws/readonly-config",
 			"AWS_SHARED_CREDENTIALS_FILE": "/home/ben/.config/aws/credentials",
+			"CLAUDE_CONFIG_DIR":           "/home/ben/.config/claude",
 		},
 	})
 	defer cleanup()
@@ -1247,6 +1292,13 @@ func TestBwrapBuildArgs_AgentEnvVarsInjected(t *testing.T) {
 	if !hasSetenv(args, "KUBECONFIG", "/home/ben/.config/kube/agents-config") {
 		t.Errorf("--setenv KUBECONFIG not found in args (must flow since #2235): %v", args)
 	}
+
+	// CLAUDE_CONFIG_DIR MUST be injected (issue #2243) — the canonical-path
+	// ~/.claude bind is gone and claude-code resolves its config dir via
+	// this env var at the host XDG path.
+	if !hasSetenv(args, "CLAUDE_CONFIG_DIR", "/home/ben/.config/claude") {
+		t.Errorf("--setenv CLAUDE_CONFIG_DIR not found in args (must flow since #2243): %v", args)
+	}
 }
 
 // TestBwrapBuildArgs_KubeconfigInjectedEvenWhenFileAbsent verifies that
@@ -1267,7 +1319,7 @@ func TestBwrapBuildArgs_KubeconfigInjectedEvenWhenFileAbsent(t *testing.T) {
 
 	// Minimal fixture: create the dirs/files required by BuildArgs.
 	for _, d := range []string{
-		filepath.Join(fakeHome, ".claude"),
+		filepath.Join(fakeHome, ".config", "claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
 		filepath.Join(fakeHome, ".local", "share", "pi"),
 		filepath.Join(fakeHome, ".cache", "nix"),
@@ -1336,7 +1388,7 @@ func TestBwrapBuildArgs_AwsEnvVarsInjectedEvenWhenFilesAbsent(t *testing.T) {
 	defer func() { _ = os.Setenv("HOME", origHome) }()
 
 	for _, d := range []string{
-		filepath.Join(fakeHome, ".claude"),
+		filepath.Join(fakeHome, ".config", "claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
 		filepath.Join(fakeHome, ".local", "share", "pi"),
 		filepath.Join(fakeHome, ".cache", "nix"),
@@ -1936,6 +1988,17 @@ func TestBwrapBuildArgs_FullFixture(t *testing.T) {
 	kubeXDG := filepath.Join(fakeHome, ".config", "kube", "agents-config")
 	if !hasROBindSrcDst(args, kubeXDG, kubeXDG) {
 		t.Errorf("kube agents-config: want --ro-bind %q %q (Dst==Src XDG delivery, #2235)", kubeXDG, kubeXDG)
+	}
+
+	// Claude config dir: the canonical ~/.claude bind is gone since #2243
+	// (env-var route via CLAUDE_CONFIG_DIR); the XDG path is RW-bound
+	// Dst==Src instead.
+	if hasArg(args, filepath.Join(fakeHome, ".claude")) {
+		t.Errorf("canonical ~/.claude must NOT appear in args (XDG relocation, #2243)")
+	}
+	claudeXDG := filepath.Join(fakeHome, ".config", "claude")
+	if !hasBind(args, claudeXDG) {
+		t.Errorf("claude config dir: want --bind %q %q (Dst==Src XDG delivery, #2243)", claudeXDG, claudeXDG)
 	}
 
 	// KUBECACHEDIR redirects kubectl's cache to the per-session /tmp tmpfs

--- a/modules/programs/prism/prism/internal/container/env_test.go
+++ b/modules/programs/prism/prism/internal/container/env_test.go
@@ -7,29 +7,35 @@ package container
 // env alongside the AWS pair (un-suppressed in #2234, Step 3a). kubectl
 // resolves the kube config via KUBECONFIG at the host XDG path; the
 // canonical-path ($HOME/.kube/config) delivery was dropped from both
-// isolators.
+// isolators. CLAUDE_CONFIG_DIR (issue #2243, Step 3c) flows the same way:
+// claude-code resolves its config dir at the host XDG path ~/.config/claude.
 
 import (
 	"testing"
 )
 
-// envSuppressionFixtureVars returns an AgentEnvVars map carrying the three
-// historically-suppressed keys plus a plain key.
+// envSuppressionFixtureVars returns an AgentEnvVars map carrying the
+// historically-suppressed keys, the claude XDG relocation key (#2243), and
+// a plain key — mirroring the production agent.envVars set declared by the
+// nix module.
 func envSuppressionFixtureVars() map[string]string {
 	return map[string]string{
 		"GIT_EDITOR":                  "true",
 		"KUBECONFIG":                  "/home/ben/.config/kube/agents-config",
 		"AWS_CONFIG_FILE":             "/home/ben/.config/aws/readonly-config",
 		"AWS_SHARED_CREDENTIALS_FILE": "/home/ben/.config/aws/credentials",
+		"CLAUDE_CONFIG_DIR":           "/home/ben/.config/claude",
 	}
 }
 
 // envFixtureWantPairs is the full K=V emission expected from the fixture —
 // every AgentEnvVars key flows through, including the historically
-// suppressed KUBECONFIG (#2235) and AWS pair (#2234).
+// suppressed KUBECONFIG (#2235), the AWS pair (#2234), and the claude
+// config dir (#2243).
 var envFixtureWantPairs = []string{
 	"AWS_CONFIG_FILE=/home/ben/.config/aws/readonly-config",
 	"AWS_SHARED_CREDENTIALS_FILE=/home/ben/.config/aws/credentials",
+	"CLAUDE_CONFIG_DIR=/home/ben/.config/claude",
 	"GIT_EDITOR=true",
 	"KUBECONFIG=/home/ben/.config/kube/agents-config",
 }

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -151,13 +151,31 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 	_ = mode // mode is retained for future per-mode mount tweaks
 
 	specs := []MountSpec{
-		// ── ~/.claude (RW) ───────────────────────────────────────────────
-		// Anthropic API credentials directory. Read-write so the
-		// pi-anthropic-oauth extension can refresh OAuth tokens. Mounted
-		// unconditionally — the agent fails gracefully when absent.
+		// ── ~/.config/claude (RW, conditional, Dst==Src at XDG path) ─────
+		// claude-code's config dir (settings, history, .claude.json, OAuth
+		// token refreshes), resolved via the CLAUDE_CONFIG_DIR env var at
+		// the host XDG path — declared in agent.envVars by the nix module
+		// (issue #2243, Step 3c of #2132; bwrap convergence per design
+		// decision §5.1). The former canonical ~/.claude RW bind is gone.
+		//
+		// The bwrap mount namespace is additive from an empty root, so the
+		// env-var route still needs the directory delivered INTO the
+		// namespace: bind it Dst==Src so CLAUDE_CONFIG_DIR resolves to a
+		// real read-write directory in-namespace, with writes flowing
+		// through to the host (same semantics as the bind it replaces).
+		// Unlike the aws/kube XDG entries this is a plain host directory,
+		// not a sops symlink — no EvalSymlinks. Mounted only when present
+		// (bwrap aborts on missing --bind sources); on a host without the
+		// dir, claude-code simply creates an ephemeral in-namespace dir at
+		// the env var path.
+		//
+		// sandbox-exec does not walk this slice (see the package comment):
+		// there generateProfile emits an explicit RW
+		// (subpath ~/.config/claude) grant on the real host path.
 		{
-			HostPath:    filepath.Join(hostHome, ".claude"),
-			SandboxPath: filepath.Join(sandboxHomeDir, ".claude"),
+			HostPath:          filepath.Join(hostHome, ".config", "claude"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".config", "claude"),
+			OptionalIfMissing: true,
 		},
 
 		// ── ~/.mcp-auth (RW, conditional) ────────────────────────────────

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -108,6 +108,8 @@ func (s *sandboxExecIsolator) BuildRunArgs() []string {
 //     delivered via env vars at the host XDG paths — issue #2234)
 //   - Literal RO grant for the real ~/.ssh/known_hosts — never (subpath ~/.ssh)
 //     (issue #2213)
+//   - RW subpath grant for ~/.config/claude — claude-code's config dir,
+//     reached via the CLAUDE_CONFIG_DIR env var (issue #2243)
 //   - Session work dir (covers the nested staging HOME) / worktree / bare
 //     repo / host-API socket dir (RW)
 //   - Symlink target allows (RW for cache/credential dirs, RO for key/config) for every symlink in the staging HOME
@@ -416,6 +418,28 @@ func generateProfile(m *Manager) string {
 		knownHosts := filepath.Join(home, ".ssh", "known_hosts")
 		sb.WriteString("(allow file-read* file-test-existence\n")
 		sb.WriteString("  (literal " + quoteSBPL(knownHosts) + "))\n")
+		sb.WriteString("\n")
+	}
+
+	// ── 5d. Claude config dir read-write (issue #2243) ───────────────────
+	// claude-code resolves its config dir (and .claude.json) via the
+	// CLAUDE_CONFIG_DIR env var at the host XDG path ~/.config/claude
+	// (declared in agent.envVars by the nix module — Step 3c of #2132; the
+	// .claude write-through staging symlink is gone). Unlike the aws/kube
+	// XDG configs, ~/.config/claude is a plain host directory — NOT a sops
+	// symlink — so the #2211 secrets.d allowlist plays no part here: this
+	// explicit RW subpath grant is the sole capability for the path.
+	// Read-write because claude-code writes config, history, and OAuth
+	// token refreshes under it; mirrors bwrap's --bind (RW) treatment of
+	// the same dir in mounts.go StandardSandboxMounts.
+	// Emitted even when the dir does not yet exist — sandbox-exec silently
+	// ignores (subpath ...) rules for non-existent paths (same shape as the
+	// ~/.pi/agent rule in 6a); the nix module's hm activation creates the
+	// dir on managed hosts.
+	if home != "" {
+		claudeConfigDir := filepath.Join(home, ".config", "claude")
+		sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
+		sb.WriteString("  (subpath " + quoteSBPL(claudeConfigDir) + "))\n")
 		sb.WriteString("\n")
 	}
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -11,10 +11,11 @@ package container
 //
 // Design decisions locked by the coordinator in issue #1017:
 //
-//  1. .claude/ is a symlink to host ~/.claude (matches bwrap's RW treatment —
-//     the ~/.claude mount in mounts.go StandardSandboxMounts). Writes to
-//     .credentials.json (e.g. token refreshes)
-//     flow through the symlink to the host's ~/.claude/.credentials.json.
+//  1. (retired in #2243, Step 3c of #2132) .claude/ used to be a
+//     write-through symlink to host ~/.claude. claude-code now resolves its
+//     config dir (and .claude.json) via the CLAUDE_CONFIG_DIR env var at the
+//     host XDG path ~/.config/claude — generateProfile emits an explicit RW
+//     (subpath ~/.config/claude) grant instead.
 //
 //  2. .config/prism/agents/ is symlinked into the staging HOME for ALL roles
 //     (including review-*) so the prism PI extension can read <role>.md at
@@ -83,8 +84,6 @@ func (m *Manager) sandboxExecHomePath() (string, error) {
 //     so the PI extension can read <role>.md (issue #2032). The former
 //     review-prefix exclusion was dropped — the dir is pure markdown with no
 //     secrets, so there is no isolation value in hiding sibling role prompts.
-//   - .claude/ is a symlink to host ~/.claude with a comment explaining the
-//     Darwin write-through behaviour.
 //
 // Calling PrepareSandboxExecHome a second time on an existing staging dir is
 // idempotent: existing symlinks are recreated (os.Symlink is preceded by
@@ -289,17 +288,15 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 		}
 	}
 
-	// ── .claude/ — symlink to host ~/.claude (RW write-through) ──────────────
-	// opencode-claude-auth token refreshes write .credentials.json inside
-	// ~/.claude/, and since this is a symlink to host ~/.claude, those writes
-	// flow through to the host path and are immediately reflected in subsequent
-	// sessions. On Linux, ~/.claude/.credentials.json already lives on disk;
-	// the bwrap path bind-mounts ~/.claude/ with RW access (mounts.go
-	// StandardSandboxMounts).
-	symlinkIfExists(
-		filepath.Join(home, ".claude"),
-		filepath.Join(stagingHome, ".claude"),
-	)
+	// ── Claude ────────────────────────────────────────────────────────────────
+	// Note (#2243, Step 3c of #2132): the .claude write-through staging symlink
+	// is no longer created. claude-code resolves its config dir (and
+	// .claude.json) via the CLAUDE_CONFIG_DIR env var at the host XDG path
+	// (~/.config/claude, declared in agent.envVars by the nix module).
+	// Unlike the aws/kube XDG configs, ~/.config/claude is a plain host
+	// directory — NOT a sops symlink — so the #2211 secrets.d allowlist is
+	// not involved: the read/write capability comes from the explicit RW
+	// (subpath ~/.config/claude) grant emitted by generateProfile.
 
 	// ── .mcp-auth/ ────────────────────────────────────────────────────────────
 	symlinkIfExists(
@@ -500,8 +497,7 @@ type StagingSymlinkTarget struct {
 	// Writable is true when the sandbox must be allowed to write to this
 	// target (and, for directories, its contents). Mirrors the bwrap --bind
 	// (RW) vs --ro-bind (RO) distinction:
-	//   RW: .cache/opencode, .cache/bun, .cache/nix,
-	//       .claude (write-through for credentials), .mcp-auth
+	//   RW: .cache/opencode, .cache/bun, .cache/nix, .mcp-auth
 	//   RO: .ssh keys, .config/opencode/*,
 	//       .config/prism/agents (role prompts; issue #2032),
 	//       .cache/prism/clipboard (read-only; mirrors bwrap.go --ro-bind)
@@ -525,7 +521,6 @@ type StagingSymlinkTarget struct {
 //   - .cache/opencode  — opencode refreshes models.json and writes bin/ shims
 //   - .cache/bun       — bun writes transpile outputs and lockfile updates
 //   - .cache/nix       — unconditional RW (mirrors bwrap's mounts.go bind)
-//   - .claude          — write-through for .credentials.json on Darwin
 //   - .mcp-auth        — MCP auth token writes
 //
 // All other targets (.ssh, .config/opencode, .cache/prism/clipboard)
@@ -594,7 +589,8 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 		".cache/nix": true, // nix eval cache (unconditional RW)
 		// .cache/prism/clipboard is intentionally absent: agents only read
 		// images staged there; mirrors bwrap.go's --ro-bind treatment.
-		".claude":   true, // write-through for .credentials.json
+		// .claude is gone (#2243): claude-code reads/writes ~/.config/claude
+		// via CLAUDE_CONFIG_DIR; generateProfile grants it RW directly.
 		".mcp-auth": true, // MCP auth token writes
 		".npm":      true, // npx package cache (mcp-remote et al.)
 		// AWS SSO and CLI cache dirs must be writable so the aws CLI can write

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -801,7 +801,13 @@ func newFakeHome(t *testing.T) string {
 		".config/kube",
 		".cache/bun",
 		".cache/nix",
+		// .claude is the OLD (pre-#2243) canonical claude dir. It is kept in
+		// the fixture so tests can prove the staging builder no longer
+		// symlinks it even when it exists on the host.
 		".claude",
+		// .config/claude is the XDG path claude-code reaches via
+		// CLAUDE_CONFIG_DIR (issue #2243).
+		".config/claude",
 		".mcp-auth",
 		".local/share/pi",
 	}
@@ -1918,12 +1924,14 @@ func TestGenerateProfile_ProfileIncludesSymlinkTargetAllows(t *testing.T) {
 		t.Errorf("profile missing (allow file-read* ...) clause; full profile:\n%s", profile)
 	}
 
-	// .cache/bun, .cache/nix, .claude, .mcp-auth are RW — the
-	// profile must grant file-write* on their resolved targets.
+	// .cache/bun, .cache/nix, .mcp-auth are RW — the profile must grant
+	// file-write* on their resolved targets. (.claude is gone since #2243:
+	// claude-code reads/writes ~/.config/claude via CLAUDE_CONFIG_DIR and
+	// generateProfile grants that path directly — see
+	// TestGenerateProfile_ClaudeConfigDirRWSubpathRule.)
 	rwPaths := []string{
 		filepath.Join(fakeHome, ".cache", "bun"),
 		filepath.Join(fakeHome, ".cache", "nix"),
-		filepath.Join(fakeHome, ".claude"),
 		filepath.Join(fakeHome, ".mcp-auth"),
 	}
 	for _, rwPath := range rwPaths {
@@ -2210,6 +2218,97 @@ func TestPrepareSandboxExecHome_NoKubeConfigSymlink(t *testing.T) {
 		if target.ResolvedPath == resolvedKube {
 			t.Errorf("collectStagingHomeSymlinkTargets emitted the kube agents-config target %q — the .kube/config staging symlink should be gone (#2235)", resolvedKube)
 		}
+	}
+}
+
+// TestPrepareSandboxExecHome_NoClaudeSymlink is the unit-level AC test for
+// issue #2243 (Step 3c of #2132): after PrepareSandboxExecHome, the staging
+// HOME contains no .claude symlink even though the old canonical dir exists
+// on the host, and collectStagingHomeSymlinkTargets no longer emits its
+// resolved target. claude-code reads/writes its config dir at the host XDG
+// path ~/.config/claude via the CLAUDE_CONFIG_DIR env var; the in-sandbox
+// capability is the explicit RW (subpath ~/.config/claude) grant (see
+// TestGenerateProfile_ClaudeConfigDirRWSubpathRule) — the dir is a plain
+// host directory, not sops-backed, so the #2211 allowlist is not involved.
+func TestPrepareSandboxExecHome_NoClaudeSymlink(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Resolve the old canonical dir before staging so we can assert its
+	// absence from the collector output below. newFakeHome creates a real
+	// dir at ~/.claude, so the source-present path is exercised.
+	resolvedClaude, err := filepath.EvalSymlinks(filepath.Join(fakeHome, ".claude"))
+	if err != nil {
+		t.Fatalf("fixture: EvalSymlinks ~/.claude: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "no-claude-symlink-test",
+	})
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".claude")); lstatErr == nil {
+		t.Errorf("staging HOME has .claude entry — removed in #2243 (CLAUDE_CONFIG_DIR env-var route), must not be recreated")
+	}
+
+	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
+	if err != nil {
+		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
+	}
+	for _, target := range targets {
+		if target.ResolvedPath == resolvedClaude {
+			t.Errorf("collectStagingHomeSymlinkTargets emitted the ~/.claude target %q — the .claude staging symlink should be gone (#2243)", resolvedClaude)
+		}
+	}
+}
+
+// TestGenerateProfile_ClaudeConfigDirRWSubpathRule verifies that
+// generateProfile emits an RW (subpath ~/.config/claude) rule (issue #2243,
+// Step 3c of #2132). claude-code resolves its config dir (and .claude.json)
+// via CLAUDE_CONFIG_DIR at the host XDG path; the dir is a plain host
+// directory (not sops-backed), so this explicit grant — not the #2211
+// secrets.d allowlist — is the sole in-sandbox capability for the path.
+//
+// The rule must be emitted even when the dir does not yet exist —
+// sandbox-exec silently ignores (subpath ...) rules for non-existent paths
+// (same shape as the ~/.pi/agent rule), and the nix module's hm activation
+// creates the dir on managed hosts.
+func TestGenerateProfile_ClaudeConfigDirRWSubpathRule(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	// Deliberately do NOT create ~/.config/claude — the rule must be
+	// emitted unconditionally.
+
+	m := newSandboxExecManager(Config{
+		SessionName: "repo@claude-grant",
+	})
+	profile := generateProfile(m)
+
+	claudeConfigDir := filepath.Join(fakeHome, ".config", "claude")
+	subpathRule := "(subpath " + quoteSBPL(claudeConfigDir) + ")"
+	idx := strings.Index(profile, subpathRule)
+	if idx < 0 {
+		t.Fatalf("profile missing %s rule; full profile:\n%s", subpathRule, profile)
+	}
+
+	// The rule must sit inside an (allow ... file-write* ...) clause — RW,
+	// not RO — and inside an allow, not a deny.
+	clauseStart := strings.LastIndex(profile[:idx], "(allow ")
+	denyStart := strings.LastIndex(profile[:idx], "(deny ")
+	if clauseStart < 0 || denyStart > clauseStart {
+		t.Fatalf("~/.config/claude subpath rule is not inside an (allow ...) clause; full profile:\n%s", profile)
+	}
+	clause := profile[clauseStart:idx]
+	if !strings.Contains(clause, "file-write*") {
+		t.Errorf("~/.config/claude allow clause lacks file-write* (must be RW — claude writes config/history/token refreshes); clause: %q", clause)
+	}
+	if !strings.Contains(clause, "file-read*") {
+		t.Errorf("~/.config/claude allow clause lacks file-read*; clause: %q", clause)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/claude_xdg_migration_script_test.go
+++ b/modules/programs/prism/prism/internal/integration/claude_xdg_migration_script_test.go
@@ -1,0 +1,255 @@
+package integration_test
+
+// claude_xdg_migration_script_test.go — unit coverage for the one-time
+// claude-code state migration script (issue #2243, Step 3c of #2132):
+// modules/programs/prism/claude-xdg-migrate.sh, invoked by the home-manager
+// activation script in claude-code.nix.
+//
+// The script lives OUTSIDE the Go module (it is a nix-module artefact, not
+// part of the prism binary), so these tests resolve it via a relative path
+// from this package directory. Two execution contexts:
+//
+//   - `go test ./...` from modules/programs/prism/prism/ (developer runs and
+//     the go-tests CI job): the full repo checkout is present, the script is
+//     found, and the tests run for real.
+//   - The nix-sandboxed build (runChecks = true, the homeless-shelter CI
+//     job): pkgs/prism.nix sets src = modules/programs/prism/prism only, so
+//     the script is absent and the tests skip with an explicit message —
+//     same explicit-skip discipline as the PTY and sandbox-exec gates.
+//
+// Everything runs against t.TempDir() paths — no real $HOME state is ever
+// read or written (homeless-shelter-safe by construction).
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// claudeMigrateEntries mirrors the entries=() list in the script.
+var claudeMigrateEntries = []string{"history.jsonl", "projects", "plugins", "telemetry", "backups"}
+
+// requireClaudeMigrateScript resolves the migration script relative to this
+// package dir and skips with an explicit message when it is not present
+// (the nix build sandbox strips the repo tree outside the Go module).
+func requireClaudeMigrateScript(t *testing.T) string {
+	t.Helper()
+	script, err := filepath.Abs(filepath.Join("..", "..", "..", "claude-xdg-migrate.sh"))
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	if _, statErr := os.Stat(script); statErr != nil {
+		t.Skipf("claude-xdg-migrate.sh not found at %s — running outside the full repo checkout (e.g. the nix build sandbox, whose src is the Go module only); the go-tests CI job covers this test", script)
+	}
+	if _, lookErr := exec.LookPath("bash"); lookErr != nil {
+		t.Skipf("bash not found in PATH: %v", lookErr)
+	}
+	return script
+}
+
+// runClaudeMigrate invokes the script with the given src dir, src json, and
+// dst dir, returning combined output and error.
+func runClaudeMigrate(t *testing.T, script, srcDir, srcJSON, dstDir string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", script, srcDir, srcJSON, dstDir)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// migrationFixture creates a fake old-layout claude state: <root>/.claude
+// with every migratable entry plus <root>/.claude.json. Returns
+// (srcDir, srcJSON, dstDir). dstDir is not created.
+func migrationFixture(t *testing.T) (srcDir, srcJSON, dstDir string) {
+	t.Helper()
+	root := t.TempDir()
+	srcDir = filepath.Join(root, ".claude")
+	srcJSON = filepath.Join(root, ".claude.json")
+	dstDir = filepath.Join(root, ".config", "claude")
+
+	for _, entry := range claudeMigrateEntries {
+		p := filepath.Join(srcDir, entry)
+		if strings.Contains(entry, ".") {
+			// File entry (history.jsonl).
+			if err := os.MkdirAll(srcDir, 0o700); err != nil {
+				t.Fatalf("MkdirAll %s: %v", srcDir, err)
+			}
+			if err := os.WriteFile(p, []byte("src-"+entry), 0o600); err != nil {
+				t.Fatalf("WriteFile %s: %v", p, err)
+			}
+		} else {
+			// Directory entry with a sentinel file inside.
+			if err := os.MkdirAll(p, 0o700); err != nil {
+				t.Fatalf("MkdirAll %s: %v", p, err)
+			}
+			if err := os.WriteFile(filepath.Join(p, "sentinel"), []byte("src-"+entry), 0o600); err != nil {
+				t.Fatalf("WriteFile sentinel in %s: %v", p, err)
+			}
+		}
+	}
+	if err := os.WriteFile(srcJSON, []byte(`{"src":"claude.json"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", srcJSON, err)
+	}
+	return srcDir, srcJSON, dstDir
+}
+
+// TestClaudeXdgMigrate_MovesAllState verifies the fresh-migration path:
+// every entry and ~/.claude.json move to the destination, and the sources
+// are gone afterwards.
+func TestClaudeXdgMigrate_MovesAllState(t *testing.T) {
+	script := requireClaudeMigrateScript(t)
+	srcDir, srcJSON, dstDir := migrationFixture(t)
+
+	out, err := runClaudeMigrate(t, script, srcDir, srcJSON, dstDir)
+	if err != nil {
+		t.Fatalf("migration failed: %v\noutput: %s", err, out)
+	}
+
+	for _, entry := range claudeMigrateEntries {
+		if _, statErr := os.Lstat(filepath.Join(dstDir, entry)); statErr != nil {
+			t.Errorf("destination missing %s after migration: %v", entry, statErr)
+		}
+		if _, statErr := os.Lstat(filepath.Join(srcDir, entry)); statErr == nil {
+			t.Errorf("source still has %s after migration — should have moved", entry)
+		}
+	}
+	// Directory contents travelled with the move.
+	got, readErr := os.ReadFile(filepath.Join(dstDir, "projects", "sentinel"))
+	if readErr != nil || string(got) != "src-projects" {
+		t.Errorf("projects/sentinel content after migration = %q, %v; want %q", got, readErr, "src-projects")
+	}
+	// .claude.json relocated into the dst dir.
+	if _, statErr := os.Lstat(filepath.Join(dstDir, ".claude.json")); statErr != nil {
+		t.Errorf("destination missing .claude.json: %v", statErr)
+	}
+	if _, statErr := os.Lstat(srcJSON); statErr == nil {
+		t.Errorf("source .claude.json still present after migration — should have moved")
+	}
+}
+
+// TestClaudeXdgMigrate_SecondRunIsNoOp verifies idempotency: running the
+// script twice leaves the destination identical and exits 0 (issue #2243
+// AC: second run is a no-op).
+func TestClaudeXdgMigrate_SecondRunIsNoOp(t *testing.T) {
+	script := requireClaudeMigrateScript(t)
+	srcDir, srcJSON, dstDir := migrationFixture(t)
+
+	if out, err := runClaudeMigrate(t, script, srcDir, srcJSON, dstDir); err != nil {
+		t.Fatalf("first run failed: %v\noutput: %s", err, out)
+	}
+	out, err := runClaudeMigrate(t, script, srcDir, srcJSON, dstDir)
+	if err != nil {
+		t.Fatalf("second run failed (must be a no-op): %v\noutput: %s", err, out)
+	}
+	if strings.Contains(out, "moved") {
+		t.Errorf("second run moved something — not a no-op:\n%s", out)
+	}
+	got, readErr := os.ReadFile(filepath.Join(dstDir, "history.jsonl"))
+	if readErr != nil || string(got) != "src-history.jsonl" {
+		t.Errorf("history.jsonl after second run = %q, %v; want unchanged %q", got, readErr, "src-history.jsonl")
+	}
+}
+
+// TestClaudeXdgMigrate_AbsentSourceIsNoOp verifies that a host with no old
+// claude state exits 0 without creating the destination dir (issue #2243
+// AC: absent ~/.claude is a no-op).
+func TestClaudeXdgMigrate_AbsentSourceIsNoOp(t *testing.T) {
+	script := requireClaudeMigrateScript(t)
+	root := t.TempDir()
+	srcDir := filepath.Join(root, ".claude")           // does not exist
+	srcJSON := filepath.Join(root, ".claude.json")     // does not exist
+	dstDir := filepath.Join(root, ".config", "claude") // must not be created
+
+	out, err := runClaudeMigrate(t, script, srcDir, srcJSON, dstDir)
+	if err != nil {
+		t.Fatalf("absent-source run failed (must be a no-op): %v\noutput: %s", err, out)
+	}
+	if _, statErr := os.Lstat(dstDir); statErr == nil {
+		t.Errorf("destination dir was created on an absent-source run — must stay a strict no-op")
+	}
+}
+
+// TestClaudeXdgMigrate_NeverClobbersDestination verifies the skip-and-warn
+// behaviour: a pre-existing destination entry is never overwritten, the
+// warning names the skipped entry, the source entry stays in place, and the
+// other entries still migrate (issue #2243 AC).
+func TestClaudeXdgMigrate_NeverClobbersDestination(t *testing.T) {
+	script := requireClaudeMigrateScript(t)
+	srcDir, srcJSON, dstDir := migrationFixture(t)
+
+	// Pre-existing destination entries with distinct content: one file, one dir.
+	if err := os.MkdirAll(filepath.Join(dstDir, "projects"), 0o700); err != nil {
+		t.Fatalf("MkdirAll dst projects: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "projects", "sentinel"), []byte("dst-projects"), 0o600); err != nil {
+		t.Fatalf("WriteFile dst projects sentinel: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dstDir, "history.jsonl"), []byte("dst-history"), 0o600); err != nil {
+		t.Fatalf("WriteFile dst history.jsonl: %v", err)
+	}
+
+	out, err := runClaudeMigrate(t, script, srcDir, srcJSON, dstDir)
+	if err != nil {
+		t.Fatalf("migration failed: %v\noutput: %s", err, out)
+	}
+
+	// The pre-existing destination entries are untouched.
+	for name, want := range map[string]string{
+		filepath.Join(dstDir, "history.jsonl"):        "dst-history",
+		filepath.Join(dstDir, "projects", "sentinel"): "dst-projects",
+	} {
+		got, readErr := os.ReadFile(name)
+		if readErr != nil || string(got) != want {
+			t.Errorf("%s = %q, %v; want untouched %q", name, got, readErr, want)
+		}
+	}
+	// The colliding source entries stay in place (not silently dropped).
+	for _, entry := range []string{"history.jsonl", "projects"} {
+		if _, statErr := os.Lstat(filepath.Join(srcDir, entry)); statErr != nil {
+			t.Errorf("source %s removed despite destination collision: %v", entry, statErr)
+		}
+		if !strings.Contains(out, "SKIP "+filepath.Join(srcDir, entry)) {
+			t.Errorf("output lacks skip warning for %s:\n%s", entry, out)
+		}
+	}
+	// Non-colliding entries still migrated.
+	for _, entry := range []string{"plugins", "telemetry", "backups"} {
+		if _, statErr := os.Lstat(filepath.Join(dstDir, entry)); statErr != nil {
+			t.Errorf("non-colliding entry %s did not migrate: %v", entry, statErr)
+		}
+	}
+	if _, statErr := os.Lstat(filepath.Join(dstDir, ".claude.json")); statErr != nil {
+		t.Errorf(".claude.json did not migrate: %v", statErr)
+	}
+	if _, statErr := os.Lstat(srcJSON); statErr == nil {
+		t.Errorf("source .claude.json still present — should have moved")
+	}
+}
+
+// TestClaudeXdgMigrate_JsonOnlyMigrates covers the partial-state case: only
+// ~/.claude.json exists (no ~/.claude dir). The json must still relocate —
+// CLAUDE_CONFIG_DIR moves .claude.json into the config dir too (claude-code
+// 2.1.161 behaviour, the #2243 edge-case AC).
+func TestClaudeXdgMigrate_JsonOnlyMigrates(t *testing.T) {
+	script := requireClaudeMigrateScript(t)
+	root := t.TempDir()
+	srcDir := filepath.Join(root, ".claude") // does not exist
+	srcJSON := filepath.Join(root, ".claude.json")
+	dstDir := filepath.Join(root, ".config", "claude")
+	if err := os.WriteFile(srcJSON, []byte(`{"only":"json"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", srcJSON, err)
+	}
+
+	out, err := runClaudeMigrate(t, script, srcDir, srcJSON, dstDir)
+	if err != nil {
+		t.Fatalf("json-only migration failed: %v\noutput: %s", err, out)
+	}
+	got, readErr := os.ReadFile(filepath.Join(dstDir, ".claude.json"))
+	if readErr != nil || string(got) != `{"only":"json"}` {
+		t.Errorf("migrated .claude.json = %q, %v; want %q", got, readErr, `{"only":"json"}`)
+	}
+	if _, statErr := os.Lstat(srcJSON); statErr == nil {
+		t.Errorf("source .claude.json still present — should have moved")
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_claude_config_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_claude_config_darwin_test.go
@@ -1,0 +1,195 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_claude_config_darwin_test.go — integration coverage for the
+// claude config XDG relocation (issue #2243, Step 3c of #2132).
+//
+// The staging-HOME .claude write-through symlink is gone. claude-code
+// resolves its config dir (and .claude.json) via the CLAUDE_CONFIG_DIR env
+// var at the host XDG path ~/.config/claude. Unlike the aws/kube XDG configs
+// (Steps 3a/3b), ~/.config/claude is a plain host directory — NOT a sops
+// symlink — so the #2211 secrets.d allowlist plays no part here: the
+// in-sandbox read/write capability is the explicit RW
+// (subpath ~/.config/claude) grant emitted by generateProfile.
+//
+// This file tests:
+//
+//  1. Shape: after PrepareSandboxExecHome, the staging HOME contains no
+//     .claude symlink (issue #2243 AC).
+//
+//  2. Positive: a process inside sandbox-exec under the production profile
+//     can create, read back, and remove a file under ~/.config/claude — a
+//     real RW round-trip at the host XDG path.
+//
+//  3. Negative: stripping the (subpath ~/.config/claude) RW allow block
+//     makes the same write fail — proving the explicit grant is
+//     load-bearing (sandbox-exec testing convention, #1192). Because the
+//     path is not sops-backed there is no allowlist fallback to mask the
+//     regression.
+//
+// Capability-probe gating (#2207) applies via requireSandboxExec. Shared
+// helpers live in sandbox_exec_helpers_darwin_test.go.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// claudeXDGDirForTest returns the host XDG claude config dir
+// (~/.config/claude). When the dir does not exist it is created and a
+// cleanup is registered to remove it again (only when this test created
+// it) — the positive test needs a real directory to write into, and the
+// production grant is on exactly this path.
+func claudeXDGDirForTest(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	dir := filepath.Join(home, ".config", "claude")
+	if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
+		if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+			t.Fatalf("create %s: %v", dir, mkErr)
+		}
+		t.Cleanup(func() { _ = os.Remove(dir) }) // os.Remove: only if empty
+	}
+	return dir
+}
+
+// claudeRoundTripScript builds a bash script that writes a sentinel file
+// under dir, reads it back, and removes it. Each step must succeed for the
+// script to exit 0.
+func claudeRoundTripScript(target string) string {
+	q := shQuote(target)
+	return "echo prism-2243-probe > " + q + " && cat " + q + " && rm " + q
+}
+
+// claudeAllowBlock returns the exact RW allow block generateProfile emits
+// for the claude config dir (issue #2243). Mirrors the generator's emission
+// format; the negative test removes the whole block (removing only the
+// (subpath ...) line would leave a filter-less (allow ...) clause, which
+// SBPL treats as allow-everything — masking the regression in the wrong
+// direction).
+func claudeAllowBlock(claudeDir string) string {
+	return "(allow file-read* file-write* file-test-existence file-read-metadata\n" +
+		"  (subpath " + sbplQuoteForTest(claudeDir) + "))\n"
+}
+
+// TestSandboxExecClaudeConfig_StagingSymlinkGone asserts the issue #2243
+// shape of the staging HOME on the real host: PrepareSandboxExecHome creates
+// no .claude symlink.
+func TestSandboxExecClaudeConfig_StagingSymlinkGone(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+
+	m := newProfileManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".claude")); lstatErr == nil {
+		t.Errorf("staging HOME has .claude entry — removed in #2243 (CLAUDE_CONFIG_DIR env-var route), must not be recreated")
+	}
+}
+
+// TestSandboxExecClaudeConfig_XDGDirReadWrite is the positive integration
+// test for the #2243 RW grant: under the production profile, a sandboxed
+// process can create, read, and remove a file under the host
+// ~/.config/claude. This is the capability claude-code needs at the path
+// CLAUDE_CONFIG_DIR carries (config writes, history, token refreshes).
+func TestSandboxExecClaudeConfig_XDGDirReadWrite(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	claudeDir := claudeXDGDirForTest(t)
+
+	m := newProfileManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Shape check inside the real flow: the staging symlink is gone.
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".claude")); lstatErr == nil {
+		t.Fatalf("staging HOME has .claude entry — removed in #2243, must not be recreated")
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The profile must carry the explicit RW allow block — the sole grant
+	// for this path (not sops-backed; no #2211 allowlist involvement).
+	if !strings.Contains(prepared.content, claudeAllowBlock(claudeDir)) {
+		t.Fatalf("profile does not carry the ~/.config/claude RW allow block (issue #2243).\nProfile:\n%s", prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	target := filepath.Join(claudeDir, fmt.Sprintf("prism-integ-2243-%d.tmp", os.Getpid()))
+	t.Cleanup(func() { _ = os.Remove(target) }) // belt-and-braces if rm in-sandbox fails
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", claudeRoundTripScript(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("write/read/remove round-trip under %s failed in-sandbox under the production profile (issue #2243 AC).\nExit: %v\nOutput: %s\nProfile: %s",
+			claudeDir, runErr, string(out), testProfilePath)
+	}
+	t.Logf("ka pai — in-sandbox RW round-trip under %s succeeded via the #2243 subpath grant", claudeDir)
+}
+
+// TestSandboxExecClaudeConfig_WriteDeniedWithoutSubpathGrant is the paired
+// negative test (sandbox-exec testing convention, #1192). It strips the
+// entire ~/.config/claude RW allow block from the profile and asserts the
+// same write fails — proving the positive is not green by accident: the
+// explicit subpath grant is the load-bearing capability for the path (there
+// is no sops allowlist or broader allow to fall back on).
+func TestSandboxExecClaudeConfig_WriteDeniedWithoutSubpathGrant(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	claudeDir := claudeXDGDirForTest(t)
+
+	m := newProfileManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, claudeAllowBlock(claudeDir), "")
+	})
+
+	target := filepath.Join(claudeDir, fmt.Sprintf("prism-integ-2243-neg-%d.tmp", os.Getpid()))
+	t.Cleanup(func() { _ = os.Remove(target) }) // in case the write unexpectedly lands
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixBash, "-c", "echo prism-2243-neg > "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write under %s succeeded WITHOUT the (subpath ~/.config/claude) RW grant.\n"+
+			"The grant is not load-bearing — investigate.\nOutput: %s\nMutated profile: %s",
+			claudeDir, string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — write under %s correctly denied without the #2243 subpath grant (exit: %v)", claudeDir, runErr)
+	}
+}


### PR DESCRIPTION
Step 3c of the #2132 staging-HOME elimination train.

Refs #2132
Closes #2243

## What

This step spans the nix module AND prism Go changes in one atomic PR — the env var, the hm settings/migration, the SBPL grant, and the bwrap mount all flip together at `nh switch`.

**Nix / host side:**

- **`CLAUDE_CONFIG_DIR`** set host-wide in `home.sessionVariables` (auto-exported by the upstream hm module from `programs.claude-code.configDir` — see next bullet) and declared in `nx.programs.prism.agent.envVars` (`default.nix` — delivered into both isolators via profiles.json `agent_env_vars`, `$HOME` expanded at build time). Verified effective in claude-code 2.1.161: relocates the config dir **and** `.claude.json`.
- **hm `settings.json` target moved** to `~/.config/claude/settings.json` via the upstream `programs.claude-code.configDir` option (round-1 review fix — the PR originally hand-rolled the env var + settings emission on the false premise that the locked home-manager rev hardcodes the `~/.claude` target; it doesn't). `configDir` renders `settings.json` (with the `$schema` key) into the relocated dir and auto-exports `home.sessionVariables.CLAUDE_CONFIG_DIR` whenever it differs from the `~/.claude` default, so the module sets `configDir` + `settings` and nothing else. Rendered settings.json verified byte-identical to the previous emission.
- **One-time idempotent migration** (`claude-xdg-migrate.sh`, invoked from an hm activation entry after `writeBoundary`): moves `history.jsonl`, `projects/`, `plugins/`, `telemetry/`, `backups/` and `~/.claude.json` to `~/.config/claude`. Absent source → strict no-op (destination not even created); second run → no-op; pre-existing destination entries → skip-and-warn, never overwritten (colliding sources stay in place). Entries are moved one-by-one (never `~/.claude` itself — it may be a mount point under impermanence); `mv` falls back to copy+remove on EXDEV, covering persisted bind mounts. The script takes explicit src/dst args so the logic is unit-testable without a real `$HOME`.
- The `home.persistence` entries for `.claude` / `.claude.json` are deliberately **kept**: they are the migration source on first post-flip activation, and stale-writer targets afterwards (see deploy notes).
- The residual no-session-vars fallback risk is documented in the module comment, not engineered around (per the issue).

**Prism Go side:**

- **`.claude` staging symlink dropped** from `PrepareSandboxExecHome`; `writableStagingPaths` entry removed (the collector scans the staging tree, so no separate emission removal was needed). Stale `.credentials.json` / opencode-claude-auth comments purged (that write path was removed in #2128).
- **RW SBPL grant `(subpath ~/.config/claude)`** added in `generateProfile` (new §5d). **Asymmetry vs 3a/3b, per the issue:** `~/.config/claude` is a plain host dir, NOT sops-backed — the #2211 allowlist is irrelevant here; this explicit grant is the sole in-sandbox capability for the path. Emitted even when the dir doesn't exist yet (sandbox-exec ignores subpath rules on non-existent paths — same shape as the `~/.pi/agent` rule).
- **Bwrap claude mount converged on the XDG path** (`mounts.go`): the canonical `~/.claude` RW bind is replaced by a Dst==Src RW bind of `~/.config/claude` (§5.1 pattern from 3a/3b — additive namespace needs the dir delivered at the env var's path). No EvalSymlinks (not a sops symlink). Changed from unconditional to `OptionalIfMissing`: the old unconditional spec emitted a bind even for a missing source, which bwrap aborts on (its "fails gracefully when absent" comment was wrong — confirmed during revert-and-fail, where the bind appeared for a non-existent fixture path); with the dir absent, claude-code just creates an ephemeral in-namespace dir.
- **`rg '\.claude'` sweep clean**: every remaining hit in prism source is a historical/explanatory comment documenting the removal, a negative test assertion proving the old path stays gone, or a migration-test fixture for the old layout. No live staging/grant/mount references.

## Acceptance criteria mapping

- **sandbox-exec RW at `~/.config/claude` (+ profile-mutation negative)** — `TestSandboxExecClaudeConfig_XDGDirReadWrite` does a real in-sandbox create/read/remove round-trip under the production profile (after asserting the profile carries the grant); `TestSandboxExecClaudeConfig_WriteDeniedWithoutSubpathGrant` strips the **entire** allow block and asserts the write fails (removing only the `(subpath ...)` line would leave a filter-less allow-everything clause, masking the regression in the wrong direction). No allowlist fallback exists for this path, so the negative isolates exactly the new grant.
- **`CLAUDE_CONFIG_DIR` in both isolators' env** — `env_test.go` (both appenders: `AppendStandardEnv` for bwrap, `AppendSandboxEnvVarsKV` for the sandbox-exec dispatch, exact full-emission asserts) and `TestBwrapBuildArgs_AgentEnvVarsInjected` (`--setenv` shape). Value verified expanded to the host XDG path in the rendered profiles.json via nix eval.
- **hm artifacts (nix eval, post-round-1)** — `configDir` and `home.sessionVariables.CLAUDE_CONFIG_DIR` both `/Users/bensherman/.config/claude`; settings.json rendered at `.config/claude/settings.json`, byte-identical content; no residual `~/.claude/settings.json` or `xdg.configFile` emission.
- **staging shape / collector / bwrap mount** — `TestPrepareSandboxExecHome_NoClaudeSymlink` (staging entry gone + collector silent even when host `~/.claude` exists), `TestGenerateProfile_ClaudeConfigDirRWSubpathRule` (RW allow, emitted with dir absent), `TestSandboxExecClaudeConfig_StagingSymlinkGone` (integration, real host), `TestBwrapBuildArgs_ClaudeConfigXDGDirBound` / `_ClaudeConfigDirAbsentNoBind` / `_FullFixture` (XDG Dst==Src bind present, canonical `~/.claude` absent from args entirely).
- **migration idempotency** — automated, not just a manual plan: `claude_xdg_migration_script_test.go` (5 tests: fresh move, second-run no-op, absent-source strict no-op, never-clobbers + skip-warnings + non-colliding entries still migrate, json-only partial state). The script lives outside the Go module, so the tests resolve it relatively and **skip with an explicit message inside the nix build sandbox** (whose `src` is the Go module only); the `go-tests` CI job runs them for real on every prism-touching PR.
- **nix eval** — see Testing.
- **`~/.claude.json` edge case** — covered by the migration (`TestClaudeXdgMigrate_JsonOnlyMigrates`, `_MovesAllState`) and the env var (2.1.161 relocates it with the config dir); sweep clean per above.

## Vacuous-pass checks (revert-and-fail, temp-commit pattern)

Each production change was individually reverted and the paired tests confirmed to FAIL, then restored and confirmed green:

- `mounts.go` canonical-mount restore → `TestBwrapBuildArgs_ClaudeConfigXDGDirBound`, `_ClaudeConfigDirAbsentNoBind`, `_FullFixture` all FAIL
- §5d grant removal → `TestGenerateProfile_ClaudeConfigDirRWSubpathRule` FAIL
- `.claude` staging symlink re-added → `TestPrepareSandboxExecHome_NoClaudeSymlink` FAIL (both staging-entry and collector assertions)
- migration script: skip-and-warn check removed → `TestClaudeXdgMigrate_NeverClobbersDestination` FAIL; absent-source early-exit removed → `TestClaudeXdgMigrate_AbsentSourceIsNoOp` FAIL

## Deploy notes (from #2243)

- **Everything flips atomically at `nh switch`**: the migration runs in the same generation that delivers the new env var, the relocated settings.json, and the new prism binary.
- **Live sessions spawned pre-switch** hold the old staging symlink at `~/.claude` — post-migration they may write stale state there which is NOT re-migrated (acceptable: history/telemetry class). **Recommend switching at a quiet moment with no workers in flight.**
- **Residual risk (documented in the module comment, not engineered around)**: claude launches that don't source hm session vars fall back to `~/.claude` and fork state. CLI-only usage makes this low.

## Testing

- `go build ./...` — pass
- `go test ./... -race` — pass (full suite)
- `nixfmt` on touched `.nix` files — pass
- `nix build .#prism` — **could not run locally**: this worker sandbox pre-dates the #2201 trusted-settings read allowance (`error: opening file ".../trusted-settings.json": Operation not permitted`). Per AGENTS.md I ran the sanctioned non-flake eval fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — pass — and additionally forced **full instantiation of all three host configs** (`darwinConfigurations.m4mac`, `nixosConfigurations.navi`, `nixosConfigurations.tui` → `system.build.toplevel.drvPath`) — all pass, so the module changes eval cleanly on Darwin and on the Linux impermanence hosts. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`).
- ⚠️ **The Darwin sandbox-exec integration tests SKIP in this worker sandbox** (nested sandbox-exec refuses to apply profiles; #2207 capability-probe gating via `sandboxexectest.Require`). Please arrange a host-side run before merge, as for PRs #2238/#2242:

  ```
  go test ./internal/integration/ -run 'TestSandboxExecClaudeConfig' -v
  ```

  Note: the positive test does a write/read/remove round-trip of a uniquely-named temp file under the real `~/.config/claude` (created if absent, removed after). The migration-script tests need no host run — they execute everywhere bash exists and passed here.

## Out of scope (untouched)

- pi-oauth symlink (3d), caches (3e), RO trio (3f), chromium / `CFFIXED_USER_HOME` (Step 4), final staging-HOME removal (Step 5)
- Removing the `~/.claude` persistence entries (kept deliberately — migration source + stale-writer landing zone)
- Pre-existing gofmt drift in other packages (go 1.26 gofmt vs older formatting; all files touched here are gofmt-clean)
