### PR TITLE
prism: drop remaining non-chromium staging symlinks — pi-oauth, RW caches, RO trio (Steps 3d–3f of #2132)

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -318,8 +318,8 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	// each MountSpec into the correct --bind / --ro-bind triple.
 	//
 	// Note on ordering: StandardSandboxMounts emits ~/.config/claude, ~/.mcp-auth,
-	// ~/.cache/nix, AWS config, AWS credentials, AWS SSO, AWS CLI, kube
-	// config, clipboard-staging. The pre-A2.M1 bwrap order interleaved the
+	// ~/.cache/nix, ~/.cache/bun, AWS config, AWS credentials, AWS SSO, AWS CLI,
+	// kube config, clipboard-staging. The pre-A2.M1 bwrap order interleaved the
 	// AWS group with the SSH/known_hosts/SSH-config group; the new order
 	// keeps the AWS entries adjacent and emits all of them before the SSH
 	// keys. Bwrap argument order does not affect the runtime mount layout
@@ -432,18 +432,11 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 	gitconfigPath := m.gitconfigFilePath()
 	args = append(args, "--ro-bind", gitconfigPath, filepath.Join(home, ".gitconfig"))
 
-	// ── bun transpiler cache (read-write, conditional) ──────────────────────
-	// Must be writable: bun writes transpile outputs and lockfile updates
-	// here on plugin load.
-	bunCacheDir := filepath.Join(home, ".cache", "bun")
-	if _, err := os.Stat(bunCacheDir); err == nil {
-		args = append(args, "--bind", bunCacheDir, bunCacheDir)
-	}
-
-	// AWS SSO cache, AWS CLI cache, kube config, and the clipboard staging
-	// dir are all emitted earlier in this function via the
-	// StandardSandboxMounts walk (A2.M1) — the inline blocks that previously
-	// duplicated those mounts here have been removed. The aws
+	// AWS SSO cache, AWS CLI cache, kube config, the bun transpiler cache,
+	// and the clipboard staging dir are all emitted earlier in this function
+	// via the StandardSandboxMounts walk (A2.M1) — the inline blocks that
+	// previously duplicated those mounts here have been removed (the bun
+	// cache block was converged in #2245, Step 3e of #2132). The aws
 	// config/credentials canonical-path ($HOME/.aws/*) binds were dropped in
 	// #2234; the files are now bound Dst==Src at the host XDG paths and
 	// reached via the AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE env vars

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -509,6 +509,94 @@ func TestBwrapBuildArgs_NixCacheDirBound(t *testing.T) {
 	}
 }
 
+// TestBwrapBuildArgs_NixCacheDirAbsentNoBind pins the OptionalIfMissing
+// semantics added in #2245 (Step 3e of #2132): when ~/.cache/nix does not
+// exist on the host (fresh machine), no bind triple is emitted for it. The
+// entry used to be unconditional, which emits a --bind with a missing
+// source — and bwrap ABORTS on missing bind sources (the #2243 lesson), so
+// the absent dir would have broken every session on a fresh host.
+func TestBwrapBuildArgs_NixCacheDirAbsentNoBind(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	// The fixture pre-creates ~/.cache/nix; remove it to simulate the fresh
+	// host before building args.
+	nixCacheDir := filepath.Join(fakeHome, ".cache", "nix")
+	if err := os.RemoveAll(nixCacheDir); err != nil {
+		t.Fatalf("RemoveAll ~/.cache/nix: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasBind(args, nixCacheDir) {
+		t.Errorf("missing ~/.cache/nix should be omitted (OptionalIfMissing, #2245) but found as --bind in args: %v", args)
+	}
+}
+
+// TestBwrapBuildArgs_BunCacheDirBound pins the ~/.cache/bun RW bind after
+// its convergence from the inline bwrap.go block into the
+// StandardSandboxMounts walk (#2245, Step 3e of #2132). Behaviour must be
+// identical to the former inline block: RW, Dst==Src, present when the host
+// dir exists.
+func TestBwrapBuildArgs_BunCacheDirBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	// The fixture does not pre-create ~/.cache/bun — create it so the
+	// conditional mount fires.
+	bunCacheDir := filepath.Join(fakeHome, ".cache", "bun")
+	if err := os.MkdirAll(bunCacheDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll ~/.cache/bun: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasBind(args, bunCacheDir) {
+		t.Errorf("~/.cache/bun %q not found as --bind SRC SRC in args: %v", bunCacheDir, args)
+	}
+	if hasROBind(args, bunCacheDir) {
+		t.Errorf("~/.cache/bun %q must be RW (--bind), not RO (--ro-bind): %v", bunCacheDir, args)
+	}
+}
+
+// TestBwrapBuildArgs_BunCacheDirAbsentNoBind pins the conditional half of
+// the bun-cache convergence (#2245): when ~/.cache/bun does not exist on
+// the host, no bind triple is emitted (OptionalIfMissing — bwrap aborts on
+// missing bind sources).
+func TestBwrapBuildArgs_BunCacheDirAbsentNoBind(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	bunCacheDir := filepath.Join(fakeHome, ".cache", "bun")
+	if _, err := os.Stat(bunCacheDir); err == nil {
+		t.Fatalf("fixture unexpectedly created ~/.cache/bun — update this test")
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasBind(args, bunCacheDir) {
+		t.Errorf("missing ~/.cache/bun should be omitted but found as --bind in args: %v", args)
+	}
+	if hasROBind(args, bunCacheDir) {
+		t.Errorf("missing ~/.cache/bun should be omitted but found as --ro-bind in args: %v", args)
+	}
+}
+
 func TestBwrapBuildArgs_BareRepoBoundAtHostPath(t *testing.T) {
 	// When BareRoot and WorktreeGitDir are set, the bare repo (.bare dir) and
 	// worktree private git state are both bound at their host paths (Dst == Src),

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -208,13 +208,35 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 			OptionalIfMissing: true,
 		},
 
-		// ── ~/.cache/nix (RW) ────────────────────────────────────────────
+		// ── ~/.cache/nix (RW, conditional) ────────────────────────────────────────────
 		// Pre-populated nix flake input cache. Read-write because nix
 		// writes to its SQLite databases during evaluation.
+		//
+		// OptionalIfMissing since #2245 (Step 3e of #2132): the entry used to
+		// be unconditional, which emits a --bind for a missing source on a
+		// fresh host — and bwrap ABORTS on missing bind sources (the #2243
+		// lesson; the old unconditional shape predated that finding). When
+		// absent, nix simply creates an ephemeral in-namespace dir.
 		{
-			HostPath:       filepath.Join(hostHome, ".cache", "nix"),
-			SandboxPath:    filepath.Join(sandboxHomeDir, ".cache", "nix"),
-			SELinuxRelabel: true,
+			HostPath:          filepath.Join(hostHome, ".cache", "nix"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".cache", "nix"),
+			OptionalIfMissing: true,
+			SELinuxRelabel:    true,
+		},
+
+		// ── ~/.cache/bun (RW, conditional) ──────────────────────────────
+		// bun transpiler cache — bun writes transpile outputs and lockfile
+		// updates here on plugin load. Converged into the shared walk from
+		// the former inline bwrap.go block in #2245 (Step 3e of #2132);
+		// behaviour-identical (RW, Dst==Src, skipped when absent).
+		//
+		// sandbox-exec does not walk this slice (see the package comment):
+		// there generateProfile emits an explicit RW (subpath ~/.cache/bun)
+		// grant on the real host path (section 5e).
+		{
+			HostPath:          filepath.Join(hostHome, ".cache", "bun"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".cache", "bun"),
+			OptionalIfMissing: true,
 		},
 
 		// ── AWS readonly-config (RO, EvalSymlinks, Dst==Src at XDG path) ─

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -105,11 +105,17 @@ func (s *sandboxExecIsolator) BuildRunArgs() []string {
 //   - sops secrets.d deny (read + write) with named re-allow exceptions for
 //     exactly the inventoried agent-needed secret names (issue #2211)
 //   - Host ~/.aws deny with sso/cli carve-outs (config/credentials are
-//     delivered via env vars at the host XDG paths — issue #2234)
+//     delivered via env vars at the host XDG paths — issue #2234; the
+//     carve-outs are the sole capability for sso/cli since #2245)
 //   - Literal RO grant for the real ~/.ssh/known_hosts — never (subpath ~/.ssh)
 //     (issue #2213)
 //   - RW subpath grant for ~/.config/claude — claude-code's config dir,
 //     reached via the CLAUDE_CONFIG_DIR env var (issue #2243)
+//   - RW subpath grants for ~/.cache/nix, ~/.cache/bun, ~/.npm, ~/.mcp-auth
+//     (Step 3e of #2132, issue #2245)
+//   - RO subpath grants for ~/.cache/prism/clipboard and
+//     ~/.config/prism/agents, plus an RO grant for the ~/.nix-profile
+//     symlink and its resolved target (Step 3f of #2132, issue #2245)
 //   - Session work dir (covers the nested staging HOME) / worktree / bare
 //     repo / host-API socket dir (RW)
 //   - Symlink target allows (RW for cache/credential dirs, RO for key/config) for every symlink in the staging HOME
@@ -348,11 +354,12 @@ func generateProfile(m *Manager) string {
 	//
 	// Exception: ~/.aws/sso and ~/.aws/cli must remain accessible so that
 	// AWS SSO auth and tools that read SSO tokens (e.g. kubectl) work inside
-	// the sandbox. The staging HOME creates symlinks for these two subdirs
-	// pointing at the host paths, and collectStagingHomeSymlinkTargets emits
-	// per-symlink allow rules for them. The more-specific allow rules below
-	// override the broad deny for exactly these two subdirs (SBPL evaluates
-	// more-specific rules as overrides of broader ones). See issue #1380.
+	// the sandbox. Since #2245 (Step 3e of #2132) the staging HOME no longer
+	// symlinks these two subdirs — the carve-out allows below are the SOLE
+	// in-sandbox capability for them, at the real host paths. The
+	// more-specific allow rules below override the broad deny for exactly
+	// these two subdirs (SBPL evaluates more-specific rules as overrides of
+	// broader ones). See issue #1380.
 	if home != "" {
 		awsPath := filepath.Join(home, ".aws")
 		sb.WriteString("(deny file-read* file-write*\n")
@@ -440,6 +447,83 @@ func generateProfile(m *Manager) string {
 		claudeConfigDir := filepath.Join(home, ".config", "claude")
 		sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
 		sb.WriteString("  (subpath " + quoteSBPL(claudeConfigDir) + "))\n")
+		sb.WriteString("\n")
+	}
+
+	// ── 5e. RW cache/auth dir grants at the real host paths (issue #2245) ─
+	// Step 3e of #2132: the RW staging symlinks for ~/.cache/nix, ~/.cache/bun,
+	// ~/.npm, and ~/.mcp-auth are gone. These explicit RW subpath grants on
+	// the real host paths are the replacement capability. The consumers derive
+	// the paths from $HOME / XDG_CACHE_HOME (§2 of the #2132 design — "just
+	// work with real HOME"), which still point into the staging HOME until
+	// Step 5 flips them; the grants are emitted now so the flip is a pure env
+	// change. None of these paths is sops-backed — the #2211 allowlist plays
+	// no part; these grants are the sole capability.
+	//
+	// Mirrors bwrap's --bind (RW) treatment of the same dirs in mounts.go
+	// StandardSandboxMounts. Emitted even when a dir does not exist on the
+	// host — sandbox-exec silently ignores (subpath ...) rules for
+	// non-existent paths (same shape as the ~/.pi/agent rule in 6a), so fresh
+	// machines without e.g. ~/.mcp-auth are unaffected.
+	if home != "" {
+		sb.WriteString("(allow file-read* file-write* file-test-existence file-read-metadata\n")
+		sb.WriteString("  (subpath " + quoteSBPL(filepath.Join(home, ".cache", "nix")) + ")\n")
+		sb.WriteString("  (subpath " + quoteSBPL(filepath.Join(home, ".cache", "bun")) + ")\n")
+		sb.WriteString("  (subpath " + quoteSBPL(filepath.Join(home, ".npm")) + ")\n")
+		sb.WriteString("  (subpath " + quoteSBPL(filepath.Join(home, ".mcp-auth")) + "))\n")
+		sb.WriteString("\n")
+	}
+
+	// ── 5f. RO grants at the real host paths (issue #2245) ─────────────
+	// Step 3f of #2132: the RO staging symlinks for ~/.cache/prism/clipboard
+	// (images staged by `prism clipboard paste-image`; the agent reads them at
+	// the absolute host path) and ~/.config/prism/agents (role prompt markdown
+	// read by the prism PI extension at before_agent_start — issue #2032) are
+	// gone. These explicit RO subpath grants on the real host paths are the
+	// replacement capability. Read-only — agents never write their own role
+	// prompt and only read staged clipboard images; RO must not silently
+	// become RW. Emitted even when a dir does not exist on the host (see 5e).
+	if home != "" {
+		sb.WriteString("(allow file-read* file-test-existence\n")
+		sb.WriteString("  (subpath " + quoteSBPL(filepath.Join(home, ".cache", "prism", "clipboard")) + ")\n")
+		sb.WriteString("  (subpath " + quoteSBPL(filepath.Join(home, ".config", "prism", "agents")) + "))\n")
+		sb.WriteString("\n")
+	}
+
+	// ── 5g. ~/.nix-profile RO grant — symlink node + resolved target ─────
+	// Step 3f of #2132 (issue #2245): the RO staging symlink for
+	// ~/.nix-profile is gone. ~/.nix-profile is itself a SYMLINK on the host
+	// (→ ~/.local/state/nix/profiles/profile → … → /nix/store/…), and SBPL
+	// path filters evaluate the RESOLVED target for open(2)-class operations
+	// (the #2132 §2 mechanism note) — so the grant must work through
+	// resolution:
+	//
+	//   - The (literal ~/.nix-profile) allow covers operations on the symlink
+	//     NODE itself — readlink(2)/lstat(2) — which are evaluated against
+	//     the link path, not the target.
+	//   - The EvalSymlinks-resolved target gets its own RO rule (subpath for
+	//     a dir, literal for a file) so reads THROUGH the link succeed. On
+	//     hm/nix-darwin hosts the chain typically lands in /nix/store (already
+	//     readable via the §2 /nix allow — the explicit rule is then a
+	//     harmless duplicate), but the rule is load-bearing wherever the
+	//     profile dir lives outside /nix. Resolution failure (no
+	//     ~/.nix-profile on the host) skips the target rule; the literal is
+	//     still emitted (sandbox-exec ignores rules for non-existent paths).
+	//
+	// Read-only throughout — nothing in-sandbox may mutate the profile.
+	if home != "" {
+		nixProfile := filepath.Join(home, ".nix-profile")
+		sb.WriteString("(allow file-read* file-test-existence\n")
+		sb.WriteString("  (literal " + quoteSBPL(nixProfile) + ")")
+		if resolved, evalErr := filepath.EvalSymlinks(nixProfile); evalErr == nil && resolved != nixProfile {
+			sb.WriteString("\n")
+			if info, statErr := os.Stat(resolved); statErr == nil && info.IsDir() {
+				sb.WriteString("  (subpath " + quoteSBPL(resolved) + ")")
+			} else {
+				sb.WriteString("  (literal " + quoteSBPL(resolved) + ")")
+			}
+		}
+		sb.WriteString(")\n")
 		sb.WriteString("\n")
 	}
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_home.go
@@ -17,14 +17,15 @@ package container
 //     host XDG path ~/.config/claude — generateProfile emits an explicit RW
 //     (subpath ~/.config/claude) grant instead.
 //
-//  2. .config/prism/agents/ is symlinked into the staging HOME for ALL roles
-//     (including review-*) so the prism PI extension can read <role>.md at
-//     before_agent_start. The dir is pure markdown with no secrets, so the
-//     former review-prefix exclusion was dropped (issue #2032; design #2031).
+//  2. (retired in #2245, Step 3f of #2132) .config/prism/agents/ used to be
+//     symlinked into the staging HOME for ALL roles (issue #2032; design
+//     #2031). generateProfile now emits an explicit RO
+//     (subpath ~/.config/prism/agents) grant on the real host path instead.
 //
-//  3. .cache/nix/ is included as an RW symlink to ~/.cache/nix (matches
-//     bwrap's unconditional RW bind — the ~/.cache/nix mount in mounts.go
-//     StandardSandboxMounts).
+//  3. (retired in #2245, Step 3e of #2132) .cache/nix/ used to be an RW
+//     symlink to ~/.cache/nix. generateProfile now emits an explicit RW
+//     (subpath ~/.cache/nix) grant on the real host path instead (and the
+//     bwrap mount in mounts.go StandardSandboxMounts is OptionalIfMissing).
 
 import (
 	"fmt"
@@ -79,11 +80,12 @@ func (m *Manager) sandboxExecHomePath() (string, error) {
 //     work dir (the staging HOME's parent — see PrepareSessionWorkDir in
 //     session_work_dir.go, issue #2213) and are wired into the sandbox via
 //     GIT_CONFIG_GLOBAL / GIT_SSH_COMMAND rather than via $HOME paths.
-//   - .cache/nix/ is always included as an RW symlink to ~/.cache/nix.
-//   - .config/prism/agents/ is symlinked in for ALL roles (including review-*)
-//     so the PI extension can read <role>.md (issue #2032). The former
-//     review-prefix exclusion was dropped — the dir is pure markdown with no
-//     secrets, so there is no isolation value in hiding sibling role prompts.
+//
+// Post-#2245 (Steps 3d–3f of #2132) the staging surface is reduced to the
+// .ssh/* symlinks (Step 5 scope) and the chromium Library skeleton (Step 4
+// scope). Every other capability is delivered by an explicit SBPL grant on
+// the real host path emitted by generateProfile — see sections 5, 5e, 5f,
+// 5g, and 6a in sandbox_exec.go.
 //
 // Calling PrepareSandboxExecHome a second time on an existing staging dir is
 // idempotent: existing symlinks are recreated (os.Symlink is preceded by
@@ -105,10 +107,6 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	dirs := []string{
 		stagingHome,
 		filepath.Join(stagingHome, ".ssh"),
-		filepath.Join(stagingHome, ".aws"),
-		filepath.Join(stagingHome, ".cache"),
-		filepath.Join(stagingHome, ".pi"),
-		filepath.Join(stagingHome, ".config", "prism"),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o700); err != nil {
@@ -224,16 +222,13 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// the exceptions from the same stable XDG source paths, so the read
 	// survives sops rotations — #1410/#1573).
 	//
-	// Only the SDK-hardcoded ~/.aws/sso and ~/.aws/cli cache dirs are still
-	// symlinked (RW write-through); they are Step 3e scope.
-	symlinkIfExists(
-		filepath.Join(home, ".aws", "sso"),
-		filepath.Join(stagingHome, ".aws", "sso"),
-	)
-	symlinkIfExists(
-		filepath.Join(home, ".aws", "cli"),
-		filepath.Join(stagingHome, ".aws", "cli"),
-	)
+	// Note (#2245, Step 3e of #2132): the .aws/sso and .aws/cli RW staging
+	// symlinks are no longer created either (and no .aws/ staging dir exists).
+	// The SDK-hardcoded ~/.aws/sso and ~/.aws/cli cache dirs are reached at
+	// their real host paths via the §5 carve-out allows that generateProfile
+	// emits after the broad ~/.aws deny — the carve-outs are now the sole
+	// in-sandbox capability for those two subtrees. The broader ~/.aws
+	// subtree stays denied.
 
 	// ── Kube ──────────────────────────────────────────────────────────────────
 	// Note (#2235, Step 3b of #2132): the .kube/config staging symlink is no
@@ -248,17 +243,10 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// SessionWorkDirKubeEnv in session_work_dir.go).
 
 	// ── prism agent role prompts (issue #2032) ─────────────────────────
-	// Symlink ~/.config/prism/agents (deployed by pi.nix) into the staging
-	// HOME at the canonical XDG path so the prism PI extension can read
-	// <role>.md at before_agent_start. Included for ALL roles, including
-	// review-* — the dir is pure markdown with no secrets (locked decision on
-	// design #2031). collectStagingHomeSymlinkTargets scans .config/prism and
-	// emits the SBPL read-allow for the resolved target, so no manual
-	// generateProfile rule is needed.
-	symlinkIfExists(
-		filepath.Join(home, ".config", "prism", "agents"),
-		filepath.Join(stagingHome, ".config", "prism", "agents"),
-	)
+	// Note (#2245, Step 3f of #2132): the .config/prism/agents staging symlink
+	// is no longer created (and no .config/ staging dir exists).
+	// generateProfile emits an explicit RO (subpath ~/.config/prism/agents)
+	// grant on the real host path instead (section 5f).
 
 	// ── Library/Application Support/Google + Library/Caches/Google (issue #2021) ─
 	// playwright-cli launches the Nix-built `Google Chrome for Testing` binary
@@ -298,42 +286,21 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// not involved: the read/write capability comes from the explicit RW
 	// (subpath ~/.config/claude) grant emitted by generateProfile.
 
-	// ── .mcp-auth/ ────────────────────────────────────────────────────────────
-	symlinkIfExists(
-		filepath.Join(home, ".mcp-auth"),
-		filepath.Join(stagingHome, ".mcp-auth"),
-	)
+	// ── .mcp-auth/, .npm/, .cache/ ──────────────────────────────────────────
+	// Note (#2245, Step 3e of #2132): the RW staging symlinks for .mcp-auth/,
+	// .npm/, .cache/bun, and .cache/nix are no longer created (and no .cache/
+	// staging dir exists). generateProfile emits an explicit RW grant block on
+	// the real host paths instead (section 5e). The consumers derive these
+	// paths from $HOME / XDG_CACHE_HOME, which still point into the staging
+	// HOME until Step 5 of #2132 flips them to the real home — interim writes
+	// land ephemerally inside the staging HOME (covered by the session work
+	// dir RW allow) and the real-path grants become load-bearing at Step 5.
 
-	// ── .npm/ ─────────────────────────────────────────────────────────────────
-	// npx caches downloaded packages (e.g. mcp-remote) under ~/.npm/_npx/.
-	// Without this symlink, npx cannot find its cache and attempts to re-download
-	// packages, which fails due to network restrictions in the sandbox.
-	symlinkIfExists(
-		filepath.Join(home, ".npm"),
-		filepath.Join(stagingHome, ".npm"),
-	)
-
-	// ── .cache/ ───────────────────────────────────────────────────────────────
-
-	// bun cache — only linked when writable (mirrors bwrap's conditional
-	// isWritable-gated bind of ~/.cache/bun).
-	bunCacheDir := filepath.Join(home, ".cache", "bun")
-	if isWritable(bunCacheDir) {
-		symlinkIfExists(bunCacheDir, filepath.Join(stagingHome, ".cache", "bun"))
-	}
-
-	// nix cache — always included as RW symlink (matches bwrap's
-	// unconditional RW bind of ~/.cache/nix in mounts.go).
-	nixCacheDir := filepath.Join(home, ".cache", "nix")
-	symlinkIfExists(nixCacheDir, filepath.Join(stagingHome, ".cache", "nix"))
-
-	// prism clipboard cache — conditional on existence.
-	clipboardCacheDir := filepath.Join(home, ".cache", "prism", "clipboard")
-	if _, err := os.Stat(clipboardCacheDir); err == nil {
-		// Create intermediate dir .cache/prism/ if needed.
-		_ = os.MkdirAll(filepath.Join(stagingHome, ".cache", "prism"), 0o700)
-		symlinkIfExists(clipboardCacheDir, filepath.Join(stagingHome, ".cache", "prism", "clipboard"))
-	}
+	// ── .cache/prism/clipboard ────────────────────────────────────────────────
+	// Note (#2245, Step 3f of #2132): the RO clipboard staging symlink is no
+	// longer created. The host writes images to the real
+	// ~/.cache/prism/clipboard and the agent reads them at that absolute path;
+	// generateProfile emits an explicit RO grant on the real path (section 5f).
 
 	// Note (#2213): the generated gitconfig is no longer written into the
 	// staging HOME. It lives at <sessionDir>/gitconfig (see
@@ -342,106 +309,24 @@ func (m *Manager) PrepareSandboxExecHome() (string, error) {
 	// preserved: PrepareSessionWorkDir fails Prepare before the session
 	// starts (see sandboxExecIsolator.Prepare in lifecycle_dispatch.go).
 
-	// ── .nix-profile symlink ──────────────────────────────────────────────────
-	symlinkIfExists(
-		filepath.Join(home, ".nix-profile"),
-		filepath.Join(stagingHome, ".nix-profile"),
-	)
+	// ── .nix-profile ──────────────────────────────────────────────────────────
+	// Note (#2245, Step 3f of #2132): the .nix-profile RO staging symlink is
+	// no longer created. ~/.nix-profile is itself a symlink on the host;
+	// generateProfile emits an RO literal allow on the symlink node plus an RO
+	// rule on its EvalSymlinks-resolved target (section 5g).
 
-	// ── PI Atlassian MCP OAuth token persistence (Darwin only) ───────────────
-	// The Atlassian MCP extension stores OAuth tokens at
-	// homedir()/.pi/agent/atlassian-mcp-oauth.json. On Darwin sandbox-exec,
-	// $HOME inside the session is the per-session staging HOME, so writes to
-	// that path land in the staging dir and are destroyed when the session
-	// ends. To persist tokens across sessions we:
-	//
-	//  1. Create <stagingHome>/.pi/agent/ as a real directory (so the
-	//     extension's mkdirSync({ recursive: true }) is a no-op).
-	//  2. Touch ~/.pi/agent/atlassian-mcp-oauth.json on the host with mode
-	//     0600 if absent — bwrap does the same in appendPIBwrapMounts.
-	//  3. Symlink <stagingHome>/.pi/agent/atlassian-mcp-oauth.json to the
-	//     real host path so reads and writes flow through to the host.
-	//
-	// The SBPL profile already emits
-	//   (allow file-read* file-write* ... (subpath ~/.pi/agent))
-	// for Harness == "pi" sessions, so no profile changes are required.
-	//
-	// The change is gated on BOTH runtime.GOOS == "darwin" AND
-	// m.cfg.Harness == "pi" so that non-pi sessions are unaffected.
-	if runtime.GOOS == "darwin" && m.cfg.Harness == "pi" {
-		if err := m.stagePIOAuthToken(home, stagingHome); err != nil {
-			log.Printf("container: sandbox-exec: stage PI OAuth token: %v", err)
-		}
-	}
+	// ── PI Atlassian MCP OAuth token (Step 3d of #2132, issue #2245) ─────────
+	// The dedicated touch-and-symlink staging step for
+	// ~/.pi/agent/atlassian-mcp-oauth.json (former stagePIOAuthToken, issue
+	// #1597) is gone. The capability collapses into the existing pi-gated RW
+	// (subpath ~/.pi/agent) grant (section 6a): the Atlassian MCP extension
+	// creates the file itself at the real path once $HOME resolution lands on
+	// the real home (Step 5 of #2132). Until then, in-sandbox homedir()-based
+	// writes land ephemerally inside the staging HOME (the extension's
+	// mkdirSync({recursive: true}) creates .pi/agent under the session work
+	// dir RW allow) — no host-side touch is needed for either window.
 
 	return stagingHome, nil
-}
-
-// stagePIOAuthToken creates the staging HOME infrastructure for the
-// Atlassian MCP OAuth token under a pi harness Darwin session:
-//
-//  1. Creates <stagingHome>/.pi/agent/ as a real directory (mode 0700).
-//  2. Ensures ~/.pi/agent/ exists on the host (mode 0700).
-//  3. Touches ~/.pi/agent/atlassian-mcp-oauth.json on the host with
-//     mode 0600 if absent (existing files are never modified).
-//  4. Symlinks <stagingHome>/.pi/agent/atlassian-mcp-oauth.json →
-//     ~/.pi/agent/atlassian-mcp-oauth.json (idempotent).
-//
-// This mirrors the bwrap touch-and-bind pattern in
-// pi_invocation.go::appendPIBwrapMounts.
-func (m *Manager) stagePIOAuthToken(home, stagingHome string) error {
-	// 1. Create <stagingHome>/.pi/agent/ as a real directory.
-	stagingAgentDir := filepath.Join(stagingHome, ".pi", "agent")
-	if err := os.MkdirAll(stagingAgentDir, 0o700); err != nil {
-		return fmt.Errorf("create staging .pi/agent dir %s: %w", stagingAgentDir, err)
-	}
-
-	// 2. Ensure ~/.pi/agent/ exists on the host.
-	hostAgentDir := filepath.Join(home, ".pi", "agent")
-	if err := os.MkdirAll(hostAgentDir, 0o700); err != nil {
-		return fmt.Errorf("create host .pi/agent dir %s: %w", hostAgentDir, err)
-	}
-
-	// 3. Touch ~/.pi/agent/atlassian-mcp-oauth.json on the host if absent.
-	// Use O_CREATE|O_EXCL so an existing file is never truncated or modified.
-	hostTokenPath := filepath.Join(hostAgentDir, "atlassian-mcp-oauth.json")
-	if _, statErr := os.Stat(hostTokenPath); os.IsNotExist(statErr) {
-		f, createErr := os.OpenFile(hostTokenPath, os.O_CREATE|os.O_EXCL, 0o600)
-		if createErr == nil {
-			_ = f.Close()
-		} else if !os.IsExist(createErr) {
-			return fmt.Errorf("touch host token file %s: %w", hostTokenPath, createErr)
-		}
-	}
-
-	// 4. Symlink <stagingHome>/.pi/agent/atlassian-mcp-oauth.json → host path.
-	// Remove any existing entry first (file, symlink, or otherwise) so
-	// the operation is idempotent.
-	stagingTokenPath := filepath.Join(stagingAgentDir, "atlassian-mcp-oauth.json")
-	_ = os.Remove(stagingTokenPath)
-	if err := os.Symlink(hostTokenPath, stagingTokenPath); err != nil {
-		return fmt.Errorf("symlink %s → %s: %w", stagingTokenPath, hostTokenPath, err)
-	}
-	return nil
-}
-
-// isWritable returns true when the path exists and is accessible for writing
-// by the current process. A nil error from a writable-test os.OpenFile call
-// indicates writeability; any error (including EACCES) returns false.
-func isWritable(path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		return false // doesn't exist
-	}
-	// Attempt to open a temp file inside the directory. This is the most
-	// reliable way to test writeability without relying on access(2) (which
-	// has TOCTOU issues and doesn't honour ACLs on all platforms).
-	tmp, err := os.CreateTemp(path, ".prism-write-test-*")
-	if err != nil {
-		return false
-	}
-	_ = tmp.Close()
-	_ = os.Remove(tmp.Name())
-	return true
 }
 
 // SandboxExecHomePath is the exported version of sandboxExecHomePath. It
@@ -496,11 +381,10 @@ type StagingSymlinkTarget struct {
 	IsDir bool
 	// Writable is true when the sandbox must be allowed to write to this
 	// target (and, for directories, its contents). Mirrors the bwrap --bind
-	// (RW) vs --ro-bind (RO) distinction:
-	//   RW: .cache/opencode, .cache/bun, .cache/nix, .mcp-auth
-	//   RO: .ssh keys, .config/opencode/*,
-	//       .config/prism/agents (role prompts; issue #2032),
-	//       .cache/prism/clipboard (read-only; mirrors bwrap.go --ro-bind)
+	// (RW) vs --ro-bind (RO) distinction. Post-#2245 the staging surface is
+	// .ssh/* only — all RO — so Writable is always false in practice; the
+	// field is retained so the RW/RO emission split in generateProfile stays
+	// shape-stable until Step 5 of #2132 deletes the whole mechanism.
 	Writable bool
 }
 
@@ -512,20 +396,13 @@ type StagingSymlinkTarget struct {
 // the appropriate SBPL rules:
 //   - Directory targets → (subpath ...) rules.
 //   - File targets → (literal ...) rules.
-//   - Writable targets (cache dirs, write-through credential dirs) → file-write*
-//     alongside file-read*; RO targets → file-read* only.
+//   - Writable targets → file-write* alongside file-read*; RO targets →
+//     file-read* only.
 //
-// Writable classification mirrors the bwrap --bind (RW) vs --ro-bind (RO)
-// distinction from bwrap.go. The following staging HOME paths are treated as
-// writable, consistent with how PrepareSandboxExecHome populates them:
-//   - .cache/opencode  — opencode refreshes models.json and writes bin/ shims
-//   - .cache/bun       — bun writes transpile outputs and lockfile updates
-//   - .cache/nix       — unconditional RW (mirrors bwrap's mounts.go bind)
-//   - .mcp-auth        — MCP auth token writes
-//
-// All other targets (.ssh, .config/opencode, .cache/prism/clipboard)
-// are read-only. .cache/prism/clipboard mirrors bwrap.go's --ro-bind treatment —
-// the agent only reads image files staged there by `prism clipboard paste-image`.
+// Post-#2245 (Steps 3d–3f of #2132) the only staging symlinks left are the
+// .ssh/* entries, all read-only — every other category is delivered by an
+// explicit grant on the real host path in generateProfile. All collected
+// targets are therefore classified Writable=false.
 //
 // Symlink targets that fall under a path that will be denied by the profile
 // (e.g. host $HOME/.aws) are excluded from the results to avoid the
@@ -545,62 +422,23 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 	// allow-literal/subpath block to avoid the literal-over-subpath precedence
 	// issue in Apple's SBPL.
 	//
-	// allowedUnderDenied lists specific sub-paths that are carved out of the
-	// denied region. generateProfile emits explicit (allow file-read* (subpath
-	// ...)) rules for these after the broad deny, so it is safe for the
-	// per-symlink allow block to reference their targets.
-	// Concretely: ~/.aws/sso and ~/.aws/cli are carved out so that the staging
-	// HOME symlinks for those dirs produce per-symlink allow rules.
+	// Post-#2245 no staging symlink targets ~/.aws any more (the sso/cli
+	// carve-out plumbing that used to live here moved entirely to the §5
+	// profile rules), but the deny-prefix exclusion is kept as defence in
+	// depth: if a future staging symlink ever resolves under ~/.aws, it must
+	// not silently punch a literal allow through the deny.
 	var deniedPrefixes []string
-	var allowedUnderDenied []string
 	if home != "" {
 		deniedPrefixes = append(deniedPrefixes, filepath.Join(home, ".aws")+"/")
-		// Carve sso/ and cli/ out of the denied region — generateProfile emits
-		// explicit (allow file-read* (subpath ~/.aws/sso)) and
-		// (allow file-read* (subpath ~/.aws/cli)) after the broad deny.
-		allowedUnderDenied = append(allowedUnderDenied,
-			filepath.Join(home, ".aws", "sso")+"/",
-			filepath.Join(home, ".aws", "cli")+"/",
-		)
 	}
 
 	isDenied := func(path string) bool {
-		// Check whether the path falls under any allowed carve-out first.
-		// If yes, it is not considered denied even if a broader deny prefix matches.
-		for _, allowed := range allowedUnderDenied {
-			if strings.HasPrefix(path+"/", allowed) || path == strings.TrimSuffix(allowed, "/") {
-				return false
-			}
-		}
 		for _, prefix := range deniedPrefixes {
 			if strings.HasPrefix(path+"/", prefix) || path == strings.TrimSuffix(prefix, "/") {
 				return true
 			}
 		}
 		return false
-	}
-
-	// writableStagingPaths is the set of staging HOME paths whose symlink
-	// targets must be granted write access in the SBPL profile. Keyed by the
-	// path relative to stagingHome (no leading slash). Matches the RW paths
-	// in PrepareSandboxExecHome and the bwrap --bind mounts in bwrap.go.
-	writableStagingPaths := map[string]bool{
-		".cache/bun": true, // bun transpile cache + lockfile
-		".cache/nix": true, // nix eval cache (unconditional RW)
-		// .cache/prism/clipboard is intentionally absent: agents only read
-		// images staged there; mirrors bwrap.go's --ro-bind treatment.
-		// .claude is gone (#2243): claude-code reads/writes ~/.config/claude
-		// via CLAUDE_CONFIG_DIR; generateProfile grants it RW directly.
-		".mcp-auth": true, // MCP auth token writes
-		".npm":      true, // npx package cache (mcp-remote et al.)
-		// AWS SSO and CLI cache dirs must be writable so the aws CLI can write
-		// STS token cache entries (~/.aws/cli/cache/) and refresh SSO tokens
-		// (~/.aws/sso/). Without write access the CLI gets EPERM and kubectl
-		// against EKS also fails (its exec-credential plugin shells out to aws).
-		// Mirrors bwrap's --bind (RW) treatment — awsSSOReadOnly/awsCLIReadOnly
-		// are both false in mounts.go (issue #1558).
-		".aws/sso": true, // AWS SSO token refresh writes
-		".aws/cli": true, // AWS CLI STS token cache writes
 	}
 
 	seen := map[string]bool{}
@@ -625,11 +463,15 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 		// Determine whether the target is a directory or a file.
 		info, statErr := os.Stat(resolved)
 		isDir := statErr == nil && info.IsDir()
-		writable := writableStagingPaths[entryRelPath]
+		// Post-#2245 every remaining staging symlink (.ssh/*) is read-only;
+		// the RW categories moved to explicit real-path grants in
+		// generateProfile. entryRelPath is retained in the signature for
+		// shape stability until Step 5 of #2132 deletes the collector.
+		_ = entryRelPath
 		targets = append(targets, StagingSymlinkTarget{
 			ResolvedPath: resolved,
 			IsDir:        isDir,
-			Writable:     writable,
+			Writable:     false,
 		})
 	}
 
@@ -666,17 +508,11 @@ func collectStagingHomeSymlinkTargets(stagingHome string) ([]StagingSymlinkTarge
 		}
 	}
 
-	// Scan the top-level staging HOME and all immediate subdirectories that
-	// the staging HOME builder creates (one level deep).
+	// Scan the top-level staging HOME and the .ssh subdirectory — the only
+	// staging surface that still holds symlinks post-#2245 (the chromium
+	// Library skeleton holds real directories, which scanDir ignores).
 	scanDir("")
-	subDirs := []string{".ssh", ".aws", ".cache", ".pi"}
-	for _, sub := range subDirs {
-		scanDir(sub)
-	}
-	// Also scan .cache/prism if it exists.
-	scanDir(".cache/prism")
-	// Scan .config/prism for the prism/agents role-prompt symlink (issue #2032).
-	scanDir(".config/prism")
+	scanDir(".ssh")
 
 	return targets, nil
 }

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -365,8 +365,9 @@ func TestGenerateProfile_AWSHomePathDenied(t *testing.T) {
 // explicit (allow file-read* file-write* (subpath ".../.aws/sso")) and
 // (allow file-read* file-write* (subpath ".../.aws/cli")) rules after the
 // broad ~/.aws deny. These more-specific allow rules let AWS SSO tokens and
-// kubectl credential files be read and written through the staging HOME
-// symlinks (issue #1380, #1558).
+// kubectl credential files be read and written at the real host paths
+// (issue #1380, #1558) — since #2245 (Step 3e of #2132) the carve-outs are
+// the SOLE in-sandbox capability for the two dirs (no staging symlinks).
 func TestGenerateProfile_AWSSSOAndCLICarveouts(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
@@ -496,16 +497,20 @@ func TestGenerateProfile_NixTrustedSettingsReadAllow(t *testing.T) {
 	}
 }
 
-// TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded verifies that when
-// ~/.aws/sso and ~/.aws/cli symlinks exist in the staging HOME, their resolved
-// targets are included in the collected set (not excluded by the deniedPrefixes
-// logic), and that both targets are classified as Writable=true so that the
-// per-symlink allow block emits file-write* for them (issue #1380, #1558).
-func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
+// TestPrepareSandboxExecHome_NoAWSSSOCLISymlinks is the unit-level AC test
+// for the AWS half of issue #2245 (Step 3e of #2132): after
+// PrepareSandboxExecHome, the staging HOME contains no .aws/sso or .aws/cli
+// symlink (nor a .aws directory at all) even though the host dirs exist, and
+// collectStagingHomeSymlinkTargets emits no target under ~/.aws. The
+// in-sandbox capability for the two cache dirs is the §5 carve-out pair
+// emitted after the broad ~/.aws deny (see
+// TestGenerateProfile_AWSSSOAndCLICarveouts) — now the SOLE capability, with
+// the broader ~/.aws subtree still denied.
+func TestPrepareSandboxExecHome_NoAWSSSOCLISymlinks(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
-	// Create ~/.aws/sso and ~/.aws/cli directories in the fake home so the
-	// symlinkIfExists helper in PrepareSandboxExecHome creates symlinks for them.
+	// Create ~/.aws/sso and ~/.aws/cli in the fake home so the test proves
+	// the symlinks stay gone even when the host sources EXIST.
 	for _, dir := range []string{
 		filepath.Join(fakeHome, ".aws", "sso"),
 		filepath.Join(fakeHome, ".aws", "cli"),
@@ -517,7 +522,7 @@ func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
 
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@feat",
-		InstanceID:  "aws-sso-not-excluded-test",
+		InstanceID:  "no-aws-sso-cli-symlinks-test",
 	})
 
 	stagingHome, err := m.PrepareSandboxExecHome()
@@ -526,48 +531,25 @@ func TestCollectStagingHomeSymlinkTargets_AWSSSONotExcluded(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
+	for _, gone := range []string{
+		filepath.Join(stagingHome, ".aws", "sso"),
+		filepath.Join(stagingHome, ".aws", "cli"),
+		filepath.Join(stagingHome, ".aws"),
+	} {
+		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
+			t.Errorf("staging entry %s should NOT exist (removed in #2245, Step 3e), but it does", gone)
+		}
+	}
+
 	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
 	if err != nil {
 		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
 	}
-
-	// The resolved targets for ~/.aws/sso and ~/.aws/cli must be present.
-	// Use filepath.EvalSymlinks to resolve the expected paths: on macOS
-	// the fakeHome is under /tmp/ which resolves to /private/tmp/ via the
-	// /var → /private/var symlink, so we must compare against canonical forms.
-	awsSSOPathRaw := filepath.Join(fakeHome, ".aws", "sso")
-	awsCLIPathRaw := filepath.Join(fakeHome, ".aws", "cli")
-	awsSSOPath, _ := filepath.EvalSymlinks(awsSSOPathRaw)
-	if awsSSOPath == "" {
-		awsSSOPath = awsSSOPathRaw
-	}
-	awsCLIPath, _ := filepath.EvalSymlinks(awsCLIPathRaw)
-	if awsCLIPath == "" {
-		awsCLIPath = awsCLIPathRaw
-	}
-	foundSSO, foundCLI := false, false
-	ssoWritable, cliWritable := false, false
+	awsPrefix := filepath.Join(fakeHome, ".aws")
 	for _, target := range targets {
-		if target.ResolvedPath == awsSSOPath {
-			foundSSO = true
-			ssoWritable = target.Writable
+		if strings.HasPrefix(target.ResolvedPath, awsPrefix) {
+			t.Errorf("collectStagingHomeSymlinkTargets emitted a ~/.aws target %q — the sso/cli staging symlinks should be gone (#2245)", target.ResolvedPath)
 		}
-		if target.ResolvedPath == awsCLIPath {
-			foundCLI = true
-			cliWritable = target.Writable
-		}
-	}
-	if !foundSSO {
-		t.Errorf("~/.aws/sso resolved path %q not found in collectStagingHomeSymlinkTargets output; got: %v", awsSSOPath, targets)
-	} else if !ssoWritable {
-		// Both sso and cli must be Writable=true so the per-symlink allow block
-		// emits file-write* for them (issue #1558).
-		t.Errorf("~/.aws/sso target %q must have Writable=true (needed for aws CLI STS token cache writes); got Writable=false", awsSSOPath)
-	}
-	if !foundCLI {
-		t.Errorf("~/.aws/cli resolved path %q not found in collectStagingHomeSymlinkTargets output; got: %v", awsCLIPath, targets)
-	} else if !cliWritable {
-		t.Errorf("~/.aws/cli target %q must have Writable=true (needed for aws CLI STS token cache writes); got Writable=false", awsCLIPath)
 	}
 }
 
@@ -911,9 +893,15 @@ func TestPrepareSandboxExecHome_SSHSymlinks(t *testing.T) {
 
 // TestPrepareSandboxExecHome_MissingSourceSkipped verifies that when a source
 // path does not exist, the corresponding symlink is NOT created (no dangling
-// symlinks).
+// symlinks). Post-#2245 the conditional staging surface is the .ssh entries.
 func TestPrepareSandboxExecHome_MissingSourceSkipped(t *testing.T) {
-	newFakeHome(t)
+	fakeHome := newFakeHome(t)
+
+	// newFakeHome writes known_hosts but never allowed_signers; additionally
+	// remove known_hosts so both missing-source paths are exercised.
+	if err := os.Remove(filepath.Join(fakeHome, ".ssh", "known_hosts")); err != nil {
+		t.Fatalf("remove fixture known_hosts: %v", err)
+	}
 
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@feat",
@@ -926,11 +914,9 @@ func TestPrepareSandboxExecHome_MissingSourceSkipped(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// The fake home has no ~/.aws/sso or ~/.aws/cli directories.
-	// Symlinks for those must not exist in the staging HOME.
 	for _, absent := range []string{
-		filepath.Join(stagingHome, ".aws", "sso"),
-		filepath.Join(stagingHome, ".aws", "cli"),
+		filepath.Join(stagingHome, ".ssh", "known_hosts"),
+		filepath.Join(stagingHome, ".ssh", "allowed_signers"),
 	} {
 		if _, err := os.Lstat(absent); err == nil {
 			t.Errorf("symlink %s should NOT exist (source absent), but it does", absent)
@@ -1015,15 +1001,26 @@ func TestPrepareSandboxExecHome_ChromiumLibraryStagingDirs(t *testing.T) {
 	}
 }
 
-// TestPrepareSandboxExecHome_NixCacheAlwaysIncluded verifies that
-// .cache/nix/ is always included as a symlink (matching bwrap.go:333-335
-// unconditional RW bind).
-func TestPrepareSandboxExecHome_NixCacheAlwaysIncluded(t *testing.T) {
-	newFakeHome(t)
+// TestPrepareSandboxExecHome_No3eStagingSymlinks is the unit-level AC test
+// for the cache/auth half of issue #2245 (Step 3e of #2132): after
+// PrepareSandboxExecHome, the staging HOME contains no .cache/nix,
+// .cache/bun, .npm, or .mcp-auth symlink (nor a .cache directory at all)
+// even though the host sources exist, and collectStagingHomeSymlinkTargets
+// emits no target for them. The in-sandbox capability is the explicit RW
+// grant block on the real host paths (section 5e — see
+// TestGenerateProfile_RWRealPathGrants3e).
+func TestPrepareSandboxExecHome_No3eStagingSymlinks(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// newFakeHome creates .cache/bun, .cache/nix, and .mcp-auth; add .npm so
+	// every 3e source exists on the host.
+	if err := os.MkdirAll(filepath.Join(fakeHome, ".npm"), 0o700); err != nil {
+		t.Fatalf("create ~/.npm: %v", err)
+	}
 
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@feat",
-		InstanceID:  "nix-cache-test",
+		InstanceID:  "no-3e-symlinks-test",
 	})
 	stagingHome, err := m.PrepareSandboxExecHome()
 	if err != nil {
@@ -1031,15 +1028,108 @@ func TestPrepareSandboxExecHome_NixCacheAlwaysIncluded(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	nixLink := filepath.Join(stagingHome, ".cache", "nix")
-	if _, err := os.Lstat(nixLink); err != nil {
-		t.Errorf(".cache/nix symlink must always be created: %v", err)
+	for _, gone := range []string{
+		filepath.Join(stagingHome, ".cache", "nix"),
+		filepath.Join(stagingHome, ".cache", "bun"),
+		filepath.Join(stagingHome, ".cache"),
+		filepath.Join(stagingHome, ".npm"),
+		filepath.Join(stagingHome, ".mcp-auth"),
+	} {
+		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
+			t.Errorf("staging entry %s should NOT exist (removed in #2245, Step 3e), but it does", gone)
+		}
 	}
-	target, err := os.Readlink(nixLink)
+
+	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
 	if err != nil {
-		t.Errorf(".cache/nix is not a symlink: %v", err)
-	} else if target == "" {
-		t.Errorf(".cache/nix symlink has empty target")
+		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
+	}
+	for _, src := range []string{
+		filepath.Join(fakeHome, ".cache", "nix"),
+		filepath.Join(fakeHome, ".cache", "bun"),
+		filepath.Join(fakeHome, ".npm"),
+		filepath.Join(fakeHome, ".mcp-auth"),
+	} {
+		resolved, evalErr := filepath.EvalSymlinks(src)
+		if evalErr != nil {
+			t.Fatalf("fixture: EvalSymlinks(%s): %v", src, evalErr)
+		}
+		for _, target := range targets {
+			if target.ResolvedPath == resolved {
+				t.Errorf("collectStagingHomeSymlinkTargets emitted 3e target %q — its staging symlink should be gone (#2245)", resolved)
+			}
+		}
+	}
+}
+
+// TestPrepareSandboxExecHome_No3fStagingSymlinks is the unit-level AC test
+// for the RO trio of issue #2245 (Step 3f of #2132): after
+// PrepareSandboxExecHome, the staging HOME contains no
+// .cache/prism/clipboard, .config/prism/agents, or .nix-profile symlink
+// (nor .cache/ or .config/ staging dirs at all) even though the host
+// sources exist, and collectStagingHomeSymlinkTargets emits no target for
+// them. The in-sandbox capability is the explicit RO grant blocks on the
+// real host paths (sections 5f and 5g).
+func TestPrepareSandboxExecHome_No3fStagingSymlinks(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	// Create every 3f source in the fake home so the test proves the
+	// symlinks stay gone even when the host sources EXIST. ~/.nix-profile is
+	// a symlink on real hosts — mirror that shape.
+	for _, dir := range []string{
+		filepath.Join(fakeHome, ".cache", "prism", "clipboard"),
+		filepath.Join(fakeHome, ".config", "prism", "agents"),
+		filepath.Join(fakeHome, "nix-profile-target"),
+	} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	if err := os.Symlink(filepath.Join(fakeHome, "nix-profile-target"), filepath.Join(fakeHome, ".nix-profile")); err != nil {
+		t.Fatalf("symlink ~/.nix-profile: %v", err)
+	}
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@feat",
+		InstanceID:  "no-3f-symlinks-test",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	for _, gone := range []string{
+		filepath.Join(stagingHome, ".cache", "prism", "clipboard"),
+		filepath.Join(stagingHome, ".cache", "prism"),
+		filepath.Join(stagingHome, ".config", "prism", "agents"),
+		filepath.Join(stagingHome, ".config", "prism"),
+		filepath.Join(stagingHome, ".config"),
+		filepath.Join(stagingHome, ".nix-profile"),
+	} {
+		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
+			t.Errorf("staging entry %s should NOT exist (removed in #2245, Step 3f), but it does", gone)
+		}
+	}
+
+	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
+	if err != nil {
+		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
+	}
+	for _, src := range []string{
+		filepath.Join(fakeHome, ".cache", "prism", "clipboard"),
+		filepath.Join(fakeHome, ".config", "prism", "agents"),
+		filepath.Join(fakeHome, ".nix-profile"),
+	} {
+		resolved, evalErr := filepath.EvalSymlinks(src)
+		if evalErr != nil {
+			t.Fatalf("fixture: EvalSymlinks(%s): %v", src, evalErr)
+		}
+		for _, target := range targets {
+			if target.ResolvedPath == resolved {
+				t.Errorf("collectStagingHomeSymlinkTargets emitted 3f target %q — its staging symlink should be gone (#2245)", resolved)
+			}
+		}
 	}
 }
 
@@ -1486,143 +1576,28 @@ func TestPrepareSandboxExecHome_PiAgentDirMissingSkipped(t *testing.T) {
 	}
 }
 
-// ── PI Atlassian MCP OAuth token staging (Darwin + pi harness) ─────────────
+// ── PI Atlassian MCP OAuth token — no staging (Step 3d of #2132) ───────────
 
-// TestPrepareSandboxExecHome_PiOAuthTokenSymlinked verifies that after
-// PrepareSandboxExecHome runs for a Harness=="pi" Manager on Darwin,
-// <stagingHome>/.pi/agent/atlassian-mcp-oauth.json exists as a symlink
-// whose target equals the host path ~/.pi/agent/atlassian-mcp-oauth.json.
-func TestPrepareSandboxExecHome_PiOAuthTokenSymlinked(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
+// TestPrepareSandboxExecHome_NoPiOAuthStaging is the unit-level AC test for
+// Step 3d of #2132 (issue #2245): after PrepareSandboxExecHome for a
+// Harness=="pi" session, the staging HOME contains no .pi entry at all (the
+// former touch-and-symlink stagePIOAuthToken step is gone), the host token
+// file is left untouched, and collectStagingHomeSymlinkTargets emits no
+// target for it. The in-sandbox capability is the existing pi-gated RW
+// (subpath ~/.pi/agent) grant (section 6a — see
+// TestGenerateProfile_PiAgentDirSubpathRule).
+func TestPrepareSandboxExecHome_NoPiOAuthStaging(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
-	m := newSandboxExecManagerWithInstance(Config{
-		SessionName: "repo@pi-oauth-token-test",
-		InstanceID:  "pi-oauth-token-symlink-test",
-		Harness:     "pi",
-	})
-	stagingHome, err := m.PrepareSandboxExecHome()
-	if err != nil {
-		t.Fatalf("PrepareSandboxExecHome: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(stagingHome)
-		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-	})
-
-	// <stagingHome>/.pi/agent/atlassian-mcp-oauth.json must be a symlink.
-	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	info, err := os.Lstat(stagingTokenPath)
-	if err != nil {
-		t.Fatalf("%s must exist: %v", stagingTokenPath, err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		t.Fatalf("%s must be a symlink, got mode %v", stagingTokenPath, info.Mode())
-	}
-
-	// The symlink target must be the real host path.
-	target, err := os.Readlink(stagingTokenPath)
-	if err != nil {
-		t.Fatalf("Readlink %s: %v", stagingTokenPath, err)
-	}
-	wantTarget := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	if target != wantTarget {
-		t.Errorf("symlink target = %q, want %q", target, wantTarget)
-	}
-}
-
-// TestPrepareSandboxExecHome_PiOAuthAgentDirIsRealDir verifies that after
-// PrepareSandboxExecHome runs for a Harness=="pi" Manager on Darwin,
-// <stagingHome>/.pi/agent is a real directory (not a symlink).
-func TestPrepareSandboxExecHome_PiOAuthAgentDirIsRealDir(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
-	fakeHome := newFakeHome(t)
-
-	m := newSandboxExecManagerWithInstance(Config{
-		SessionName: "repo@pi-oauth-agent-dir",
-		InstanceID:  "pi-oauth-agent-dir-test",
-		Harness:     "pi",
-	})
-	stagingHome, err := m.PrepareSandboxExecHome()
-	if err != nil {
-		t.Fatalf("PrepareSandboxExecHome: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(stagingHome)
-		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-	})
-
-	// <stagingHome>/.pi/agent must be a real directory, not a symlink.
-	agentPath := filepath.Join(stagingHome, ".pi", "agent")
-	info, err := os.Lstat(agentPath)
-	if err != nil {
-		t.Fatalf("%s must exist: %v", agentPath, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		t.Errorf("%s must be a real directory, not a symlink", agentPath)
-	}
-	if !info.IsDir() {
-		t.Errorf("%s must be a directory, got mode %v", agentPath, info.Mode())
-	}
-}
-
-// TestPrepareSandboxExecHome_PiOAuthHostFileMode verifies that when
-// PrepareSandboxExecHome creates ~/.pi/agent/atlassian-mcp-oauth.json because
-// it was absent, the file has mode 0600.
-func TestPrepareSandboxExecHome_PiOAuthHostFileMode(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
-	fakeHome := newFakeHome(t)
-
-	// Ensure the token file does not exist before the test.
-	hostTokenPath := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-
-	m := newSandboxExecManagerWithInstance(Config{
-		SessionName: "repo@pi-oauth-mode",
-		InstanceID:  "pi-oauth-mode-test",
-		Harness:     "pi",
-	})
-	stagingHome, err := m.PrepareSandboxExecHome()
-	if err != nil {
-		t.Fatalf("PrepareSandboxExecHome: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(stagingHome)
-		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-	})
-
-	// Suppress the "declared and not used" warning for hostTokenPath.
-	info, err := os.Stat(hostTokenPath)
-	if err != nil {
-		t.Fatalf("host token file %s must exist: %v", hostTokenPath, err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("host token file mode = %04o, want 0600", info.Mode().Perm())
-	}
-}
-
-// TestPrepareSandboxExecHome_PiOAuthExistingFileNotOverwritten verifies that
-// when ~/.pi/agent/atlassian-mcp-oauth.json already exists with non-empty
-// content, PrepareSandboxExecHome does NOT truncate or overwrite it.
-func TestPrepareSandboxExecHome_PiOAuthExistingFileNotOverwritten(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
-	fakeHome := newFakeHome(t)
-
-	// Pre-create the token file with sentinel content.
+	// Pre-create the host token file with sentinel content so the test
+	// proves (a) staging stays empty even when the host file exists and
+	// (b) the host file is never modified.
 	hostAgentDir := filepath.Join(fakeHome, ".pi", "agent")
 	if err := os.MkdirAll(hostAgentDir, 0o700); err != nil {
 		t.Fatalf("create host agent dir: %v", err)
 	}
 	hostTokenPath := filepath.Join(hostAgentDir, "atlassian-mcp-oauth.json")
-	const sentinel = `{"access_token":"sentinel-do-not-overwrite"}`
+	const sentinel = `{"access_token":"sentinel-2245-untouched"}`
 	if err := os.WriteFile(hostTokenPath, []byte(sentinel), 0o600); err != nil {
 		t.Fatalf("write sentinel token: %v", err)
 	}
@@ -1632,167 +1607,87 @@ func TestPrepareSandboxExecHome_PiOAuthExistingFileNotOverwritten(t *testing.T) 
 	}
 
 	m := newSandboxExecManagerWithInstance(Config{
-		SessionName: "repo@pi-oauth-existing",
-		InstanceID:  "pi-oauth-existing-test",
+		SessionName: "repo@pi-oauth-no-staging",
+		InstanceID:  "pi-oauth-no-staging-test",
 		Harness:     "pi",
 	})
 	stagingHome, err := m.PrepareSandboxExecHome()
 	if err != nil {
 		t.Fatalf("PrepareSandboxExecHome: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(stagingHome)
-		_ = os.Remove(hostTokenPath)
-	})
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// Verify content unchanged.
-	got, err := os.ReadFile(hostTokenPath)
-	if err != nil {
-		t.Fatalf("read host token: %v", err)
+	// No .pi staging entry of any kind (dir, symlink, file).
+	for _, gone := range []string{
+		filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"),
+		filepath.Join(stagingHome, ".pi", "agent"),
+		filepath.Join(stagingHome, ".pi"),
+	} {
+		if _, lstatErr := os.Lstat(gone); lstatErr == nil {
+			t.Errorf("staging entry %s should NOT exist (removed in #2245, Step 3d), but it does", gone)
+		}
+	}
+
+	// Host token file untouched: content and mtime unchanged.
+	got, readErr := os.ReadFile(hostTokenPath)
+	if readErr != nil {
+		t.Fatalf("read host token after staging: %v", readErr)
 	}
 	if string(got) != sentinel {
 		t.Errorf("host token content changed: got %q, want %q", string(got), sentinel)
 	}
-
-	// Verify mtime unchanged.
-	afterStat, err := os.Stat(hostTokenPath)
-	if err != nil {
-		t.Fatalf("stat host token after: %v", err)
+	afterStat, statErr := os.Stat(hostTokenPath)
+	if statErr != nil {
+		t.Fatalf("stat host token after: %v", statErr)
 	}
 	if !afterStat.ModTime().Equal(origStat.ModTime()) {
 		t.Errorf("host token mtime changed: orig %v, after %v", origStat.ModTime(), afterStat.ModTime())
 	}
-}
 
-// TestPrepareSandboxExecHome_PiOAuthMissingHostAgentDirAutoCreated verifies
-// that when ~/.pi/agent/ does not exist on the host, PrepareSandboxExecHome
-// creates it with mode 0700 and returns nil error.
-func TestPrepareSandboxExecHome_PiOAuthMissingHostAgentDirAutoCreated(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
-	fakeHome := newFakeHome(t)
-
-	// Ensure ~/.pi/agent does not exist.
-	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-
-	m := newSandboxExecManagerWithInstance(Config{
-		SessionName: "repo@pi-oauth-mkdir",
-		InstanceID:  "pi-oauth-mkdir-test",
-		Harness:     "pi",
-	})
-	stagingHome, err := m.PrepareSandboxExecHome()
+	// Collector silence for the host token path.
+	targets, err := collectStagingHomeSymlinkTargets(stagingHome)
 	if err != nil {
-		t.Fatalf("PrepareSandboxExecHome with missing host agent dir: %v", err)
+		t.Fatalf("collectStagingHomeSymlinkTargets: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(stagingHome)
-		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-	})
-
-	// Host agent dir must now exist with mode 0700.
-	hostAgentDir := filepath.Join(fakeHome, ".pi", "agent")
-	info, err := os.Stat(hostAgentDir)
-	if err != nil {
-		t.Fatalf("host agent dir %s must exist after autocreate: %v", hostAgentDir, err)
+	resolvedToken, evalErr := filepath.EvalSymlinks(hostTokenPath)
+	if evalErr != nil {
+		t.Fatalf("fixture: EvalSymlinks(%s): %v", hostTokenPath, evalErr)
 	}
-	if info.Mode().Perm() != 0o700 {
-		t.Errorf("host agent dir mode = %04o, want 0700", info.Mode().Perm())
-	}
-
-	// The symlink in the staging dir must also be created.
-	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	if _, err := os.Lstat(stagingTokenPath); err != nil {
-		t.Errorf("staging token symlink must exist after autocreate: %v", err)
-	}
-}
-
-// TestPrepareSandboxExecHome_PiOAuthNonPiHarnessNoOp verifies that when
-// Harness != "pi", PrepareSandboxExecHome does NOT create
-// <stagingHome>/.pi/agent and does NOT touch ~/.pi/agent/atlassian-mcp-oauth.json.
-func TestPrepareSandboxExecHome_PiOAuthNonPiHarnessNoOp(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
-	fakeHome := newFakeHome(t)
-	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-
-	for _, harness := range []string{"", "other-harness"} {
-		t.Run("harness="+harness, func(t *testing.T) {
-			m := newSandboxExecManagerWithInstance(Config{
-				SessionName: "repo@non-pi-" + harness,
-				InstanceID:  "pi-oauth-non-pi-" + harness,
-				Harness:     harness,
-			})
-			stagingHome, err := m.PrepareSandboxExecHome()
-			if err != nil {
-				t.Fatalf("PrepareSandboxExecHome: %v", err)
-			}
-			t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
-
-			// <stagingHome>/.pi/agent must NOT be created for non-pi harness.
-			agentPath := filepath.Join(stagingHome, ".pi", "agent")
-			if _, err := os.Lstat(agentPath); err == nil {
-				t.Errorf("<stagingHome>/.pi/agent must not exist for harness=%q", harness)
-			}
-
-			// ~/.pi/agent/atlassian-mcp-oauth.json must NOT be created.
-			hostTokenPath := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-			if _, err := os.Stat(hostTokenPath); err == nil {
-				t.Errorf("host token file must not be created for harness=%q", harness)
-			}
-		})
-	}
-}
-
-// TestPrepareSandboxExecHome_PiOAuthIdempotent verifies that calling
-// PrepareSandboxExecHome twice on the same staging HOME leaves the symlink
-// at <stagingHome>/.pi/agent/atlassian-mcp-oauth.json valid and pointing at
-// the same host path; no error is returned on the second call.
-func TestPrepareSandboxExecHome_PiOAuthIdempotent(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("PI OAuth token staging is Darwin-only")
-	}
-	fakeHome := newFakeHome(t)
-
-	m := newSandboxExecManagerWithInstance(Config{
-		SessionName: "repo@pi-oauth-idem",
-		InstanceID:  "pi-oauth-idempotent-test",
-		Harness:     "pi",
-	})
-
-	// First call.
-	stagingHome, err := m.PrepareSandboxExecHome()
-	if err != nil {
-		t.Fatalf("first PrepareSandboxExecHome: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.RemoveAll(stagingHome)
-		_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
-	})
-
-	wantTarget := filepath.Join(fakeHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	getTarget := func() string {
-		t.Helper()
-		target, err := os.Readlink(filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"))
-		if err != nil {
-			t.Fatalf("Readlink after first call: %v", err)
+	for _, target := range targets {
+		if target.ResolvedPath == resolvedToken {
+			t.Errorf("collectStagingHomeSymlinkTargets emitted the pi oauth token target %q — staging should be gone (#2245)", resolvedToken)
 		}
-		return target
 	}
-	firstTarget := getTarget()
-	if firstTarget != wantTarget {
-		t.Errorf("first call: symlink target = %q, want %q", firstTarget, wantTarget)
-	}
+}
 
-	// Second call — must not fail and symlink must still point at same host path.
-	_, err = m.PrepareSandboxExecHome()
+// TestPrepareSandboxExecHome_PiOAuthHostAbsent_NoTouch verifies that with the
+// 3d staging step gone, PrepareSandboxExecHome no longer creates ~/.pi/agent
+// or touches the host token file when they are absent (a fresh machine). The
+// host dir is created at spawn time by EnsurePIAgentConfigDir instead, and
+// the Atlassian MCP extension creates the token file itself on first login
+// (the §6a subpath grant covers the create).
+func TestPrepareSandboxExecHome_PiOAuthHostAbsent_NoTouch(t *testing.T) {
+	fakeHome := newFakeHome(t)
+	_ = os.RemoveAll(filepath.Join(fakeHome, ".pi"))
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@pi-oauth-host-absent",
+		InstanceID:  "pi-oauth-host-absent-test",
+		Harness:     "pi",
+	})
+	stagingHome, err := m.PrepareSandboxExecHome()
 	if err != nil {
-		t.Fatalf("second PrepareSandboxExecHome: %v", err)
+		t.Fatalf("PrepareSandboxExecHome with host ~/.pi absent: %v", err)
 	}
-	secondTarget := getTarget()
-	if secondTarget != wantTarget {
-		t.Errorf("second call: symlink target = %q, want %q", secondTarget, wantTarget)
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// Host ~/.pi must NOT have been created by the staging builder.
+	if _, statErr := os.Stat(filepath.Join(fakeHome, ".pi")); statErr == nil {
+		t.Errorf("host ~/.pi was created by PrepareSandboxExecHome — the 3d host-touch is gone (#2245); EnsurePIAgentConfigDir owns host-dir creation")
+	}
+	// And no staging .pi entry either.
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".pi")); lstatErr == nil {
+		t.Errorf("staging .pi entry should NOT exist (removed in #2245, Step 3d)")
 	}
 }
 
@@ -1823,10 +1718,12 @@ func TestPrepareSandboxExecHome_IdempotentReCreation(t *testing.T) {
 		t.Errorf("staging HOME changed between calls: %q != %q", stagingHome1, stagingHome2)
 	}
 
-	// Verify that the .cache/nix symlink is still valid after re-creation.
-	nixLink := filepath.Join(stagingHome2, ".cache", "nix")
-	if _, err := os.Lstat(nixLink); err != nil {
-		t.Errorf(".cache/nix not present after re-creation: %v", err)
+	// Verify that the .ssh/access-key symlink is still valid after
+	// re-creation (the .ssh entries are the only staging symlinks left
+	// post-#2245).
+	accessKeyLink := filepath.Join(stagingHome2, ".ssh", "access-key")
+	if _, err := os.Lstat(accessKeyLink); err != nil {
+		t.Errorf(".ssh/access-key not present after re-creation: %v", err)
 	}
 }
 
@@ -1895,8 +1792,10 @@ func TestSandboxExecCleanup_RemovesStagingHome(t *testing.T) {
 }
 
 // TestGenerateProfile_ProfileIncludesSymlinkTargetAllows verifies that the
-// profile emitted by generateProfile includes (allow file-read* (literal ...))
-// rules for symlink targets in the staging HOME.
+// profile emitted by generateProfile includes read-only allow rules for the
+// resolved targets of the remaining staging symlinks (.ssh/* — post-#2245
+// the only staging surface left), and that none of them lands in a
+// file-write* block.
 func TestGenerateProfile_ProfileIncludesSymlinkTargetAllows(t *testing.T) {
 	fakeHome := newFakeHome(t)
 
@@ -1918,44 +1817,32 @@ func TestGenerateProfile_ProfileIncludesSymlinkTargetAllows(t *testing.T) {
 
 	profile := generateProfile(m)
 
-	// The profile must contain (allow file-read* for RO targets (e.g. SSH keys)
-	// and (allow file-read* file-write* for RW targets (e.g. .cache/bun).
 	if !strings.Contains(profile, "(allow file-read*") {
 		t.Errorf("profile missing (allow file-read* ...) clause; full profile:\n%s", profile)
 	}
 
-	// .cache/bun, .cache/nix, .mcp-auth are RW — the profile must grant
-	// file-write* on their resolved targets. (.claude is gone since #2243:
-	// claude-code reads/writes ~/.config/claude via CLAUDE_CONFIG_DIR and
-	// generateProfile grants that path directly — see
-	// TestGenerateProfile_ClaudeConfigDirRWSubpathRule.)
-	rwPaths := []string{
-		filepath.Join(fakeHome, ".cache", "bun"),
-		filepath.Join(fakeHome, ".cache", "nix"),
-		filepath.Join(fakeHome, ".mcp-auth"),
-	}
-	for _, rwPath := range rwPaths {
-		resolved, evalErr := filepath.EvalSymlinks(rwPath)
+	// The .ssh staging symlinks resolve to the fixture key files; each
+	// resolved target must appear as an RO (literal ...) — NOT inside a
+	// file-write* block.
+	for _, name := range []string{"prismatic-koi-ed25519", "known_hosts"} {
+		resolved, evalErr := filepath.EvalSymlinks(filepath.Join(fakeHome, ".ssh", name))
 		if evalErr != nil {
-			// Path may not be in staging home for this test — skip.
-			continue
+			t.Fatalf("fixture: EvalSymlinks(.ssh/%s): %v", name, evalErr)
 		}
-		// Find the resolved path in the profile and verify file-write* precedes it
-		// in the same allow block.
-		idx := strings.Index(profile, resolved)
+		literalRule := "(literal " + quoteSBPL(resolved) + ")"
+		idx := strings.Index(profile, literalRule)
 		if idx < 0 {
-			t.Errorf("RW path %q (resolved: %q) missing from profile;\nfull profile:\n%s", rwPath, resolved, profile)
+			t.Errorf("resolved .ssh/%s target %q missing from profile;\nfull profile:\n%s", name, resolved, profile)
 			continue
 		}
-		// Look backward for the nearest (allow ... clause.
 		clauseStart := strings.LastIndex(profile[:idx], "(allow ")
 		if clauseStart < 0 {
-			t.Errorf("RW path %q: no preceding (allow clause found in profile", rwPath)
+			t.Errorf("resolved .ssh/%s target: no preceding (allow clause found", name)
 			continue
 		}
 		clause := profile[clauseStart:idx]
-		if !strings.Contains(clause, "file-write*") {
-			t.Errorf("RW path %q is present in profile but NOT inside a file-write* allow block;\nclause: %q\nfull profile:\n%s", rwPath, clause, profile)
+		if strings.Contains(clause, "file-write*") {
+			t.Errorf(".ssh/%s target %q sits inside a file-write* allow block — staging symlink targets must be read-only (post-#2245 there are no RW staging targets);\nclause: %q", name, resolved, clause)
 		}
 	}
 }
@@ -2309,6 +2196,197 @@ func TestGenerateProfile_ClaudeConfigDirRWSubpathRule(t *testing.T) {
 	}
 	if !strings.Contains(clause, "file-read*") {
 		t.Errorf("~/.config/claude allow clause lacks file-read*; clause: %q", clause)
+	}
+}
+
+// TestGenerateProfile_RWRealPathGrants3e verifies that generateProfile emits
+// the section-5e RW grant block on the real host paths for ~/.cache/nix,
+// ~/.cache/bun, ~/.npm, and ~/.mcp-auth (issue #2245, Step 3e of #2132).
+// The block replaces the dropped RW staging symlinks; none of the paths is
+// sops-backed, so this grant — not the #2211 allowlist — is the sole
+// in-sandbox capability.
+//
+// The block must be emitted even when none of the dirs exists on the host —
+// sandbox-exec silently ignores (subpath ...) rules for non-existent paths,
+// and fresh machines (e.g. no ~/.mcp-auth) must not lose the grant shape.
+func TestGenerateProfile_RWRealPathGrants3e(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	// Deliberately create NONE of the four dirs — emission is unconditional.
+
+	m := newSandboxExecManager(Config{SessionName: "repo@3e-grants"})
+	profile := generateProfile(m)
+
+	wantBlock := "(allow file-read* file-write* file-test-existence file-read-metadata\n" +
+		"  (subpath " + quoteSBPL(filepath.Join(fakeHome, ".cache", "nix")) + ")\n" +
+		"  (subpath " + quoteSBPL(filepath.Join(fakeHome, ".cache", "bun")) + ")\n" +
+		"  (subpath " + quoteSBPL(filepath.Join(fakeHome, ".npm")) + ")\n" +
+		"  (subpath " + quoteSBPL(filepath.Join(fakeHome, ".mcp-auth")) + "))\n"
+	if !strings.Contains(profile, wantBlock) {
+		t.Errorf("profile missing the 3e RW grant block:\n%s\nfull profile:\n%s", wantBlock, profile)
+	}
+}
+
+// TestGenerateProfile_RORealPathGrants3f verifies that generateProfile emits
+// the section-5f RO grant block on the real host paths for
+// ~/.cache/prism/clipboard and ~/.config/prism/agents (issue #2245, Step 3f
+// of #2132). The block replaces the dropped RO staging symlinks. It must be
+// read-only — RO must not silently become RW — and emitted even when the
+// dirs do not exist on the host.
+func TestGenerateProfile_RORealPathGrants3f(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	// Deliberately create NEITHER dir — emission is unconditional.
+
+	m := newSandboxExecManager(Config{SessionName: "repo@3f-grants"})
+	profile := generateProfile(m)
+
+	wantBlock := "(allow file-read* file-test-existence\n" +
+		"  (subpath " + quoteSBPL(filepath.Join(fakeHome, ".cache", "prism", "clipboard")) + ")\n" +
+		"  (subpath " + quoteSBPL(filepath.Join(fakeHome, ".config", "prism", "agents")) + "))\n"
+	if !strings.Contains(profile, wantBlock) {
+		t.Errorf("profile missing the 3f RO grant block:\n%s\nfull profile:\n%s", wantBlock, profile)
+	}
+
+	// RO means RO: neither path may appear inside a block that carries
+	// file-write*.
+	for _, path := range []string{
+		filepath.Join(fakeHome, ".cache", "prism", "clipboard"),
+		filepath.Join(fakeHome, ".config", "prism", "agents"),
+	} {
+		rule := "(subpath " + quoteSBPL(path) + ")"
+		idx := 0
+		for {
+			rel := strings.Index(profile[idx:], rule)
+			if rel < 0 {
+				break
+			}
+			at := idx + rel
+			clauseStart := strings.LastIndex(profile[:at], "(allow ")
+			if clauseStart >= 0 && strings.Contains(profile[clauseStart:at], "file-write*") {
+				t.Errorf("3f path %q appears inside a file-write* allow block — RO must not become RW;\nclause: %q", path, profile[clauseStart:at])
+			}
+			idx = at + len(rule)
+		}
+	}
+}
+
+// TestGenerateProfile_NixProfileROGrant verifies the section-5g grant for
+// ~/.nix-profile (issue #2245, Step 3f of #2132). ~/.nix-profile is a
+// symlink on the host, and SBPL filters evaluate the resolved target for
+// open-class operations, so the grant must carry BOTH a literal allow on the
+// symlink node (readlink/lstat) and an RO rule on the EvalSymlinks-resolved
+// target (reads through the link). Both must be read-only.
+func TestGenerateProfile_NixProfileROGrant(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Mirror the real host shape: ~/.nix-profile → a real directory.
+	profileTarget := filepath.Join(fakeHome, "nix-profile-target")
+	if err := os.MkdirAll(profileTarget, 0o700); err != nil {
+		t.Fatalf("create profile target: %v", err)
+	}
+	nixProfile := filepath.Join(fakeHome, ".nix-profile")
+	if err := os.Symlink(profileTarget, nixProfile); err != nil {
+		t.Fatalf("symlink ~/.nix-profile: %v", err)
+	}
+
+	m := newSandboxExecManager(Config{SessionName: "repo@nix-profile-grant"})
+	profile := generateProfile(m)
+
+	resolved, evalErr := filepath.EvalSymlinks(nixProfile)
+	if evalErr != nil {
+		t.Fatalf("fixture: EvalSymlinks(~/.nix-profile): %v", evalErr)
+	}
+	wantBlock := "(allow file-read* file-test-existence\n" +
+		"  (literal " + quoteSBPL(nixProfile) + ")\n" +
+		"  (subpath " + quoteSBPL(resolved) + "))\n"
+	if !strings.Contains(profile, wantBlock) {
+		t.Errorf("profile missing the 5g nix-profile RO block (literal link node + resolved subpath):\n%s\nfull profile:\n%s", wantBlock, profile)
+	}
+
+	// Neither the link node nor the resolved target may sit in a
+	// file-write* block.
+	for _, rule := range []string{
+		"(literal " + quoteSBPL(nixProfile) + ")",
+		"(subpath " + quoteSBPL(resolved) + ")",
+	} {
+		idx := strings.Index(profile, rule)
+		if idx < 0 {
+			continue // already reported above
+		}
+		clauseStart := strings.LastIndex(profile[:idx], "(allow ")
+		if clauseStart >= 0 && strings.Contains(profile[clauseStart:idx], "file-write*") {
+			t.Errorf("nix-profile rule %q appears inside a file-write* allow block — must be RO", rule)
+		}
+	}
+}
+
+// TestGenerateProfile_NixProfileAbsent_LiteralStillEmitted covers the
+// fresh-machine edge case for section 5g: when ~/.nix-profile does not exist
+// on the host, EvalSymlinks fails, no resolved-target rule is emitted, and
+// the literal allow on the (future) symlink node is still present — profile
+// generation must not break (sandbox-exec ignores rules for non-existent
+// paths).
+func TestGenerateProfile_NixProfileAbsent_LiteralStillEmitted(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	// No ~/.nix-profile created.
+
+	m := newSandboxExecManager(Config{SessionName: "repo@nix-profile-absent"})
+	profile := generateProfile(m)
+
+	nixProfile := filepath.Join(fakeHome, ".nix-profile")
+	wantBlock := "(allow file-read* file-test-existence\n" +
+		"  (literal " + quoteSBPL(nixProfile) + "))\n"
+	if !strings.Contains(profile, wantBlock) {
+		t.Errorf("profile missing the literal-only 5g block when ~/.nix-profile is absent:\n%s\nfull profile:\n%s", wantBlock, profile)
+	}
+}
+
+// TestPrepareSandboxExec_MinimalHomeNoOptionalDirs is the absent-host-dirs
+// edge-case AC for issue #2245: on a host with NONE of the 3d/3e/3f source
+// dirs (fresh machine — no ~/.mcp-auth, ~/.npm, caches, ~/.nix-profile,
+// ~/.pi, prism config), full session prep (staging HOME + work dir + profile
+// write) must succeed and the generated profile must still carry the 3e/3f
+// grant blocks.
+func TestPrepareSandboxExec_MinimalHomeNoOptionalDirs(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	m := newSandboxExecManager(Config{
+		SessionName:   "repo@minimal-home",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14011,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if stagingHome, err := m.sandboxExecHomePath(); err == nil {
+			_ = os.RemoveAll(stagingHome)
+		}
+	})
+
+	args, err := m.PrepareSandboxExec()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExec on a minimal home must succeed: %v", err)
+	}
+	if len(args) < 3 {
+		t.Fatalf("unexpected args shape: %v", args)
+	}
+	profileBytes, readErr := os.ReadFile(args[2])
+	if readErr != nil {
+		t.Fatalf("read generated profile: %v", readErr)
+	}
+	profile := string(profileBytes)
+	for _, want := range []string{
+		"(subpath " + quoteSBPL(filepath.Join(fakeHome, ".mcp-auth")) + ")",
+		"(subpath " + quoteSBPL(filepath.Join(fakeHome, ".npm")) + ")",
+		"(subpath " + quoteSBPL(filepath.Join(fakeHome, ".config", "prism", "agents")) + ")",
+		"(literal " + quoteSBPL(filepath.Join(fakeHome, ".nix-profile")) + ")",
+	} {
+		if !strings.Contains(profile, want) {
+			t.Errorf("minimal-home profile missing %s;\nfull profile:\n%s", want, profile)
+		}
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_cache_writable_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_cache_writable_darwin_test.go
@@ -23,16 +23,15 @@ package integration_test
 //	  (subpath "~/.aws/sso")
 //	  (subpath "~/.aws/cli"))
 //
-// Additionally, collectStagingHomeSymlinkTargets previously did not list
-// .aws/sso or .aws/cli in writableStagingPaths, so the per-symlink allow
-// block emitted the resolved host paths in the RO group. The fix adds
-// them to writableStagingPaths so the per-symlink allow emits file-write*
-// for their resolved targets too.
+// Since #2245 (Step 3e of #2132) the staging HOME no longer symlinks
+// .aws/sso or .aws/cli at all — the carve-out rules above are the SOLE
+// in-sandbox capability for the two cache dirs, exercised at the real host
+// paths.
 //
 // This file tests:
 //
 //  1. Positive case (SSO write): with the production profile, writing a
-//     file inside ~/.aws/sso via the staging HOME symlink chain succeeds.
+//     file inside the real ~/.aws/sso succeeds.
 //
 //  2. Negative case (SSO write denied without file-write*): removing the
 //     file-write* from the carve-out causes the same write to fail —
@@ -50,11 +49,10 @@ package integration_test
 //     ~/.aws subtree.
 //
 //  6. Edge-case: when ~/.aws/cli and ~/.aws/sso do NOT exist on the host
-//     at session-spawn time, PrepareSandboxExecHome creates no symlinks for
-//     them (symlinkIfExists skips missing sources), the generated profile
-//     still loads under /usr/bin/sandbox-exec, and a non-AWS workload exits 0.
-//     This validates that the carve-out rules (which reference non-existent
-//     paths) do not break sandbox initialisation — sandbox-exec silently ignores
+//     at session-spawn time, the generated profile still loads under
+//     /usr/bin/sandbox-exec and a non-AWS workload exits 0. This validates
+//     that the carve-out rules (which reference non-existent paths) do not
+//     break sandbox initialisation — sandbox-exec silently ignores
 //     (subpath ...) rules for paths that do not exist on the host.
 //
 // Shared helpers (requireSandboxExec, requireNixBash, newProfileManagerWithBareRoot,
@@ -84,12 +82,10 @@ const awsCacheCLIWriteContent = "prism-1558-aws-cli-write-sentinel"
 //
 //  1. Creates ~/.aws/sso under the real user HOME (so the write attempt
 //     targets the deny-covered path, not /private/var/folders).
-//  2. Calls PrepareSandboxExecHome so the staging HOME contains
-//     <stagingHome>/.aws/sso → ~/.aws/sso.
-//  3. Generates the production profile (which emits file-read* file-write*
+//  2. Generates the production profile (which emits file-read* file-write*
 //     for both ~/.aws/sso and ~/.aws/cli).
-//  4. Writes a file inside ~/.aws/sso via the staging HOME symlink from
-//     inside the sandbox and asserts exit 0.
+//  3. Writes a file inside the real ~/.aws/sso from inside the sandbox and
+//     asserts exit 0 (no staging symlink involved — #2245).
 func TestSandboxExecProfile_AWSSSOWritable(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -107,12 +103,6 @@ func TestSandboxExecProfile_AWSSSOWritable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// Verify the staging HOME has the sso symlink before generating the profile.
-	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
-	if _, lstatErr := os.Lstat(ssoLink); lstatErr != nil {
-		t.Fatalf("staging HOME must have a .aws/sso symlink after PrepareSandboxExecHome: %v", lstatErr)
-	}
-
 	prepared, _ := preparePositiveProfile(t, m)
 
 	// The carve-out must include file-write* in the generated profile.
@@ -126,9 +116,9 @@ func TestSandboxExecProfile_AWSSSOWritable(t *testing.T) {
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	// Write a sentinel file inside <stagingHome>/.aws/sso from inside the sandbox.
-	// The write targets the host path via the staging HOME symlink.
-	writeTarget := filepath.Join(ssoLink, ".prism-1558-write-test")
+	// Write a sentinel file inside the REAL ~/.aws/sso from inside the
+	// sandbox — the carve-out grants the real path directly (#2245).
+	writeTarget := filepath.Join(ssoDir, ".prism-1558-write-test")
 	t.Cleanup(func() { _ = os.Remove(writeTarget) })
 
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
@@ -149,8 +139,6 @@ func TestSandboxExecProfile_AWSSSOWritable(t *testing.T) {
 	if !strings.Contains(string(got), awsCacheSSOWriteContent) {
 		t.Errorf("written file does not contain expected content.\nGot: %s", string(got))
 	}
-
-	_ = ssoDir
 }
 
 // TestSandboxExecProfile_AWSSSOWriteDeniedWithoutFileWrite is the paired
@@ -174,8 +162,6 @@ func TestSandboxExecProfile_AWSSSOWriteDeniedWithoutFileWrite(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
-
 	// Remove file-write* from the carve-out allow block. The production
 	// profile emits:
 	//   (allow file-read* file-write*
@@ -189,7 +175,7 @@ func TestSandboxExecProfile_AWSSSOWriteDeniedWithoutFileWrite(t *testing.T) {
 		)
 	})
 
-	writeTarget := filepath.Join(ssoLink, ".prism-1558-write-test-neg")
+	writeTarget := filepath.Join(ssoDir, ".prism-1558-write-test-neg")
 	t.Cleanup(func() { _ = os.Remove(writeTarget) })
 
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
@@ -203,8 +189,6 @@ func TestSandboxExecProfile_AWSSSOWriteDeniedWithoutFileWrite(t *testing.T) {
 	} else {
 		t.Logf("ka pai — ~/.aws/sso write correctly denied without file-write* (exit: %v)", runErr)
 	}
-
-	_ = ssoDir
 }
 
 // TestSandboxExecProfile_AWSCLIWritable is the positive integration test for
@@ -226,11 +210,6 @@ func TestSandboxExecProfile_AWSCLIWritable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	cliLink := filepath.Join(stagingHome, ".aws", "cli")
-	if _, lstatErr := os.Lstat(cliLink); lstatErr != nil {
-		t.Fatalf("staging HOME must have a .aws/cli symlink after PrepareSandboxExecHome: %v", lstatErr)
-	}
-
 	prepared, _ := preparePositiveProfile(t, m)
 
 	// The carve-out must include file-write* and the cli path.
@@ -247,7 +226,7 @@ func TestSandboxExecProfile_AWSCLIWritable(t *testing.T) {
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	writeTarget := filepath.Join(cliLink, ".prism-1558-write-test")
+	writeTarget := filepath.Join(cliDir, ".prism-1558-write-test")
 	t.Cleanup(func() { _ = os.Remove(writeTarget) })
 
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
@@ -267,8 +246,6 @@ func TestSandboxExecProfile_AWSCLIWritable(t *testing.T) {
 	if !strings.Contains(string(got), awsCacheCLIWriteContent) {
 		t.Errorf("written file does not contain expected content.\nGot: %s", string(got))
 	}
-
-	_ = cliDir
 }
 
 // TestSandboxExecProfile_AWSCLIWriteDeniedWithoutFileWrite is the paired
@@ -291,8 +268,6 @@ func TestSandboxExecProfile_AWSCLIWriteDeniedWithoutFileWrite(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	cliLink := filepath.Join(stagingHome, ".aws", "cli")
-
 	mutatedPath := withMutatedProfile(t, m, func(p string) string {
 		return strings.ReplaceAll(p,
 			"(allow file-read* file-write*\n  (subpath "+sbplQuoteForTest(filepath.Join(realUserHome(t), ".aws", "sso")),
@@ -300,7 +275,7 @@ func TestSandboxExecProfile_AWSCLIWriteDeniedWithoutFileWrite(t *testing.T) {
 		)
 	})
 
-	writeTarget := filepath.Join(cliLink, ".prism-1558-write-test-neg")
+	writeTarget := filepath.Join(cliDir, ".prism-1558-write-test-neg")
 	t.Cleanup(func() { _ = os.Remove(writeTarget) })
 
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
@@ -314,8 +289,6 @@ func TestSandboxExecProfile_AWSCLIWriteDeniedWithoutFileWrite(t *testing.T) {
 	} else {
 		t.Logf("ka pai — ~/.aws/cli write correctly denied without file-write* (exit: %v)", runErr)
 	}
-
-	_ = cliDir
 }
 
 // TestSandboxExecProfile_AWSOutsideCarveoutDenied is the security test for
@@ -382,13 +355,12 @@ func TestSandboxExecProfile_AWSOutsideCarveoutDenied(t *testing.T) {
 // exist on the host at session-spawn time, the generated profile still loads
 // under /usr/bin/sandbox-exec and a non-AWS workload exits 0.
 //
-// PrepareSandboxExecHome uses symlinkIfExists for the sso/ and cli/ entries,
-// so when the host directories are absent no symlinks are created — but
-// generateProfile still unconditionally emits the carve-out rules with the
-// host paths (filepath.Join(home, ".aws", "sso") and ".aws", "cli").
-// sandbox-exec silently ignores (subpath ...) rules for paths that do not
-// exist, so the profile must still load and allow a simple non-AWS workload
-// (echo) to succeed.
+// Since #2245 PrepareSandboxExecHome never creates sso/cli staging entries
+// (present or not) — but generateProfile still unconditionally emits the
+// carve-out rules with the host paths (filepath.Join(home, ".aws", "sso")
+// and ".aws", "cli"). sandbox-exec silently ignores (subpath ...) rules for
+// paths that do not exist, so the profile must still load and allow a
+// simple non-AWS workload (echo) to succeed.
 //
 // This guards against a regression where the carve-out rules cause sandbox
 // initialisation to fail when the host has no ~/.aws/sso or ~/.aws/cli.
@@ -429,13 +401,10 @@ func TestSandboxExecProfile_AWSCarveoutAbsent_ProfileLoads(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// Verify that no sso/cli symlinks were created in the staging HOME
-	// (they should be absent since symlinkIfExists skips missing sources).
-	for _, rel := range []string{".aws/sso", ".aws/cli"} {
-		link := filepath.Join(stagingHome, rel)
-		if _, lstatErr := os.Lstat(link); lstatErr == nil {
-			t.Errorf("staging HOME has %s symlink even though host dir is absent — symlinkIfExists should have skipped it", rel)
-		}
+	// Verify that no .aws staging entry exists at all (the sso/cli staging
+	// symlinks were removed wholesale in #2245).
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".aws")); lstatErr == nil {
+		t.Errorf("staging HOME has a .aws entry — removed in #2245, must not be recreated")
 	}
 
 	prepared, _ := preparePositiveProfile(t, m)

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
@@ -3,25 +3,23 @@
 package integration_test
 
 // sandbox_exec_aws_sso_darwin_test.go — integration coverage for the
-// ~/.aws/sso and ~/.aws/cli carve-outs in the SBPL profile (issue #1380).
+// ~/.aws/sso and ~/.aws/cli carve-outs in the SBPL profile (issue #1380;
+// real-path-only since #2245, Step 3e of #2132).
 //
 // The SBPL profile contains a broad (deny file-read* file-write* (subpath
-// ~/.aws)) to prevent host credential leakage. However, the staging HOME
-// creates symlinks for ~/.aws/sso and ~/.aws/cli pointing at the host paths
-// so that AWS SSO auth and kubectl (which reads SSO tokens) work inside the
-// sandbox.
-//
-// generateProfile emits explicit (allow file-read* (subpath ~/.aws/sso)) and
-// (allow file-read* (subpath ~/.aws/cli)) rules after the broad deny. In SBPL,
-// more-specific rules override broader ones, so these carve-outs let the
-// sandbox traverse into those two subdirs while the rest of ~/.aws remains
-// denied.
+// ~/.aws)) to prevent host credential leakage. generateProfile emits
+// explicit (allow ... (subpath ~/.aws/sso)) and (allow ... (subpath
+// ~/.aws/cli)) rules after the broad deny. In SBPL, more-specific rules
+// override broader ones, so these carve-outs let the sandbox access exactly
+// those two subdirs AT THEIR REAL HOST PATHS while the rest of ~/.aws
+// remains denied. Since #2245 the staging HOME no longer symlinks the two
+// dirs — the carve-outs are the sole in-sandbox capability for them.
 //
 // This file tests:
 //
 //  1. Positive case: when ~/.aws/sso exists on the host, a sentinel file
-//     inside it is readable from inside the sandbox via the staging HOME
-//     symlink chain.
+//     inside it is readable from inside the sandbox at the real host path
+//     (and the staging HOME contains no .aws entry).
 //
 //  2. Negative case: removing the (subpath ~/.aws/sso) carve-out from the
 //     profile causes the same read to fail — proving the positive is not
@@ -154,11 +152,11 @@ func prepareCLISentinel(t *testing.T) (cliDir, sentinelPath string) {
 // the ~/.aws/sso carve-out (issue #1380). It:
 //
 //  1. Creates ~/.aws/sso and plants a sentinel file inside it.
-//  2. Calls PrepareSandboxExecHome so the staging HOME contains
-//     <stagingHome>/.aws/sso → ~/.aws/sso.
+//  2. Calls PrepareSandboxExecHome and asserts the staging HOME contains
+//     no .aws entry (the sso/cli staging symlinks were removed in #2245).
 //  3. Generates the production profile (which emits the carve-out rule).
-//  4. Reads the sentinel via the staging HOME symlink chain from inside
-//     the sandbox and asserts exit 0 and correct content.
+//  4. Reads the sentinel at the REAL host path from inside the sandbox and
+//     asserts exit 0 and correct content.
 func TestSandboxExecProfile_AWSSSOReadable(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -178,10 +176,11 @@ func TestSandboxExecProfile_AWSSSOReadable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// Verify the staging HOME has the sso symlink before generating the profile.
-	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
-	if _, lstatErr := os.Lstat(ssoLink); lstatErr != nil {
-		t.Fatalf("staging HOME must have a .aws/sso symlink after PrepareSandboxExecHome: %v", lstatErr)
+	// The staging HOME must contain NO .aws entry — the sso/cli staging
+	// symlinks were removed in #2245 (Step 3e); the carve-out at the real
+	// path is the sole capability.
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".aws")); lstatErr == nil {
+		t.Fatalf("staging HOME has a .aws entry — the sso/cli staging symlinks were removed in #2245 and must not be recreated")
 	}
 
 	prepared, _ := preparePositiveProfile(t, m)
@@ -201,11 +200,10 @@ func TestSandboxExecProfile_AWSSSOReadable(t *testing.T) {
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	// Read the sentinel via <stagingHome>/.aws/sso/<sentinel> inside the sandbox.
-	sentinelInSandbox := filepath.Join(ssoLink, filepath.Base(sentinelPath))
+	// Read the sentinel at its REAL host path inside the sandbox.
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(sentinelInSandbox))
+		"cat "+shQuote(sentinelPath))
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
 		t.Fatalf("read ~/.aws/sso sentinel failed under production profile with carve-out.\n"+
@@ -237,8 +235,6 @@ func TestSandboxExecProfile_AWSSSODeniedWithoutCarveout(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	ssoLink := filepath.Join(stagingHome, ".aws", "sso")
-
 	home, _ := os.UserHomeDir()
 	awsSSOPath := filepath.Join(home, ".aws", "sso")
 
@@ -250,10 +246,9 @@ func TestSandboxExecProfile_AWSSSODeniedWithoutCarveout(t *testing.T) {
 		return strings.ReplaceAll(p, carveoutLine, "")
 	})
 
-	sentinelInSandbox := filepath.Join(ssoLink, filepath.Base(sentinelPath))
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(sentinelInSandbox))
+		"cat "+shQuote(sentinelPath))
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
 		t.Errorf("read ~/.aws/sso sentinel succeeded WITHOUT the (subpath %q) carve-out rule.\n"+
@@ -283,9 +278,9 @@ func TestSandboxExecProfile_AWSCLIReadable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	cliLink := filepath.Join(stagingHome, ".aws", "cli")
-	if _, lstatErr := os.Lstat(cliLink); lstatErr != nil {
-		t.Fatalf("staging HOME must have a .aws/cli symlink after PrepareSandboxExecHome: %v", lstatErr)
+	// The staging HOME must contain NO .aws entry (see the sso positive).
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".aws")); lstatErr == nil {
+		t.Fatalf("staging HOME has a .aws entry — the sso/cli staging symlinks were removed in #2245 and must not be recreated")
 	}
 
 	prepared, _ := preparePositiveProfile(t, m)
@@ -300,10 +295,9 @@ func TestSandboxExecProfile_AWSCLIReadable(t *testing.T) {
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	sentinelInSandbox := filepath.Join(cliLink, filepath.Base(sentinelPath))
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(sentinelInSandbox))
+		"cat "+shQuote(sentinelPath))
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
 		t.Fatalf("read ~/.aws/cli sentinel failed under production profile with carve-out.\n"+
@@ -335,8 +329,6 @@ func TestSandboxExecProfile_AWSCLIDeniedWithoutCarveout(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	cliLink := filepath.Join(stagingHome, ".aws", "cli")
-
 	home, _ := os.UserHomeDir()
 	awsCLIPath := filepath.Join(home, ".aws", "cli")
 
@@ -345,10 +337,9 @@ func TestSandboxExecProfile_AWSCLIDeniedWithoutCarveout(t *testing.T) {
 		return strings.ReplaceAll(p, carveoutLine, "")
 	})
 
-	sentinelInSandbox := filepath.Join(cliLink, filepath.Base(sentinelPath))
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(sentinelInSandbox))
+		"cat "+shQuote(sentinelPath))
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
 		t.Errorf("read ~/.aws/cli sentinel succeeded WITHOUT the (subpath %q) carve-out rule.\n"+

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_aws_sso_darwin_test.go
@@ -330,11 +330,28 @@ func TestSandboxExecProfile_AWSCLIDeniedWithoutCarveout(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
 	home, _ := os.UserHomeDir()
+	awsSSOPath := filepath.Join(home, ".aws", "sso")
 	awsCLIPath := filepath.Join(home, ".aws", "cli")
 
-	carveoutLine := "  (subpath " + sbplQuoteForTest(awsCLIPath) + ")\n"
+	// The cli carve-out is the LAST entry of the carve-out allow block, so
+	// generateProfile emits it as `  (subpath "<cli>"))\n` — with the block's
+	// closing paren attached. A bare `  (subpath "<cli>")\n` substitution
+	// therefore never matches (withMutatedProfile's no-op detection catches
+	// exactly this). Strip the cli line by replacing the sso+cli tail of the
+	// block with an sso-only tail, keeping the block well-formed and removing
+	// ONLY the cli carve-out:
+	//
+	//   (allow file-read* file-write*        (allow file-read* file-write*
+	//     (subpath "<sso>")             →      (subpath "<sso>"))
+	//     (subpath "<cli>"))
+	//
+	// (The paired sso negative strips a middle line and needs no special
+	// handling.)
+	ssoLine := "  (subpath " + sbplQuoteForTest(awsSSOPath) + ")\n"
+	cliLastLine := "  (subpath " + sbplQuoteForTest(awsCLIPath) + "))\n"
+	ssoOnlyTail := "  (subpath " + sbplQuoteForTest(awsSSOPath) + "))\n"
 	mutatedPath := withMutatedProfile(t, m, func(p string) string {
-		return strings.ReplaceAll(p, carveoutLine, "")
+		return strings.ReplaceAll(p, ssoLine+cliLastLine, ssoOnlyTail)
 	})
 
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_pi_atlassian_oauth_darwin_test.go
@@ -3,40 +3,33 @@
 package integration_test
 
 // sandbox_exec_pi_atlassian_oauth_darwin_test.go — integration tests for the
-// PI Atlassian MCP OAuth token persistence via sandbox-exec symlink (issue #1597).
+// PI Atlassian MCP OAuth token capability at its REAL host path (Step 3d of
+// #2132, issue #2245; original staging mechanism: issue #1597).
 //
 // Background:
 //
 //	The Atlassian MCP extension stores OAuth tokens at
-//	homedir()/.pi/agent/atlassian-mcp-oauth.json. Inside a Darwin
-//	sandbox-exec pi session, $HOME is overridden to a per-session staging
-//	HOME, so writes to that path land in the staging dir and are destroyed
-//	when the session ends. The fix in PrepareSandboxExecHome (for Harness ==
-//	"pi" on Darwin):
-//
-//	  1. Creates <stagingHome>/.pi/agent/ as a real directory.
-//	  2. Touches ~/.pi/agent/atlassian-mcp-oauth.json on the host with mode
-//	     0600 if absent.
-//	  3. Symlinks <stagingHome>/.pi/agent/atlassian-mcp-oauth.json → the
-//	     real host path.
-//
-//	The SBPL profile already emits (allow file-read* file-write* ...
-//	(subpath ~/.pi/agent)) for pi sessions, so writes inside the sandbox go
-//	through the symlink to the real host path.
+//	homedir()/.pi/agent/atlassian-mcp-oauth.json. The former
+//	stagePIOAuthToken step touch-and-symlinked the file into the per-session
+//	staging HOME; #2245 removed it. The capability now collapses into the
+//	pi-gated RW (subpath ~/.pi/agent) grant (sandbox_exec.go section 6a):
+//	reads and writes of the token file at the REAL host path succeed
+//	in-sandbox, with no staging entry involved.
 //
 // These tests verify:
 //
 //  1. Positive: a bash command running inside sandbox-exec (with the
-//     production SBPL profile for Harness == "pi") writes JSON bytes to
-//     $HOME/.pi/agent/atlassian-mcp-oauth.json; those exact bytes are
-//     readable from the real host ~/.pi/agent/atlassian-mcp-oauth.json
-//     after sandbox-exec exits. This confirms the symlink write-through
-//     works end-to-end.
+//     production SBPL profile for Harness == "pi") writes JSON bytes
+//     directly to the real ~/.pi/agent/atlassian-mcp-oauth.json and reads
+//     them back; the bytes are visible on the host after sandbox-exec
+//     exits. The staging HOME is asserted to contain NO .pi entry.
 //
-//  2. Negative: when the symlink at <stagingHome>/.pi/agent/atlassian-mcp-oauth.json
-//     is removed (breaking the write-through), the same write either fails
-//     or does NOT appear at the real host path, proving the positive test
-//     is not a no-op. (Per docs/sandbox-exec-testing.md, issue #1192.)
+//  2. Negative (whole-block strip, per the #2243 lesson): removing the
+//     entire section-6a allow block makes the same write fail and nothing
+//     appears at the host path — proving the 6a grant is the load-bearing
+//     capability for the token file, not some broader rule.
+//
+// Per docs/sandbox-exec-testing.md (issue #1192).
 
 import (
 	"os"
@@ -50,8 +43,8 @@ import (
 )
 
 // newPIOAuthPersistenceManager creates a Manager configured for a pi-harness
-// session with a BareRoot (required for the pi agent dir subpath allow in the
-// SBPL profile).
+// session with a BareRoot (required for the BareRoot-ancestor allow block,
+// which grants the metadata traversal of $HOME that real-path access needs).
 func newPIOAuthPersistenceManager(t *testing.T) *container.Manager {
 	t.Helper()
 	instanceID := "integ-sbx-pi-atlassian-oauth-" + strings.ReplaceAll(t.Name(), "/", "-")
@@ -69,37 +62,21 @@ func newPIOAuthPersistenceManager(t *testing.T) *container.Manager {
 	return container.New(cfg)
 }
 
-// TestSandboxExecPIAtlassianOAuth_WriteThrough is the positive integration
-// test. It verifies that:
-//
-//  1. PrepareSandboxExecHome for Harness=="pi" creates a symlink at
-//     <stagingHome>/.pi/agent/atlassian-mcp-oauth.json pointing at the real
-//     host ~/.pi/agent/atlassian-mcp-oauth.json.
-//  2. A bash command inside sandbox-exec (using the production SBPL profile)
-//     can write JSON bytes to $HOME/.pi/agent/atlassian-mcp-oauth.json.
-//  3. Those exact bytes are readable from the real host path after sandbox-exec
-//     exits, confirming the symlink write-through is functional end-to-end.
-func TestSandboxExecPIAtlassianOAuth_WriteThrough(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("sandbox-exec is Darwin-only")
-	}
-	requireSandboxExec(t)
-	nixBash := requireNixBash(t)
-
+// stashHostAtlassianToken moves any existing real
+// ~/.pi/agent/atlassian-mcp-oauth.json out of the way for the duration of
+// the test and registers a cleanup that restores it. Returns the host token
+// path. The host ~/.pi/agent dir is created when absent (and that creation
+// is NOT cleaned up — it matches what EnsurePIAgentConfigDir does at spawn).
+func stashHostAtlassianToken(t *testing.T) string {
+	t.Helper()
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		t.Skipf("cannot determine user home: %v", err)
 	}
-
-	// Ensure ~/.pi/agent/ exists on the host so PrepareSandboxExecHome can
-	// create the host token file.
 	piAgentDir := filepath.Join(home, ".pi", "agent")
 	if mkErr := os.MkdirAll(piAgentDir, 0o700); mkErr != nil {
-		t.Fatalf("MkdirAll ~/.pi/agent: %v", mkErr)
+		t.Skipf("cannot create ~/.pi/agent for test: %v", mkErr)
 	}
-
-	// Stash any existing atlassian-mcp-oauth.json so we can restore it and
-	// so we start with a clean state for the write-through assertion.
 	hostTokenPath := filepath.Join(piAgentDir, "atlassian-mcp-oauth.json")
 	stashPath := hostTokenPath + ".integ-pi-atlassian-oauth-stash"
 	stashed := false
@@ -110,109 +87,42 @@ func TestSandboxExecPIAtlassianOAuth_WriteThrough(t *testing.T) {
 				_ = os.Remove(hostTokenPath)
 				_ = os.Rename(stashPath, hostTokenPath)
 			})
+		} else {
+			t.Skipf("cannot stash existing host token file: %v", renErr)
 		}
 	}
 	if !stashed {
 		t.Cleanup(func() { _ = os.Remove(hostTokenPath) })
 	}
-
-	m := newPIOAuthPersistenceManager(t)
-
-	stagingHome, err := m.PrepareSandboxExecHome()
-	if err != nil {
-		t.Fatalf("PrepareSandboxExecHome: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
-
-	// Verify the symlink exists in the staging HOME before running sandbox-exec.
-	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	linkTarget, readlinkErr := os.Readlink(stagingTokenPath)
-	if readlinkErr != nil {
-		t.Fatalf("staging token symlink not created by PrepareSandboxExecHome: %v", readlinkErr)
-	}
-	if linkTarget != hostTokenPath {
-		t.Fatalf("staging token symlink target = %q, want %q", linkTarget, hostTokenPath)
-	}
-
-	prepared, _ := preparePositiveProfile(t, m)
-
-	// Confirm the profile contains the (subpath ~/.pi/agent) rule.
-	piAgentSubpath := "(subpath " + sbplQuoteForTest(piAgentDir) + ")"
-	if !strings.Contains(prepared.content, piAgentSubpath) {
-		t.Fatalf("generated profile does not contain %q\nProfile:\n%s", piAgentSubpath, prepared.content)
-	}
-
-	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
-
-	// Use a unique sentinel value for this test run so we can assert the
-	// specific bytes were written (not a leftover from a previous run).
-	const sentinel = `{"access_token":"integ-pi-atlassian-oauth-positive-sentinel"}`
-
-	// Inside sandbox-exec with HOME=<stagingHome>, write the sentinel JSON to
-	// $HOME/.pi/agent/atlassian-mcp-oauth.json. The symlink routes the write
-	// through to the real host path.
-	script := "printf '%s' " + shQuote(sentinel) + " > " +
-		shQuote(filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"))
-	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
-		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
-	out, runErr := cmd.CombinedOutput()
-	if runErr != nil {
-		t.Fatalf("write to $HOME/.pi/agent/atlassian-mcp-oauth.json inside sandbox failed.\n"+
-			"Exit: %v\nOutput: %s\nProfile: %s\nStagingTokenPath: %s",
-			runErr, string(out), testProfilePath, stagingTokenPath)
-	}
-
-	// Assert the sentinel bytes are readable from the real host path.
-	got, readErr := os.ReadFile(hostTokenPath)
-	if readErr != nil {
-		t.Fatalf("cannot read host token file %s after sandbox write: %v", hostTokenPath, readErr)
-	}
-	if string(got) != sentinel {
-		t.Errorf("host token content = %q, want %q\n"+
-			"(write inside sandbox-exec did not reach the host path via symlink)",
-			string(got), sentinel)
-	}
+	return hostTokenPath
 }
 
-// TestSandboxExecPIAtlassianOAuth_WriteThroughBroken is the paired negative
-// test. It removes the symlink at <stagingHome>/.pi/agent/atlassian-mcp-oauth.json
-// (breaking the write-through) and asserts that the same write either fails or
-// does NOT appear at the real host path. This proves the positive test is not
-// green by accident — the symlink is the specific mechanism that routes writes
-// from the staging HOME to the host.
-func TestSandboxExecPIAtlassianOAuth_WriteThroughBroken(t *testing.T) {
+// piAgentSubpathBlock returns the exact section-6a allow block emitted by
+// generateProfile for the real ~/.pi/agent dir. Used for the presence
+// assertion in the positive test and the whole-block strip in the negative.
+func piAgentSubpathBlock(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	piAgentDir := filepath.Join(home, ".pi", "agent")
+	return "(allow file-read* file-write* file-test-existence file-read-metadata\n" +
+		"  (subpath " + sbplQuoteForTest(piAgentDir) + "))\n"
+}
+
+// TestSandboxExecPIAtlassianOAuth_RealPathReadWrite is the positive
+// integration test for Step 3d of #2132: the oauth token file is read-write
+// in-sandbox at its REAL host path via the section-6a (subpath ~/.pi/agent)
+// grant, with no staging symlink involved.
+func TestSandboxExecPIAtlassianOAuth_RealPathReadWrite(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
 	}
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		t.Skipf("cannot determine user home: %v", err)
-	}
-
-	piAgentDir := filepath.Join(home, ".pi", "agent")
-	if mkErr := os.MkdirAll(piAgentDir, 0o700); mkErr != nil {
-		t.Fatalf("MkdirAll ~/.pi/agent: %v", mkErr)
-	}
-
-	// Stash any existing token file so we start clean.
-	hostTokenPath := filepath.Join(piAgentDir, "atlassian-mcp-oauth.json")
-	stashPath := hostTokenPath + ".integ-pi-atlassian-oauth-neg-stash"
-	stashed := false
-	if _, statErr := os.Lstat(hostTokenPath); statErr == nil {
-		if renErr := os.Rename(hostTokenPath, stashPath); renErr == nil {
-			stashed = true
-			t.Cleanup(func() {
-				_ = os.Remove(hostTokenPath)
-				_ = os.Rename(stashPath, hostTokenPath)
-			})
-		}
-	}
-	if !stashed {
-		t.Cleanup(func() { _ = os.Remove(hostTokenPath) })
-	}
+	hostTokenPath := stashHostAtlassianToken(t)
 
 	m := newPIOAuthPersistenceManager(t)
 
@@ -222,37 +132,92 @@ func TestSandboxExecPIAtlassianOAuth_WriteThroughBroken(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// Break the write-through: remove the symlink from the staging HOME.
-	// The directory entry <stagingHome>/.pi/agent/atlassian-mcp-oauth.json
-	// becomes absent; the sandbox write will either fail or create a file
-	// inside the ephemeral staging dir rather than at the host path.
-	stagingTokenPath := filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json")
-	if err := os.Remove(stagingTokenPath); err != nil {
-		t.Fatalf("remove staging token symlink: %v", err)
+	// The staging HOME must contain NO .pi entry — the 3d staging step is gone.
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".pi")); lstatErr == nil {
+		t.Fatalf("staging HOME has a .pi entry — the 3d touch-and-symlink staging step was removed in #2245 and must not be recreated")
 	}
 
 	prepared, _ := preparePositiveProfile(t, m)
+
+	// The production profile must carry the section-6a block — the sole
+	// capability for the token path.
+	block := piAgentSubpathBlock(t)
+	if !strings.Contains(prepared.content, block) {
+		t.Fatalf("generated profile does not contain the section-6a ~/.pi/agent RW block:\n%s\nProfile:\n%s", block, prepared.content)
+	}
+
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	const sentinel = `{"access_token":"integ-pi-atlassian-oauth-negative-sentinel"}`
-
-	// Allow the sandbox write to fail OR succeed into the staging dir — either
-	// outcome is acceptable for the negative test; what matters is that the
-	// host path does NOT contain the sentinel.
-	script := "printf '%s' " + shQuote(sentinel) + " > " +
-		shQuote(filepath.Join(stagingHome, ".pi", "agent", "atlassian-mcp-oauth.json"))
+	// Write JSON to the REAL host token path from inside the sandbox, then
+	// read it back in the same invocation.
+	const tokenJSON = `{"access_token":"prism-2245-3d-real-path-sentinel"}`
+	script := "printf '%s' " + shQuote(tokenJSON) + " > " + shQuote(hostTokenPath) +
+		" && cat " + shQuote(hostTokenPath)
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
-	_, _ = cmd.CombinedOutput() // ignore exit code — the sandbox may deny or permit the write
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("in-sandbox RW round-trip of the oauth token at its real path failed.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
+			runErr, string(out), testProfilePath, hostTokenPath)
+	}
+	if !strings.Contains(string(out), "prism-2245-3d-real-path-sentinel") {
+		t.Errorf("in-sandbox read did not return the written token bytes.\nGot: %s", string(out))
+	}
 
-	// The host token file must NOT contain the negative sentinel: without the
-	// symlink, the sandbox write cannot reach the host path.
-	got, readErr := os.ReadFile(hostTokenPath)
-	if readErr == nil && string(got) == sentinel {
-		t.Errorf("host token contains negative sentinel %q even though the staging symlink was removed.\n"+
-			"The positive test is not catching the write-through — investigate.\n"+
-			"Host token path: %s", sentinel, hostTokenPath)
+	// The bytes must be visible on the host after sandbox-exec exits.
+	hostBytes, readErr := os.ReadFile(hostTokenPath)
+	if readErr != nil {
+		t.Fatalf("host-side read of the token file after sandbox exit: %v", readErr)
+	}
+	if string(hostBytes) != tokenJSON {
+		t.Errorf("host token content = %q, want %q", string(hostBytes), tokenJSON)
+	}
+}
+
+// TestSandboxExecPIAtlassianOAuth_DeniedWithoutPiAgentGrant is the paired
+// negative test. It strips the ENTIRE section-6a allow block (whole-block
+// strip per the #2243 lesson — removing only the (subpath ...) line would
+// leave a filter-less allow-everything clause) and asserts the same write
+// fails and nothing lands at the host path — proving the 6a grant is
+// load-bearing for the token file.
+func TestSandboxExecPIAtlassianOAuth_DeniedWithoutPiAgentGrant(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	hostTokenPath := stashHostAtlassianToken(t)
+
+	m := newPIOAuthPersistenceManager(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	block := piAgentSubpathBlock(t)
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.Replace(p, block, "", 1)
+	})
+
+	const tokenJSON = `{"access_token":"prism-2245-3d-denied-sentinel"}`
+	script := "printf '%s' " + shQuote(tokenJSON) + " > " + shQuote(hostTokenPath)
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("oauth token write succeeded WITHOUT the section-6a ~/.pi/agent block.\n"+
+			"The 6a grant is not the load-bearing rule — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
 	} else {
-		t.Logf("ka pai — write did NOT reach host path without staging symlink (host content: %q)", string(got))
+		t.Logf("ka pai — oauth token write correctly denied without the 6a block (exit: %v)", runErr)
+	}
+
+	// Nothing may have landed at the host path.
+	if hostBytes, readErr := os.ReadFile(hostTokenPath); readErr == nil && string(hostBytes) == tokenJSON {
+		t.Errorf("token bytes appeared at the host path despite the stripped grant — the deny is not effective")
 	}
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_ro_real_paths_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_ro_real_paths_darwin_test.go
@@ -1,0 +1,303 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_ro_real_paths_darwin_test.go — integration coverage for the
+// read-only real-path grants of Step 3f of #2132 (issue #2245):
+//
+//   - section 5f: ~/.cache/prism/clipboard (images staged by
+//     `prism clipboard paste-image`, read by the agent at the absolute host
+//     path). The ~/.config/prism/agents half of 5f is covered by
+//     sandbox_exec_role_prompt_darwin_test.go.
+//   - section 5g: ~/.nix-profile — a host SYMLINK; the grant carries a
+//     literal allow on the link node plus an RO rule on the
+//     EvalSymlinks-resolved target so access works through resolution.
+//
+// Each capability gets an RO positive AND a write-denied negative (RO must
+// not silently become RW). The clipboard additionally gets a whole-block
+// strip negative proving the 5f block is load-bearing.
+//
+// Note on 5g and the strip negative: on hm/nix-darwin hosts the
+// ~/.nix-profile chain resolves into /nix/store (covered by the broad §2
+// /nix allow) and link-node metadata is covered by the BareRoot-ancestor
+// (subpath HOME) metadata allow — so a stripped 5g block does NOT
+// deterministically deny the read on such hosts; the block is
+// defence-in-depth for layouts where the profile dir lives outside /nix.
+// A strip negative would therefore be flaky-by-layout and is deliberately
+// omitted; the 5g emission shape is pinned at unit level
+// (TestGenerateProfile_NixProfileROGrant) and the security property (no
+// writes) is integration-tested here.
+//
+// Per docs/sandbox-exec-testing.md (issue #1192); #2207 capability-probe
+// gating via requireSandboxExec.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const clipboardSentinelContent = "prism-2245-3f-clipboard-sentinel"
+
+// roGrantBlock5f returns the exact section-5f allow block emitted by
+// generateProfile (clipboard + role prompts), for presence assertions and
+// whole-block strips.
+func roGrantBlock5f(t *testing.T) string {
+	t.Helper()
+	home := realUserHome(t)
+	return "(allow file-read* file-test-existence\n" +
+		"  (subpath " + sbplQuoteForTest(filepath.Join(home, ".cache", "prism", "clipboard")) + ")\n" +
+		"  (subpath " + sbplQuoteForTest(filepath.Join(home, ".config", "prism", "agents")) + "))\n"
+}
+
+// prepareClipboardSentinel creates ~/.cache/prism/clipboard under the real
+// HOME (when absent) and plants a sentinel file inside it. Cleanup removes
+// only what the test created.
+func prepareClipboardSentinel(t *testing.T) (clipboardDir, sentinelPath string) {
+	t.Helper()
+	home := realUserHome(t)
+	clipboardDir = filepath.Join(home, ".cache", "prism", "clipboard")
+	dirExisted := false
+	if _, statErr := os.Stat(clipboardDir); statErr == nil {
+		dirExisted = true
+	}
+	if mkErr := os.MkdirAll(clipboardDir, 0o700); mkErr != nil {
+		t.Skipf("cannot create ~/.cache/prism/clipboard for test: %v", mkErr)
+	}
+	sentinelPath = filepath.Join(clipboardDir, ".prism-2245-3f-clipboard-test")
+	if wErr := os.WriteFile(sentinelPath, []byte(clipboardSentinelContent), 0o600); wErr != nil {
+		t.Skipf("cannot plant clipboard sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+	if dirExisted {
+		t.Cleanup(func() { _ = os.Remove(sentinelPath) })
+	} else {
+		t.Cleanup(func() { _ = os.RemoveAll(clipboardDir) })
+	}
+	return clipboardDir, sentinelPath
+}
+
+// TestSandboxExecClipboard_RealPathReadable is the RO positive for the
+// clipboard half of section 5f: a staged image (sentinel) is readable
+// in-sandbox at the REAL host path under the production profile, with no
+// staging symlink involved.
+func TestSandboxExecClipboard_RealPathReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, sentinelPath := prepareClipboardSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// No clipboard staging entry (nor a .cache staging dir at all).
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".cache")); lstatErr == nil {
+		t.Fatalf("staging HOME has a .cache entry — the 3e/3f staging symlinks were removed in #2245 and must not be recreated")
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	block := roGrantBlock5f(t)
+	if !strings.Contains(prepared.content, block) {
+		t.Fatalf("generated profile does not contain the section-5f RO block:\n%s\nProfile:\n%s", block, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(sentinelPath))
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("in-sandbox read of the clipboard sentinel at its real path failed.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
+			runErr, string(out), testProfilePath, sentinelPath)
+	}
+	if !strings.Contains(string(out), clipboardSentinelContent) {
+		t.Errorf("clipboard read did not return the sentinel content.\nGot: %s", string(out))
+	}
+}
+
+// TestSandboxExecClipboard_DeniedWithoutGrantBlock is the strip negative for
+// section 5f: with the ENTIRE block removed, the same clipboard read fails —
+// proving the 5f block is load-bearing (whole-block strip per the #2243
+// lesson: stripping only one (subpath ...) line would leave the other path
+// granted).
+func TestSandboxExecClipboard_DeniedWithoutGrantBlock(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	_, sentinelPath := prepareClipboardSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	block := roGrantBlock5f(t)
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.Replace(p, block, "", 1)
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"cat "+shQuote(sentinelPath))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("clipboard read succeeded WITHOUT the section-5f block.\n"+
+			"The 5f grant is not the load-bearing rule — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — clipboard read correctly denied without the 5f block (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecClipboard_WriteDenied is the write-denied negative for the
+// clipboard half of section 5f: under the PRODUCTION profile (no mutation),
+// writing into the real clipboard dir fails — RO must not silently become RW.
+func TestSandboxExecClipboard_WriteDenied(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	clipboardDir, _ := prepareClipboardSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	writeTarget := filepath.Join(clipboardDir, ".prism-2245-3f-write-denied")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) }) // in case the deny fails
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo prism-2245-write > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write into the RO clipboard dir succeeded under the production profile — RO silently became RW.\n"+
+			"Output: %s\nProfile: %s\nTarget: %s", string(out), testProfilePath, writeTarget)
+	} else {
+		t.Logf("ka pai — clipboard write correctly denied under the production profile (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecNixProfile_ReadableThroughSymlink is the RO positive for
+// section 5g: ~/.nix-profile (a host symlink) is readable in-sandbox at its
+// real path — both the link node itself (readlink) and a directory listing
+// through the resolved chain. Skips when the host has no ~/.nix-profile.
+func TestSandboxExecNixProfile_ReadableThroughSymlink(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home := realUserHome(t)
+	nixProfile := filepath.Join(home, ".nix-profile")
+	if _, lstatErr := os.Lstat(nixProfile); lstatErr != nil {
+		t.Skipf("~/.nix-profile absent on this host: %v", lstatErr)
+	}
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// No nix-profile staging entry.
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".nix-profile")); lstatErr == nil {
+		t.Fatalf("staging HOME has a .nix-profile entry — removed in #2245 (Step 3f), must not be recreated")
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// The 5g literal on the link node must be present.
+	literalRule := "(literal " + sbplQuoteForTest(nixProfile) + ")"
+	if !strings.Contains(prepared.content, literalRule) {
+		t.Fatalf("generated profile does not contain the 5g literal for ~/.nix-profile:\n%s\nProfile:\n%s",
+			literalRule, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// readlink exercises the link node; ls -1 through the path exercises
+	// resolution to the target.
+	script := "readlink " + shQuote(nixProfile) + " && ls -1 " + shQuote(nixProfile)
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("in-sandbox readlink/ls of ~/.nix-profile failed under the production profile.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s", runErr, string(out), testProfilePath)
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		t.Errorf("readlink/ls produced no output — expected the link target and a profile listing")
+	}
+}
+
+// TestSandboxExecNixProfile_WriteDenied is the write-denied negative for
+// section 5g: under the PRODUCTION profile, writing through ~/.nix-profile
+// fails — the grant is read-only and must not silently become RW.
+func TestSandboxExecNixProfile_WriteDenied(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	home := realUserHome(t)
+	nixProfile := filepath.Join(home, ".nix-profile")
+	if _, lstatErr := os.Lstat(nixProfile); lstatErr != nil {
+		t.Skipf("~/.nix-profile absent on this host: %v", lstatErr)
+	}
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	writeTarget := filepath.Join(nixProfile, ".prism-2245-5g-write-denied")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) }) // in case the deny fails
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"touch "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write through ~/.nix-profile succeeded under the production profile — the 5g grant must be RO.\n"+
+			"Output: %s\nProfile: %s\nTarget: %s", string(out), testProfilePath, writeTarget)
+	} else {
+		t.Logf("ka pai — write through ~/.nix-profile correctly denied (exit: %v)", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
@@ -10,14 +10,34 @@ package integration_test
 // (subpath ~/.config/prism/agents) grant in the section-5f block emitted by
 // generateProfile, evaluated at the REAL host path.
 //
+// Read-target strategy (#2245 host-run follow-up): on deployed hosts the
+// agents dir is home-manager-managed — typically a read-only symlink into
+// the nix store, overwritten on every switch — so planting a test sentinel
+// there is impossible. The tests therefore prefer the DEPLOYED role file
+// (worker.md) when one exists, and fall back to sentinel-planting only when
+// the dir is genuinely writable (dev machines without hm management).
+//
 // Per the #1192 convention this file carries:
 //
-//   - a positive (worker.md readable at the real path under the production
-//     profile),
+//   - a positive (the role file readable at the real path under the
+//     production profile — the exact capability the PI extension needs),
 //   - a whole-block strip negative (removing the ENTIRE 5f block makes the
 //     same read fail — per the #2243 lesson, stripping only the agents
-//     (subpath ...) line would leave the clipboard line carrying the block),
-//   - a write-denied negative (RO must not silently become RW).
+//     (subpath ...) line would leave the clipboard line carrying the block).
+//     The strip negative additionally requires a read target whose
+//     EvalSymlinks-resolved path is the lexical path itself: SBPL evaluates
+//     open(2)-class operations against the RESOLVED target (the #2132 §2
+//     mechanism note, same as the documented §5g no-strip-negative
+//     deviation), so a store-symlinked deployed role file remains readable
+//     via the §2 /nix allow even with 5f stripped — the denial is
+//     unobservable there. On hm-managed hosts where no in-place target can
+//     be planted either, the strip negative SKIPs with that justification;
+//     the 5f grant shape is pinned at unit level.
+//   - a write-denied negative (RO must not silently become RW). No sentinel
+//     needed: attempting to create a file in the agents dir from inside the
+//     sandbox and asserting denial suffices. On hm hosts the write is doubly
+//     denied (no SBPL write grant on the resolved store path + the store
+//     itself is unwritable) — both denials are correct outcomes.
 //
 // Build tag: darwin (sandbox-exec is Darwin-only).
 
@@ -30,60 +50,55 @@ import (
 	"testing"
 )
 
-// rolePromptSentinelContent is the sentinel written into the test worker.md
-// so the positive test can assert the bytes round-trip through the sandbox.
+// rolePromptSentinelContent is the sentinel written into a planted role file
+// on hosts where the agents dir is writable (dev machines without hm
+// management).
 const rolePromptSentinelContent = "PRISM-2032-ROLE-PROMPT-SENTINEL"
 
-// prepareRolePromptSentinel creates ~/.config/prism/agents/worker.md under
-// the user's real HOME (NOT t.TempDir, which resolves under
-// /private/var/folders and is broadly allowed) and plants a sentinel inside
-// it. Returns the real agents-dir path and the worker.md path.
-//
-// Skips when the directory cannot be created (e.g. running inside a
-// restricted sandbox that denies writes to ~/.config).
-func prepareRolePromptSentinel(t *testing.T) (agentsDir, workerMD string) {
+// rolePromptAgentsDir returns the real-host path of the role-prompt agents
+// dir governed by the section-5f grant.
+func rolePromptAgentsDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(realUserHome(t), ".config", "prism", "agents")
+}
+
+// plantRolePromptSentinel attempts to plant a sentinel role file in the real
+// agents dir. Returns (path, true) on success. Returns ("", false) when the
+// dir hierarchy cannot be created or written — e.g. on home-manager-managed
+// hosts where ~/.config/prism/agents is a read-only symlink into the nix
+// store. Cleanup removes only what this call created.
+func plantRolePromptSentinel(t *testing.T) (string, bool) {
 	t.Helper()
 	home := realUserHome(t)
-	agentsDir = filepath.Join(home, ".config", "prism", "agents")
+	agentsDir := rolePromptAgentsDir(t)
 
 	agentsDirExisted := false
 	if _, statErr := os.Stat(agentsDir); statErr == nil {
 		agentsDirExisted = true
 	}
 	if mkErr := os.MkdirAll(agentsDir, 0o700); mkErr != nil {
-		t.Skipf("cannot create ~/.config/prism/agents for test: %v", mkErr)
+		return "", false
 	}
 
-	workerMD = filepath.Join(agentsDir, "worker.md")
-	workerMDExisted := false
-	if _, statErr := os.Stat(workerMD); statErr == nil {
-		workerMDExisted = true
-	}
-	if workerMDExisted {
-		// Pre-existing worker.md (e.g. the real deployed prompt) — do not
-		// clobber it. Use a test-specific filename instead; the grant under
-		// test is the directory subpath, so any file inside it carries the
-		// same signal.
-		workerMD = filepath.Join(agentsDir, ".prism-2245-test-role.md")
-	}
-	if wErr := os.WriteFile(workerMD, []byte(rolePromptSentinelContent), 0o600); wErr != nil {
-		t.Skipf("cannot plant role-prompt sentinel (may be running inside a restricted sandbox): %v", wErr)
+	sentinel := filepath.Join(agentsDir, ".prism-2245-test-role.md")
+	if wErr := os.WriteFile(sentinel, []byte(rolePromptSentinelContent), 0o600); wErr != nil {
+		return "", false
 	}
 
 	if agentsDirExisted {
-		mdPath := workerMD
-		t.Cleanup(func() { _ = os.Remove(mdPath) })
+		t.Cleanup(func() { _ = os.Remove(sentinel) })
 	} else {
 		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(home, ".config", "prism")) })
 	}
-	return agentsDir, workerMD
+	return sentinel, true
 }
 
 // TestSandboxExecProfile_RolePromptReadable is the positive integration test:
 // the role-prompt markdown is readable at its REAL host path under the
 // production profile via the section-5f RO grant — the same path shape the
 // PI extension will resolve once Step 5 of #2132 flips $HOME/XDG to the real
-// home.
+// home. The deployed worker.md is preferred as the read target (see the
+// file-top strategy note); a planted sentinel is the dev-machine fallback.
 func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -91,7 +106,17 @@ func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	_, workerMD := prepareRolePromptSentinel(t)
+	deployed := filepath.Join(rolePromptAgentsDir(t), "worker.md")
+	var readTarget, wantContent string
+	if content, readErr := os.ReadFile(deployed); readErr == nil && len(content) > 0 {
+		// Deployed role file present (hm-managed or otherwise) — read the
+		// real thing. This is the exact file the PI extension loads.
+		readTarget, wantContent = deployed, string(content)
+	} else if planted, ok := plantRolePromptSentinel(t); ok {
+		readTarget, wantContent = planted, rolePromptSentinelContent
+	} else {
+		t.Skipf("no readable deployed role file at %s and the agents dir is not writable for sentinel planting", deployed)
+	}
 
 	m := newProfileManagerWithBareRoot(t)
 
@@ -120,15 +145,15 @@ func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 	// Read the role prompt at the REAL path from inside the sandbox.
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(workerMD))
+		"cat "+shQuote(readTarget))
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
 		t.Fatalf("reading the role prompt at its real path failed under the production profile.\n"+
 			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
-			runErr, string(out), testProfilePath, workerMD)
+			runErr, string(out), testProfilePath, readTarget)
 	}
-	if !strings.Contains(string(out), rolePromptSentinelContent) {
-		t.Errorf("role-prompt read did not return the sentinel content.\nGot: %s", string(out))
+	if !strings.Contains(string(out), wantContent) {
+		t.Errorf("role-prompt read did not return the expected content.\nTarget: %s\nGot: %s", readTarget, string(out))
 	}
 }
 
@@ -136,6 +161,15 @@ func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 // strip negative: removing the ENTIRE section-5f block makes the same
 // real-path read fail — proving the block is load-bearing and the positive
 // is not green by accident (#1192; whole-block strip per the #2243 lesson).
+//
+// The read target must resolve to itself (no symlinks): SBPL evaluates
+// open(2) against the RESOLVED path, so a deployed role file that is a
+// symlink into /nix/store stays readable via the §2 /nix allow even with 5f
+// stripped — the denial cannot manifest (the same mechanism behind the
+// documented §5g no-strip-negative deviation). On hosts where no in-place
+// target exists or can be planted (hm-managed agents dir), the test SKIPs;
+// the 5f grant shape is pinned at unit level and the RO property is covered
+// by the write-denied negative below.
 func TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -143,7 +177,22 @@ func TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock(t *testing.T) {
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	_, workerMD := prepareRolePromptSentinel(t)
+	deployed := filepath.Join(rolePromptAgentsDir(t), "worker.md")
+	var readTarget string
+	if resolved, evalErr := filepath.EvalSymlinks(deployed); evalErr == nil && resolved == deployed {
+		// Deployed role file is a regular file at its lexical path — the
+		// 5f grant is the only rule covering it, so the strip is observable.
+		readTarget = deployed
+	} else if planted, ok := plantRolePromptSentinel(t); ok {
+		// Planted sentinel is a regular file in a real dir — resolves to
+		// itself by construction.
+		readTarget = planted
+	} else {
+		t.Skipf("no strip-negative-capable read target: the deployed role file resolves outside its lexical path "+
+			"(reads through it are independently allowed at the resolved target, e.g. the §2 /nix allow — "+
+			"same justification as the documented §5g no-strip-negative deviation) and the agents dir is not "+
+			"writable for sentinel planting; the 5f grant shape is pinned at unit level (deployed: %s)", deployed)
+	}
 
 	m := newProfileManagerWithBareRoot(t)
 
@@ -160,12 +209,12 @@ func TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock(t *testing.T) {
 
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(workerMD))
+		"cat "+shQuote(readTarget))
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
 		t.Errorf("role-prompt read succeeded WITHOUT the section-5f block.\n"+
 			"The 5f grant is not load-bearing — investigate.\n"+
-			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+			"Output: %s\nMutated profile: %s\nTarget: %s", string(out), mutatedPath, readTarget)
 	} else {
 		t.Logf("ka pai — role-prompt read correctly denied without the 5f block (exit: %v)", runErr)
 	}
@@ -174,7 +223,11 @@ func TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock(t *testing.T) {
 // TestSandboxExecProfile_RolePromptWriteDenied is the write-denied negative:
 // under the PRODUCTION profile, writing into the real agents dir fails — the
 // 5f grant is read-only and must not silently become RW (agents never write
-// their own role prompts).
+// their own role prompts). No sentinel is needed: the assertion is on the
+// in-sandbox CREATE attempt itself. On hm-managed hosts the write is doubly
+// denied (no SBPL write grant on the resolved store path + the nix store is
+// unwritable) — either denial is the correct outcome; the SBPL grant shape
+// is pinned at unit level.
 func TestSandboxExecProfile_RolePromptWriteDenied(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -182,7 +235,26 @@ func TestSandboxExecProfile_RolePromptWriteDenied(t *testing.T) {
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	agentsDir, _ := prepareRolePromptSentinel(t)
+	agentsDir := rolePromptAgentsDir(t)
+
+	// The dir must exist on the host so the in-sandbox failure is a denial,
+	// not a vacuous ENOENT. On deployed hosts it exists (hm-managed); on dev
+	// machines create it (and clean up what we created).
+	if _, statErr := os.Stat(agentsDir); statErr != nil {
+		home := realUserHome(t)
+		prismDirExisted := false
+		if _, pErr := os.Stat(filepath.Join(home, ".config", "prism")); pErr == nil {
+			prismDirExisted = true
+		}
+		if mkErr := os.MkdirAll(agentsDir, 0o700); mkErr != nil {
+			t.Skipf("agents dir %s does not exist and cannot be created: %v", agentsDir, mkErr)
+		}
+		if prismDirExisted {
+			t.Cleanup(func() { _ = os.Remove(agentsDir) })
+		} else {
+			t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(home, ".config", "prism")) })
+		}
+	}
 
 	m := newProfileManagerWithBareRoot(t)
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
@@ -3,17 +3,21 @@
 package integration_test
 
 // Integration tests for the prism agent role-prompt directory under
-// sandbox-exec (issue #2032). The prism PI extension reads
-// ~/.config/prism/agents/<role>.md at before_agent_start and injects it as the
-// role system prompt. For that to work inside a sandbox-exec session,
-// PrepareSandboxExecHome must symlink ~/.config/prism/agents into the staging
-// HOME, and the generated SBPL profile (via collectStagingHomeSymlinkTargets)
-// must grant file-read* on the resolved target.
+// sandbox-exec (issue #2032; real-path grant since #2245, Step 3f of #2132).
+// The prism PI extension reads ~/.config/prism/agents/<role>.md at
+// before_agent_start and injects it as the role system prompt. The former
+// staging-HOME symlink is gone — the capability is the explicit RO
+// (subpath ~/.config/prism/agents) grant in the section-5f block emitted by
+// generateProfile, evaluated at the REAL host path.
 //
-// Per the #1192 convention, the change to PrepareSandboxExecHome is paired with
-// a positive integration test (the dir is readable through the staging symlink
-// under the production profile) and a negative test (mutating the profile to
-// drop the read-allow for the resolved target proves the rule is load-bearing).
+// Per the #1192 convention this file carries:
+//
+//   - a positive (worker.md readable at the real path under the production
+//     profile),
+//   - a whole-block strip negative (removing the ENTIRE 5f block makes the
+//     same read fail — per the #2243 lesson, stripping only the agents
+//     (subpath ...) line would leave the clipboard line carrying the block),
+//   - a write-denied negative (RO must not silently become RW).
 //
 // Build tag: darwin (sandbox-exec is Darwin-only).
 
@@ -26,23 +30,21 @@ import (
 	"testing"
 )
 
-// roledPromptContent is the sentinel written into the test worker.md so the
-// positive test can assert the bytes round-trip through the sandbox.
+// rolePromptSentinelContent is the sentinel written into the test worker.md
+// so the positive test can assert the bytes round-trip through the sandbox.
 const rolePromptSentinelContent = "PRISM-2032-ROLE-PROMPT-SENTINEL"
 
-// prepareRolePromptSentinel creates ~/.config/prism/agents/worker.md under the
-// user's real HOME (NOT t.TempDir, which resolves under /private/var/folders
-// and is broadly allowed) and plants a sentinel inside it. Returns the resolved
-// (EvalSymlinks) path of the agents directory — that is the path the SBPL
-// read-allow targets — and the path of the worker.md file as seen through the
-// staging HOME symlink chain.
+// prepareRolePromptSentinel creates ~/.config/prism/agents/worker.md under
+// the user's real HOME (NOT t.TempDir, which resolves under
+// /private/var/folders and is broadly allowed) and plants a sentinel inside
+// it. Returns the real agents-dir path and the worker.md path.
 //
-// Skips when the directory cannot be created (e.g. running inside a restricted
-// sandbox that denies writes to ~/.config).
-func prepareRolePromptSentinel(t *testing.T) (resolvedAgentsDir string) {
+// Skips when the directory cannot be created (e.g. running inside a
+// restricted sandbox that denies writes to ~/.config).
+func prepareRolePromptSentinel(t *testing.T) (agentsDir, workerMD string) {
 	t.Helper()
 	home := realUserHome(t)
-	agentsDir := filepath.Join(home, ".config", "prism", "agents")
+	agentsDir = filepath.Join(home, ".config", "prism", "agents")
 
 	agentsDirExisted := false
 	if _, statErr := os.Stat(agentsDir); statErr == nil {
@@ -52,40 +54,36 @@ func prepareRolePromptSentinel(t *testing.T) (resolvedAgentsDir string) {
 		t.Skipf("cannot create ~/.config/prism/agents for test: %v", mkErr)
 	}
 
-	workerMD := filepath.Join(agentsDir, "worker.md")
+	workerMD = filepath.Join(agentsDir, "worker.md")
 	workerMDExisted := false
 	if _, statErr := os.Stat(workerMD); statErr == nil {
 		workerMDExisted = true
 	}
-	if wErr := os.WriteFile(workerMD, []byte(rolePromptSentinelContent), 0o600); wErr != nil {
-		t.Skipf("cannot plant worker.md sentinel (may be running inside a restricted sandbox): %v", wErr)
-	}
-
 	if workerMDExisted {
 		// Pre-existing worker.md (e.g. the real deployed prompt) — do not
-		// clobber it on cleanup. We cannot restore the original bytes, so the
-		// test deliberately skips when worker.md already exists to avoid
-		// trashing a developer's deployed prompt.
-		t.Skip("~/.config/prism/agents/worker.md already exists; skipping to avoid overwriting the deployed prompt")
+		// clobber it. Use a test-specific filename instead; the grant under
+		// test is the directory subpath, so any file inside it carries the
+		// same signal.
+		workerMD = filepath.Join(agentsDir, ".prism-2245-test-role.md")
 	}
+	if wErr := os.WriteFile(workerMD, []byte(rolePromptSentinelContent), 0o600); wErr != nil {
+		t.Skipf("cannot plant role-prompt sentinel (may be running inside a restricted sandbox): %v", wErr)
+	}
+
 	if agentsDirExisted {
-		t.Cleanup(func() { _ = os.Remove(workerMD) })
+		mdPath := workerMD
+		t.Cleanup(func() { _ = os.Remove(mdPath) })
 	} else {
 		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(home, ".config", "prism")) })
 	}
-
-	resolved, evalErr := filepath.EvalSymlinks(agentsDir)
-	if evalErr != nil {
-		resolved = agentsDir
-	}
-	return resolved
+	return agentsDir, workerMD
 }
 
-// TestSandboxExecProfile_RolePromptReadable is the positive integration test
-// for issue #2032: the prism agent role-prompt dir, symlinked into the staging
-// HOME by PrepareSandboxExecHome, is readable through the staging symlink under
-// the production profile. This exercises the same path the PI extension uses to
-// read <role>.md at before_agent_start.
+// TestSandboxExecProfile_RolePromptReadable is the positive integration test:
+// the role-prompt markdown is readable at its REAL host path under the
+// production profile via the section-5f RO grant — the same path shape the
+// PI extension will resolve once Step 5 of #2132 flips $HOME/XDG to the real
+// home.
 func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
@@ -93,7 +91,7 @@ func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	resolvedAgentsDir := prepareRolePromptSentinel(t)
+	_, workerMD := prepareRolePromptSentinel(t)
 
 	m := newProfileManagerWithBareRoot(t)
 
@@ -103,52 +101,49 @@ func TestSandboxExecProfile_RolePromptReadable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	// The staging HOME must contain the .config/prism/agents symlink.
-	agentsLink := filepath.Join(stagingHome, ".config", "prism", "agents")
-	if _, lstatErr := os.Lstat(agentsLink); lstatErr != nil {
-		t.Fatalf("staging HOME must have a .config/prism/agents symlink after PrepareSandboxExecHome: %v", lstatErr)
+	// The staging HOME must NOT contain a .config entry — the agents staging
+	// symlink was removed in #2245 (Step 3f).
+	if _, lstatErr := os.Lstat(filepath.Join(stagingHome, ".config")); lstatErr == nil {
+		t.Fatalf("staging HOME has a .config entry — the agents staging symlink was removed in #2245 and must not be recreated")
 	}
 
 	prepared, _ := preparePositiveProfile(t, m)
 
-	// The production profile must grant file-read* on the resolved agents dir.
-	expectedRule := "(subpath " + sbplQuoteForTest(resolvedAgentsDir) + ")"
-	if !strings.Contains(prepared.content, expectedRule) {
-		t.Fatalf("generated profile does not contain a read-allow subpath for the resolved agents dir.\n"+
-			"Expected to find: %q\nProfile:\n%s", expectedRule, prepared.content)
+	// The production profile must carry the whole 5f block.
+	block := roGrantBlock5f(t)
+	if !strings.Contains(prepared.content, block) {
+		t.Fatalf("generated profile does not contain the section-5f RO block:\n%s\nProfile:\n%s", block, prepared.content)
 	}
 
 	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
 
-	// Read worker.md through the staging HOME symlink from inside the sandbox.
-	workerMDViaStaging := filepath.Join(agentsLink, "worker.md")
+	// Read the role prompt at the REAL path from inside the sandbox.
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(workerMDViaStaging))
+		"cat "+shQuote(workerMD))
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
-		t.Fatalf("reading worker.md through the staging symlink failed under the production profile.\n"+
+		t.Fatalf("reading the role prompt at its real path failed under the production profile.\n"+
 			"Exit: %v\nOutput: %s\nProfile: %s\nTarget: %s",
-			runErr, string(out), testProfilePath, workerMDViaStaging)
+			runErr, string(out), testProfilePath, workerMD)
 	}
 	if !strings.Contains(string(out), rolePromptSentinelContent) {
-		t.Errorf("worker.md read did not return the sentinel content.\nGot: %s", string(out))
+		t.Errorf("role-prompt read did not return the sentinel content.\nGot: %s", string(out))
 	}
 }
 
-// TestSandboxExecProfile_RolePromptDeniedWithoutAllow is the paired negative
-// test for RolePromptReadable. It removes the read-allow (subpath ...) for the
-// resolved agents dir from the profile and asserts the same read fails —
-// proving the read-allow rule is load-bearing and the positive is not green by
-// accident (#1192).
-func TestSandboxExecProfile_RolePromptDeniedWithoutAllow(t *testing.T) {
+// TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock is the paired
+// strip negative: removing the ENTIRE section-5f block makes the same
+// real-path read fail — proving the block is load-bearing and the positive
+// is not green by accident (#1192; whole-block strip per the #2243 lesson).
+func TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
 	}
 	requireSandboxExec(t)
 	nixBash := requireNixBash(t)
 
-	resolvedAgentsDir := prepareRolePromptSentinel(t)
+	_, workerMD := prepareRolePromptSentinel(t)
 
 	m := newProfileManagerWithBareRoot(t)
 
@@ -158,27 +153,58 @@ func TestSandboxExecProfile_RolePromptDeniedWithoutAllow(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
 
-	agentsLink := filepath.Join(stagingHome, ".config", "prism", "agents")
-
-	// Remove the (subpath "<resolvedAgentsDir>") read-allow line. The
-	// collectStagingHomeSymlinkTargets RO block emits each target on its own
-	// indented line: "  (subpath \"<resolved>\")\n". Stripping that single
-	// line simulates the pre-#2032 state where the agents dir was not allowed.
-	target := "  (subpath " + sbplQuoteForTest(resolvedAgentsDir) + ")\n"
+	block := roGrantBlock5f(t)
 	mutatedPath := withMutatedProfile(t, m, func(p string) string {
-		return strings.Replace(p, target, "", 1)
+		return strings.Replace(p, block, "", 1)
 	})
 
-	workerMDViaStaging := filepath.Join(agentsLink, "worker.md")
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(workerMDViaStaging))
+		"cat "+shQuote(workerMD))
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
-		t.Errorf("reading worker.md succeeded WITHOUT the read-allow subpath for the agents dir.\n"+
-			"The (subpath \"%s\") rule is not load-bearing — investigate.\n"+
-			"Output: %s\nMutated profile: %s", resolvedAgentsDir, string(out), mutatedPath)
+		t.Errorf("role-prompt read succeeded WITHOUT the section-5f block.\n"+
+			"The 5f grant is not load-bearing — investigate.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
 	} else {
-		t.Logf("ka pai — agents dir read correctly denied without the read-allow subpath (exit: %v)", runErr)
+		t.Logf("ka pai — role-prompt read correctly denied without the 5f block (exit: %v)", runErr)
+	}
+}
+
+// TestSandboxExecProfile_RolePromptWriteDenied is the write-denied negative:
+// under the PRODUCTION profile, writing into the real agents dir fails — the
+// 5f grant is read-only and must not silently become RW (agents never write
+// their own role prompts).
+func TestSandboxExecProfile_RolePromptWriteDenied(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	agentsDir, _ := prepareRolePromptSentinel(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	prepared, _ := preparePositiveProfile(t, m)
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	writeTarget := filepath.Join(agentsDir, ".prism-2245-write-denied.md")
+	t.Cleanup(func() { _ = os.Remove(writeTarget) }) // in case the deny fails
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
+		"echo prism-2245-write > "+shQuote(writeTarget))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write into the RO agents dir succeeded under the production profile — RO silently became RW.\n"+
+			"Output: %s\nProfile: %s\nTarget: %s", string(out), testProfilePath, writeTarget)
+	} else {
+		t.Logf("ka pai — agents-dir write correctly denied under the production profile (exit: %v)", runErr)
 	}
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_role_prompt_darwin_test.go
@@ -71,7 +71,16 @@ func plantRolePromptSentinel(t *testing.T) (string, bool) {
 	t.Helper()
 	home := realUserHome(t)
 	agentsDir := rolePromptAgentsDir(t)
+	prismDir := filepath.Join(home, ".config", "prism")
 
+	// Track pre-existence at each level so cleanup removes ONLY what this
+	// call created — a pre-existing ~/.config/prism (e.g. holding the live
+	// config.json on a non-hm dev machine) must never be deleted. Mirrors
+	// prepareClipboardSentinel's scoping.
+	prismDirExisted := false
+	if _, statErr := os.Stat(prismDir); statErr == nil {
+		prismDirExisted = true
+	}
 	agentsDirExisted := false
 	if _, statErr := os.Stat(agentsDir); statErr == nil {
 		agentsDirExisted = true
@@ -82,13 +91,29 @@ func plantRolePromptSentinel(t *testing.T) (string, bool) {
 
 	sentinel := filepath.Join(agentsDir, ".prism-2245-test-role.md")
 	if wErr := os.WriteFile(sentinel, []byte(rolePromptSentinelContent), 0o600); wErr != nil {
+		// MkdirAll may have created the dir(s) before the write failed —
+		// remove what was created even on the failure path.
+		if !agentsDirExisted {
+			if prismDirExisted {
+				_ = os.Remove(agentsDir)
+			} else {
+				_ = os.RemoveAll(prismDir)
+			}
+		}
 		return "", false
 	}
 
-	if agentsDirExisted {
+	switch {
+	case agentsDirExisted:
+		// Dir pre-existed — remove only the planted sentinel.
 		t.Cleanup(func() { _ = os.Remove(sentinel) })
-	} else {
-		t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(home, ".config", "prism")) })
+	case prismDirExisted:
+		// ~/.config/prism pre-existed but agents/ did not — remove only the
+		// agents dir this call created (with the sentinel inside it).
+		t.Cleanup(func() { _ = os.RemoveAll(agentsDir) })
+	default:
+		// Neither existed — this call created ~/.config/prism and below.
+		t.Cleanup(func() { _ = os.RemoveAll(prismDir) })
 	}
 	return sentinel, true
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_rw_real_paths_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_rw_real_paths_darwin_test.go
@@ -1,0 +1,184 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_rw_real_paths_darwin_test.go — integration coverage for the
+// section-5e RW grant block on the real host paths (Step 3e of #2132, issue
+// #2245): ~/.cache/nix, ~/.cache/bun, ~/.npm, ~/.mcp-auth.
+//
+// The RW staging symlinks for these dirs are gone; the explicit (subpath ...)
+// RW grants emitted by generateProfile are the sole in-sandbox capability
+// (none of the paths is sops-backed, so the #2211 allowlist plays no part).
+//
+// This file tests:
+//
+//  1. Positive: under the production profile, a create→read→remove
+//     round-trip of a uniquely-named file succeeds inside each real host
+//     dir (skipping dirs absent on this host). The staging HOME is asserted
+//     to contain no 3e entries.
+//
+//  2. Negative (whole-block strip, per the #2243 lesson): removing the
+//     ENTIRE section-5e allow block makes the same writes fail — proving
+//     the block is load-bearing for every path in the set (stripping only a
+//     single (subpath ...) line would leave the others granted and, in the
+//     single-filter case, risk a filter-less allow-everything clause).
+//
+// The ~/.aws/{sso,cli} half of Step 3e is covered by the carve-out tests in
+// sandbox_exec_aws_sso_darwin_test.go and
+// sandbox_exec_aws_cache_writable_darwin_test.go (the §5 carve-outs are the
+// capability there, not the 5e block).
+//
+// Per docs/sandbox-exec-testing.md (issue #1192); #2207 capability-probe
+// gating via requireSandboxExec.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// rwRealPaths3e returns the 3e RW dirs that exist on this host, keyed by a
+// short label. Dirs absent on the host are skipped (the grant is emitted
+// unconditionally, but a round-trip needs a real dir to write into).
+func rwRealPaths3e(t *testing.T) map[string]string {
+	t.Helper()
+	home := realUserHome(t)
+	candidates := map[string]string{
+		"cache-nix": filepath.Join(home, ".cache", "nix"),
+		"cache-bun": filepath.Join(home, ".cache", "bun"),
+		"npm":       filepath.Join(home, ".npm"),
+		"mcp-auth":  filepath.Join(home, ".mcp-auth"),
+	}
+	present := map[string]string{}
+	for label, dir := range candidates {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			present[label] = dir
+		} else {
+			t.Logf("3e dir %s absent on this host — skipping its round-trip", dir)
+		}
+	}
+	if len(present) == 0 {
+		t.Skip("none of the 3e dirs exist on this host — nothing to round-trip")
+	}
+	return present
+}
+
+// rwGrantBlock5e returns the exact section-5e allow block emitted by
+// generateProfile, for the presence assertion in the positive test and the
+// whole-block strip in the negative.
+func rwGrantBlock5e(t *testing.T) string {
+	t.Helper()
+	home := realUserHome(t)
+	return "(allow file-read* file-write* file-test-existence file-read-metadata\n" +
+		"  (subpath " + sbplQuoteForTest(filepath.Join(home, ".cache", "nix")) + ")\n" +
+		"  (subpath " + sbplQuoteForTest(filepath.Join(home, ".cache", "bun")) + ")\n" +
+		"  (subpath " + sbplQuoteForTest(filepath.Join(home, ".npm")) + ")\n" +
+		"  (subpath " + sbplQuoteForTest(filepath.Join(home, ".mcp-auth")) + "))\n"
+}
+
+// TestSandboxExecRWRealPaths_RoundTrip is the positive integration test for
+// the section-5e RW grants: a create→read→remove round-trip succeeds at each
+// real host path under the production profile.
+func TestSandboxExecRWRealPaths_RoundTrip(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	dirs := rwRealPaths3e(t)
+
+	// BareRoot manager: real-path access under HOME requires the
+	// BareRoot-ancestor block's metadata allow on (subpath HOME).
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	// The staging HOME must contain no 3e entries.
+	for _, rel := range []string{".cache", ".npm", ".mcp-auth"} {
+		if _, lstatErr := os.Lstat(filepath.Join(stagingHome, rel)); lstatErr == nil {
+			t.Fatalf("staging HOME has a %s entry — the 3e staging symlinks were removed in #2245 and must not be recreated", rel)
+		}
+	}
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	block := rwGrantBlock5e(t)
+	if !strings.Contains(prepared.content, block) {
+		t.Fatalf("generated profile does not contain the section-5e RW block:\n%s\nProfile:\n%s", block, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	for label, dir := range dirs {
+		t.Run(label, func(t *testing.T) {
+			testFile := filepath.Join(dir, ".prism-2245-3e-rw-"+label)
+			t.Cleanup(func() { _ = os.Remove(testFile) }) // host-side safety net
+			sentinel := "prism-2245-3e-" + label + "-sentinel"
+			script := "printf '%s' " + shQuote(sentinel) + " > " + shQuote(testFile) +
+				" && cat " + shQuote(testFile) +
+				" && rm " + shQuote(testFile)
+			cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+				"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
+			out, runErr := cmd.CombinedOutput()
+			if runErr != nil {
+				t.Fatalf("in-sandbox RW round-trip in %s failed under the production profile.\n"+
+					"Exit: %v\nOutput: %s\nProfile: %s", dir, runErr, string(out), testProfilePath)
+			}
+			if !strings.Contains(string(out), sentinel) {
+				t.Errorf("round-trip read in %s did not return the sentinel.\nGot: %s", dir, string(out))
+			}
+		})
+	}
+}
+
+// TestSandboxExecRWRealPaths_DeniedWithoutGrantBlock is the paired negative
+// test: with the ENTIRE section-5e block stripped, the same writes fail in
+// every present 3e dir — proving the block is the load-bearing capability.
+func TestSandboxExecRWRealPaths_DeniedWithoutGrantBlock(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	dirs := rwRealPaths3e(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.PrepareSandboxExecHome()
+	if err != nil {
+		t.Fatalf("PrepareSandboxExecHome: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(stagingHome) })
+
+	block := rwGrantBlock5e(t)
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.Replace(p, block, "", 1)
+	})
+
+	for label, dir := range dirs {
+		t.Run(label, func(t *testing.T) {
+			testFile := filepath.Join(dir, ".prism-2245-3e-denied-"+label)
+			t.Cleanup(func() { _ = os.Remove(testFile) }) // in case the deny fails
+			script := "echo prism-2245-denied > " + shQuote(testFile)
+			cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+				"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c", script)
+			out, runErr := cmd.CombinedOutput()
+			if runErr == nil {
+				t.Errorf("write into %s succeeded WITHOUT the section-5e block.\n"+
+					"The 5e grant is not the load-bearing rule — investigate.\n"+
+					"Output: %s\nMutated profile: %s", dir, string(out), mutatedPath)
+			} else {
+				t.Logf("ka pai — write into %s correctly denied without the 5e block (exit: %v)", dir, runErr)
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_staging_home_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_staging_home_darwin_test.go
@@ -174,16 +174,17 @@ func hostCredentialDir(t *testing.T) string {
 //
 // The test plants a sentinel credential file directly under HOME (NOT
 // /private/var/folders/, which is broadly allowed by the system-paths rule),
-// creates a symlink at $stagingHome/.aws/credentials → that file, then
+// creates a symlink at $stagingHome/.ssh/test-credential → that file, then
 // generates the production profile (which resolves the symlink and emits a
 // (literal "<resolved>") allow for the target). It reads the file from
 // inside the sandbox via the staging HOME path and asserts the read
 // succeeds.
 //
-// Note (#2234): production no longer creates a .aws/credentials staging
-// symlink — the test plants its own purely as a vehicle for the generic
-// collectStagingHomeSymlinkTargets mechanism (the .aws/ staging dir is still
-// scanned for the sso/cli entries until Step 3e/5 of #2132 retire it).
+// Note (#2234/#2245): production creates no credential staging symlinks any
+// more — the test plants its own purely as a vehicle for the generic
+// collectStagingHomeSymlinkTargets mechanism. It lives under .ssh/ because
+// post-#2245 that is the only staging subdirectory the collector still
+// scans (Step 5 of #2132 deletes the mechanism wholesale).
 //
 // The negative test in StagingCredentialDeniedWithoutTargetAllow strips
 // that (literal ...) allow line from the profile and asserts the same read
@@ -217,7 +218,7 @@ func TestSandboxExecProfile_StagingCredentialReadable(t *testing.T) {
 		t.Fatalf("write host credential file: %v", err)
 	}
 
-	stagingCredentialLink := filepath.Join(stagingHome, ".aws", "credentials")
+	stagingCredentialLink := filepath.Join(stagingHome, ".ssh", "test-credential")
 	_ = os.Remove(stagingCredentialLink) // overwrite whatever PrepareSandboxExecHome may have placed
 	if err := os.Symlink(hostCredentialFile, stagingCredentialLink); err != nil {
 		t.Fatalf("create staging credentials symlink: %v", err)
@@ -246,7 +247,7 @@ func TestSandboxExecProfile_StagingCredentialReadable(t *testing.T) {
 	// which the profile allows.
 	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(filepath.Join(stagingHome, ".aws", "credentials")))
+		"cat "+shQuote(filepath.Join(stagingHome, ".ssh", "test-credential")))
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
 		t.Fatalf("read staged credential symlink failed under production profile.\n"+
@@ -296,7 +297,7 @@ func TestSandboxExecProfile_StagingCredentialDeniedWithoutTargetAllow(t *testing
 		t.Fatalf("write host credential file: %v", err)
 	}
 
-	stagingCredentialLink := filepath.Join(stagingHome, ".aws", "credentials")
+	stagingCredentialLink := filepath.Join(stagingHome, ".ssh", "test-credential")
 	_ = os.Remove(stagingCredentialLink)
 	if err := os.Symlink(hostCredentialFile, stagingCredentialLink); err != nil {
 		t.Fatalf("create staging credentials symlink: %v", err)
@@ -318,7 +319,7 @@ func TestSandboxExecProfile_StagingCredentialDeniedWithoutTargetAllow(t *testing
 
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
 		"/usr/bin/env", "HOME="+stagingHome, nixBash, "-c",
-		"cat "+shQuote(filepath.Join(stagingHome, ".aws", "credentials")))
+		"cat "+shQuote(filepath.Join(stagingHome, ".ssh", "test-credential")))
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
 		t.Errorf("read staged credential succeeded WITHOUT the (literal ...) allow for the resolved target.\n"+


### PR DESCRIPTION
Steps 3d–3f of the #2132 staging-HOME elimination train, bundled per the coordinator decision in the issue.

Refs #2132
Closes #2245

## What

**3d — pi oauth:** `stagePIOAuthToken` (touch-and-symlink of `~/.pi/agent/atlassian-mcp-oauth.json` into the staging HOME, #1597) is deleted along with its 7 unit tests. NO new grant: the capability collapses into the existing pi-gated RW `(subpath ~/.pi/agent)` block (§6a). The host-side touch is gone too — `EnsurePIAgentConfigDir` owns host-dir creation at spawn, and the extension creates the token file itself under the §6a grant (its `mkdirSync({recursive:true})`/write works both interim and post-Step-5).

**3e — RW category:** staging symlinks for `~/.cache/nix`, `~/.cache/bun`, `~/.npm`, `~/.mcp-auth`, `~/.aws/{sso,cli}` are gone (no `.cache/`/`.aws/` staging dirs exist any more; the bun `isWritable` gate died with its only caller). New **§5e RW block** grants the four cache/auth dirs at the real host paths (emitted unconditionally — sandbox-exec ignores rules for non-existent paths, so fresh machines are unaffected). **The `~/.aws` deny-with-carve-outs semantics move with this step:** the §5 deny + sso/cli carve-outs (untouched since 3a left them in place) are now the SOLE capability for the two SDK-hardcoded cache dirs; broader `~/.aws` stays denied and is tested both ways (carve-out readable+writable at the real path, outside-carve-out write denied). The collector's `allowedUnderDenied` carve-out plumbing is deleted (it existed only to admit the sso/cli staging targets); the `~/.aws` denied-prefix exclusion is kept as defence in depth.

**3f — RO category:** staging symlinks for `~/.cache/prism/clipboard`, `~/.config/prism/agents`, `~/.nix-profile` are gone (no `.config/` staging dir either). New **§5f RO block** grants clipboard + role-prompts at the real paths. New **§5g block** for `~/.nix-profile`, which is a host SYMLINK: per the #2132 §2 mechanism note, SBPL evaluates resolved targets for open-class ops, so the grant carries a literal allow on the link node (readlink/lstat) **plus** an RO rule on the EvalSymlinks-resolved target (subpath for a dir, literal for a file); resolution failure (fresh machine) skips the target rule and keeps the literal.

**Collector:** scans only `""` + `.ssh` now; `writableStagingPaths` is deleted (every remaining staging symlink is RO); all targets are classified `Writable=false`. The RW/RO emission split in `generateProfile` is retained shape-stable for Step 5 to delete wholesale.

**Bwrap convergence (§5.1):**
- `~/.cache/nix` becomes `OptionalIfMissing` in `StandardSandboxMounts` — it was unconditional, which emits a `--bind` with a missing source on a fresh host, and **bwrap aborts on missing bind sources** (the 3c lesson; the old comment shape predated that finding).
- `~/.cache/bun` converges from the inline `bwrap.go` block into `StandardSandboxMounts` (RW, Dst==Src, `OptionalIfMissing`) — behaviour-identical.
- Everything else in the 3d–3f set was already Dst==Src at the real paths in bwrap (`~/.npm`/`~/.mcp-auth`/clipboard/agents in the walk; `~/.nix-profile` + `~/.local/state/nix/profile` in the conditional inline pair; pi-oauth touch-and-bind in `appendPIBwrapMounts`) — **no canonical-path binds existed for these categories**, so there was nothing to drop; bwrap is unchanged there.

**`rg` sweep clean:** every remaining reference to the dropped staging entries in prism source is a historical/explanatory comment or a negative test assertion proving the old entries stay gone.

## Post-PR staging-HOME inventory (exact — Step 5 will be specified against this)

`~/.local/state/prism/sessions/<instance_id>/home/` now contains ONLY:

- `.ssh/` with conditional symlinks `access-key`, `signing-key`, `signing-key.pub`, `known_hosts`, `allowed_signers` → stable host `~/.ssh/` paths (Step 5 removes-wholesale scope; the generated ssh-config/gitconfig already reference the stable sops paths via the session work dir, #2213)
- `Library/Application Support/Google/` and `Library/Caches/Google/` — empty real dirs, the chromium/`CFFIXED_USER_HOME` surface (Step 4 scope, untouched here)

Nothing else. The collector emits targets for the `.ssh` entries only.

## Interim semantics until Step 5 (deliberate, per the #2132 design)

`HOME`/`XDG_CACHE_HOME`/`XDG_CONFIG_HOME` still point into the staging HOME until Step 5 flips them (§2: these consumers are "$HOME/XDG-derived and just work with real HOME"). Between deploying this PR and deploying Step 5, in-sandbox consumers that derive these paths from $HOME/XDG (npm, bun, nix caches, mcp-remote, the Atlassian MCP extension via `homedir()`, and the PI extension's role-prompt read via `XDG_CONFIG_HOME`) resolve to staging paths that are now plain writable dirs inside the session work-dir allow — so writes become per-session-ephemeral (cache misses, per-session oauth re-auth) and **role-prompt injection no-ops for sessions spawned in that window** (graceful: agents start with the default prompt). No crashes — `TestPrepareSandboxExec_MinimalHomeNoOptionalDirs` and the round-trip tests cover the mechanics. **Recommendation: run `nh switch` once Steps 4–5 have merged (they are queued immediately behind this PR) rather than mid-train.** AWS sso/cli and clipboard are NOT affected by the window (consumers already use real absolute paths).

## Acceptance criteria mapping

- **staging has no 3d/3e/3f symlinks + collector silent** — `TestPrepareSandboxExecHome_NoPiOAuthStaging`, `_PiOAuthHostAbsent_NoTouch`, `_NoAWSSSOCLISymlinks`, `_No3eStagingSymlinks`, `_No3fStagingSymlinks` (unit; each also asserts collector silence with host sources PRESENT), plus staging-gone assertions inside every integration positive.
- **3e + pi-oauth RW round-trips at real paths** — `TestSandboxExecRWRealPaths_RoundTrip` (per-dir create→read→remove, skip-if-absent) and `TestSandboxExecPIAtlassianOAuth_RealPathReadWrite` (write JSON at the real token path in-sandbox, bytes visible on host after exit; existing token stashed/restored).
- **3f RO positives + write-denied negatives** — `TestSandboxExecProfile_RolePromptReadable`/`_RolePromptWriteDenied`, `TestSandboxExecClipboard_RealPathReadable`/`_WriteDenied`, `TestSandboxExecNixProfile_ReadableThroughSymlink` (readlink + ls through the link)/`_WriteDenied`.
- **~/.aws deny with only sso/cli carved out** — updated `TestSandboxExecProfile_AWSSSO*`/`AWSCLI*` read+write positives now exercise the REAL paths (staging symlink chain gone), `TestSandboxExecProfile_AWSOutsideCarveoutDenied` (denied outside carve-out), `_AWSCarveoutAbsent_ProfileLoads` (absent dirs), carve-out/file-write* strip negatives retained, `TestGenerateProfile_AWSSSOAndCLICarveouts` + `_AWSDenyPresent_NoStagedAWSConfig` (unit, deny-before-allow ordering).
- **profile-mutation negatives, whole-block strip (3c lesson)** — §6a: `TestSandboxExecPIAtlassianOAuth_DeniedWithoutPiAgentGrant`; §5e: `TestSandboxExecRWRealPaths_DeniedWithoutGrantBlock` (all present dirs); §5f: `TestSandboxExecProfile_RolePromptDeniedWithoutGrantBlock` + `TestSandboxExecClipboard_DeniedWithoutGrantBlock`. **Documented deviation for §5g:** a strip negative is deliberately omitted — on hm/nix-darwin hosts the `~/.nix-profile` chain resolves into `/nix/store` (covered by the broad §2 `/nix` allow) and link-node metadata rides the BareRoot-ancestor `(subpath HOME)` allow, so a stripped 5g block does not deterministically deny and the test would be flaky-by-layout. The 5g block is defence-in-depth for layouts where the profile dir lives outside `/nix`; its emission shape is pinned at unit level (`TestGenerateProfile_NixProfileROGrant`, `_NixProfileAbsent_LiteralStillEmitted`, both verified by revert-and-fail) and the security property (RO) is integration-tested via the write-denied negative.
- **bwrap** — `TestBwrapBuildArgs_NixCacheDirAbsentNoBind` (absent → no bind; would have aborted bwrap pre-change), `_BunCacheDirBound`/`_BunCacheDirAbsentNoBind` (convergence), existing `_NixCacheDirBound`/`_McpAuthBound`/`_NpmCache*`/`_NixProfile*`/clipboard/agents walk tests unchanged and green.
- **absent host dirs break nothing** — `TestPrepareSandboxExec_MinimalHomeNoOptionalDirs` (bare home: prep + work dir + profile write succeed; 3e/3f blocks still emitted), `TestGenerateProfile_NixProfileAbsent_LiteralStillEmitted`, `_AWSCarveoutAbsent_ProfileLoads`, the bwrap absent-no-bind tests.
- **~/.nix-profile works through resolution** — §5g EvalSymlinks shape above; integration positive readlink+ls through the real link.

## Vacuous-pass checks (revert-and-fail, temp-commit pattern)

- `sandbox_exec_home.go` reverted to HEAD~1 → all 5 staging-gone unit tests FAIL; restored → green.
- `sandbox_exec.go` reverted → `RWRealPathGrants3e`, `RORealPathGrants3f`, `NixProfileROGrant`, `NixProfileAbsent_LiteralStillEmitted`, `MinimalHomeNoOptionalDirs` all FAIL; restored → green.
- `mounts.go` reverted → `NixCacheDirAbsentNoBind` + `BunCacheDirBound` FAIL; restored → green.
- `bwrap.go`'s change is a pure duplicate-removal (reverting it alone would just re-add a redundant inline bun bind on top of the walk entry — no observable behaviour change), so it has no dedicated revert-and-fail pair; the walk entry's load-bearing-ness is covered by the `mounts.go` check.

## Testing

- `go build ./...` — pass
- `go test ./... -race` — pass (full suite, 29 packages)
- `nix build .#prism` — **could not run locally**: this worker sandbox pre-dates the #2201 trusted-settings read allowance (`error: opening file ".../trusted-settings.json": Operation not permitted`). Per AGENTS.md I ran the sanctioned non-flake eval fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` — pass. The authoritative homeless-shelter build runs in CI (`nix-build-prism-checked`). No `.nix` files are touched by this PR.
- ⚠️ **The Darwin sandbox-exec integration tests SKIP in this worker sandbox** (nested sandbox-exec refuses to apply profiles; #2207 capability-probe gating via `sandboxexectest.Require` — all new/updated tests verified to compile and SKIP cleanly here). Please arrange a host-side run before merge, as for PRs #2238/#2242/#2244:

  ```
  go test ./internal/integration/ -run 'TestSandboxExecRWRealPaths|TestSandboxExecClipboard|TestSandboxExecNixProfile|TestSandboxExecProfile_RolePrompt|TestSandboxExecPIAtlassianOAuth|TestSandboxExecProfile_AWS|TestSandboxExecProfile_Staging' -v
  ```

  Notes for the host run: the RW round-trips create uniquely-named dot-files inside the real `~/.cache/{nix,bun}`, `~/.npm`, `~/.mcp-auth`, `~/.aws/{sso,cli}` and remove them; the pi-oauth tests stash and restore the real `~/.pi/agent/atlassian-mcp-oauth.json`; the role-prompt tests prefer READING the deployed `worker.md` when present (on hm-managed hosts the agents dir is a read-only symlink into the nix store, so sentinel-planting is impossible) and fall back to planting a sentinel only when the dir is genuinely writable; the role-prompt strip negative additionally requires a read target that resolves in place — a store-symlinked deployed file stays readable via the §2 /nix allow even with 5f stripped (the same resolved-target mechanism as the documented §5g no-strip-negative deviation) — and SKIPs with that justification otherwise; the role-prompt write-denied negative plants nothing and asserts the in-sandbox create attempt is denied (doubly denied on hm hosts: SBPL RO + unwritable store); the clipboard test creates `~/.cache/prism/clipboard` if absent and removes only what it created.

## Out of scope (untouched)

- Chromium / `CFFIXED_USER_HOME` / staging `Library/` skeleton (Step 4) and the final staging-HOME + `.ssh` symlink removal, `HOME`/`XDG_*` env flip, collector deletion (Step 5)
- The dispatcher's `HOME`/`XDG_CACHE_HOME`/`XDG_CONFIG_HOME` staging overrides in `cmd/agent_run_sandbox_exec_darwin.go` (Step 5 deletes them)
- `~/.ssh` staging symlinks (Step 5 removes-wholesale scope)
- Pre-existing gofmt drift in other packages (go 1.26 gofmt vs older formatting; all files touched here are gofmt-clean — the two integration files with pre-existing drift, `sandbox_exec_helpers_darwin_test.go` and `sandbox_exec_profile_darwin_test.go`, are not modified)

