### PR TITLE
sandbox-exec: allow iokit-open-service on IOPMrootDomain (#2249)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -73,6 +73,18 @@ import (
 //     real home, an unredirected daemon would pollute the real
 //     ~/Library/Caches. Routed to the session work dir alongside the
 //     CF-routed chromium state.
+//   - PLAYWRIGHT_SERVER_REGISTRY=<sessionDir>/Library/Caches/ms-playwright/b
+//     — same class, second writer (issue #2249, round-2 host capture):
+//     playwright-core's ServerRegistry (browser-server descriptor
+//     registry + chokidar watcher) derives `ms-playwright/b` from the
+//     same POSIX-$HOME cache root and mkdirSync's it on every successful
+//     browser-server launch (coreBundle.js registryDirectory2 — the env
+//     override is read in ServerRegistry._browsersDir). Note
+//     PLAYWRIGHT_BROWSERS_PATH (the browser-download registry,
+//     `ms-playwright` itself) is deliberately NOT overridden: in this
+//     deployment browsers come from the Nix store via
+//     PLAYWRIGHT_MCP_EXECUTABLE_PATH, the download registry is read-side
+//     only, and it did not appear as a writer in either host capture.
 //
 // Extracted from runAgentRunSandboxExec so the env construction is unit
 // testable (the dispatch function itself forks a supervised child).
@@ -88,6 +100,7 @@ func buildSandboxExecHomeEnv(env []string, stagingHome, sessionDir, realHome str
 		"CFFIXED_USER_HOME": true,
 
 		"PLAYWRIGHT_DAEMON_SESSION_DIR": true,
+		"PLAYWRIGHT_SERVER_REGISTRY":    true,
 	}
 	filtered := make([]string, 0, len(env))
 	for _, kv := range env {
@@ -111,6 +124,7 @@ func buildSandboxExecHomeEnv(env []string, stagingHome, sessionDir, realHome str
 		"XDG_STATE_HOME="+filepath.Join(realHome, ".local", "state"),
 		"CFFIXED_USER_HOME="+sessionDir,
 		"PLAYWRIGHT_DAEMON_SESSION_DIR="+filepath.Join(sessionDir, "Library", "Caches", "ms-playwright", "daemon"),
+		"PLAYWRIGHT_SERVER_REGISTRY="+filepath.Join(sessionDir, "Library", "Caches", "ms-playwright", "b"),
 	)
 }
 

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -61,6 +61,18 @@ import (
 //     #2021, #2247). The Library skeleton dirs inside the work dir are
 //     created by PrepareSessionWorkDir; writes ride the profile's existing
 //     (subpath <sessionDir>) RW allow — no host-Library grant exists.
+//   - PLAYWRIGHT_DAEMON_SESSION_DIR=<sessionDir>/Library/Caches/ms-playwright/daemon
+//     — redirects the playwright-cli daemon's session registry and log
+//     directory (issue #2249). On Darwin playwright-core derives this dir
+//     from os.homedir()/Library/Caches (POSIX $HOME — it ignores
+//     XDG_CACHE_HOME on darwin, see cli-client/registry.js baseDaemonDir),
+//     which would land `Library/Caches/ms-playwright/daemon/...` inside
+//     the staging HOME — violating the #2247 invariant that the staging
+//     HOME holds no Library/ entries. The explicit override is also the
+//     #2250 (Step 5 of #2132) robustness story: once HOME flips to the
+//     real home, an unredirected daemon would pollute the real
+//     ~/Library/Caches. Routed to the session work dir alongside the
+//     CF-routed chromium state.
 //
 // Extracted from runAgentRunSandboxExec so the env construction is unit
 // testable (the dispatch function itself forks a supervised child).
@@ -74,6 +86,8 @@ func buildSandboxExecHomeEnv(env []string, stagingHome, sessionDir, realHome str
 		"XDG_CONFIG_HOME":   true,
 		"XDG_STATE_HOME":    true,
 		"CFFIXED_USER_HOME": true,
+
+		"PLAYWRIGHT_DAEMON_SESSION_DIR": true,
 	}
 	filtered := make([]string, 0, len(env))
 	for _, kv := range env {
@@ -96,6 +110,7 @@ func buildSandboxExecHomeEnv(env []string, stagingHome, sessionDir, realHome str
 		"XDG_DATA_HOME="+filepath.Join(realHome, ".local", "share"),
 		"XDG_STATE_HOME="+filepath.Join(realHome, ".local", "state"),
 		"CFFIXED_USER_HOME="+sessionDir,
+		"PLAYWRIGHT_DAEMON_SESSION_DIR="+filepath.Join(sessionDir, "Library", "Caches", "ms-playwright", "daemon"),
 	)
 }
 

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin_test.go
@@ -156,6 +156,46 @@ func TestBuildSandboxExecHomeEnv_CFFixedUserHomePointsAtSessionWorkDir(t *testin
 	}
 }
 
+// TestBuildSandboxExecHomeEnv_PlaywrightDaemonSessionDirPointsAtWorkDir is
+// the env-construction AC for the playwright-daemon redirect (issue #2249):
+// the sandbox-exec session env carries
+// PLAYWRIGHT_DAEMON_SESSION_DIR=<sessionDir>/Library/Caches/ms-playwright/daemon
+// exactly once, and any host-inherited value is stripped. Without the
+// override, playwright-core on Darwin derives the daemon dir from POSIX
+// $HOME (os.homedir()/Library/Caches — it ignores XDG_CACHE_HOME on
+// darwin), landing daemon logs in the staging HOME's Library/ and
+// violating the #2247 no-staging-Library invariant.
+func TestBuildSandboxExecHomeEnv_PlaywrightDaemonSessionDirPointsAtWorkDir(t *testing.T) {
+	env, stagingHome, sessionDir, realHome := sandboxExecHomeEnvFixture()
+
+	// Simulate a host-inherited value to prove the strip works.
+	env = append(env, "PLAYWRIGHT_DAEMON_SESSION_DIR="+realHome+"/Library/Caches/ms-playwright/daemon")
+
+	got := buildSandboxExecHomeEnv(env, stagingHome, sessionDir, realHome)
+
+	want := "PLAYWRIGHT_DAEMON_SESSION_DIR=" + sessionDir + "/Library/Caches/ms-playwright/daemon"
+	stagingValue := "PLAYWRIGHT_DAEMON_SESSION_DIR=" + stagingHome + "/Library/Caches/ms-playwright/daemon"
+	count := 0
+	found := false
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "PLAYWRIGHT_DAEMON_SESSION_DIR=") {
+			count++
+		}
+		switch kv {
+		case want:
+			found = true
+		case stagingValue:
+			t.Errorf("env carries a staging-HOME PLAYWRIGHT_DAEMON_SESSION_DIR value %q — must be the session work dir (issue #2249)", kv)
+		}
+	}
+	if !found {
+		t.Errorf("env does not contain %q\nenv: %v", want, got)
+	}
+	if count != 1 {
+		t.Errorf("env contains %d PLAYWRIGHT_DAEMON_SESSION_DIR entries, want exactly 1 (host-inherited value must be stripped)\nenv: %v", count, got)
+	}
+}
+
 // TestBuildSandboxExecHomeEnv_HomeAndXDGLayerUnchangedByStep4 pins the
 // rest of the home env layer across the #2247 change: HOME and
 // XDG_CACHE_HOME/XDG_CONFIG_HOME still point into the staging HOME (the

--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin_test.go
@@ -156,43 +156,57 @@ func TestBuildSandboxExecHomeEnv_CFFixedUserHomePointsAtSessionWorkDir(t *testin
 	}
 }
 
-// TestBuildSandboxExecHomeEnv_PlaywrightDaemonSessionDirPointsAtWorkDir is
-// the env-construction AC for the playwright-daemon redirect (issue #2249):
-// the sandbox-exec session env carries
+// TestBuildSandboxExecHomeEnv_PlaywrightDirsPointAtWorkDir is the
+// env-construction AC for the playwright POSIX-$HOME redirects (issue
+// #2249): the sandbox-exec session env carries
 // PLAYWRIGHT_DAEMON_SESSION_DIR=<sessionDir>/Library/Caches/ms-playwright/daemon
-// exactly once, and any host-inherited value is stripped. Without the
-// override, playwright-core on Darwin derives the daemon dir from POSIX
-// $HOME (os.homedir()/Library/Caches — it ignores XDG_CACHE_HOME on
-// darwin), landing daemon logs in the staging HOME's Library/ and
-// violating the #2247 no-staging-Library invariant.
-func TestBuildSandboxExecHomeEnv_PlaywrightDaemonSessionDirPointsAtWorkDir(t *testing.T) {
-	env, stagingHome, sessionDir, realHome := sandboxExecHomeEnvFixture()
-
-	// Simulate a host-inherited value to prove the strip works.
-	env = append(env, "PLAYWRIGHT_DAEMON_SESSION_DIR="+realHome+"/Library/Caches/ms-playwright/daemon")
-
-	got := buildSandboxExecHomeEnv(env, stagingHome, sessionDir, realHome)
-
-	want := "PLAYWRIGHT_DAEMON_SESSION_DIR=" + sessionDir + "/Library/Caches/ms-playwright/daemon"
-	stagingValue := "PLAYWRIGHT_DAEMON_SESSION_DIR=" + stagingHome + "/Library/Caches/ms-playwright/daemon"
-	count := 0
-	found := false
-	for _, kv := range got {
-		if strings.HasPrefix(kv, "PLAYWRIGHT_DAEMON_SESSION_DIR=") {
-			count++
-		}
-		switch kv {
-		case want:
-			found = true
-		case stagingValue:
-			t.Errorf("env carries a staging-HOME PLAYWRIGHT_DAEMON_SESSION_DIR value %q — must be the session work dir (issue #2249)", kv)
-		}
+// (daemon registry + logs) and
+// PLAYWRIGHT_SERVER_REGISTRY=<sessionDir>/Library/Caches/ms-playwright/b
+// (browser-server descriptor registry) exactly once each, with any
+// host-inherited values stripped. Without the overrides, playwright-core
+// on Darwin derives both dirs from POSIX $HOME
+// (os.homedir()/Library/Caches — it ignores XDG_CACHE_HOME on darwin),
+// landing them in the staging HOME's Library/ and violating the #2247
+// no-staging-Library invariant.
+func TestBuildSandboxExecHomeEnv_PlaywrightDirsPointAtWorkDir(t *testing.T) {
+	cases := []struct {
+		key    string
+		subdir string
+	}{
+		{"PLAYWRIGHT_DAEMON_SESSION_DIR", "/Library/Caches/ms-playwright/daemon"},
+		{"PLAYWRIGHT_SERVER_REGISTRY", "/Library/Caches/ms-playwright/b"},
 	}
-	if !found {
-		t.Errorf("env does not contain %q\nenv: %v", want, got)
-	}
-	if count != 1 {
-		t.Errorf("env contains %d PLAYWRIGHT_DAEMON_SESSION_DIR entries, want exactly 1 (host-inherited value must be stripped)\nenv: %v", count, got)
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			env, stagingHome, sessionDir, realHome := sandboxExecHomeEnvFixture()
+
+			// Simulate a host-inherited value to prove the strip works.
+			env = append(env, tc.key+"="+realHome+tc.subdir)
+
+			got := buildSandboxExecHomeEnv(env, stagingHome, sessionDir, realHome)
+
+			want := tc.key + "=" + sessionDir + tc.subdir
+			stagingValue := tc.key + "=" + stagingHome + tc.subdir
+			count := 0
+			found := false
+			for _, kv := range got {
+				if strings.HasPrefix(kv, tc.key+"=") {
+					count++
+				}
+				switch kv {
+				case want:
+					found = true
+				case stagingValue:
+					t.Errorf("env carries a staging-HOME %s value %q — must be the session work dir (issue #2249)", tc.key, kv)
+				}
+			}
+			if !found {
+				t.Errorf("env does not contain %q\nenv: %v", want, got)
+			}
+			if count != 1 {
+				t.Errorf("env contains %d %s entries, want exactly 1 (host-inherited value must be stripped)\nenv: %v", count, tc.key, got)
+			}
+		})
 	}
 }
 

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -828,6 +828,35 @@ func generateProfile(m *Manager) string {
 	sb.WriteString("  (iokit-user-client-class \"RootDomainUserClient\"))\n")
 	sb.WriteString("\n")
 
+	// ── 9c. iokit-open-service — IOPMrootDomain (#2249) ──────────────────
+	// Current Chrome for Testing acquires its power-management port via
+	// iokit-open-service on the IOPMrootDomain registry entry — a different
+	// operation class from the iokit-open-user-client RootDomainUserClient
+	// allow above (§9b). Without this rule the open is denied and chromium
+	// SIGSEGVs (SEGV_ACCERR) during early init — the same observable
+	// fingerprint as the #2021 user-client denial. Deny-log smoking gun:
+	//
+	//   Sandbox: Google Chrome for Testing(NNN) deny(1) iokit-open-service IOPMrootDomain
+	//
+	// The rule shape mirrors Apple's own power-assertions definition in
+	// /System/Library/Sandbox/Profiles/appsandbox-common.sb, which pairs
+	// exactly these two allows:
+	//
+	//   (allow iokit-open-service (iokit-registry-entry-class "IOPMrootDomain"))
+	//   (allow iokit-open-user-client
+	//          (iokit-user-client-class "RootDomainUserClient"))
+	//
+	// The filter is iokit-registry-entry-class (the class of the IOService
+	// being opened), NOT iokit-user-client-class (which filters the
+	// user-client connection type and applies to iokit-open-user-client).
+	//
+	// The unqualified form `(allow iokit-open-service)` MUST NOT be used —
+	// it would permit opening arbitrary IOKit services. Only the
+	// IOPMrootDomain registry entry is granted.
+	sb.WriteString("(allow iokit-open-service\n")
+	sb.WriteString("  (iokit-registry-entry-class \"IOPMrootDomain\"))\n")
+	sb.WriteString("\n")
+
 	// ── 12. POSIX shared memory ────────────────────────────────────────────
 	// CRITICAL: The v1 (allow ipc-posix-shm) is an UNBOUND VARIABLE in v3.
 	// Use the split read*/write* variants instead. See F.1 §2 rule 12.

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -192,7 +192,6 @@ func TestGenerateProfile_ProcessAndIPCAllows(t *testing.T) {
 		t.Errorf("profile must not contain unqualified (allow iokit-open-service) — only the IOPMrootDomain registry entry is granted (issue #2249); full profile:\n%s", profile)
 	}
 
-
 	// The signal widening MUST NOT include (target others) — that would
 	// permit signalling arbitrary host PIDs. Only (target self) and
 	// (target children) are allowed (issue #2021).

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -188,6 +188,10 @@ func TestGenerateProfile_ProcessAndIPCAllows(t *testing.T) {
 	if strings.Contains(profile, "(allow iokit-open-user-client)") {
 		t.Errorf("profile must not contain unqualified (allow iokit-open-user-client) — enumerate iokit-user-client-class entries instead (issue #2021); full profile:\n%s", profile)
 	}
+	if strings.Contains(profile, "(allow iokit-open-service)") {
+		t.Errorf("profile must not contain unqualified (allow iokit-open-service) — only the IOPMrootDomain registry entry is granted (issue #2249); full profile:\n%s", profile)
+	}
+
 
 	// The signal widening MUST NOT include (target others) — that would
 	// permit signalling arbitrary host PIDs. Only (target self) and
@@ -263,6 +267,43 @@ func TestGenerateProfile_IOKitChromiumClasses(t *testing.T) {
 		if !strings.Contains(iokitBlock, want) {
 			t.Errorf("iokit-open block missing required class %q; block:\n%s", want, iokitBlock)
 		}
+	}
+}
+
+// TestGenerateProfile_IOKitOpenServiceIOPMrootDomain verifies the
+// iokit-open-service allow for the IOPMrootDomain registry entry
+// (issue #2249). Current Chrome for Testing acquires its power-management
+// port via iokit-open-service on IOPMrootDomain — a different operation
+// class from the iokit-open-user-client RootDomainUserClient allow — and
+// SIGSEGVs during early init when it is denied.
+//
+// The allow must be scoped to exactly the IOPMrootDomain registry entry:
+// no unqualified (allow iokit-open-service), no registry-entry-class-prefix
+// wildcard, and no additional registry entries beyond IOPMrootDomain.
+func TestGenerateProfile_IOKitOpenServiceIOPMrootDomain(t *testing.T) {
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	serviceBlock := extractClause(t, profile, "(allow iokit-open-service")
+	if !strings.Contains(serviceBlock, "(iokit-registry-entry-class \"IOPMrootDomain\")") {
+		t.Errorf("iokit-open-service block missing the IOPMrootDomain registry-entry-class filter (issue #2249); block:\n%s", serviceBlock)
+	}
+
+	// Exactly one registry-entry filter is granted — the block must not
+	// grow extra entries or switch to a prefix wildcard without a paired
+	// integration test per docs/sandbox-exec-testing.md.
+	if got := strings.Count(serviceBlock, "iokit-registry-entry-class"); got != 1 {
+		t.Errorf("iokit-open-service block must contain exactly one iokit-registry-entry-class filter, got %d; block:\n%s", got, serviceBlock)
+	}
+	if strings.Contains(serviceBlock, "iokit-registry-entry-class-prefix") {
+		t.Errorf("iokit-open-service block must not use a registry-entry-class-prefix wildcard (issue #2249); block:\n%s", serviceBlock)
+	}
+
+	// The iokit-open-service operation must appear exactly once in the
+	// profile — a second occurrence would indicate an unqualified or
+	// duplicate grant sneaking in elsewhere.
+	if got := strings.Count(profile, "iokit-open-service"); got != 1 {
+		t.Errorf("profile must contain exactly one iokit-open-service occurrence, got %d; full profile:\n%s", got, profile)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
@@ -171,13 +171,15 @@ func runPlaywrightCLI(t *testing.T, profilePath, playwrightBin, stagingHome, ses
 		"PATH=" + os.Getenv("PATH"),
 		"XDG_CACHE_HOME=" + filepath.Join(stagingHome, ".cache"),
 		"XDG_CONFIG_HOME=" + filepath.Join(stagingHome, ".config"),
-		// Mirrors buildSandboxExecHomeEnv (issue #2249): without this,
+		// Mirrors buildSandboxExecHomeEnv (issue #2249): without these,
 		// playwright-core on Darwin derives its daemon registry/log dir
-		// from POSIX $HOME (os.homedir()/Library/Caches — XDG_CACHE_HOME
-		// is ignored on darwin), writing
-		// <stagingHome>/Library/Caches/ms-playwright/daemon/... and
-		// tripping the #2247 no-staging-Library assertion below.
+		// AND its browser-server descriptor registry from POSIX $HOME
+		// (os.homedir()/Library/Caches — XDG_CACHE_HOME is ignored on
+		// darwin), writing <stagingHome>/Library/Caches/ms-playwright/
+		// daemon/... and .../b respectively, tripping the #2247
+		// no-staging-Library assertion below.
 		"PLAYWRIGHT_DAEMON_SESSION_DIR=" + filepath.Join(sessionDir, "Library", "Caches", "ms-playwright", "daemon"),
+		"PLAYWRIGHT_SERVER_REGISTRY=" + filepath.Join(sessionDir, "Library", "Caches", "ms-playwright", "b"),
 	}
 	if term := os.Getenv("TERM"); term != "" {
 		envVars = append(envVars, "TERM="+term)

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
@@ -32,7 +32,8 @@ package integration_test
 //      profile (issue #2249) — the launch path is repeatable in-sandbox,
 //      not green only on first-boot state.
 //
-// The three negative tests use the `withMutatedProfile` helper to:
+// The two negative tests in this file use the `withMutatedProfile` helper
+// to:
 //
 //   - Remove the iokit-open-user-client allow block. The positive test
 //     above must then fail with the SEGV fingerprint, proving the
@@ -43,10 +44,12 @@ package integration_test
 //     Chrome for Testing acquires its power-management port via
 //     iokit-open-service on IOPMrootDomain, a different operation class
 //     from the user-client allow.
-//   - Remove the `(target children)` qualifier from the signal allow.
-//     The positive test above must then surface a `kill EPERM` warning
-//     in the launcher stderr, proving the signal widening is
-//     load-bearing.
+//
+// The signal `(target children)` widening is covered by the deterministic
+// positive/negative pair in sandbox_exec_signal_darwin_test.go (issue
+// #2249 — the former playwright-based kill-EPERM negative lost its
+// distinguishing premise once the browser stopped SEGVing; see the NOTE
+// near the end of this file).
 //
 // We intentionally do not exercise the headless / WindowServer-bootstrap
 // rule here — that follow-up is out of scope (issue #2021, "Out of scope"
@@ -68,6 +71,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -167,6 +171,13 @@ func runPlaywrightCLI(t *testing.T, profilePath, playwrightBin, stagingHome, ses
 		"PATH=" + os.Getenv("PATH"),
 		"XDG_CACHE_HOME=" + filepath.Join(stagingHome, ".cache"),
 		"XDG_CONFIG_HOME=" + filepath.Join(stagingHome, ".config"),
+		// Mirrors buildSandboxExecHomeEnv (issue #2249): without this,
+		// playwright-core on Darwin derives its daemon registry/log dir
+		// from POSIX $HOME (os.homedir()/Library/Caches — XDG_CACHE_HOME
+		// is ignored on darwin), writing
+		// <stagingHome>/Library/Caches/ms-playwright/daemon/... and
+		// tripping the #2247 no-staging-Library assertion below.
+		"PLAYWRIGHT_DAEMON_SESSION_DIR=" + filepath.Join(sessionDir, "Library", "Caches", "ms-playwright", "daemon"),
 	}
 	if term := os.Getenv("TERM"); term != "" {
 		envVars = append(envVars, "TERM="+term)
@@ -265,7 +276,7 @@ func TestSandboxExecProfile_PlaywrightCLIOpensUnderProductionProfile(t *testing.
 		}
 	}
 	if _, statErr := os.Lstat(filepath.Join(stagingHome, "Library")); statErr == nil {
-		t.Fatalf("staging HOME still contains a Library/ entry — the chromium skeleton must live only in the session work dir (issue #2247)")
+		t.Fatalf("staging HOME still contains a Library/ entry — the chromium skeleton must live only in the session work dir (issue #2247).\nOffending entries:\n%s", listTreeForDiag(filepath.Join(stagingHome, "Library")))
 	}
 
 	// Load-bearing regression guard: the iokit-open-user-client block
@@ -366,7 +377,7 @@ func TestSandboxExecProfile_PlaywrightCLIOpensUnderProductionProfile(t *testing.
 	// Post-run: the staging HOME must still hold no Library/ entries —
 	// nothing in the run may have re-created the pre-#2247 staging layout.
 	if _, statErr := os.Lstat(filepath.Join(stagingHome, "Library")); statErr == nil {
-		t.Errorf("staging HOME gained a Library/ entry during the run — chromium state must land in the session work dir (issue #2247)")
+		t.Errorf("staging HOME gained a Library/ entry during the run — chromium state must land in the session work dir (issue #2247).\nOffending entries:\n%s", listTreeForDiag(filepath.Join(stagingHome, "Library")))
 	}
 }
 
@@ -496,57 +507,51 @@ func TestSandboxExecProfile_PlaywrightCLIFailsWithoutIOPMrootDomainAllow(t *test
 	}
 }
 
+// NOTE (issue #2249): the former
 // TestSandboxExecProfile_PlaywrightCLISignalEPERMWithoutTargetChildren
-// is the paired negative test for the signal (target children) widening.
-// It removes the (target children) qualifier from the signal allow and
-// asserts that the playwright-cli launcher now surfaces a `kill EPERM`
-// warning when trying to clean up its chromium grandchild.
-//
-// Note: this negative test does NOT necessarily produce a non-zero exit
-// code from playwright-cli \u2014 the open itself may still succeed,
-// and the kill EPERM is a warning during cleanup. The assertion is on
-// the stderr substring, not the exit code.
-func TestSandboxExecProfile_PlaywrightCLISignalEPERMWithoutTargetChildren(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("sandbox-exec is Darwin-only")
-	}
-	requireSandboxExec(t)
-	playwrightBin := requirePlaywrightCLI(t)
+// negative was REMOVED here. Its premise broke with the #2249 fix: pre-fix,
+// the SEGVd browser forced the node launcher down the force-kill path,
+// surfacing `kill EPERM` when (target children) was absent. Post-fix the
+// browser runs healthily, `playwright-cli close` tears the session down
+// gracefully over CDP (no signal is sent), and the launcher never exercises
+// the kill path — so the EPERM fingerprint cannot manifest without
+// contriving a SEGV. The signal (target children) widening is instead
+// covered by the deterministic positive/negative pair in
+// sandbox_exec_signal_darwin_test.go, which proves the rule's semantics
+// (child-signalling allowed with the rule, EPERM without it) directly with
+// a bash child-kill probe. The killEPERMFingerprint absence assertion in
+// the positive test above is retained — it guards any future close-path
+// force-kill regression.
 
-	m := newProfileManagerWithBareRoot(t)
-
-	stagingHome, err := m.SandboxExecHomePath()
-	if err != nil {
-		t.Fatalf("SandboxExecHomePath: %v", err)
-	}
-	sessionDir, err := m.SessionWorkDir()
-	if err != nil {
-		t.Fatalf("SessionWorkDir: %v", err)
-	}
-
-	// Replace the widened signal clause with self-only. The mutation must
-	// produce a syntactically valid SBPL profile so the sandbox still
-	// loads \u2014 we want the failure to come from the runtime signal
-	// denial, not a profile parse error. The mutation leaves the sessionDir
-	// grant intact, so the launch-dir variant keeps node's CWD resolvable
-	// and the surfaced failure is the kill EPERM, not a getcwd bootstrap
-	// death.
-	mutatedPath := withMutatedProfileAndLaunchDir(t, m, sessionDir, func(p string) string {
-		return strings.ReplaceAll(p,
-			"(allow signal (target self) (target children))",
-			"(allow signal (target self))")
+// listTreeForDiag returns a newline-separated recursive listing of root
+// (relative paths), capped at 200 entries, for assertion diagnostics. When
+// the #2247 staging-Library assertions fire, the listing names the
+// offending writer (e.g. Caches/ms-playwright/daemon/... → the playwright
+// daemon log dir, issue #2249) instead of leaving the operator to re-run
+// with manual instrumentation.
+func listTreeForDiag(root string) string {
+	const maxEntries = 200
+	var entries []string
+	_ = filepath.WalkDir(root, func(path string, _ os.DirEntry, err error) error {
+		if err != nil {
+			entries = append(entries, path+" (walk error: "+err.Error()+")")
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
+		}
+		entries = append(entries, rel)
+		if len(entries) >= maxEntries {
+			entries = append(entries, "... (truncated at "+strconv.Itoa(maxEntries)+" entries)")
+			return filepath.SkipAll
+		}
+		return nil
 	})
-
-	combined, _ := runPlaywrightCLIOpen(t, mutatedPath, playwrightBin, stagingHome, sessionDir)
-
-	if !strings.Contains(combined, killEPERMFingerprint) {
-		t.Errorf("playwright-cli output does not contain %q after removing\n"+
-			"(target children) from the signal allow.\n"+
-			"The negative test is not catching the signal-widening regression.\n"+
-			"Profile: %s\nOutput:\n%s", killEPERMFingerprint, mutatedPath, combined)
-	} else {
-		t.Logf("ka pai \u2014 launcher correctly surfaced %q without (target children)", killEPERMFingerprint)
+	if len(entries) == 0 {
+		return "(empty or unreadable: " + root + ")"
 	}
+	return strings.Join(entries, "\n")
 }
 
 // removeIOKitAllowBlock returns a copy of the generated profile with the

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
@@ -29,11 +29,17 @@ package integration_test
 //      under the host ~/Library/Application Support/... and NOT under the
 //      staging HOME (which holds no Library/ entries post-#2247).
 //
-// The two negative tests use the `withMutatedProfile` helper to:
+// The three negative tests use the `withMutatedProfile` helper to:
 //
 //   - Remove the iokit-open-user-client allow block. The positive test
 //     above must then fail with the SEGV fingerprint, proving the
 //     iokit-open-user-client rule is load-bearing.
+//   - Remove the iokit-open-service IOPMrootDomain allow (issue #2249).
+//     The positive test above must then fail with the SEGV fingerprint,
+//     proving the iokit-open-service rule is load-bearing — current
+//     Chrome for Testing acquires its power-management port via
+//     iokit-open-service on IOPMrootDomain, a different operation class
+//     from the user-client allow.
 //   - Remove the `(target children)` qualifier from the signal allow.
 //     The positive test above must then surface a `kill EPERM` warning
 //     in the launcher stderr, proving the signal widening is
@@ -43,11 +49,7 @@ package integration_test
 // rule here — that follow-up is out of scope (issue #2021, "Out of scope"
 // §4.2 — headless-by-default is tracked separately).
 //
-// Status note (2026-06-12): the POSITIVE test is skipped pending #2249
-// (pre-existing iokit-open-service IOPMrootDomain denial, fails on main
-// identically — see the test's own comment). Both NEGATIVES remain active
-// and host-green; their fingerprint guards are load-bearing.
-//
+
 // Why playwright-cli end-to-end rather than a minimal IOKit harness:
 // the iokit-open-user-client class set was empirically chosen against the
 // Chrome for Testing framework's exact init path. A minimal harness that
@@ -207,21 +209,17 @@ func runPlaywrightCLIOpen(t *testing.T, profilePath, playwrightBin, stagingHome,
 // user-data directory landed under the work-dir Library (not the host
 // Library, and not the staging HOME — which holds no Library/ post-#2247).
 //
-// SKIPPED pending #2249, which owns unskipping. The 2026-06-12 host bisect
-// (PR #2248) showed this positive fails IDENTICALLY on main — pre-existing,
-// not a #2247 regression (the production profile is byte-identical either
-// side of the #2247 retarget, and the retarget was exonerated by the
-// bisect). Deny-log smoking gun: the live Chrome for Testing performs
-// iokit-open-service on IOPMrootDomain — a different operation class from
-// the profile's iokit-open-user-client RootDomainUserClient allow — and the
-// denial cascades into an AMFI core-dump denial and SEGV_ACCERR at render
-// init. The production fix is #2021-scope, tracked with the full
-// diagnostic record in #2249. The paired negatives below stay ACTIVE —
-// they pass with their correct fingerprints (iokit SEGV, kill EPERM) and
-// those guards are load-bearing.
+// History: this positive was skipped between 2026-06-12 and #2249's fix.
+// The 2026-06-12 host bisect (PR #2248) showed it failing identically on
+// main — the live Chrome for Testing performs iokit-open-service on
+// IOPMrootDomain, a different operation class from the profile's
+// iokit-open-user-client RootDomainUserClient allow, and the denial
+// cascades into an AMFI core-dump denial and SEGV_ACCERR at render init.
+// The §9c iokit-open-service IOPMrootDomain allow (issue #2249) closed the
+// gap; the paired negative
+// TestSandboxExecProfile_PlaywrightCLIFailsWithoutIOPMrootDomainAllow
+// proves it is load-bearing.
 func TestSandboxExecProfile_PlaywrightCLIOpensUnderProductionProfile(t *testing.T) {
-	t.Skip("skipped pending #2249 — pre-existing iokit-open-service IOPMrootDomain denial on main (not a #2247 regression); #2249 owns unskipping")
-
 	if runtime.GOOS != "darwin" {
 		t.Skip("sandbox-exec is Darwin-only")
 	}
@@ -399,6 +397,70 @@ func TestSandboxExecProfile_PlaywrightCLIFailsWithoutIOKitAllow(t *testing.T) {
 	}
 }
 
+// TestSandboxExecProfile_PlaywrightCLIFailsWithoutIOPMrootDomainAllow is
+// the paired negative test for the iokit-open-service IOPMrootDomain allow
+// (issue #2249). It strips only the iokit-open-service clause from the
+// profile — leaving the iokit-open-user-client block (#2021) fully intact —
+// and asserts that playwright-cli now fails with the SEGV fingerprint.
+//
+// This proves the new allow is load-bearing on its own: the user-client
+// allow set from #2021 is NOT sufficient for current Chrome for Testing,
+// which acquires its power-management port via iokit-open-service on the
+// IOPMrootDomain registry entry (deny-log smoking gun from 2026-06-12:
+// `deny(1) iokit-open-service IOPMrootDomain`).
+func TestSandboxExecProfile_PlaywrightCLIFailsWithoutIOPMrootDomainAllow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	playwrightBin := requirePlaywrightCLI(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	stagingHome, err := m.SandboxExecHomePath()
+	if err != nil {
+		t.Fatalf("SandboxExecHomePath: %v", err)
+	}
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+
+	// The iokit-open-service mutation leaves the sessionDir grant intact,
+	// so the launch-dir variant keeps node's CWD resolvable and the failure
+	// under test is the SEGV, not a getcwd bootstrap death.
+	mutatedPath := withMutatedProfileAndLaunchDir(t, m, sessionDir, removeIOPMrootDomainAllowBlock)
+
+	combined, runErr := runPlaywrightCLIOpen(t, mutatedPath, playwrightBin, stagingHome, sessionDir)
+	if runErr == nil {
+		t.Errorf("playwright-cli open exited 0 WITHOUT the iokit-open-service IOPMrootDomain allow.\n"+
+			"The negative test is not catching the regression \u2014 chromium should\n"+
+			"have SIGSEGV'd acquiring its power-management port (issue #2249).\n"+
+			"Mutated profile: %s\nOutput:\n%s", mutatedPath, combined)
+		return
+	}
+
+	// At least one of the SEGV fingerprints must appear in the launcher
+	// stderr. If chromium failed for a different reason (e.g. parse error
+	// in the mutated profile), the negative test is not isolating the
+	// iokit-open-service rule.
+	sawSegV := false
+	for _, fp := range segVFingerprint {
+		if strings.Contains(combined, fp) {
+			sawSegV = true
+			break
+		}
+	}
+	if !sawSegV {
+		t.Errorf("playwright-cli failed under the mutated profile, but the failure mode\n"+
+			"does not match the iokit-denial SEGV fingerprint (issue #2249).\n"+
+			"Expected one of %v in output.\nExit: %v\nProfile: %s\nOutput:\n%s",
+			segVFingerprint, runErr, mutatedPath, combined)
+	} else {
+		t.Logf("ka pai \u2014 chromium correctly SIGSEGV'd without the iokit-open-service IOPMrootDomain allow (exit: %v)", runErr)
+	}
+}
+
 // TestSandboxExecProfile_PlaywrightCLISignalEPERMWithoutTargetChildren
 // is the paired negative test for the signal (target children) widening.
 // It removes the (target children) qualifier from the signal allow and
@@ -475,6 +537,24 @@ func removeIOKitAllowBlock(p string) string {
   (iokit-user-client-class "IOAudioEngineUserClient")
   (iokit-user-client-class "IOFramebufferSharedUserClient")
   (iokit-user-client-class "RootDomainUserClient"))
+`
+	return strings.Replace(p, block, "", 1)
+}
+
+// removeIOPMrootDomainAllowBlock returns a copy of the generated profile
+// with the (allow iokit-open-service ...) clause stripped (issue #2249).
+// The clause spans two lines in the current generator output:
+//
+//	(allow iokit-open-service
+//	  (iokit-registry-entry-class "IOPMrootDomain"))
+//
+// We match the verbatim block so the substitution is unambiguous and any
+// future addition of a second registry entry would invalidate the match —
+// at which point the test fails loudly (withMutatedProfile rejects no-op
+// mutations) rather than silently mutating the wrong region.
+func removeIOPMrootDomainAllowBlock(p string) string {
+	const block = `(allow iokit-open-service
+  (iokit-registry-entry-class "IOPMrootDomain"))
 `
 	return strings.Replace(p, block, "", 1)
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_playwright_darwin_test.go
@@ -28,6 +28,9 @@ package integration_test
 //      CFFIXED_USER_HOME points at — issue #2247, Step 4 of #2132), NOT
 //      under the host ~/Library/Application Support/... and NOT under the
 //      staging HOME (which holds no Library/ entries post-#2247).
+//   5. A full open → close → re-open cycle succeeds under the same
+//      profile (issue #2249) — the launch path is repeatable in-sandbox,
+//      not green only on first-boot state.
 //
 // The three negative tests use the `withMutatedProfile` helper to:
 //
@@ -133,8 +136,8 @@ const crashpadEPERMFingerprint = "Operation not permitted"
 // even on a cold box; a successful run typically completes in ~3 s.
 const playwrightCLITimeout = 60 * time.Second
 
-// runPlaywrightCLIOpen invokes sandbox-exec on the given profile path
-// against playwright-cli with `open <data-url>` followed by `close`.
+// runPlaywrightCLI invokes sandbox-exec on the given profile path against
+// playwright-cli with the given CLI args (e.g. "open", <url> — or "close").
 // The env mirrors what agent_run_sandbox_exec_darwin.go does in
 // production: HOME and XDG_CACHE/CONFIG at the staging HOME, and
 // CFFIXED_USER_HOME at the per-session work dir (issue #2247, Step 4 of
@@ -152,16 +155,12 @@ const playwrightCLITimeout = 60 * time.Second
 // inherited from the go-test binary, ungranted) these tests could never
 // have passed a host run — a pre-existing hole from #2022, surfaced by the
 // first host run that exercised them (#2247).
-func runPlaywrightCLIOpen(t *testing.T, profilePath, playwrightBin, stagingHome, sessionDir string) (combinedOutput string, runErr error) {
+func runPlaywrightCLI(t *testing.T, profilePath, playwrightBin, stagingHome, sessionDir string, cliArgs ...string) (combinedOutput string, runErr error) {
 	t.Helper()
 
 	// The Nix-built playwright-cli is a #! /nix/store/.../bash script. We
 	// run it directly via sandbox-exec; the shebang line resolves to a
 	// Nix store bash that is covered by the system-paths /nix allow.
-	//
-	// open <url> then close releases the chromium child so the test does
-	// not leak a long-running daemon. If the open SIGSEGVs, the close
-	// becomes a no-op against an already-dead session.
 	envVars := []string{
 		"HOME=" + stagingHome,
 		"CFFIXED_USER_HOME=" + sessionDir,
@@ -176,7 +175,8 @@ func runPlaywrightCLIOpen(t *testing.T, profilePath, playwrightBin, stagingHome,
 	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
 		"/usr/bin/env", "-i")
 	cmd.Args = append(cmd.Args, envVars...)
-	cmd.Args = append(cmd.Args, playwrightBin, "open", playwrightDataURL)
+	cmd.Args = append(cmd.Args, playwrightBin)
+	cmd.Args = append(cmd.Args, cliArgs...)
 	cmd.Dir = sessionDir
 
 	// Belt-and-suspenders timeout: spawn a goroutine that kills the
@@ -197,6 +197,15 @@ func runPlaywrightCLIOpen(t *testing.T, profilePath, playwrightBin, stagingHome,
 	return string(out), err
 }
 
+// runPlaywrightCLIOpen invokes runPlaywrightCLI with `open <data-url>`.
+// If the open SIGSEGVs (the negative tests' expected outcome), the
+// playwright daemon never establishes a session, so no close is needed
+// against the dead session.
+func runPlaywrightCLIOpen(t *testing.T, profilePath, playwrightBin, stagingHome, sessionDir string) (combinedOutput string, runErr error) {
+	t.Helper()
+	return runPlaywrightCLI(t, profilePath, playwrightBin, stagingHome, sessionDir, "open", playwrightDataURL)
+}
+
 // TestSandboxExecProfile_PlaywrightCLIOpensUnderProductionProfile is the
 // positive integration test for the chromium-under-sandbox-exec fix
 // (issue #2021).
@@ -204,7 +213,8 @@ func runPlaywrightCLIOpen(t *testing.T, profilePath, playwrightBin, stagingHome,
 // It generates the production SBPL profile (which also prepares the
 // session work dir — creating the chromium Library/Application
 // Support/Google skeleton inside it — and the staging HOME), and invokes
-// playwright-cli with `open <data-url>` under sandbox-exec. Asserts exit 0
+// playwright-cli with `open <data-url>` (then close → re-open → close,
+// issue #2249) under sandbox-exec. Asserts exit 0
 // with no SEGV or kill-EPERM fingerprints in stderr, and that the chromium
 // user-data directory landed under the work-dir Library (not the host
 // Library, and not the staging HOME — which holds no Library/ post-#2247).
@@ -304,6 +314,31 @@ func TestSandboxExecProfile_PlaywrightCLIOpensUnderProductionProfile(t *testing.
 			"Support/Google skeleton is not being honoured or CFFIXED_USER_HOME\n"+
 			"is not redirecting NSHomeDirectory() at the session work dir\n"+
 			"(issue #2247).\nOutput:\n%s", crashpadEPERMFingerprint, combined)
+	}
+
+	// open → close → re-open cycle (issue #2249 AC): the first open above
+	// spawned the playwright daemon; close must tear the session down
+	// cleanly, and a second open must then succeed from scratch — proving
+	// the in-sandbox launch path is repeatable, not green only on
+	// first-boot state.
+	closeOut, closeErr := runPlaywrightCLI(t, testProfilePath, playwrightBin, stagingHome, sessionDir, "close")
+	if closeErr != nil {
+		t.Errorf("playwright-cli close exited non-zero under production profile (issue #2249).\nExit: %v\nOutput:\n%s", closeErr, closeOut)
+	}
+
+	reopenOut, reopenErr := runPlaywrightCLIOpen(t, testProfilePath, playwrightBin, stagingHome, sessionDir)
+	if reopenErr != nil {
+		t.Errorf("playwright-cli re-open exited non-zero under production profile (issue #2249).\nExit: %v\nOutput:\n%s", reopenErr, reopenOut)
+	}
+	for _, fp := range segVFingerprint {
+		if strings.Contains(reopenOut, fp) {
+			t.Errorf("re-open output contains SEGV fingerprint %q (issue #2249).\nOutput:\n%s", fp, reopenOut)
+		}
+	}
+
+	// Final close so the test does not leak a long-running daemon.
+	if finalCloseOut, finalCloseErr := runPlaywrightCLI(t, testProfilePath, playwrightBin, stagingHome, sessionDir, "close"); finalCloseErr != nil {
+		t.Errorf("final playwright-cli close exited non-zero (issue #2249).\nExit: %v\nOutput:\n%s", finalCloseErr, finalCloseOut)
 	}
 
 	// The chromium user-data directory must live under the work-dir

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_signal_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_signal_darwin_test.go
@@ -1,0 +1,135 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_signal_darwin_test.go — deterministic integration coverage
+// for the signal (target self) (target children) allow in the production
+// SBPL profile (issues #2021, #2249).
+//
+// History: the (target children) widening was added in #2021 so the
+// playwright-cli node launcher could clean up its chromium child, and was
+// originally covered by a playwright-based negative asserting a
+// `kill EPERM` launcher warning. That negative's premise broke with the
+// #2249 iokit-open-service fix: pre-fix, the SEGVd browser forced the
+// launcher down the force-kill path; post-fix the browser runs healthily
+// and `playwright-cli close` tears the session down gracefully over CDP —
+// no signal is ever sent, so the EPERM fingerprint cannot manifest without
+// contriving a SEGV (and the 2026-06-12 host capture suggests a contrived
+// SEGV would not isolate the rule either: kill EPERM was observed on the
+// SEGV path even WITH (target children) present — the daemon → launcher →
+// chromium grandchild depth observation in #2249).
+//
+// This file replaces it with a direct probe of the rule's semantics using
+// bash: a parent process spawning a child and signalling it. This is
+// deterministic (no browser failure modes), fast (no chromium launch), and
+// isolates exactly the clause under test:
+//
+//   - Positive: under the production profile, `bash -c 'sleep & kill $!'`
+//     exits 0 — child-signalling is permitted by (target children).
+//   - Negative: with the signal clause mutated to (target self) only, the
+//     same operation fails with "Operation not permitted" — proving
+//     (target children) is the load-bearing qualifier, not a no-op.
+//
+// The (target children) rule remains load-bearing well beyond playwright:
+// shell job control, pi killing a timed-out tool child, and any harness
+// subprocess cleanup all signal child processes. The playwright positive in
+// sandbox_exec_playwright_darwin_test.go retains its killEPERMFingerprint
+// absence assertion as a guard on the close-path force-kill case.
+//
+// Per docs/sandbox-exec-testing.md: bash is the right probe binary here —
+// the strip negative leaves the launch CWD ungranted-tolerant (bash only
+// warns on an unresolvable CWD), and requireNixBash skips when bash is not
+// a Nix store binary.
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// signalChildScript spawns a background sleep child (output detached so
+// the kernel pipe to the test harness closes when bash exits, not when an
+// orphaned sleep does), signals it via the kill builtin (which calls
+// kill(2) from the bash process targeting its direct child), and exits
+// with the kill's status. Under (target self)-only the kill(2) is denied
+// by seatbelt with EPERM; bash reports "Operation not permitted" and the
+// script exits non-zero.
+const signalChildScript = `sleep 5 >/dev/null 2>&1 & kill -TERM $!`
+
+// TestSandboxExecProfile_SignalChildAllowed is the positive: under the
+// production profile, a sandboxed process can signal its own child.
+func TestSandboxExecProfile_SignalChildAllowed(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Regression guard at the string level first: a generator change that
+	// drops the widening should fail here with a precise message before
+	// the behavioural probe below.
+	if !strings.Contains(prepared.content, "(allow signal (target self) (target children))") {
+		t.Fatalf("generated profile is missing the signal (target self) (target children) widening (issues #2021, #2249).\nProfile:\n%s", prepared.content)
+	}
+
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath, nixBash, "-c", signalChildScript)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Errorf("signalling a direct child failed under the production profile.\n"+
+			"The signal (target children) allow should permit kill(2) on a\n"+
+			"child process (issues #2021, #2249).\nExit: %v\nOutput:\n%s", runErr, out)
+	}
+	if strings.Contains(string(out), "Operation not permitted") {
+		t.Errorf("child-kill output contains an EPERM under the production profile.\nOutput:\n%s", out)
+	}
+}
+
+// TestSandboxExecProfile_SignalChildEPERMWithoutTargetChildren is the
+// paired negative: with the signal clause narrowed to (target self) only,
+// the same child-kill must be denied with EPERM. This proves the positive
+// above is not green by accident — (target children) is specifically what
+// permits the child signal.
+func TestSandboxExecProfile_SignalChildEPERMWithoutTargetChildren(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+
+	// Replace the widened signal clause with self-only. The mutation must
+	// produce a syntactically valid SBPL profile so the sandbox still
+	// loads — the failure under test is the runtime signal denial, not a
+	// profile parse error. withMutatedProfile fatals if the substitution
+	// matches nothing, so a generator reshape cannot silently turn this
+	// negative into a no-op.
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p,
+			"(allow signal (target self) (target children))",
+			"(allow signal (target self))")
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath, nixBash, "-c", signalChildScript)
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("signalling a direct child succeeded WITHOUT (target children).\n"+
+			"The negative test is not catching the signal-widening regression\n"+
+			"(issues #2021, #2249).\nMutated profile: %s\nOutput:\n%s", mutatedPath, out)
+		return
+	}
+	if !strings.Contains(string(out), "Operation not permitted") {
+		t.Errorf("child-kill failed under the mutated profile, but not with the\n"+
+			"expected EPERM fingerprint — the failure mode does not isolate the\n"+
+			"signal rule.\nExit: %v\nProfile: %s\nOutput:\n%s", runErr, mutatedPath, out)
+	} else {
+		t.Logf("ka pai — child-kill correctly denied EPERM without (target children) (exit: %v)", runErr)
+	}
+}

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_signal_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_signal_darwin_test.go
@@ -36,10 +36,17 @@ package integration_test
 // sandbox_exec_playwright_darwin_test.go retains its killEPERMFingerprint
 // absence assertion as a guard on the close-path force-kill case.
 //
-// Per docs/sandbox-exec-testing.md: bash is the right probe binary here —
-// the strip negative leaves the launch CWD ungranted-tolerant (bash only
-// warns on an unresolvable CWD), and requireNixBash skips when bash is not
-// a Nix store binary.
+// Per docs/sandbox-exec-testing.md: bash is the probe binary
+// (requireNixBash skips when bash is not a Nix store binary), and both
+// tests launch with cmd.Dir set to the session work dir using the
+// launch-dir profile variants — otherwise bash inherits the go-test
+// binary's ungranted CWD and emits shell-init getcwd noise
+// ("Operation not permitted") that is indistinguishable from a kill
+// denial by naive substring matching. That exact false positive surfaced
+// on the 2026-06-13 round-2 host run. Belt and braces, the assertions
+// additionally key on the kill-specific denial fingerprint (bash's kill
+// builtin reports `kill: (<pid>) - Operation not permitted`), not on any
+// bare EPERM substring.
 
 import (
 	"os/exec"
@@ -57,6 +64,21 @@ import (
 // script exits non-zero.
 const signalChildScript = `sleep 5 >/dev/null 2>&1 & kill -TERM $!`
 
+// killDenialFingerprint is the bash kill-builtin failure prefix — the
+// full line is `kill: (<pid>) - Operation not permitted`. Both substrings
+// below must co-occur for output to count as a kill denial; shell-init
+// getcwd noise contains "Operation not permitted" but never "kill: (".
+const killDenialFingerprint = "kill: ("
+
+// epermText is the errno string shared by all seatbelt denials.
+const epermText = "Operation not permitted"
+
+// containsKillDenial reports whether out contains the kill-specific
+// denial fingerprint (both the kill-builtin prefix and the EPERM text).
+func containsKillDenial(out string) bool {
+	return strings.Contains(out, killDenialFingerprint) && strings.Contains(out, epermText)
+}
+
 // TestSandboxExecProfile_SignalChildAllowed is the positive: under the
 // production profile, a sandboxed process can signal its own child.
 func TestSandboxExecProfile_SignalChildAllowed(t *testing.T) {
@@ -70,6 +92,11 @@ func TestSandboxExecProfile_SignalChildAllowed(t *testing.T) {
 
 	prepared, _ := preparePositiveProfile(t, m)
 
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+
 	// Regression guard at the string level first: a generator change that
 	// drops the widening should fail here with a precise message before
 	// the behavioural probe below.
@@ -77,17 +104,20 @@ func TestSandboxExecProfile_SignalChildAllowed(t *testing.T) {
 		t.Fatalf("generated profile is missing the signal (target self) (target children) widening (issues #2021, #2249).\nProfile:\n%s", prepared.content)
 	}
 
-	profilePath := writeAugmentedPositiveProfile(t, prepared)
+	// Launch-dir variant + cmd.Dir: keep bash's CWD resolvable so the
+	// output is free of shell-init getcwd EPERM noise (see file header).
+	profilePath := writeAugmentedPositiveProfileWithLaunchDir(t, prepared, sessionDir)
 
 	cmd := exec.Command(sandboxExecPath, "-f", profilePath, nixBash, "-c", signalChildScript)
+	cmd.Dir = sessionDir
 	out, runErr := cmd.CombinedOutput()
 	if runErr != nil {
 		t.Errorf("signalling a direct child failed under the production profile.\n"+
 			"The signal (target children) allow should permit kill(2) on a\n"+
 			"child process (issues #2021, #2249).\nExit: %v\nOutput:\n%s", runErr, out)
 	}
-	if strings.Contains(string(out), "Operation not permitted") {
-		t.Errorf("child-kill output contains an EPERM under the production profile.\nOutput:\n%s", out)
+	if containsKillDenial(string(out)) {
+		t.Errorf("child-kill output contains the kill-denial fingerprint under the production profile.\nOutput:\n%s", out)
 	}
 }
 
@@ -105,19 +135,27 @@ func TestSandboxExecProfile_SignalChildEPERMWithoutTargetChildren(t *testing.T) 
 
 	m := newProfileManager(t)
 
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+
 	// Replace the widened signal clause with self-only. The mutation must
 	// produce a syntactically valid SBPL profile so the sandbox still
 	// loads — the failure under test is the runtime signal denial, not a
 	// profile parse error. withMutatedProfile fatals if the substitution
 	// matches nothing, so a generator reshape cannot silently turn this
-	// negative into a no-op.
-	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+	// negative into a no-op. The mutation leaves the sessionDir grant
+	// intact, so the launch-dir variant keeps bash's CWD resolvable and
+	// the only EPERM in the output can be the kill denial itself.
+	mutatedPath := withMutatedProfileAndLaunchDir(t, m, sessionDir, func(p string) string {
 		return strings.ReplaceAll(p,
 			"(allow signal (target self) (target children))",
 			"(allow signal (target self))")
 	})
 
 	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath, nixBash, "-c", signalChildScript)
+	cmd.Dir = sessionDir
 	out, runErr := cmd.CombinedOutput()
 	if runErr == nil {
 		t.Errorf("signalling a direct child succeeded WITHOUT (target children).\n"+
@@ -125,10 +163,12 @@ func TestSandboxExecProfile_SignalChildEPERMWithoutTargetChildren(t *testing.T) 
 			"(issues #2021, #2249).\nMutated profile: %s\nOutput:\n%s", mutatedPath, out)
 		return
 	}
-	if !strings.Contains(string(out), "Operation not permitted") {
+	if !containsKillDenial(string(out)) {
 		t.Errorf("child-kill failed under the mutated profile, but not with the\n"+
-			"expected EPERM fingerprint — the failure mode does not isolate the\n"+
-			"signal rule.\nExit: %v\nProfile: %s\nOutput:\n%s", runErr, mutatedPath, out)
+			"kill-specific denial fingerprint (%q + %q) — the failure mode does\n"+
+			"not isolate the signal rule (a getcwd or other EPERM would be a\n"+
+			"different failure).\nExit: %v\nProfile: %s\nOutput:\n%s",
+			killDenialFingerprint, epermText, runErr, mutatedPath, out)
 	} else {
 		t.Logf("ka pai — child-kill correctly denied EPERM without (target children) (exit: %v)", runErr)
 	}


### PR DESCRIPTION
Closes #2249

## What

Fixes the headless-chromium SIGSEGV under the production sandbox-exec profile by adding the minimal SBPL allow for the `iokit-open-service` open on the **IOPMrootDomain** registry entry (§9c in `generateProfile`):

```scheme
(allow iokit-open-service
  (iokit-registry-entry-class "IOPMrootDomain"))
```

Current Chrome for Testing acquires its power-management port via `iokit-open-service` on IOPMrootDomain — a different operation class from the `iokit-open-user-client` `RootDomainUserClient` allow added in #2021 — and SIGSEGVs (`SEGV_ACCERR`) during early init when it is denied.

Host verification of the fix surfaced and this PR also resolves two adjacent issues:

- **Playwright POSIX-`$HOME` writers redirected off the staging HOME** (#2247 invariant): playwright-core derives two writable dirs from `os.homedir()/Library/Caches` on Darwin (ignoring `XDG_CACHE_HOME`) — the daemon registry/log dir and the ServerRegistry browser-server descriptor dir (`ms-playwright/b`, `mkdirSync`'d on every successful launch). `buildSandboxExecHomeEnv` now sets the overrides both code paths read — `PLAYWRIGHT_DAEMON_SESSION_DIR` and `PLAYWRIGHT_SERVER_REGISTRY` — routing both to `<sessionDir>/Library/Caches/ms-playwright/...` alongside the CF-routed chromium state. This is also the #2250 (Step 5 of #2132) robustness story: post-flip, unredirected writers would pollute the real `~/Library`. A full bundle sweep found no third writer: `PLAYWRIGHT_BROWSERS_PATH` (download registry) and the channel-browser `Application Support` paths are read-side in this deployment (browsers ship from the Nix store via `PLAYWRIGHT_MCP_EXECUTABLE_PATH`) and are deliberately not overridden.
- **Signal `(target children)` coverage reworked** (see "Signal negative rework" below).

## SBPL scoping verification

- The rule shape mirrors Apple's own `power-assertions` definition in `/System/Library/Sandbox/Profiles/appsandbox-common.sb`, which pairs exactly these two allows (`iokit-open-service` on `IOPMrootDomain` + `iokit-open-user-client` on `RootDomainUserClient`). The filter for `iokit-open-service` is `iokit-registry-entry-class`, not `iokit-user-client-class`.
- Compile-verified empirically under `(version 3)(deny default)`; bogus operation/filter names fail at compile, proving the check is real.
- No unscoped `(allow iokit-open-service)`, no prefix wildcard: `TestGenerateProfile_IOKitOpenServiceIOPMrootDomain` locks the block to exactly one `iokit-registry-entry-class` filter and exactly one `iokit-open-service` occurrence in the whole profile; `TestGenerateProfile_ProcessAndIPCAllows` gains unqualified-form guards.

## Tests (per docs/sandbox-exec-testing.md, issue #1192)

- **Positive unskipped and extended**: `TestSandboxExecProfile_PlaywrightCLIOpensUnderProductionProfile` (skip-with-reference from PR #2248 removed) now exercises a full **open → close → re-open → close** cycle under the production profile, and the #2247 staging-Library assertions print the offending entries when they fire.
- **New mutation negative**: `TestSandboxExecProfile_PlaywrightCLIFailsWithoutIOPMrootDomainAllow` strips only the two-line `iokit-open-service` clause (leaving the #2021 user-client block intact) and asserts the SEGV fingerprint — the new allow is load-bearing on its own.
- **Pre-existing iokit negative retained**: still distinguishes (host-verified).
- **Signal rule**: deterministic positive/negative pair in `sandbox_exec_signal_darwin_test.go` (see below).
- **#2207 capability-probe gating retained**: all integration tests skip cleanly where sandbox-exec is unavailable.
- New unit tests verified non-vacuous (fix reverted → FAIL; restored → PASS) for the SBPL clause and both env redirects.

## Signal negative rework (replaces the playwright kill-EPERM negative)

The former negative removed `(target children)` and asserted a `kill EPERM` warning from the playwright launcher. Its premise broke with this fix: pre-fix, the SEGVd browser forced the launcher down the force-kill path; post-fix the browser runs healthily and `playwright-cli close` tears down gracefully over CDP — no signal is sent, so the fingerprint cannot manifest without contriving a SEGV. The 2026-06-12 host capture additionally showed `kill EPERM` on the SEGV path even *with* `(target children)` present (daemon → launcher → chromium grandchild depth), so a contrived-SEGV variant would not isolate the rule either.

Replacement: `sandbox_exec_signal_darwin_test.go` probes the rule semantics directly — bash spawns a child and signals it; the production profile permits it, and the `(target self)`-only mutation must deny it with the kill-specific fingerprint (`kill: (` + `Operation not permitted` co-occurring; bare-EPERM matching would false-positive on shell-init getcwd noise, which surfaced on the round-2 host run). Both tests launch from the session work dir via the launch-dir profile variants. The playwright positive retains its `kill EPERM`-absence assertion as a guard on the close-path force-kill case.

## Host verification (3 rounds, run by Ben on the real host — full record in PR comments)

Round 3 (commit `c0e7b9b0`): **5/5 PASS** — positive incl. open→close→re-open cycle and clean staging-Library assertion; both iokit mutation negatives distinguish (SEGV); signal positive clean; signal negative distinguishes (kill denial).

- [x] Positive passes on the real host (no SEGV / kill EPERM / crashpad EPERM fingerprints)
- [x] New IOPMrootDomain mutation negative fails the launch with the SEGV fingerprint
- [x] Pre-existing iokit negative still distinguishes
- [x] Deny-log capture during the passing run: no fatal denials (classification below)
- [x] `kill EPERM`: **does not reproduce post-fix** — 0 occurrences in all three positive-run captures. The original observation was a cascade symptom of the SEGV failure path, not a residual `(target children)` depth limitation. No follow-up issue needed.

### Deny-log classification (round 3; stable across all three rounds)

| Denial | Count | Classification |
|---|---|---|
| `iokit-open-service IOPMrootDomain` | **0** | Fixed by this PR (third consecutive clean capture) |
| `iokit-get-properties` (AppleSmartBattery, IOService syscfg-v2-data, AppleDiagnosticDataAccessReadOnly, IOPlatformExpertDevice via crashpad) | 589 | Benign hardware-property probes; browser fully functional — not allowed |
| `forbidden-sandbox-reinit` | 45 | Chrome Helpers attempting their own seatbelt init under our outer profile; non-fatal by design — not allowed |
| `socket-ioctl` / `file-read-data` / `mach-lookup` / `necp-client-open` / `file-read-xattr` / `file-issue-extension` | 30/16/10/8/4/4 | Non-fatal probes; browser fully functional — not allowed |
| `file-write-data` (`com.apple.IntlDataCache.le` under TMPDIR/C, `/dev/tty` from bash) | 12 | Non-fatal; the `/dev/tty` writes are test-harness noise — not allowed |
| `hid-control` | 4 | Matches the issue's expected-benign list; non-fatal — not allowed |
| `iokit-open-service` AppleSMCKeysEndpoint / IOSurfaceRoot | 2/2 | Non-fatal (browser runs without them); deliberately **not** allowed — not load-bearing |

No remaining fatal sandbox denials for the chromium launch.

## Build notes

- `go build ./...` and `go test ./...` green from `modules/programs/prism/prism/`.
- Local `nix build .#prism` could not run in this worker sandbox (pre-#2201 sandbox generation: `trusted-settings.json` read denied). Sanctioned fallback `nix-instantiate --eval --expr 'builtins.getFlake (toString ./.)'` passes. CI's `nix-build-prism-checked` is the authoritative homeless-shelter build.

## Sequencing

Issue #2250 (Step 5 final removal of #2132) is sequenced behind this change — its acceptance sweep needs the clean chromium deny-log baseline this PR establishes. The playwright env redirects added here are part of that story: they pre-empt real-`~/Library` pollution once HOME flips to the real home.
