### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780795403,
-        "narHash": "sha256-AkWx4Zt9pQbD/f82Z8N57+d0HGLN/rV3gdMKJTpBPKs=",
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6a771120d607dcccb279a27d227650e324815c35",
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
         "type": "github"
       },
       "original": {
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780894562,
-        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780943742,
-        "narHash": "sha256-01bTMR9ZPG+uxPaZBeOwagg5uxIaFYs2/3YIrOX+bCA=",
+        "lastModified": 1781305496,
+        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df39142474950e42d5fc3bf2fef9d6c62abbe8d7",
+        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780749050,
-        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1780997039,
-        "narHash": "sha256-8pPXOCZkrySE3zwtix2MYxm9NzzHT/XQr0mHJsf3lis=",
+        "lastModified": 1781328464,
+        "narHash": "sha256-j9uBlHI0eJ9zWU9IlF6SlBBPdeJu30hcvar31IRKHpw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "872eb0174d0d5a1bc37388ff84eea2bca44b1065",
+        "rev": "5a722a7155bfc9fbe657f28d26b71860d95324bc",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1780511130,
-        "narHash": "sha256-2v9lT4ya59Lh1FqPeLnz1MoX9y/wz2huqfe9RtQZITk=",
+        "lastModified": 1780952837,
+        "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "535f3e6942cb1cead3929c604320d3db54b542b9",
+        "rev": "e820eb4a444b46a19b2e03e8dfd2359439ff30fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/27458255120

## Closure diff: navi

```
calibre: 9.8.0 → 9.9.0, 151.4 KiB
chromium: 149.0.7827.53 → 149.0.7827.102
chromium-unwrapped: 149.0.7827.53 → 149.0.7827.102, 56.6 KiB
claude-code: 2.1.161 → 2.1.175, 5.8 MiB
cloudflared: 2026.5.0 → 2026.5.2, 92.4 KiB
deno: 2.8.0 → 2.8.2, -1.3 MiB
fastfetch: 2.63.1 → 2.64.2, 32.7 KiB
fuse: -315.4 KiB
fuse-overlayfs: 1.16 → 1.17
gimp: -125.0 KiB
gnupg: 1.2 MiB
hubble: 1.19.3 → 1.19.4, 36.5 KiB
hyprland: 0.55.2 → 0.55.3, 80.9 KiB
initrd-linux: 7.0.11 → 7.0.12, -480.4 KiB
kitty: 0.47.1 → 0.47.2, 156.7 KiB
kubernetes-helm: 3.20.2 → 4.2.0, 7.1 MiB
linux: 7.0.11 → 7.0.12, 385.6 KiB
mangohud: 0.8.3 → 0.8.4
nixos-manual: -16.6 KiB
nixos-system-navi: 26.11.20260606.a799d3e → 26.11.20260610.9ae611a
onnxruntime: 98.3 KiB
openrazer: 3.12.3-7.0.11 → 3.12.3-7.0.12
rclone: 1.74.2 → 1.74.3, 13.2 KiB
ripgrep: 6.2 MiB
source: 441.2 KiB
```

## Closure diff: tui

```
calibre: 9.8.0 → 9.9.0, 151.4 KiB
chromium: 149.0.7827.53 → 149.0.7827.102
chromium-unwrapped: 149.0.7827.53 → 149.0.7827.102, 56.6 KiB
claude-code: 2.1.161 → 2.1.175, 5.8 MiB
cloudflared: 2026.5.0 → 2026.5.2, 92.4 KiB
deno: 2.8.0 → 2.8.2, -1.3 MiB
fastfetch: 2.63.1 → 2.64.2, 32.7 KiB
fuse-overlayfs: 1.16 → 1.17
gimp: -125.0 KiB
gnupg: 1.2 MiB
hubble: 1.19.3 → 1.19.4, 36.5 KiB
hyprland: 0.55.2 → 0.55.3, 80.9 KiB
initrd-linux: 7.0.11 → 7.0.12
kitty: 0.47.1 → 0.47.2, 156.7 KiB
kubernetes-helm: 3.20.2 → 4.2.0, 7.1 MiB
linux: 7.0.11 → 7.0.12, 385.6 KiB
mangohud: 0.8.3 → 0.8.4
nixos-manual: -16.6 KiB
nixos-system-tui: 26.11.20260606.a799d3e → 26.11.20260610.9ae611a
onnxruntime: 98.3 KiB
openrazer: 3.12.3-7.0.11 → 3.12.3-7.0.12
ripgrep: 6.2 MiB
source: 441.2 KiB
```