### PR TITLE
m4mac: declare datadog-labs/pack as a homebrew tap

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -143,6 +143,7 @@ in
 
   homebrew = {
     enable = true;
+    taps = [ "datadog-labs/pack" ];
     onActivation = {
       autoUpdate = true;
       cleanup = "uninstall";


### PR DESCRIPTION
Closes #2266

## What

Adds `taps = [ "datadog-labs/pack" ];` to the `homebrew = { ... }` block in `machines/m4mac/configuration.nix`. One-line addition; no other keys touched.

## Why

`homebrew.brews` includes the tap-qualified formula `"datadog-labs/pack/pup"`, but `homebrew.taps` was empty. The Brewfile rendered by nix-darwin therefore had no `tap "datadog-labs/pack"` line, and modern Homebrew refuses to load formulae from third-party taps that are neither declared via `brew tap` nor trusted via `brew trust`. Result: `brew bundle` during `darwin-rebuild switch` aborted with:

```
Error: Refusing to load formula datadog-labs/pack/pup from untrusted tap datadog-labs/pack.
```

The activation script exits non-zero at that step, and `home-manager` activation runs **after** the brew step in this configuration — so the brew failure silently skipped home-manager activation on every `darwin-rebuild switch` for the last few days. That's why PR #2262's `PLAYWRIGHT_MCP_SANDBOX` env var (and #2216's `AWS_SHARED_CREDENTIALS_FILE`, and #2244's `CLAUDE_CONFIG_DIR`) had not landed in `~/.config/prism/profiles.json` on m4mac despite all three PRs evaluating correctly via `nix eval`.

Declaring the tap renders `tap "datadog-labs/pack"` at the top of the Brewfile. `brew bundle` processes the `tap` line first via `brew tap`, which adds the tap to the registry — the supported channel the tap-trust gate keys on (separate from the per-user `brew trust` DB, which the nix-darwin activation script does not consult).

## Verification

- [x] `homebrew.taps` in `machines/m4mac/configuration.nix` includes `"datadog-labs/pack"`.
- [x] `nix eval --json .#darwinConfigurations.m4mac.config.homebrew.taps` →
      `[{"brewfileLine":"tap \"datadog-labs/pack\"","clone_target":null,"force_auto_update":null,"name":"datadog-labs/pack"}]`
- [x] `nix build .#darwinConfigurations.m4mac.system --dry-run` succeeds (eval clean; only the Brewfile + darwin-system stubs need building).
- [x] No change to `homebrew.brews`, `homebrew.casks`, `homebrew.onActivation`, or any other module.
- [x] `nixfmt .` is clean (file unchanged after formatting).

## Out of scope

Post-merge user verification (running `sudo darwin-rebuild switch` to confirm the brew step now succeeds, then `grep PLAYWRIGHT_MCP_SANDBOX ~/.config/prism/profiles.json`) is captured in #2266 and remains the user's step — it requires sudo and cannot be performed from a prism session.
