### PR TITLE
m4mac: codify homebrew tap-trust shim via home-manager

### DIFF
--- a/machines/m4mac/configuration.nix
+++ b/machines/m4mac/configuration.nix
@@ -143,7 +143,10 @@ in
 
   homebrew = {
     enable = true;
-    taps = [ "datadog-labs/pack" ];
+    taps = [
+      "datadog-labs/pack"
+      "nikitabobko/tap"
+    ];
     onActivation = {
       autoUpdate = true;
       cleanup = "uninstall";
@@ -183,7 +186,7 @@ in
     extraSpecialArgs = {
       inherit inputs;
     };
-    users.${username} = {
+    users.${username} = { config, ... }: {
       programs.chromium = {
         enable = false;
         package = pkgs.hello; # override Linux-only default so Darwin eval doesn't fail
@@ -228,6 +231,13 @@ in
         file = {
           ".config/karabiner/karabiner.json".source = ./files/karabiner.json;
           ".config/aerospace/aerospace.toml".source = ./files/aerospace.toml;
+          # Bridge the activation-script brew bundle's tap-trust DB path
+          # (~/.homebrew/trust.json — the fallback used when XDG_CONFIG_HOME is
+          # stripped by sudo --preserve-env=PATH) to the interactive
+          # `brew trust` write location (~/.config/homebrew/trust.json).
+          # Out-of-store so interactive `brew trust X` can still write to it.
+          # See issue #2268 for the full kōrero.
+          ".homebrew".source = config.lib.file.mkOutOfStoreSymlink "${config.xdg.configHome}/homebrew";
         };
       };
     };


### PR DESCRIPTION
Closes #2268.

Two small additions to `machines/m4mac/configuration.nix` to codify the manual workaround that unblocked this evening's activation chain:

1. **`homebrew.taps`** — add `"nikitabobko/tap"` alongside the existing `"datadog-labs/pack"` from #2267. Symmetric coverage for the tap-qualified items currently in `homebrew.brews` / `homebrew.casks`.

2. **`home.file.".homebrew"`** — declare an out-of-store symlink pointing at `${config.xdg.configHome}/homebrew` (i.e. `~/.config/homebrew`). This bridges the activation-script brew-bundle's tap-trust DB fallback path (`~/.homebrew/trust.json`, which is what `/opt/homebrew/bin/brew` falls through to when `sudo --preserve-env=PATH` strips `XDG_CONFIG_HOME` from the env) to the interactive-shell write location (`~/.config/homebrew/trust.json`). Out-of-store (not `text` / not `./files` source) so interactive `brew trust X` can still write to it without EACCES.

To use `config.lib.file.mkOutOfStoreSymlink`, the `home-manager.users.${username}` block was converted from an attrset to function form (`{ config, ... }: { ... }`) so home-manager's `config` is in scope. No other surface change.

This completes the **Layer 1** unblock described in #2268. Layers 2 (drop `nikitabobko/tap/aerospace` in favour of `pkgs.aerospace`) and 3 (upstream nix-darwin fix to preserve `XDG_CONFIG_HOME` through the activation env) are intentionally out of scope.

## Existing-symlink conflict — Option A (require user to `rm ~/.homebrew` first)

The user already has a manual `~/.homebrew → ~/.config/homebrew` symlink in place from tonight's unblock. Home-manager activation will refuse to overwrite a non-managed file at that path with the default `force = false`.

I chose **Option A** — no `force = true`, matching the prevailing style of the other `home.file` entries in this file (none of them set `force`). So the post-merge step on the host is:

```bash
rm ~/.homebrew && sudo darwin-rebuild switch --flake ~/code/nixos-config/main
```

If we'd rather not require that step, switching to `force = true` is a one-line followup.

## Pre-PR checks

```
✔ nixfmt --check machines/m4mac/configuration.nix
✔ nix eval --json .#darwinConfigurations.m4mac.config.homebrew.taps
  → ["datadog-labs/pack", "nikitabobko/tap"]
✔ nix eval --raw .#darwinConfigurations.m4mac.config.home-manager.users.bensherman.home.file.".homebrew".source
  → /nix/store/…-hm_homebrew (readlink → /Users/bensherman/.config/homebrew)
✔ nix build .#darwinConfigurations.m4mac.system --dry-run (eval clean, 6 derivs to build)
```

`sudo darwin-rebuild switch` itself is the user's post-merge step.