### PR TITLE
pi: set defaultProjectTrust = "always" to silence recurring trust prompts

### DIFF
--- a/modules/programs/prism/pi.nix
+++ b/modules/programs/prism/pi.nix
@@ -110,6 +110,7 @@
       # container config blobs at lines 29-73) and reference piSettings there.
       piSettings = {
         steeringMode = "one-at-a-time";
+        defaultProjectTrust = "always";
         transport = "sse";
         theme = config.theme.name;
         treeFilterMode = "default";


### PR DESCRIPTION
Pi v0.79.1 added a global `defaultProjectTrust` setting. The default
`"ask"` prompt fires for every new worktree because prism mints a fresh
worktree path per spawn (`~/code/<repo>/<branch>`) and trust decisions in
`~/.pi/agent/trust.json` are keyed by canonical directory, so a decision
saved in one worktree never matches the next.

`"always"` rather than `"never"`: the repos triggering prompts are our own,
and `"never"` would silently skip their trust-gated inputs
(`.pi/settings.json`, project extensions, `.agents/skills`). The actual
isolation boundary here is prism's bwrap/sandbox-exec, not pi's trust prompt.

Single-line addition to the `piSettings` attrset in
`modules/programs/prism/pi.nix`, which is serialised via `builtins.toJSON`
into `~/.pi/agent/settings.json` (the shared agent dir bind-mounted into
every bwrap/sandbox-exec session).

## Verification

- `nixfmt --check modules/programs/prism/pi.nix` — clean.
- Diff is a one-line addition; no other `piSettings` keys touched.
- Post-merge / post-`nh switch`: a fresh pi session in a previously-unseen
  worktree containing `.pi/` or `.agents/skills` will start without the
  project-trust prompt and load the project's trust-gated resources.

Closes #2254