### PR TITLE
prism (test): cap B's pipe.sock path under sun_path 104 bytes

### DIFF
--- a/modules/programs/prism/prism/internal/sidecar/sidecar_duplicate_start_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_duplicate_start_test.go
@@ -54,43 +54,6 @@ func newDuplicateStartSidecar(t *testing.T, hostAPISockPath, pipeSockPath string
 	return New(cfg)
 }
 
-// shortPipeSockPath returns a pipe.sock path safely within the POSIX
-// sockaddr_un.sun_path 104-byte ceiling (Darwin's hard cap; Linux's is
-// 108, but maxSunPath uses 104 as the conservative cross-platform
-// limit).
-//
-// It first tries t.TempDir(). If that path joined with /pipe.sock would
-// exceed maxSunPath — the failure mode that surfaces inside the
-// nix-build sandbox on Darwin, where t.TempDir() embeds the long test
-// name beneath /nix/var/nix/builds/nix-NNNNN-NNNNNNNNNN/ — it falls
-// back to a hand-built short-prefix directory under os.TempDir() (via
-// os.MkdirTemp("", "sp"), which skips the long test-name component
-// that t.TempDir() injects). The fallback registers t.Cleanup so the
-// directory is removed when the test ends and tmpdir leftovers do not
-// accumulate across runs.
-//
-// The fallback is keyed on the rendered path length only, not on
-// runtime.GOOS, so a hypothetical future Darwin host whose t.TempDir()
-// fits within 104 bytes continues to exercise the t.TempDir() path,
-// and conversely any platform whose t.TempDir() grows long enough to
-// trip the limit gets the same defensive treatment.
-func shortPipeSockPath(t *testing.T) string {
-	t.Helper()
-	if p := filepath.Join(t.TempDir(), "pipe.sock"); len(p) <= maxSunPath {
-		return p
-	}
-	dir, err := os.MkdirTemp("", "sp")
-	if err != nil {
-		t.Fatalf("shortPipeSockPath MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	p := filepath.Join(dir, "pipe.sock")
-	if len(p) > maxSunPath {
-		t.Fatalf("shortPipeSockPath: fallback path still too long (%d > %d): %s", len(p), maxSunPath, p)
-	}
-	return p
-}
-
 // pingHostAPI dials the host-API socket and issues a trivial GET. Returns the
 // HTTP status code on success. The endpoint may not exist (returns 404); the
 // caller only cares that a response came back, proving the listener is alive.
@@ -270,7 +233,7 @@ func TestSidecarRun_RefusesWhenHostAPISockIsLive(t *testing.T) {
 	// Give B its own DB / worktree (newDuplicateStartSidecar does this via
 	// openTestDB(t) and t.TempDir()) so that "did not write to DB" can be
 	// verified independently of A's DB.
-	pipeSockPathB := shortPipeSockPath(t)
+	pipeSockPathB := shortSockPath(t)
 	scB := newDuplicateStartSidecar(t, hostAPISockPath, pipeSockPathB)
 
 	ctxB, cancelB := context.WithTimeout(context.Background(), 5*time.Second)

--- a/modules/programs/prism/prism/internal/sidecar/sidecar_duplicate_start_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar_duplicate_start_test.go
@@ -54,6 +54,43 @@ func newDuplicateStartSidecar(t *testing.T, hostAPISockPath, pipeSockPath string
 	return New(cfg)
 }
 
+// shortPipeSockPath returns a pipe.sock path safely within the POSIX
+// sockaddr_un.sun_path 104-byte ceiling (Darwin's hard cap; Linux's is
+// 108, but maxSunPath uses 104 as the conservative cross-platform
+// limit).
+//
+// It first tries t.TempDir(). If that path joined with /pipe.sock would
+// exceed maxSunPath — the failure mode that surfaces inside the
+// nix-build sandbox on Darwin, where t.TempDir() embeds the long test
+// name beneath /nix/var/nix/builds/nix-NNNNN-NNNNNNNNNN/ — it falls
+// back to a hand-built short-prefix directory under os.TempDir() (via
+// os.MkdirTemp("", "sp"), which skips the long test-name component
+// that t.TempDir() injects). The fallback registers t.Cleanup so the
+// directory is removed when the test ends and tmpdir leftovers do not
+// accumulate across runs.
+//
+// The fallback is keyed on the rendered path length only, not on
+// runtime.GOOS, so a hypothetical future Darwin host whose t.TempDir()
+// fits within 104 bytes continues to exercise the t.TempDir() path,
+// and conversely any platform whose t.TempDir() grows long enough to
+// trip the limit gets the same defensive treatment.
+func shortPipeSockPath(t *testing.T) string {
+	t.Helper()
+	if p := filepath.Join(t.TempDir(), "pipe.sock"); len(p) <= maxSunPath {
+		return p
+	}
+	dir, err := os.MkdirTemp("", "sp")
+	if err != nil {
+		t.Fatalf("shortPipeSockPath MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	p := filepath.Join(dir, "pipe.sock")
+	if len(p) > maxSunPath {
+		t.Fatalf("shortPipeSockPath: fallback path still too long (%d > %d): %s", len(p), maxSunPath, p)
+	}
+	return p
+}
+
 // pingHostAPI dials the host-API socket and issues a trivial GET. Returns the
 // HTTP status code on success. The endpoint may not exist (returns 404); the
 // caller only cares that a response came back, proving the listener is alive.
@@ -233,10 +270,7 @@ func TestSidecarRun_RefusesWhenHostAPISockIsLive(t *testing.T) {
 	// Give B its own DB / worktree (newDuplicateStartSidecar does this via
 	// openTestDB(t) and t.TempDir()) so that "did not write to DB" can be
 	// verified independently of A's DB.
-	pipeSockPathB := filepath.Join(t.TempDir(), "pipe.sock")
-	if len(pipeSockPathB) > maxSunPath {
-		t.Fatalf("B's pipe sock path too long: %s", pipeSockPathB)
-	}
+	pipeSockPathB := shortPipeSockPath(t)
 	scB := newDuplicateStartSidecar(t, hostAPISockPath, pipeSockPathB)
 
 	ctxB, cancelB := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## Summary

`TestSidecarRun_RefusesWhenHostAPISockIsLive` built B's pipe.sock path as
`filepath.Join(t.TempDir(), "pipe.sock")`. On aarch64-darwin under
`nix build --impure ... runChecks = true`, `t.TempDir()` lives under
`/nix/var/nix/builds/nix-NNNNN-NNNNNNNNNN/` and embeds the full test
name (43 chars) plus a 10-digit suffix plus a per-call counter, pushing
the joined path past Darwin's `struct sockaddr_un.sun_path` 104-byte
limit. Linux's limit is 108, which is why the failure was Darwin-only and
not caught by either CI lane. The test's existing `len > maxSunPath`
guard then `t.Fatal`'d in setup before the duplicate-start guard ran.

## Fix shape

Per issue #2264's recommended **approach 3** (defensive runtime
construction). Added a `shortPipeSockPath(t)` helper that:

1. Tries `filepath.Join(t.TempDir(), "pipe.sock")` first. If it fits
   within `maxSunPath` (the unchanged 104-byte conservative ceiling
   already used across the package), use it.
2. Otherwise, falls back to `os.MkdirTemp("", "sp")` under
   `os.TempDir()` — which skips the long test-name component that
   `t.TempDir()` injects — and registers `t.Cleanup` so the fallback
   directory is removed at test end and `/tmp` does not accumulate
   leftovers across runs.

The fallback is keyed on the rendered path length only, **not** on
`runtime.GOOS` — so a hypothetical future Darwin path that fits within
104 bytes continues to exercise the `t.TempDir()` branch (per AC #4),
and any platform whose `t.TempDir()` grows long enough to trip the
limit gets the same defensive treatment.

## Verification

From `modules/programs/prism/prism/`:

- `go build ./...` — clean
- `go test ./...` — all packages green
- `go test ./internal/sidecar/ -run 'TestSidecarRun_RefusesWhenHostAPISockIsLive|TestSidecarRun_RefusesWhenPipeSockIsLive|TestSidecarRun_TombstoneHostAPISockProceeds|TestSidecarRun_NonExistentSockProceeds' -v` — all four PASS

From the repo root:

- `nix build .#prism` — succeeds

**Test-not-a-no-op discipline** (per AGENTS.md): simulated the Darwin
nix-build scenario by setting `TMPDIR=/tmp/<67-char-prefix>` (longer
than the nix-build prefix, so `t.TempDir()` definitely overflows):

| Configuration | Result |
| --- | --- |
| Fix reverted + long TMPDIR | **FAIL** with exact issue-2264 message: `B's pipe sock path too long: /tmp/<long-prefix>/TestSidecarRun_RefusesWhenHostAPISockIsLive3852997365/003/pipe.sock` |
| Fix applied + long TMPDIR | **PASS** (fallback branch exercised) |
| Fix applied + normal TMPDIR | **PASS** (`t.TempDir()` branch exercised) |

The CI homeless-shelter build will exercise the fix on Linux. The
aarch64-darwin `runChecks = true` reproducer in the issue cannot run in
this Linux worker sandbox, but the long-TMPDIR simulation confirms the
fallback branch behaves correctly on the failing path-length condition,
which is what the Darwin failure mode reduces to.

## Acceptance criteria

- [x] On aarch64-darwin, the nix-build reproducer no longer fails on a
      too-long sock path. (Verified by long-TMPDIR simulation;
      aarch64-darwin reproducer to be run by reviewer.)
- [x] The test continues to exercise its original behavioural check
      (duplicate-start refusal, inode unchanged, A's listener still
      responsive, no DB write from B) — only the path construction
      changed, not the assertions.
- [x] The test still passes under `go test ./internal/sidecar/...`
      outside the nix build sandbox on Linux. (Verified above; Darwin
      verification to be confirmed by reviewer.)
- [x] The conditional is keyed on rendered path length only, **not**
      `runtime.GOOS` — both code branches stay reachable on every
      platform as soon as `t.TempDir()` length crosses 104 bytes.

Closes #2264