### PR TITLE
prism (sidecar): strip provider/ prefix from set_model wire frames

### DIFF
--- a/modules/programs/prism/pi/extensions/prism.test.ts
+++ b/modules/programs/prism/pi/extensions/prism.test.ts
@@ -617,6 +617,126 @@ describe("dispatchInboundFrame: set_model", () => {
     assert.equal(calls.errors.length, 1)
     assert.equal(calls.errors[0].code, "malformed_frame")
   })
+
+  // Defence-in-depth normalisation for issue #2252. The sidecar now strips a
+  // leading "<provider>/" before sending, but mixed sidecar/extension builds
+  // may still ship the prefixed form on the wire. The handler must strip a
+  // single leading "<provider>/" matching the frame's provider before the
+  // registry lookup so the swap still applies.
+  it(
+    "strips a leading provider/ prefix matching the frame provider before lookup (issue #2252)",
+    async () => {
+      const { api, calls, emit, registerModel } = makeMockApi()
+      const fakeModel = { id: "claude-fable-5" }
+      // Registry keyed on the BARE model id — the wire contract.
+      registerModel("anthropic", "claude-fable-5", fakeModel)
+      await dispatchInboundFrame(
+        {
+          type: "set_model",
+          provider: "anthropic",
+          model: "anthropic/claude-fable-5", // prefixed form
+          thinking: "high",
+        },
+        api,
+        emit,
+      )
+      assert.equal(calls.errors.length, 0, "prefixed form must not emit an error")
+      assert.equal(calls.setModel.length, 1)
+      assert.equal(calls.setModel[0], fakeModel)
+      assert.deepEqual(calls.setThinkingLevel, ["high"])
+      // The lookup itself must use the bare ID.
+      assert.equal(calls.modelLookups.length, 1)
+      assert.deepEqual(calls.modelLookups[0], {
+        provider: "anthropic",
+        model: "claude-fable-5",
+      })
+    },
+  )
+
+  it(
+    "strips at most ONE leading provider/ segment and only when it equals the frame provider",
+    async () => {
+      const { api, calls, emit, registerModel } = makeMockApi()
+      // Openrouter-style nested ID. provider="openrouter"; the model carries
+      // a leading "openrouter/" segment plus a further "anthropic/" segment
+      // that MUST be preserved (it is not the frame's provider).
+      const fakeModel = { id: "anthropic/claude-3.5-sonnet" }
+      registerModel("openrouter", "anthropic/claude-3.5-sonnet", fakeModel)
+      await dispatchInboundFrame(
+        {
+          type: "set_model",
+          provider: "openrouter",
+          model: "openrouter/anthropic/claude-3.5-sonnet",
+          thinking: "off",
+        },
+        api,
+        emit,
+      )
+      assert.equal(calls.errors.length, 0)
+      assert.equal(calls.setModel.length, 1)
+      assert.equal(calls.setModel[0], fakeModel)
+      assert.equal(calls.modelLookups.length, 1)
+      assert.deepEqual(calls.modelLookups[0], {
+        provider: "openrouter",
+        model: "anthropic/claude-3.5-sonnet",
+      })
+    },
+  )
+
+  it(
+    "does not strip when the leading segment differs from the frame provider",
+    async () => {
+      const { api, calls, emit, registerModel } = makeMockApi()
+      // provider="openai" but the model carries a leading "anthropic/".
+      // It must NOT be stripped — "anthropic" is not the frame's provider.
+      const fakeModel = { id: "anthropic/claude-fable-5" }
+      registerModel("openai", "anthropic/claude-fable-5", fakeModel)
+      await dispatchInboundFrame(
+        {
+          type: "set_model",
+          provider: "openai",
+          model: "anthropic/claude-fable-5",
+          thinking: "off",
+        },
+        api,
+        emit,
+      )
+      assert.equal(calls.errors.length, 0)
+      assert.equal(calls.modelLookups.length, 1)
+      assert.deepEqual(calls.modelLookups[0], {
+        provider: "openai",
+        model: "anthropic/claude-fable-5",
+      })
+    },
+  )
+
+  it(
+    "a genuinely unknown model after stripping still emits model_not_found with the attempted ID",
+    async () => {
+      const { api, calls, emit } = makeMockApi()
+      // Registry is empty for this provider/model combination.
+      await dispatchInboundFrame(
+        {
+          type: "set_model",
+          provider: "anthropic",
+          model: "anthropic/claude-does-not-exist",
+          thinking: "off",
+        },
+        api,
+        emit,
+      )
+      assert.equal(calls.setModel.length, 0)
+      assert.equal(calls.errors.length, 1)
+      assert.equal(calls.errors[0].code, "model_not_found")
+      // The error message must reflect what was actually attempted (the
+      // stripped bare form), not the doubled-prefix shape from the #2252
+      // symptom ("anthropic/anthropic/claude-...").
+      assert.equal(
+        calls.errors[0].message,
+        "model anthropic/claude-does-not-exist not found in registry",
+      )
+    },
+  )
 })
 
 describe("dispatchInboundFrame: register_provider", () => {

--- a/modules/programs/prism/pi/extensions/prism.ts
+++ b/modules/programs/prism/pi/extensions/prism.ts
@@ -1516,10 +1516,10 @@ export async function dispatchInboundFrame(
       case "set_model": {
         const provider =
           typeof frame.provider === "string" ? frame.provider : ""
-        const modelId = typeof frame.model === "string" ? frame.model : ""
+        const rawModelId = typeof frame.model === "string" ? frame.model : ""
         const thinking =
           typeof frame.thinking === "string" ? frame.thinking : "off"
-        if (!provider || !modelId) {
+        if (!provider || !rawModelId) {
           emitError(
             "malformed_frame",
             "set_model missing provider or model",
@@ -1527,6 +1527,16 @@ export async function dispatchInboundFrame(
           )
           return
         }
+        // Defence-in-depth normalisation (issue #2252). The wire contract is
+        // a bare model ID, and the sidecar now normalises before sending,
+        // but older sidecar builds may still send a provider-prefixed model
+        // (e.g. "anthropic/claude-fable-5"). Strip at most ONE leading
+        // "<provider>/" segment, and only when it equals the frame's
+        // provider, so nested model IDs (openrouter-style) are preserved.
+        const prefix = provider + "/"
+        const modelId = rawModelId.startsWith(prefix)
+          ? rawModelId.slice(prefix.length)
+          : rawModelId
         const model = api.modelRegistryFind(provider, modelId)
         if (!model) {
           emitError(

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -3190,6 +3190,36 @@ func knownReviewAgentNames() []string {
 
 // ── P3.LIVE live-model-swap helpers (#1214) ───────────────────────────────────
 
+// stripProviderPrefix normalises a model ID for the set_model wire contract
+// by removing a single leading "<provider>/" segment when the leading segment
+// matches the supplied provider. The wire contract for set_model frames is a
+// bare model ID; profiles.json conventionally stores the prefixed form
+// ("anthropic/claude-sonnet-4") for the spawn-time --model CLI flag, so the
+// live-swap path must normalise before building the frame. Issue #2252.
+//
+// Constraints (from the issue):
+//   - Strip at most ONE leading "<provider>/" segment.
+//   - Strip only when that segment exactly equals the frame's provider.
+//   - Preserve any remaining '/' characters — model IDs may legitimately
+//     contain nested slashes (e.g. openrouter-style IDs). Do NOT split on the
+//     last '/'.
+//
+// Empty provider or empty model is returned unchanged: there is nothing to
+// match against and the downstream validation will reject it.
+//
+// Idempotent: a bare-ID input is returned unchanged, so it is safe to call
+// this helper at multiple layers of the live-swap stack.
+func stripProviderPrefix(provider, model string) string {
+	if provider == "" || model == "" {
+		return model
+	}
+	prefix := provider + "/"
+	if strings.HasPrefix(model, prefix) {
+		return model[len(prefix):]
+	}
+	return model
+}
+
 // liveModelSwapForSession delivers a set_model frame to the named session.
 //
 // When targetSess == s.cfg.SessionName (own session) and the sidecar is
@@ -3197,8 +3227,17 @@ func knownReviewAgentNames() []string {
 // When targetSess is a different session, the call is forwarded to that
 // session's own sidecar host-API socket via an HTTP POST to /set-model.
 //
+// The model argument is normalised via stripProviderPrefix before being
+// placed on the wire — both the own-session SetModel enqueue and the
+// forwarded peer /set-model call see the bare model ID. This is the canonical
+// fix for issue #2252 (the live-swap silent no-op): the bug shape was
+// /apply-profile passing slot.Model ("anthropic/claude-fable-5") verbatim
+// into the frame, which the extension's modelRegistryFind then failed to
+// resolve.
+//
 // Returns a status string: "applied" or "error:disconnected".
 func liveModelSwapForSession(s *Sidecar, targetSess, provider, model, thinking string) string {
+	model = stripProviderPrefix(provider, model)
 	if targetSess == s.cfg.SessionName {
 		if !isPipeConnected(s) {
 			return "error:disconnected"
@@ -3272,11 +3311,19 @@ func resolveRoleForSession(s *Sidecar, targetSess string) (role, skipStatus stri
 
 // forwardSetModel dials the target session's host-API socket and POSTs a
 // /set-model request.
+//
+// The model field is normalised via stripProviderPrefix before the POST so
+// that the wire body always carries the bare model ID, matching the
+// /apply-profile fan-out and same-session enqueue paths. The peer's
+// /set-model handler will also normalise on receipt — the dual-strip is
+// deliberate defence in depth and harmless because stripProviderPrefix is
+// idempotent. Issue #2252.
 func forwardSetModel(targetSess, provider, model, thinking string) error {
 	sockPath, err := hostAPISocketPath(targetSess)
 	if err != nil {
 		return fmt.Errorf("resolve socket: %w", err)
 	}
+	model = stripProviderPrefix(provider, model)
 	body := struct {
 		Session  string `json:"session"`
 		Provider string `json:"provider"`

--- a/modules/programs/prism/prism/internal/sidecar/host_api_strip_prefix_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_strip_prefix_test.go
@@ -1,0 +1,398 @@
+package sidecar
+
+// Tests for the set_model provider-prefix normalisation fix (issue #2252).
+//
+// Symptom: profiles.json stores slot.Model in the prefixed form
+// "anthropic/claude-fable-5" (the same form that becomes the spawn-time
+// `--model <provider/model>` CLI flag). The live-swap fan-out
+// (/apply-profile, /set-model, forwardSetModel) used to pass that string
+// verbatim into the set_model wire frame; the extension's
+// modelRegistryFind expects a bare model ID and the lookup failed with
+// the doubled-prefix message `model anthropic/anthropic/claude-fable-5
+// not found in registry`. Live-swap silently no-op'd.
+//
+// Fix: stripProviderPrefix(provider, model) removes a single leading
+// "<provider>/" segment from model when it equals provider — applied at
+// both the local enqueue (liveModelSwapForSession) and the peer forward
+// (forwardSetModel) layers.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/config"
+)
+
+// ── unit tests for stripProviderPrefix ────────────────────────────────────────
+
+// TestStripProviderPrefix verifies the normalisation contract from issue #2252:
+//   - strip at most ONE leading "<provider>/" segment;
+//   - strip only when that segment exactly equals the supplied provider;
+//   - preserve all remaining slashes (nested / openrouter-style IDs);
+//   - empty inputs are returned unchanged.
+func TestStripProviderPrefix(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		model    string
+		want     string
+	}{
+		{
+			name:     "strips matching provider prefix (the bug case)",
+			provider: "anthropic",
+			model:    "anthropic/claude-fable-5",
+			want:     "claude-fable-5",
+		},
+		{
+			name:     "bare model id is returned unchanged",
+			provider: "anthropic",
+			model:    "claude-sonnet-4-20250514",
+			want:     "claude-sonnet-4-20250514",
+		},
+		{
+			name:     "non-matching prefix is left intact",
+			provider: "openai",
+			model:    "anthropic/claude-fable-5",
+			want:     "anthropic/claude-fable-5",
+		},
+		{
+			name:     "strips at most one segment (idempotency target)",
+			provider: "anthropic",
+			model:    "anthropic/anthropic/claude-fable-5",
+			want:     "anthropic/claude-fable-5",
+		},
+		{
+			name:     "preserves nested slashes after the leading segment",
+			provider: "openrouter",
+			model:    "openrouter/anthropic/claude-3.5-sonnet",
+			want:     "anthropic/claude-3.5-sonnet",
+		},
+		{
+			name:     "preserves a model id that contains slashes but no provider prefix",
+			provider: "openrouter",
+			model:    "anthropic/claude-3.5-sonnet",
+			want:     "anthropic/claude-3.5-sonnet",
+		},
+		{
+			name:     "idempotent on already-stripped input",
+			provider: "anthropic",
+			model:    "claude-fable-5",
+			want:     "claude-fable-5",
+		},
+		{
+			name:     "empty provider returns model unchanged",
+			provider: "",
+			model:    "anthropic/claude-fable-5",
+			want:     "anthropic/claude-fable-5",
+		},
+		{
+			name:     "empty model returns empty",
+			provider: "anthropic",
+			model:    "",
+			want:     "",
+		},
+		{
+			name:     "provider that is a prefix-substring (no slash) is not stripped",
+			provider: "anth",
+			model:    "anthropic/claude-fable-5",
+			want:     "anthropic/claude-fable-5",
+		},
+		{
+			name:     "exact equality with no trailing slash is not stripped",
+			provider: "anthropic",
+			model:    "anthropic",
+			want:     "anthropic",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripProviderPrefix(tc.provider, tc.model)
+			if got != tc.want {
+				t.Errorf("stripProviderPrefix(%q, %q) = %q, want %q",
+					tc.provider, tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStripProviderPrefix_Idempotent verifies that calling stripProviderPrefix
+// twice (the dual-strip done by liveModelSwapForSession and forwardSetModel)
+// produces the same result as calling it once. This is the contract that
+// makes the defence-in-depth strip on the peer side safe.
+func TestStripProviderPrefix_Idempotent(t *testing.T) {
+	inputs := []struct {
+		provider string
+		model    string
+	}{
+		{"anthropic", "anthropic/claude-fable-5"},
+		{"anthropic", "claude-fable-5"},
+		{"openrouter", "openrouter/anthropic/claude-3.5-sonnet"},
+		{"openai", "gpt-4o"},
+		{"", "anything"},
+	}
+	for _, in := range inputs {
+		once := stripProviderPrefix(in.provider, in.model)
+		twice := stripProviderPrefix(in.provider, once)
+		if once != twice {
+			t.Errorf("stripProviderPrefix not idempotent for (%q, %q): once=%q twice=%q",
+				in.provider, in.model, once, twice)
+		}
+	}
+}
+
+// ── integration: /set-model round-trip strips a prefixed model field ─────────
+
+// TestHostAPI_SetModel_StripsProviderPrefix_OwnSession is the round-trip the
+// issue calls out as the canonical fix signal: a /set-model call carrying a
+// provider-prefixed model lands at the extension as a bare-ID set_model
+// frame. Without the fix, the frame would carry the doubled prefix.
+func TestHostAPI_SetModel_StripsProviderPrefix_OwnSession(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	wait := runSocketPipeSidecar(sc)
+
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/set-model", map[string]any{
+		"session":  sc.cfg.SessionName,
+		"provider": "anthropic",
+		"model":    "anthropic/claude-fable-5", // prefixed form
+		"thinking": "auto",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /set-model status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "set_model" {
+		t.Fatalf("frame type = %v, want set_model", got)
+	}
+	if got := frame["provider"]; got != "anthropic" {
+		t.Errorf("frame provider = %v, want anthropic", got)
+	}
+	// The crux: the frame carries the bare ID, not the doubled-prefix form
+	// (`anthropic/anthropic/claude-fable-5`) and not the input prefixed form
+	// (`anthropic/claude-fable-5`).
+	if got := frame["model"]; got != "claude-fable-5" {
+		t.Errorf("frame model = %v, want claude-fable-5 (bare ID, no provider prefix)", got)
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestHostAPI_ApplyProfile_StripsProviderPrefix_SessionScope verifies the
+// /apply-profile fan-out path also strips the provider prefix from slot.Model
+// before the set_model frame reaches the extension. This is the primary
+// real-world trigger from issue #2252 (every Nix-generated profile slot
+// stores the prefixed form).
+func TestHostAPI_ApplyProfile_StripsProviderPrefix_SessionScope(t *testing.T) {
+	sockPath := shortSockPath(t)
+	sc := newSocketPipeSidecar(t, sockPath)
+	sc.cfg.HarnessName = "pi"
+	sc.cfg.AgentRole = "coordinator"
+	// Pre-set root agent name so resolveRoleForSession returns "worker".
+	_ = sc.cfg.DB.UpsertStatusWithRootAgent(sc.cfg.SessionName, sc.cfg.Repo, sc.cfg.Worktree, "active", nil, nil, strPtr("worker"), nil)
+	if err := sc.cfg.DB.SetHarness(sc.cfg.SessionName, "pi"); err != nil {
+		t.Skipf("SetHarness not available: %v", err)
+	}
+
+	wait := runSocketPipeSidecar(sc)
+	conn, _ := dialAndHandshake(t, sockPath)
+	rd := bufio.NewReader(conn)
+
+	// Install a profile loader whose worker slot uses the prefixed form
+	// `anthropic/claude-fable-5` — the shape that triggered #2252 in
+	// production profiles.json.
+	origLoader := hostAPILoadProfiles
+	hostAPILoadProfiles = func() (*config.ProfilesFile, error) {
+		return &config.ProfilesFile{
+			Default: "fable",
+			Profiles: map[string]config.ProfileEntry{
+				"fable": {
+					"worker": {Provider: "anthropic", Model: "anthropic/claude-fable-5", Thinking: "high"},
+				},
+			},
+		}, nil
+	}
+	defer func() { hostAPILoadProfiles = origLoader }()
+
+	handler := sc.hostAPIHandler()
+	rr := postJSON(t, handler, "/apply-profile", map[string]any{
+		"profile": "fable",
+		"scope":   "session",
+		"session": sc.cfg.SessionName,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST /apply-profile status %d, body: %s", rr.Code, rr.Body.String())
+	}
+
+	frame := readFrameWithDeadline(t, rd, conn)
+	if got := frame["type"]; got != "set_model" {
+		t.Fatalf("frame type = %v, want set_model", got)
+	}
+	if got := frame["provider"]; got != "anthropic" {
+		t.Errorf("frame provider = %v, want anthropic", got)
+	}
+	if got := frame["model"]; got != "claude-fable-5" {
+		t.Errorf("frame model = %v, want claude-fable-5 (bare, no provider prefix)", got)
+	}
+	if got := frame["thinking"]; got != "high" {
+		t.Errorf("frame thinking = %v, want high", got)
+	}
+
+	var result map[string]any
+	decodeJSON(t, rr, &result)
+	results, _ := result["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r0, _ := results[0].(map[string]any)
+	if r0["status"] != "applied" {
+		t.Errorf("result[0].status = %v, want applied", r0["status"])
+	}
+
+	sendJSON(t, conn, map[string]any{"type": "session_shutdown"})
+	conn.Close()
+	_ = wait()
+}
+
+// TestHostAPI_ForwardSetModel_StripsProviderPrefix verifies the peer-forward
+// path (forwardSetModel → dialUnixAndPostFn) normalises the model field before
+// it goes on the wire. The peer's /set-model handler will also normalise on
+// receipt; the AC requires both layers strip identically. This test pins the
+// sender-side strip so the wire body is bare-ID even against an older peer
+// that does not normalise.
+func TestHostAPI_ForwardSetModel_StripsProviderPrefix(t *testing.T) {
+	// Capture the POST body that forwardSetModel sends.
+	type captured struct {
+		Session  string `json:"session"`
+		Provider string `json:"provider"`
+		Model    string `json:"model"`
+		Thinking string `json:"thinking"`
+	}
+	gotCh := make(chan captured, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/set-model" {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		var c captured
+		_ = json.NewDecoder(r.Body).Decode(&c)
+		gotCh <- c
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"applied"}`))
+	}))
+	defer srv.Close()
+
+	// Replace the socket-path resolver and the unix-post function so
+	// forwardSetModel routes to our test server via TCP.
+	origSocketPath := hostAPISocketPath
+	hostAPISocketPath = func(_ string) (string, error) {
+		return srv.Listener.Addr().String(), nil
+	}
+	defer func() { hostAPISocketPath = origSocketPath }()
+
+	origDialFn := dialUnixAndPostFn
+	dialUnixAndPostFn = func(addr, path string, body any) error {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post("http://"+addr+path, "application/json", bytes.NewReader(b))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fmt.Errorf("http %d", resp.StatusCode)
+		}
+		return nil
+	}
+	defer func() { dialUnixAndPostFn = origDialFn }()
+
+	if err := forwardSetModel("otherrepo@worker1", "anthropic", "anthropic/claude-fable-5", "off"); err != nil {
+		t.Fatalf("forwardSetModel: %v", err)
+	}
+
+	select {
+	case got := <-gotCh:
+		if got.Provider != "anthropic" {
+			t.Errorf("body.provider = %q, want anthropic", got.Provider)
+		}
+		if got.Model != "claude-fable-5" {
+			t.Errorf("body.model = %q, want claude-fable-5 (bare, no provider prefix)", got.Model)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for forwarded /set-model POST")
+	}
+}
+
+// TestHostAPI_ForwardSetModel_PreservesNestedSlashes verifies the nested-ID
+// guarantee from the issue: when the leading segment matches the provider,
+// only that segment is removed; any further '/' characters in the model ID
+// are preserved verbatim on the wire.
+func TestHostAPI_ForwardSetModel_PreservesNestedSlashes(t *testing.T) {
+	type captured struct {
+		Model string `json:"model"`
+	}
+	gotCh := make(chan captured, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var c captured
+		_ = json.NewDecoder(r.Body).Decode(&c)
+		gotCh <- c
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"applied"}`))
+	}))
+	defer srv.Close()
+
+	origSocketPath := hostAPISocketPath
+	hostAPISocketPath = func(_ string) (string, error) {
+		return srv.Listener.Addr().String(), nil
+	}
+	defer func() { hostAPISocketPath = origSocketPath }()
+
+	origDialFn := dialUnixAndPostFn
+	dialUnixAndPostFn = func(addr, path string, body any) error {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post("http://"+addr+path, "application/json", bytes.NewReader(b))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		return nil
+	}
+	defer func() { dialUnixAndPostFn = origDialFn }()
+
+	// Openrouter-style nested ID: provider=openrouter, model carries the
+	// leading "openrouter/" segment plus a further "anthropic/" segment that
+	// must NOT be stripped (it isn't the frame's provider).
+	if err := forwardSetModel("otherrepo@worker1", "openrouter", "openrouter/anthropic/claude-3.5-sonnet", ""); err != nil {
+		t.Fatalf("forwardSetModel: %v", err)
+	}
+
+	select {
+	case got := <-gotCh:
+		if got.Model != "anthropic/claude-3.5-sonnet" {
+			t.Errorf("body.model = %q, want anthropic/claude-3.5-sonnet (only leading provider segment stripped)", got.Model)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for forwarded /set-model POST")
+	}
+}


### PR DESCRIPTION
Closes #2252.

## What

Profile live-swap was a silent no-op for every Nix-generated profile. `prism profile use anthropic-fable` reported `applied: 1` but the live session kept its previous model — the `set_model` frame carried a doubled provider prefix (`anthropic/anthropic/claude-fable-5`) and the extension's `modelRegistryFind` rejected it. The CLI never saw the failure because `liveModelSwapForSession` returns `"applied"` on frame **enqueue**, not on harness ack.

## Fix

**Sidecar (canonical fix).** `internal/sidecar/host_api.go`:

- New helper `stripProviderPrefix(provider, model)` — removes a single leading `<provider>/` segment when it equals the frame's provider. Preserves any further `/` characters in the model ID so openrouter-style nested IDs (`openrouter/anthropic/claude-3.5-sonnet`) only lose the leading segment. Idempotent on bare-ID input.
- Apply at the top of `liveModelSwapForSession` — covers both the `/apply-profile` fan-out and the `/set-model` endpoint (both reach this function).
- Apply at the top of `forwardSetModel` — defence in depth on the peer-forward path so the wire body is bare-ID even against an older peer that does not normalise on receipt. Dual-strip is safe because the helper is idempotent.

**Extension (defence in depth).** `pi/extensions/prism.ts`:

- `set_model` handler strips a leading `<provider>/` matching the frame's provider before `modelRegistryFind`. Older sidecar builds that still ship the prefixed form continue to work.
- The `model_not_found` error message now reports the bare ID that was actually attempted, not the doubled-prefix shape from the #2252 symptom.

## Constraints (from the issue)

- Strip at most **one** leading `<provider>/` segment.
- Strip only when that segment exactly equals the frame's provider — `provider="openai", model="anthropic/foo"` is left intact.
- Preserve all remaining `/` characters. Do **not** split on the last `/`.
- The spawn-time `--model <provider/model>` CLI flag (built from `slot.Model`) is unaffected — only the live-swap wire-frame path normalises.

## Test coverage

**Go (`internal/sidecar/host_api_strip_prefix_test.go`):**

- `TestStripProviderPrefix` — table-driven unit test covering the bug case, bare-ID passthrough, non-matching prefix, only-one-segment, nested-slash preservation (both openrouter direction and incidental-anthropic-segment direction), idempotency, empty inputs, prefix-substring (provider with no `/`), and exact-equality-without-trailing-slash.
- `TestStripProviderPrefix_Idempotent` — proves dual-strip safety.
- `TestHostAPI_SetModel_StripsProviderPrefix_OwnSession` — round-trip integration: POST `/set-model` with the prefixed form, assert the frame the extension receives carries `model: "claude-fable-5"` (bare).
- `TestHostAPI_ApplyProfile_StripsProviderPrefix_SessionScope` — round-trip integration via the `/apply-profile` fan-out with `slot.Model = "anthropic/claude-fable-5"`. This is the primary real-world trigger from the issue.
- `TestHostAPI_ForwardSetModel_StripsProviderPrefix` — peer-forward path: the HTTP POST body to the peer's `/set-model` carries the bare ID.
- `TestHostAPI_ForwardSetModel_PreservesNestedSlashes` — openrouter-style nested ID: only the leading `openrouter/` is stripped.

**TypeScript (`pi/extensions/prism.test.ts`):**

- Strips `anthropic/claude-fable-5` to `claude-fable-5` before lookup (the bug case).
- Only one segment is stripped; openrouter nested ID lookup uses `anthropic/claude-3.5-sonnet` (preserving the nested provider segment).
- Non-matching leading segment is left intact (`provider=openai, model=anthropic/claude-fable-5`).
- Genuinely-unknown model after stripping still emits `model_not_found` with the bare attempted ID in the message.

**Non-vacuous-test discipline.** Verified by surgical revert:

- Sidecar: with `stripProviderPrefix` defined but the two call sites removed, all four new integration tests FAIL with the expected prefixed-model output. The unit test still passes (it tests the helper directly).
- Extension: reverting `prism.ts` to the committed state makes all four new extension tests FAIL.

Restored to fixed state and the full suites pass:

- `go test ./...` from `modules/programs/prism/prism/` — all packages green.
- `tsx --test pi/extensions/prism.test.ts` — 374/374 pass.
- `nix build .#prism` — succeeds.

## Coupling

Companion issue #2253 (spawn-time profile pin in `cmd/event.go`) is being addressed in a parallel session. No file overlap.