### PR TITLE
prism: AgentPaneCmd emits the absolute prism binary path (#2260)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_default_test.go
+++ b/modules/programs/prism/prism/cmd/agent_default_test.go
@@ -125,7 +125,11 @@ func TestBuildAgentCmd_UsesAgent(t *testing.T) {
 		{session.Opts{Agent: "worker", SessionName: ""}, "pi --agent worker"},
 	}
 	for _, tc := range cases {
-		got := session.BuildAgentCmd(tc.opts)
+		got, err := session.BuildAgentCmd(tc.opts)
+		if err != nil {
+			t.Errorf("BuildAgentCmd(%+v): unexpected error: %v", tc.opts, err)
+			continue
+		}
 		if got != tc.want {
 			t.Errorf("BuildAgentCmd(%+v) = %q, want %q", tc.opts, got, tc.want)
 		}

--- a/modules/programs/prism/prism/internal/container/agent_pane_binary_path_test.go
+++ b/modules/programs/prism/prism/internal/container/agent_pane_binary_path_test.go
@@ -1,0 +1,211 @@
+package container
+
+// agent_pane_binary_path_test.go — issue #2260 regression test for the
+// absolute-path-of-prism that the agent-run pane command must carry.
+//
+// Pre-#2260, AgentPaneCmd emitted a bare `prism agent-run ...` token; the
+// tmux pane shell then PATH-resolved that to whatever lived first on $PATH
+// at exec time. On a worker host this is almost always the deployed binary,
+// even when the operator's shell has `result/bin` ahead on PATH for a branch
+// build — because `prism spawn` creates the tmux session from a non-tmux
+// client, inheriting env from the spawn process, NOT from any
+// `tmux set-environment` push.
+//
+// The structural fix is to emit the ABSOLUTE PATH of the currently-running
+// prism binary (via os.Executable) into the pane command. This file pins
+// that contract for both pane-owned isolation modes (bwrap, sandbox-exec).
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestBwrapAgentPaneCmd_StartsWithAbsolutePrismPath verifies the AgentPaneCmd
+// for bwrap begins with a shell-quoted absolute path (starts with `/`),
+// followed immediately by ` agent-run --session <name>`. This is the core
+// invariant: the tmux shell must exec the binary by absolute path, not by
+// PATH lookup.
+func TestBwrapAgentPaneCmd_StartsWithAbsolutePrismPath(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/xxxx-prism-0.0.0/bin/prism")
+	iso := &bwrapIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
+	// Must begin with `'/...` — a shell-quoted absolute path. No bare
+	// "prism" token at the start.
+	if !strings.HasPrefix(got, "'/") {
+		t.Errorf("bwrap pane cmd must start with a shell-quoted absolute path, got %q", got)
+	}
+	if strings.HasPrefix(got, "prism ") {
+		t.Errorf("bwrap pane cmd starts with bare \"prism\" — PATH-shadow class (#2260) re-introduced; got %q", got)
+	}
+	// Full shape contract.
+	want := "'/nix/store/xxxx-prism-0.0.0/bin/prism' agent-run --session 'prism-test@bwrap'"
+	if got != want {
+		t.Errorf("bwrap pane cmd shape changed: got %q, want %q", got, want)
+	}
+}
+
+// TestSandboxExecAgentPaneCmd_StartsWithAbsolutePrismPath mirrors the bwrap
+// assertion for sandbox-exec. Both pane-owned modes share the same fix.
+func TestSandboxExecAgentPaneCmd_StartsWithAbsolutePrismPath(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/yyyy-prism-0.0.0/bin/prism")
+	iso := &sandboxExecIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@sbx",
+	})
+	if err != nil {
+		t.Fatalf("sandbox-exec AgentPaneCmd: unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(got, "'/") {
+		t.Errorf("sandbox-exec pane cmd must start with a shell-quoted absolute path, got %q", got)
+	}
+	if strings.HasPrefix(got, "prism ") {
+		t.Errorf("sandbox-exec pane cmd starts with bare \"prism\" — PATH-shadow class (#2260) re-introduced; got %q", got)
+	}
+	want := "'/nix/store/yyyy-prism-0.0.0/bin/prism' agent-run --session 'prism-test@sbx'"
+	if got != want {
+		t.Errorf("sandbox-exec pane cmd shape changed: got %q, want %q", got, want)
+	}
+}
+
+// TestBwrapAgentPaneCmd_BinaryPath_WithSingleQuote_ShellEscaped verifies the
+// edge-case AC: a binary path containing a single quote (improbable in a
+// real Nix store path, but the shell quoting must still be correct) is
+// escaped via the standard '\'' sequence so the rendered command does not
+// break out of its single-quote context.
+//
+// This is defence-in-depth: if a future deployment lands prism under a path
+// containing a quote — or a developer's branch build is in such a path — the
+// pane command must still parse correctly.
+func TestBwrapAgentPaneCmd_BinaryPath_WithSingleQuote_ShellEscaped(t *testing.T) {
+	withFakePrismBinary(t, "/tmp/weird's-build/result/bin/prism")
+	iso := &bwrapIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
+	// The standard '\'' escape: close the single-quote string, emit a
+	// literal single quote, reopen the single-quote string. shellQuoteContainer
+	// implements this; we assert it actually fired on the binary path.
+	want := `'/tmp/weird'\''s-build/result/bin/prism' agent-run --session 'prism-test@bwrap'`
+	if got != want {
+		t.Errorf("bwrap pane cmd must shell-escape single quote in binary path\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestSandboxExecAgentPaneCmd_BinaryPath_WithSingleQuote_ShellEscaped mirrors
+// the single-quote-in-path test for sandbox-exec — both pane-owned modes
+// share the same shellQuoteContainer helper.
+func TestSandboxExecAgentPaneCmd_BinaryPath_WithSingleQuote_ShellEscaped(t *testing.T) {
+	withFakePrismBinary(t, "/tmp/weird's-build/result/bin/prism")
+	iso := &sandboxExecIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@sbx",
+	})
+	if err != nil {
+		t.Fatalf("sandbox-exec AgentPaneCmd: unexpected error: %v", err)
+	}
+	want := `'/tmp/weird'\''s-build/result/bin/prism' agent-run --session 'prism-test@sbx'`
+	if got != want {
+		t.Errorf("sandbox-exec pane cmd must shell-escape single quote in binary path\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestBwrapAgentPaneCmd_BinaryPathError_PropagatesAsError verifies the
+// edge-case AC: when os.Executable returns an error, AgentPaneCmd must
+// return a non-nil error rather than fall back to a bare "prism" string.
+// Silent fallback would re-introduce the PATH-shadow class structurally.
+func TestBwrapAgentPaneCmd_BinaryPathError_PropagatesAsError(t *testing.T) {
+	sentinel := errors.New("readlink /proc/self/exe: file deleted")
+	withErrorPrismBinary(t, sentinel)
+	iso := &bwrapIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@bwrap",
+	})
+	if err == nil {
+		t.Fatalf("bwrap AgentPaneCmd: expected non-nil error when prismBinaryPathFn fails; got cmd=%q", got)
+	}
+	if got != "" {
+		t.Errorf("bwrap AgentPaneCmd: expected empty cmd on error, got %q", got)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("bwrap AgentPaneCmd: expected wrapped sentinel error, got %v", err)
+	}
+	// The error must NOT have silently rendered to a bare-prism fallback.
+	if strings.Contains(got, "prism agent-run") {
+		t.Errorf("bwrap AgentPaneCmd: silently fell back to bare-prism command on os.Executable error (#2260 silent-fallback regression): %q", got)
+	}
+}
+
+// TestSandboxExecAgentPaneCmd_BinaryPathError_PropagatesAsError mirrors the
+// error-propagation test for sandbox-exec.
+func TestSandboxExecAgentPaneCmd_BinaryPathError_PropagatesAsError(t *testing.T) {
+	sentinel := errors.New("os.Executable: not implemented")
+	withErrorPrismBinary(t, sentinel)
+	iso := &sandboxExecIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@sbx",
+	})
+	if err == nil {
+		t.Fatalf("sandbox-exec AgentPaneCmd: expected non-nil error when prismBinaryPathFn fails; got cmd=%q", got)
+	}
+	if got != "" {
+		t.Errorf("sandbox-exec AgentPaneCmd: expected empty cmd on error, got %q", got)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("sandbox-exec AgentPaneCmd: expected wrapped sentinel error, got %v", err)
+	}
+	if strings.Contains(got, "prism agent-run") {
+		t.Errorf("sandbox-exec AgentPaneCmd: silently fell back to bare-prism command on os.Executable error (#2260 silent-fallback regression): %q", got)
+	}
+}
+
+// TestHostAgentPaneCmd_DoesNotResolvePrismBinary verifies that host mode
+// does NOT consult prismBinaryPathFn — the host isolator returns DirectCmd
+// unchanged, so an os.Executable failure must not affect host-mode spawn
+// (which has no `prism agent-run` indirection at all).
+//
+// Stubbed to return an error: if host mode accidentally started calling
+// prismBinaryPathFn, this test would surface a non-nil error and we would
+// know about the regression.
+func TestHostAgentPaneCmd_DoesNotResolvePrismBinary(t *testing.T) {
+	withErrorPrismBinary(t, errors.New("must not be called"))
+	iso := &hostIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "prism-test@host",
+		DirectCmd:   "pi --agent worker",
+	})
+	if err != nil {
+		t.Fatalf("host AgentPaneCmd: unexpected error: %v (host mode must not call prismBinaryPathFn)", err)
+	}
+	if got != "pi --agent worker" {
+		t.Errorf("host AgentPaneCmd: expected DirectCmd unchanged; got %q", got)
+	}
+}
+
+// TestBwrapAgentPaneCmd_EmptySessionName_BypassesBinaryResolution verifies
+// that the defensive fallback (empty SessionName → return DirectCmd) does
+// NOT call prismBinaryPathFn either. This is a pre-existing fast-path that
+// the #2260 change must preserve — an unrelated os.Executable failure should
+// not affect callers that pass an empty SessionName.
+func TestBwrapAgentPaneCmd_EmptySessionName_BypassesBinaryResolution(t *testing.T) {
+	withErrorPrismBinary(t, errors.New("must not be called"))
+	iso := &bwrapIsolator{}
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
+		SessionName: "",
+		DirectCmd:   "fallback direct cmd",
+	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd (empty SessionName): unexpected error: %v", err)
+	}
+	if got != "fallback direct cmd" {
+		t.Errorf("bwrap AgentPaneCmd (empty SessionName): expected DirectCmd unchanged; got %q", got)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/agent_pane_overrides_test.go
+++ b/modules/programs/prism/prism/internal/container/agent_pane_overrides_test.go
@@ -24,22 +24,47 @@ import (
 	"testing"
 )
 
+// withFakePrismBinary stubs prismBinaryPathFn for the duration of t so
+// AgentPaneCmd renders a deterministic absolute path instead of os.Executable()'s
+// runtime value (which is the go-test binary under `go test`). Restored on
+// cleanup. This is the canonical test fixture for any case that needs to
+// assert the rendered command contains a specific binary path.
+func withFakePrismBinary(t *testing.T, path string) {
+	t.Helper()
+	orig := prismBinaryPathFn
+	prismBinaryPathFn = func() (string, error) { return path, nil }
+	t.Cleanup(func() { prismBinaryPathFn = orig })
+}
+
+// withErrorPrismBinary stubs prismBinaryPathFn to return an error so
+// AgentPaneCmd exercises the os.Executable-failed branch. Restored on cleanup.
+func withErrorPrismBinary(t *testing.T, err error) {
+	t.Helper()
+	orig := prismBinaryPathFn
+	prismBinaryPathFn = func() (string, error) { return "", err }
+	t.Cleanup(func() { prismBinaryPathFn = orig })
+}
+
 // TestBwrapAgentPaneCmd_OverrideFlagsAppended asserts that --model and
 // --variant land on the tmux pane command when AgentPaneOpts carries them.
 func TestBwrapAgentPaneCmd_OverrideFlagsAppended(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/abcd-prism/bin/prism")
 	iso := &bwrapIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@bwrap",
 		Model:       "anthropic/claude-opus-4-8",
 		Variant:     "high",
 	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
 
 	// Order is load-bearing for readability of `ps` output but not for
 	// cobra's flag parser. Use substring checks so a reordering inside
 	// appendAgentRunOverrides does not break the test (cobra still parses
 	// the flags correctly regardless of position).
 	for _, want := range []string{
-		"prism agent-run --session 'prism-test@bwrap'",
+		"'/nix/store/abcd-prism/bin/prism' agent-run --session 'prism-test@bwrap'",
 		"--model 'anthropic/claude-opus-4-8'",
 		"--variant 'high'",
 	} {
@@ -54,11 +79,15 @@ func TestBwrapAgentPaneCmd_OverrideFlagsAppended(t *testing.T) {
 // the pre-#2086 shape so existing tests, restore semantics, and operator
 // expectations are preserved.
 func TestBwrapAgentPaneCmd_NoOverrideFlagsByDefault(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/abcd-prism/bin/prism")
 	iso := &bwrapIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@bwrap",
 	})
-	want := "prism agent-run --session 'prism-test@bwrap'"
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
+	want := "'/nix/store/abcd-prism/bin/prism' agent-run --session 'prism-test@bwrap'"
 	if got != want {
 		t.Errorf("bwrap AgentPaneCmd = %q, want %q", got, want)
 	}
@@ -71,14 +100,18 @@ func TestBwrapAgentPaneCmd_NoOverrideFlagsByDefault(t *testing.T) {
 // for sandbox-exec — both isolators dispatch through the same
 // appendAgentRunOverrides helper so a divergence would be a real bug.
 func TestSandboxExecAgentPaneCmd_OverrideFlagsAppended(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/abcd-prism/bin/prism")
 	iso := &sandboxExecIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@sbx",
 		Model:       "anthropic/claude-opus-4-8",
 		Variant:     "high",
 	})
+	if err != nil {
+		t.Fatalf("sandbox-exec AgentPaneCmd: unexpected error: %v", err)
+	}
 	for _, want := range []string{
-		"prism agent-run --session 'prism-test@sbx'",
+		"'/nix/store/abcd-prism/bin/prism' agent-run --session 'prism-test@sbx'",
 		"--model 'anthropic/claude-opus-4-8'",
 		"--variant 'high'",
 	} {
@@ -90,11 +123,15 @@ func TestSandboxExecAgentPaneCmd_OverrideFlagsAppended(t *testing.T) {
 
 // TestSandboxExecAgentPaneCmd_NoOverrideFlagsByDefault — no-regression case.
 func TestSandboxExecAgentPaneCmd_NoOverrideFlagsByDefault(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/abcd-prism/bin/prism")
 	iso := &sandboxExecIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@sbx",
 	})
-	want := "prism agent-run --session 'prism-test@sbx'"
+	if err != nil {
+		t.Fatalf("sandbox-exec AgentPaneCmd: unexpected error: %v", err)
+	}
+	want := "'/nix/store/abcd-prism/bin/prism' agent-run --session 'prism-test@sbx'"
 	if got != want {
 		t.Errorf("sandbox-exec AgentPaneCmd = %q, want %q", got, want)
 	}
@@ -104,11 +141,15 @@ func TestSandboxExecAgentPaneCmd_NoOverrideFlagsByDefault(t *testing.T) {
 // only Model (no Variant) emits --model but not --variant. Mirrors the
 // operator workflow where one axis is varied for an A/B test.
 func TestBwrapAgentPaneCmd_PartialOverride_ModelOnly(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/abcd-prism/bin/prism")
 	iso := &bwrapIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@bwrap",
 		Model:       "anthropic/claude-opus-4-8",
 	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
 	if !strings.Contains(got, "--model 'anthropic/claude-opus-4-8'") {
 		t.Errorf("expected --model in pane cmd; got %q", got)
 	}
@@ -123,13 +164,17 @@ func TestBwrapAgentPaneCmd_PartialOverride_ModelOnly(t *testing.T) {
 // regardless, but the tmux pane wraps the command in `sh -c "<cmd>"` so
 // unquoted values are a real injection risk.
 func TestBwrapAgentPaneCmd_ShellQuoting_SingleQuotedValues(t *testing.T) {
+	withFakePrismBinary(t, "/nix/store/abcd-prism/bin/prism")
 	iso := &bwrapIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		SessionName: "prism-test@bwrap",
 		// A value containing a single quote exercises the escape path in
 		// shellQuoteContainer.
 		Model: "danger'name",
 	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
 	want := `--model 'danger'\''name'`
 	if !strings.Contains(got, want) {
 		t.Errorf("expected shell-escaped Model %q in cmd; got %q", want, got)
@@ -143,11 +188,14 @@ func TestBwrapAgentPaneCmd_ShellQuoting_SingleQuotedValues(t *testing.T) {
 // by `prism agent-run`, not by the direct pi launch).
 func TestBwrapAgentPaneCmd_EmptySessionName_FallsBackToDirect(t *testing.T) {
 	iso := &bwrapIsolator{}
-	got := iso.AgentPaneCmd(AgentPaneOpts{
+	got, err := iso.AgentPaneCmd(AgentPaneOpts{
 		DirectCmd: "pi --agent worker",
 		Model:     "anthropic/claude-opus-4-8",
 		Variant:   "high",
 	})
+	if err != nil {
+		t.Fatalf("bwrap AgentPaneCmd: unexpected error: %v", err)
+	}
 	if got != "pi --agent worker" {
 		t.Errorf("expected fallback to DirectCmd; got %q", got)
 	}

--- a/modules/programs/prism/prism/internal/container/dispatch.go
+++ b/modules/programs/prism/prism/internal/container/dispatch.go
@@ -313,16 +313,27 @@ func (b *bwrapIsolator) WriteHarnessConfigBlob(sessionName, content string) erro
 	return WriteHarnessConfig(NameForSession(sessionName), content)
 }
 
-// AgentPaneCmd returns the tmux pane command for bwrap: "prism agent-run
-// --session <name>". The bwrap sandbox is owned by the tmux pane (not the
-// sidecar), so the agent-run dispatch reads the session's isolation mode
-// from the DB and invokes the bwrap arg builder there. Mirrors the
-// pre-refactor branch in BuildOpencodeCmd (internal/session/session.go:286-294).
-func (b *bwrapIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
+// AgentPaneCmd returns the tmux pane command for bwrap:
+// "<abs-path>/prism agent-run --session <name>". The bwrap sandbox is owned
+// by the tmux pane (not the sidecar), so the agent-run dispatch reads the
+// session's isolation mode from the DB and invokes the bwrap arg builder
+// there. Mirrors the pre-refactor branch in BuildOpencodeCmd
+// (internal/session/session.go:286-294).
+//
+// The prism binary's absolute path is resolved via prismBinaryPathFn (os.Executable
+// in production) and shell-quoted into the rendered command so the agent-run
+// pane exec'd from the tmux shell is the same binary the operator is running
+// today — not whatever a PATH lookup happens to land on. Issue #2260.
+func (b *bwrapIsolator) AgentPaneCmd(opts AgentPaneOpts) (string, error) {
 	if opts.SessionName == "" {
-		return opts.DirectCmd
+		return opts.DirectCmd, nil
 	}
-	return appendAgentRunOverrides("prism agent-run --session "+shellQuoteContainer(opts.SessionName), opts)
+	self, err := prismBinaryPathFn()
+	if err != nil {
+		return "", fmt.Errorf("bwrap AgentPaneCmd: resolve prism binary path: %w", err)
+	}
+	cmd := shellQuoteContainer(self) + " agent-run --session " + shellQuoteContainer(opts.SessionName)
+	return appendAgentRunOverrides(cmd, opts), nil
 }
 
 // SidecarFlags returns the sidecar argv extensions for bwrap: --port and the
@@ -398,14 +409,24 @@ func (s *sandboxExecIsolator) WriteHarnessConfigBlob(sessionName, content string
 }
 
 // AgentPaneCmd returns the tmux pane command for sandbox-exec — same shape
-// as bwrap because both modes are pane-owned: "prism agent-run --session
-// <name>". Mirrors the pre-refactor branch in BuildOpencodeCmd
-// (internal/session/session.go:286-294).
-func (s *sandboxExecIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
+// as bwrap because both modes are pane-owned:
+// "<abs-path>/prism agent-run --session <name>". Mirrors the pre-refactor
+// branch in BuildOpencodeCmd (internal/session/session.go:286-294).
+//
+// The prism binary's absolute path is resolved via prismBinaryPathFn (os.Executable
+// in production) and shell-quoted into the rendered command so the agent-run
+// pane exec'd from the tmux shell is the same binary the operator is running
+// today — not whatever a PATH lookup happens to land on. Issue #2260.
+func (s *sandboxExecIsolator) AgentPaneCmd(opts AgentPaneOpts) (string, error) {
 	if opts.SessionName == "" {
-		return opts.DirectCmd
+		return opts.DirectCmd, nil
 	}
-	return appendAgentRunOverrides("prism agent-run --session "+shellQuoteContainer(opts.SessionName), opts)
+	self, err := prismBinaryPathFn()
+	if err != nil {
+		return "", fmt.Errorf("sandbox-exec AgentPaneCmd: resolve prism binary path: %w", err)
+	}
+	cmd := shellQuoteContainer(self) + " agent-run --session " + shellQuoteContainer(opts.SessionName)
+	return appendAgentRunOverrides(cmd, opts), nil
 }
 
 // SidecarFlags returns the sidecar argv extensions for sandbox-exec — same
@@ -460,8 +481,13 @@ func (h *hostIsolator) WriteHarnessConfigBlob(sessionName, content string) error
 // AgentPaneCmd returns DirectCmd unchanged — host mode runs the agent
 // directly in the tmux pane and has no sandbox wrapper command. The caller
 // is responsible for constructing DirectCmd with all env vars and flags.
-func (h *hostIsolator) AgentPaneCmd(opts AgentPaneOpts) string {
-	return opts.DirectCmd
+//
+// Host mode never needs to resolve the prism binary path (no `prism
+// agent-run` indirection), so this method does not call prismBinaryPathFn and
+// cannot return an error — the signature still returns one purely for
+// interface conformance with the bwrap / sandbox-exec implementations.
+func (h *hostIsolator) AgentPaneCmd(opts AgentPaneOpts) (string, error) {
+	return opts.DirectCmd, nil
 }
 
 // SidecarFlags returns the sidecar argv extensions for host mode. Host
@@ -518,6 +544,14 @@ func appendAgentRunOverrides(cmd string, opts AgentPaneOpts) string {
 func shellQuoteContainer(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
+
+// prismBinaryPathFn returns the absolute path of the currently-running prism
+// binary. Production uses os.Executable; tests override this hook to inject
+// deterministic values (and to exercise the os.Executable-returns-error
+// branch in AgentPaneCmd). Issue #2260 — emitting bare "prism" into the
+// agent-run pane command lets a PATH shadow silently run the wrong binary,
+// so the rendered command must carry the absolute path of THIS binary.
+var prismBinaryPathFn = os.Executable
 
 // commonHostAPISidecarFlags returns the SidecarFlags shared by bwrap,
 // sandbox-exec, and host. All three modes set up a host-API socket and

--- a/modules/programs/prism/prism/internal/container/isolator.go
+++ b/modules/programs/prism/prism/internal/container/isolator.go
@@ -168,10 +168,23 @@ type Isolator interface {
 
 	// AgentPaneCmd returns the shell command string emitted into the tmux
 	// agent pane for this session.
-	//   - bwrap, sandbox-exec:   "prism agent-run --session <session>"
+	//   - bwrap, sandbox-exec:   "<abs-path>/prism agent-run --session <session>"
 	//   - host:                  the DirectCmd supplied by the caller
+	//
+	// The bwrap / sandbox-exec branches resolve the prism binary's absolute
+	// path via os.Executable() and shell-quote it into the rendered command,
+	// so the agent-run pane exec'd from the tmux shell is the same binary
+	// the operator is currently running. A bare "prism" would be PATH-
+	// resolved at exec time and could silently land on an earlier-in-PATH
+	// shadow (e.g. /usr/local/bin/prism), running the wrong code in the
+	// agent-run pane with no signal to the operator (issue #2260).
+	//
+	// Returns a non-nil error when the implementation cannot resolve its
+	// own binary path. Callers must propagate the error rather than fall
+	// back to a bare "prism" — silent fallback re-introduces the PATH-
+	// shadow class this method exists to eliminate.
 	// Cites: internal/session/session.go:265-298 (BuildOpencodeCmd switch).
-	AgentPaneCmd(opts AgentPaneOpts) string
+	AgentPaneCmd(opts AgentPaneOpts) (string, error)
 
 	// SidecarFlags returns the per-mode argv extensions appended to the
 	// `prism sidecar` command line for sessions that use this mode. The

--- a/modules/programs/prism/prism/internal/session/initial_prompt_test.go
+++ b/modules/programs/prism/prism/internal/session/initial_prompt_test.go
@@ -164,7 +164,10 @@ func TestBuildAgentCmd_HostMode_PromptFile(t *testing.T) {
 		Prompt:         prompt,
 		PromptFilePath: "/var/state/prism/run/myrepo@feat/initial-prompt.txt",
 	}
-	cmd := BuildAgentCmd(opts)
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
 
 	// The command must reference the file via $(cat …) — operators (and
 	// the size guard) rely on this contract so the launch command size
@@ -200,7 +203,10 @@ func TestBuildAgentCmd_HostMode_NoPromptFile(t *testing.T) {
 		SessionName:   "myrepo@feat",
 		Prompt:        "small prompt",
 	}
-	cmd := BuildAgentCmd(opts)
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
 
 	if strings.Contains(cmd, "$(cat") {
 		t.Errorf("host-mode cmd unexpectedly uses cat-substitution for inline prompt: %q", cmd)
@@ -225,7 +231,10 @@ func TestBuildAgentCmd_HostMode_PromptFile_PathQuoted(t *testing.T) {
 		Prompt:         "x",
 		PromptFilePath: `/tmp/weird's-path/initial-prompt.txt`,
 	}
-	cmd := BuildAgentCmd(opts)
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
 
 	// Single quote must be escaped with the standard '\'' sequence.
 	if !strings.Contains(cmd, `'/tmp/weird'\''s-path/initial-prompt.txt'`) {
@@ -244,7 +253,10 @@ func TestBuildAgentCmd_HostMode_PromptFile_IgnoredWhenPromptEmpty(t *testing.T) 
 		SessionName:    "myrepo@feat",
 		PromptFilePath: "/tmp/initial-prompt.txt",
 	}
-	cmd := BuildAgentCmd(opts)
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
 	if strings.Contains(cmd, "$(cat") {
 		t.Errorf("expected no cat-substitution when Prompt is empty, got: %q", cmd)
 	}
@@ -358,7 +370,10 @@ func TestSpawnSession_HostMode_AcceptsBoundedLaunchCmd(t *testing.T) {
 			"GIT_EDITOR":      "true",
 		},
 	}
-	cmd := BuildAgentCmd(opts)
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
 	if len(cmd) > HostLaunchCmdSafeBound {
 		t.Errorf("realistic host-mode cmd (%d bytes) unexpectedly exceeds safe bound %d — guard would reject normal spawns. cmd=%q",
 			len(cmd), HostLaunchCmdSafeBound, cmd)

--- a/modules/programs/prism/prism/internal/session/session.go
+++ b/modules/programs/prism/prism/internal/session/session.go
@@ -355,20 +355,27 @@ func effectiveIsolationMode(opts Opts) string {
 // BuildAgentCmd returns the agent launch command string for the given opts.
 //
 // Isolation mode determines the command:
-//   - "bwrap":        "prism agent-run --session <session-name>"
-//   - "sandbox-exec": "prism agent-run --session <session-name>"
+//   - "bwrap":        "<abs-path>/prism agent-run --session <session-name>"
+//   - "sandbox-exec": "<abs-path>/prism agent-run --session <session-name>"
 //   - "host":         direct agent invocation (default)
 //
 // D4 (issue #1133): the per-mode switch collapses into a single
 // Isolator.AgentPaneCmd dispatch. Unknown / unregistered modes fall back to
 // the direct (host-shape) command — matching the pre-refactor "default" arm.
-func BuildAgentCmd(opts Opts) string {
+//
+// Returns a non-nil error when the bwrap / sandbox-exec branch cannot
+// resolve the prism binary's absolute path (os.Executable failure). Host
+// mode and the unknown-mode fallback never fail. Issue #2260: callers must
+// propagate the error rather than fall back to a bare "prism" — silent
+// fallback would re-introduce the PATH-shadow class the fix exists to
+// eliminate.
+func BuildAgentCmd(opts Opts) (string, error) {
 	mode := config.IsolationMode(effectiveIsolationMode(opts))
 	direct := buildDirectAgentCmd(opts)
 	iso, err := container.For(mode, container.ConstructorOpts{Name: opts.SessionName})
 	if err != nil {
 		// Unknown mode: behave like the pre-refactor default arm.
-		return direct
+		return direct, nil
 	}
 	return iso.AgentPaneCmd(container.AgentPaneOpts{
 		SessionName: opts.SessionName,
@@ -862,7 +869,10 @@ func setupFullLayout(name, directory string, opts Opts) error {
 	// modes ignore opts.Worktree — their `prism agent-run` dispatch reads
 	// the worktree from the DB row instead.
 	opts.Worktree = directory
-	agentCmd := BuildAgentCmd(opts)
+	agentCmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		return fmt.Errorf("setupFullLayout: build agent command for %q: %w", name, err)
+	}
 
 	// Persist isolation_mode BEFORE opening the agent window. This is the
 	// critical ordering fix: prism agent-run in window 1 reads isolation_mode

--- a/modules/programs/prism/prism/internal/session/session_test.go
+++ b/modules/programs/prism/prism/internal/session/session_test.go
@@ -187,18 +187,26 @@ func TestBuildDirectAgentCmd_AgentEnvVarsNil(t *testing.T) {
 // ── Isolation mode command construction ─────────────────────────────────────
 
 // TestBuildAgentCmd_BwrapMode verifies that IsolationMode="bwrap" produces
-// "prism agent-run --session <session-name>".
+// "<abs-path>/prism agent-run --session '<session-name>'". Post-#2260 the
+// command begins with a shell-quoted absolute path (os.Executable resolves
+// to the running go-test binary under `go test`, hence we only assert the
+// shape rather than a specific path).
 func TestBuildAgentCmd_BwrapMode(t *testing.T) {
 	opts := Opts{
 		IsolationMode: "bwrap",
 		SessionName:   "nixos-config@feature",
 	}
-	cmd := BuildAgentCmd(opts)
-	if !strings.HasPrefix(cmd, "prism agent-run --session") {
-		t.Errorf("bwrap mode: got %q, want prefix 'prism agent-run --session'", cmd)
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
 	}
-	if !strings.Contains(cmd, "nixos-config@feature") {
-		t.Errorf("bwrap mode: session name not in cmd: %q", cmd)
+	// The bwrap shape carries an absolute path to the running binary
+	// (issue #2260), shell-quoted, followed by ` agent-run --session`.
+	if !strings.HasPrefix(cmd, "'/") {
+		t.Errorf("bwrap mode: cmd must start with a shell-quoted absolute path; got %q", cmd)
+	}
+	if !strings.Contains(cmd, " agent-run --session 'nixos-config@feature'") {
+		t.Errorf("bwrap mode: cmd missing agent-run subcommand and session; got %q", cmd)
 	}
 }
 
@@ -211,8 +219,11 @@ func TestBuildAgentCmd_HostMode(t *testing.T) {
 		Port:          14000,
 		SessionName:   "nixos-config@feature",
 	}
-	cmd := BuildAgentCmd(opts)
-	if strings.HasPrefix(cmd, "prism agent-run") {
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
+	if strings.Contains(cmd, " agent-run ") {
 		t.Errorf("host mode: got prism agent-run command %q, want direct pi invocation", cmd)
 	}
 	if !strings.Contains(cmd, "pi") {
@@ -228,8 +239,11 @@ func TestBuildAgentCmd_EmptyIsolationMode(t *testing.T) {
 		Agent:       "worker",
 		Port:        14000,
 	}
-	cmd := BuildAgentCmd(opts)
-	if strings.HasPrefix(cmd, "prism agent-run") {
+	cmd, err := BuildAgentCmd(opts)
+	if err != nil {
+		t.Fatalf("BuildAgentCmd: %v", err)
+	}
+	if strings.Contains(cmd, " agent-run ") {
 		t.Errorf("empty IsolationMode: got %q, want direct pi invocation", cmd)
 	}
 	if !strings.Contains(cmd, "pi") {

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -488,7 +488,11 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 	switch {
 	case mode == "host" && opts.Layout == LayoutFull:
 		previewOpts := buildOptsForLayout(opts, 0, promptFilePath)
-		hostLaunchCmd := BuildAgentCmd(previewOpts)
+		hostLaunchCmd, buildErr := BuildAgentCmd(previewOpts)
+		if buildErr != nil {
+			removeInitialPrompt(opts.SessionName)
+			return fmt.Errorf("spawn session: build host launch command for %q: %w", opts.SessionName, buildErr)
+		}
 		hostLaunchCmdSize = len(hostLaunchCmd)
 		if hostLaunchCmdSize > HostLaunchCmdSafeBound {
 			startup.log("spawn-session: host launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
@@ -535,7 +539,12 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			Model:            opts.Model,
 			Variant:          opts.Variant,
 		}
-		size += len(BuildAgentCmd(previewOpts))
+		agentOnlyCmd, buildErr := BuildAgentCmd(previewOpts)
+		if buildErr != nil {
+			removeInitialPrompt(opts.SessionName)
+			return fmt.Errorf("spawn session: build host/LayoutAgentOnly launch command for %q: %w", opts.SessionName, buildErr)
+		}
+		size += len(agentOnlyCmd)
 		hostLaunchCmdSize = size
 		if size > HostLaunchCmdSafeBound {
 			startup.log("spawn-session: host/LayoutAgentOnly launch command size %d exceeds safe bound %d — rejecting before tmux state is created",
@@ -565,7 +574,11 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 			Model:            opts.Model,
 			Variant:          opts.Variant,
 		}
-		previewCmd := BuildAgentCmd(previewOpts)
+		previewCmd, buildErr := BuildAgentCmd(previewOpts)
+		if buildErr != nil {
+			removeInitialPrompt(opts.SessionName)
+			return fmt.Errorf("spawn session: build %s launch command for %q: %w", mode, opts.SessionName, buildErr)
+		}
 		// For the env-var preview, route through the same helper used at
 		// spawn time so the file-path branch (post-#1092) and the legacy
 		// inline branch produce matching size estimates.
@@ -1085,7 +1098,10 @@ func spawnAgentOnlyLayout(opts SpawnOpts, port int) error {
 		// AgentEnvVars intentionally omitted: review sessions don't inject
 		// profile env vars in host mode today.
 	}
-	agentCmd := BuildAgentCmd(buildOpts)
+	agentCmd, err := BuildAgentCmd(buildOpts)
+	if err != nil {
+		return fmt.Errorf("spawnAgentOnlyLayout: build agent command for %q: %w", opts.SessionName, err)
+	}
 
 	// Persist isolation_mode to the DB BEFORE creating the agent window.
 	// prism agent-run (the bwrap entry point) reads isolation_mode from


### PR DESCRIPTION
The bwrap and sandbox-exec branches of `Isolator.AgentPaneCmd` used to emit
a bare `prism agent-run --session <name>` token into the tmux pane
command, which the pane shell then PATH-resolved at exec time. On a worker
host the deployed binary is normally what's first on PATH, but any
earlier-in-PATH shadow (e.g. `/usr/local/bin/prism`, a stray homebrew
install, a leftover dev symlink) would silently run the wrong code in the
agent-run pane with no signal to the operator.

This is exactly the class that produced the false-green verification on
PR #2257 — a branch-build acceptance run silently exercised the deployed
binary because the per-session pane command was PATH-resolved.

## Fix

Resolve the binary path via `os.Executable()` (production) at `AgentPaneCmd`
time and shell-quote it into the rendered command. Propagate any
`os.Executable` failure up through `BuildAgentCmd` to `SpawnSession` callers
rather than silently falling back to bare `prism` — silent fallback would
re-introduce the PATH-shadow class this fix exists to eliminate.

## API changes

- `Isolator.AgentPaneCmd` now returns `(string, error)`. Host mode never
  fails; bwrap / sandbox-exec fail only when `os.Executable` does.
- `session.BuildAgentCmd` returns `(string, error)`. All call sites
  updated (`setupFullLayout`, the three pre-spawn size-guard previews in
  `SpawnSession`, and `spawnAgentOnlyLayout`).
- A package-level `prismBinaryPathFn` hook lets tests stub the resolution
  to a deterministic path (and exercise the error branch).

## Tests

- Update existing `agent_pane_overrides_test.go` assertions to expect the
  shell-quoted absolute-path prefix instead of bare `prism`.
- Add `agent_pane_binary_path_test.go` (issue #2260 regression suite):
  - Bwrap / sandbox-exec each carry a shell-quoted absolute path prefix
    (matches `^'/.+/prism' agent-run --session ...`).
  - A binary path containing a single quote is shell-escaped via `'\''`.
  - `os.Executable()` failure propagates as a wrapped error; no silent
    fallback to bare `prism`.
  - Host mode does NOT consult `prismBinaryPathFn` (defence-in-depth).
  - The empty-`SessionName` fast path on bwrap also bypasses resolution.
- Update `BuildAgentCmd` tests (`cmd/`, `session/`) to handle the new
  return signature and the absolute-path prefix in bwrap mode.

The fix was verified to be non-vacuous: transiently reverting the body
of `AgentPaneCmd` to emit bare \"prism\" makes every new test in
`agent_pane_binary_path_test.go` fail.

## Out of scope

Angle (b) from the issue (the dev-experience doc covering `prism spawn`
branch-build verification) is deliberately deferred to a separate PR.

## Quality gates

- `go build ./...` ✅
- `go test ./...` ✅
- `go test -race ./internal/container/... ./internal/session/...` ✅
- `nix build .#prism` ✅

Closes #2260