### PR TITLE
overlays: disable kubernetes-helm checkPhase on Darwin

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -144,6 +144,32 @@ rec {
           '';
         });
 
+      # kubernetes-helm: disable checkPhase on Darwin to work around a
+      # broken `substitute()` call in nixpkgs' helm 4.2.0 derivation.
+      # Upstream helm 4.2.0 renamed or removed
+      # `cmd/helm/dependency_build_test.go`, but the nixpkgs derivation
+      # still patches its shebang during checkPhase / postPatch, failing
+      # with:
+      #   substitute(): ERROR: file 'cmd/helm/dependency_build_test.go' does not exist
+      # The build itself (and the produced binary) is unaffected; only the
+      # test phase trips on the missing file, and only on Darwin — Linux's
+      # helm 4.2.0 build succeeds against the same nixpkgs input.
+      #
+      # No upstream nixpkgs issue filed yet (out of scope here); see this
+      # repo's issue #2272 for the local failure and CI logs.
+      #
+      # REMOVAL CONDITION: delete this block once nixpkgs' kubernetes-helm
+      # derivation stops referencing the removed test file (either by
+      # dropping the offending `substitute()` call or by helm restoring
+      # the file upstream).
+      kubernetes-helm =
+        if final.stdenv.isDarwin then
+          prev.kubernetes-helm.overrideAttrs (_: {
+            doCheck = false;
+          })
+        else
+          prev.kubernetes-helm;
+
       # direnv: disable the test phase on Darwin to work around a hang in
       # `direnv-test.zsh` introduced when libarchive was bumped 3.8.4 -> 3.8.6
       # on staging-25.11 (nixpkgs commit 32e655f). Direnv's source is


### PR DESCRIPTION
## Summary

`build-and-cache` has been red on `main` for `darwinConfigurations.m4mac` since PR #2265 bumped `kubernetes-helm` from 3.20.2 to 4.2.0. The nixpkgs helm 4.2.0 derivation runs a `substitute()` against `cmd/helm/dependency_build_test.go` during `checkPhase` / `postPatch`, but upstream helm 4.2.0 renamed or removed that file:

```
kubernetes-helm> substitute(): ERROR: file 'cmd/helm/dependency_build_test.go' does not exist
```

Linux helm 4.2.0 builds clean against the same nixpkgs input — only Darwin trips, so the broken codepath is platform-conditional.

## Fix

Add a Darwin-only override in `overlays/default.nix` under the `modifications` overlay that sets `doCheck = false` on `kubernetes-helm`. Scoped via `final.stdenv.isDarwin` so Linux's derivation is untouched and still runs its full `checkPhase`.

Why `doCheck = false` over pinning back to 3.x:

- The failure is in `checkPhase`, not the build itself — disabling the test phase does not affect the produced binary's behaviour.
- Pinning to 3.x means deliberately not picking up upstream helm fixes/security patches.
- Skipping tests during a nix build is a normal nixpkgs pattern.

The override is patterned after the existing `direnv` block (structure: Darwin-conditional `overrideAttrs` with `doCheck = false`) and the `openrazer` block (doc comment style with explicit `REMOVAL CONDITION`).

## Verification

Linux (this PR, x86_64-linux):
- `nix build --no-link '.#nixosConfigurations.navi.config.system.build.toplevel'` — succeeds.
- `nix build --no-link '.#nixosConfigurations.tui.config.system.build.toplevel'` — succeeds.
- `nix eval '.#nixosConfigurations.navi.pkgs.kubernetes-helm.doCheck'` → `true` (Linux check phase unchanged).

Darwin (eval-only on this host):
- `nix eval '.#darwinConfigurations.m4mac.pkgs.kubernetes-helm.doCheck'` → `false`.
- `nix eval '.#darwinConfigurations.m4mac.pkgs.kubernetes-helm.version'` → `4.2.0` (still 4.2.0, just without checkPhase).
- Full Darwin realisation cannot be exercised on the Linux host running this work; CI's `build (macos-15, darwinConfigurations.m4mac, m4mac)` job is the authoritative check (AC #2).

Closes #2272