### PR TITLE
prism: mint fresh instance_id on respawn after incarnation end (#2253)

### DIFF
--- a/modules/programs/prism/prism/cmd/event.go
+++ b/modules/programs/prism/prism/cmd/event.go
@@ -329,14 +329,47 @@ var eventTmuxSessionStartCmd = &cobra.Command{
 			return fmt.Errorf("event tmux-session-start: clear ended: %w", err)
 		}
 
-		// Determine the instance_id for this session incarnation. When the
-		// caller (ensureAndSwitch) has already written an instance_id to the DB
-		// (e.g. before starting the sidecar), we preserve it so the sidecar and
-		// the DB remain in sync. For standalone invocations (tmux hook, restore
-		// path) where no instance_id has been pre-written, generate a fresh UUID.
+		// Determine the instance_id for this session incarnation. Three cases:
+		//
+		//  1. agent_status has no instance_id (cleared by tmux-session-end, or
+		//     never written for this session) — mint a fresh UUID.
+		//
+		//  2. agent_status has an instance_id AND the corresponding sessions
+		//     row has ended_at unset (live incarnation) — reuse it. This
+		//     preserves the post-#1507 host-side mint (SpawnSession writes the
+		//     fresh instance_id before tmux-session-start fires) and the
+		//     within-incarnation profile-pin semantics from #2092 (an
+		//     agent-pane restart while ended_at is unset must keep resolving
+		//     to the same spawn_inputs.profile_name, including legitimate
+		//     `prism spawn --profile X` / `--abtest A B` pins).
+		//
+		//  3. agent_status has an instance_id AND the corresponding sessions
+		//     row has ended_at set (previous incarnation is over) — mint a
+		//     fresh UUID (#2253). Reusing the instance_id would otherwise
+		//     carry the previous incarnation's `spawn_inputs.profile_name`
+		//     pin forward forever, so respawned long-lived coordinators (e.g.
+		//     `home-ops@main` reopened via `prism switch`) ignore the
+		//     currently-active profile. A fresh instance_id has no
+		//     spawn_inputs row, so profile resolution at agent-run time falls
+		//     through to the state file / nix default (the user's active
+		//     profile). Historical spawn_inputs rows are left intact as the
+		//     #2090 audit trail that `prism stats` / archive queries
+		//     aggregate by profile_name — see SessionByInstanceID lookup
+		//     below; we never UPDATE or DELETE the ended row.
+		//
+		// A nil prevSess (legacy pre-#1606 agent_status row whose instance_id
+		// has no matching sessions entry) and any lookup error preserve the
+		// existing reuse behaviour — only a positive "previous incarnation
+		// has ended" signal triggers a fresh mint.
 		var instanceID string
 		currentStatus, stErr := d.CurrentStatus(session)
-		if stErr == nil && currentStatus != nil && currentStatus.InstanceID != nil {
+		reuseInstance := stErr == nil && currentStatus != nil && currentStatus.InstanceID != nil
+		if reuseInstance {
+			if prevSess, prevErr := d.SessionByInstanceID(*currentStatus.InstanceID); prevErr == nil && prevSess != nil && prevSess.EndedAt != nil {
+				reuseInstance = false
+			}
+		}
+		if reuseInstance {
 			instanceID = *currentStatus.InstanceID
 		} else {
 			instanceID = uuid.New().String()

--- a/modules/programs/prism/prism/cmd/event_test.go
+++ b/modules/programs/prism/prism/cmd/event_test.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/prismatic-koi/prism/internal/db"
 	"github.com/prismatic-koi/prism/internal/tmux"
 )
@@ -793,5 +795,311 @@ func TestEventTmuxSessionStart_NonWorktreeSession_ClearsEnded(t *testing.T) {
 	}
 	if status.EndedAt != nil {
 		t.Errorf("ended_at = %v, want NULL — ClearEnded did not fire", *status.EndedAt)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #2253 — tmux-session-start must mint a fresh instance_id when the
+// previous incarnation's sessions row has ended_at set.
+//
+// Before the fix, the handler reused the agent_status.instance_id
+// unconditionally, so a long-lived coordinator session that was once spawned
+// with `prism spawn --profile X` carried that profile pin forward forever via
+// the spawn_inputs.profile_name column — even after `prism profile use Y`
+// and many respawns. The fix detects the ended-previous-incarnation case and
+// mints a fresh UUID so profile resolution at agent-run time falls through
+// to state-file / nix-default (the user's currently-active profile).
+//
+// Historical spawn_inputs rows belonging to ended incarnations must NOT be
+// mutated or deleted by the respawn path — they are the #2090 audit trail
+// that `prism stats` / archive queries aggregate by profile_name.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestEventTmuxSessionStart_RespawnAfterEnd_MintsFreshInstance verifies AC #1:
+// when the previous sessions row has ended_at set, tmux-session-start mints
+// a fresh instance_id and writes it into agent_status.
+func TestEventTmuxSessionStart_RespawnAfterEnd_MintsFreshInstance(t *testing.T) {
+	resetRootCmdFlags(t)
+	t.Setenv("PRISM_HOST_API", "")
+	const session = "prism-test@2253-respawn-after-end"
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// Pre-seed the bug scenario: a previous incarnation exists in
+	// agent_status + sessions, was cleanly closed (ended_at set), and
+	// recorded a spawn_inputs.profile_name pin.
+	oldIID := uuid.New().String()
+	if err := d.UpsertStatus(session, "prism-test", worktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID(session, oldIID); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID:  oldIID,
+		SessionName: session,
+		Repo:        "prism-test",
+		Worktree:    worktree,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	pinned := "anthropic-opus"
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:  oldIID,
+		ProfileName: &pinned,
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+	if err := d.UpdateSessionEnded(oldIID, "finished"); err != nil {
+		t.Fatalf("UpdateSessionEnded: %v", err)
+	}
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "tmux-session-start",
+		"--session", session,
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	// agent_status.instance_id must now be a freshly-minted UUID,
+	// not the old (ended) one.
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil || status.InstanceID == nil {
+		t.Fatal("expected agent_status row with non-nil instance_id")
+	}
+	newIID := *status.InstanceID
+	if newIID == oldIID {
+		t.Fatalf("instance_id was reused (%q) — fresh mint required when previous incarnation has ended_at set", oldIID)
+	}
+
+	// MostRecentSessionForName must return the new (live) sessions row,
+	// not the old one — so SpawnTimeForSession's lookup chain naturally
+	// falls through to state-file / nix-default profile resolution.
+	mostRecent, err := d2.MostRecentSessionForName(session)
+	if err != nil {
+		t.Fatalf("MostRecentSessionForName: %v", err)
+	}
+	if mostRecent == nil || mostRecent.InstanceID != newIID {
+		t.Fatalf("MostRecentSessionForName: got %+v, want row with instance_id=%q", mostRecent, newIID)
+	}
+	if mostRecent.EndedAt != nil {
+		t.Errorf("new sessions row has ended_at=%v, want NULL", *mostRecent.EndedAt)
+	}
+
+	// The new instance_id must have NO spawn_inputs row — that is what
+	// makes profile resolution fall through to the active profile.
+	newSI, err := d2.SpawnInputsByInstanceID(newIID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID(new): %v", err)
+	}
+	if newSI != nil {
+		t.Errorf("new instance_id %q has spawn_inputs row %+v, want none", newIID, newSI)
+	}
+
+	// AC #4 — the historical spawn_inputs row for the ENDED incarnation
+	// must not be mutated or deleted by the respawn path. `prism stats`
+	// and archive queries depend on it.
+	oldSI, err := d2.SpawnInputsByInstanceID(oldIID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID(old): %v", err)
+	}
+	if oldSI == nil {
+		t.Fatal("old spawn_inputs row was deleted — audit trail must be preserved (#2090)")
+	}
+	if oldSI.ProfileName == nil || *oldSI.ProfileName != pinned {
+		t.Errorf("old spawn_inputs.profile_name = %v, want preserved %q (must not be mutated)", oldSI.ProfileName, pinned)
+	}
+	oldSess, err := d2.SessionByInstanceID(oldIID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID(old): %v", err)
+	}
+	if oldSess == nil {
+		t.Fatal("old sessions row was deleted — audit trail must be preserved")
+	}
+	if oldSess.EndedAt == nil {
+		t.Error("old sessions row's ended_at was cleared — must not be mutated")
+	}
+}
+
+// TestEventTmuxSessionStart_LiveIncarnation_PreservesInstance verifies AC #2:
+// when the previous sessions row has ended_at unset (within-incarnation
+// agent-pane restart), tmux-session-start reuses the existing instance_id so
+// the spawn_inputs.profile_name pin keeps resolving (the #2092 semantics).
+func TestEventTmuxSessionStart_LiveIncarnation_PreservesInstance(t *testing.T) {
+	resetRootCmdFlags(t)
+	t.Setenv("PRISM_HOST_API", "")
+	const session = "prism-test@2253-live-incarnation"
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	liveIID := uuid.New().String()
+	if err := d.UpsertStatus(session, "prism-test", worktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID(session, liveIID); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	if err := d.InsertSession(db.Session{
+		InstanceID:  liveIID,
+		SessionName: session,
+		Repo:        "prism-test",
+		Worktree:    worktree,
+		Harness:     "pi",
+	}); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+	pinned := "anthropic-opus"
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:  liveIID,
+		ProfileName: &pinned,
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+	// Intentionally do NOT call UpdateSessionEnded — the incarnation is live.
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "tmux-session-start",
+		"--session", session,
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil || status.InstanceID == nil {
+		t.Fatal("expected agent_status row with non-nil instance_id")
+	}
+	if *status.InstanceID != liveIID {
+		t.Fatalf("instance_id = %q, want preserved %q — live incarnation must keep its instance_id", *status.InstanceID, liveIID)
+	}
+
+	// The spawn_inputs pin must still resolve through the unchanged
+	// instance_id — this is what guarantees `prism spawn --profile X`
+	// keeps X across agent-pane restarts (#2092).
+	si, err := d2.SpawnInputsByInstanceID(liveIID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si == nil || si.ProfileName == nil || *si.ProfileName != pinned {
+		t.Errorf("spawn_inputs.profile_name lookup via reused instance_id failed: si=%+v, want %q", si, pinned)
+	}
+}
+
+// TestEventTmuxSessionStart_LegacyAgentStatusNoSessionsRow verifies AC #5:
+// when agent_status carries an instance_id that has no matching sessions row
+// (pre-#1606 legacy), the respawn path falls through to the existing reuse
+// behaviour — the instance_id is preserved and a sessions row is created
+// for it via INSERT OR IGNORE. Because no spawn_inputs row exists for the
+// reused instance_id, profile resolution still naturally falls through to
+// state-file / nix-default at agent-run time.
+func TestEventTmuxSessionStart_LegacyAgentStatusNoSessionsRow(t *testing.T) {
+	resetRootCmdFlags(t)
+	t.Setenv("PRISM_HOST_API", "")
+	const session = "prism-test@2253-legacy-no-sessions-row"
+	worktree := t.TempDir()
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	legacyIID := uuid.New().String()
+	if err := d.UpsertStatus(session, "prism-test", worktree, "idle", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+	if err := d.SetInstanceID(session, legacyIID); err != nil {
+		t.Fatalf("SetInstanceID: %v", err)
+	}
+	// Intentionally no InsertSession — the legacy / pre-#1606 shape.
+	d.Close()
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	rootCmd.SetArgs([]string{
+		"event", "tmux-session-start",
+		"--session", session,
+		"--worktree", worktree,
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	d2, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("re-open db: %v", err)
+	}
+	defer d2.Close()
+
+	status, err := d2.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if status == nil || status.InstanceID == nil {
+		t.Fatal("expected agent_status row with non-nil instance_id")
+	}
+	if *status.InstanceID != legacyIID {
+		t.Fatalf("instance_id = %q, want preserved legacy %q — nil prevSess must preserve reuse behaviour", *status.InstanceID, legacyIID)
+	}
+
+	// A sessions row should now exist for the (reused) legacy instance_id.
+	sess, err := d2.SessionByInstanceID(legacyIID)
+	if err != nil {
+		t.Fatalf("SessionByInstanceID: %v", err)
+	}
+	if sess == nil {
+		t.Error("expected sessions row inserted for legacy instance_id, got nil")
+	}
+
+	// And no spawn_inputs row exists — so SpawnTimeForSession returns ""
+	// and profile resolution falls through to state-file / nix-default,
+	// unchanged from today.
+	si, err := d2.SpawnInputsByInstanceID(legacyIID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si != nil {
+		t.Errorf("unexpected spawn_inputs row for legacy session: %+v", si)
 	}
 }


### PR DESCRIPTION
Closes #2253.

## Symptom

Long-lived coordinator sessions (e.g. `home-ops@main`) ignored the
currently-active profile forever after they were once spawned with
`prism spawn --profile <X>` — even after `prism profile use <Y>` and
many respawns. `home-ops@main` always opened on `claude-opus-4-7` +
`medium` (the `anthropic-opus` profile's coordinator slot), regardless
of the active-profile state file.

## Root cause

`prism event tmux-session-start` (`cmd/event.go`) reused
`agent_status.instance_id` unconditionally. The previous incarnation's
`spawn_inputs.profile_name` row (written by spawn.go per the #2090
audit design) therefore kept winning the #2092 profile precedence chain
at agent-run time, because `populatePIConfig` → `profile.SpawnTimeForSession`
→ `MostRecentSessionForName` → `SpawnInputsByInstanceID` resolves to
the same instance_id every respawn.

## Fix

In `cmd/event.go::eventTmuxSessionStartCmd`, look up the sessions row
for the reused `agent_status.instance_id`. When that row has `ended_at`
set, the previous incarnation is over — mint a fresh UUID instead of
reusing the old one. A fresh `instance_id` has no `spawn_inputs` row,
so profile resolution naturally falls through to the state file / nix
default (the user's active profile).

This is **Option A** from the issue. Option B was rejected because
`spawn_inputs` PK is `instance_id`: writing a "new" row for the same
instance_id would require either `UPDATE`-in-place (banned by AC #4
— the historical row is the #2090 audit trail aggregated by `prism
stats` and archive queries) or no insert at all.

## Within-incarnation semantics preserved (#2092)

While a session's most recent sessions row has `ended_at` unset, the
`instance_id` is reused unchanged. This is the AC #2 / #3 guarantee:

- `prism spawn --profile X` keeps X across agent-pane restarts within
  the live incarnation.
- Both legs of `prism spawn --abtest A B` keep resolving their own
  recorded profiles.

A nil `prevSess` (legacy pre-#1606 `agent_status` row whose
`instance_id` has no matching `sessions` entry) and any DB lookup
error preserve the existing reuse behaviour — only a positive
"previous incarnation has ended" signal triggers a fresh mint.

## Side-effect analysis

- **Ports** are keyed by `session_name`, not `instance_id` — unaffected.
- **Bus messages** — the existing `PurgeStaleInstanceMessages(session,
  instanceID)` call below the mint already purges messages addressed
  to any other instance_id for this session.
- **Archive linkage** is per-incarnation. The new `instance_id` gets
  its own archive entry; the old incarnation's archive linkage is
  preserved (AC #4).
- **agent_status.instance_id** update via `SetInstanceID` is already
  on the fresh-mint code path.

## Tests

`cmd/event_test.go` gains three tests covering the three branches:

- `TestEventTmuxSessionStart_RespawnAfterEnd_MintsFreshInstance`
  asserts AC #1 + #4 — fresh mint, and the historical
  `spawn_inputs` / `sessions` rows are not mutated or deleted.
- `TestEventTmuxSessionStart_LiveIncarnation_PreservesInstance` asserts
  AC #2 — within-incarnation reuse keeps the
  `spawn_inputs.profile_name` pin resolvable.
- `TestEventTmuxSessionStart_LegacyAgentStatusNoSessionsRow` asserts
  AC #5 — nil `prevSess` preserves the existing reuse + `INSERT OR
  IGNORE` behaviour for pre-#1606 legacy rows.

AC #6 (degraded `ensureAndSwitch` with no DB) is unaffected — the
`tmux-session-start` handler's DB-failure semantics are unchanged.

The reverse-the-fix discipline was applied: reverting only the
`cmd/event.go` hunk makes `RespawnAfterEnd_MintsFreshInstance` fail
with `instance_id was reused (...) — fresh mint required when
previous incarnation has ended_at set`. The other two tests pass
both with and without the fix (they assert the unchanged code paths).

## Local verification

- `go build ./...` ✅
- `go test ./... -count=1` ✅
- `go test ./... -race -count=1` ✅
- `nix build .#prism` ✅

## Acceptance criteria

- [x] [functional] Respawning an ended `@main` coordinator launches the agent with the active profile, not the previous incarnation's `spawn_inputs.profile_name`.
- [x] [functional] `prism spawn --profile X` keeps X across agent restarts within a live incarnation (`ended_at` unset).
- [x] [functional] Both legs of `prism spawn --abtest A B` continue to resolve their own recorded profiles.
- [x] [functional] `spawn_inputs` rows for ended incarnations are not mutated or deleted by the respawn path.
- [x] [edge-case] Sessions whose most recent `sessions` row has no `spawn_inputs` row (pre-#2090 legacy) resolve via state file / nix default, unchanged.
- [x] [edge-case] No-DB respawn path unaffected (handler-level DB-failure behaviour unchanged).

## Coupled work in flight

Issue #2252 (live-swap `set_model` prefix bug — the broken escape
hatch that masked this) is being worked on a parallel session. Files
touched here (`cmd/event.go` + `cmd/event_test.go`) do not overlap
with that PR's surface (`internal/sidecar/host_api.go` +
`pi/extensions/prism.ts`).