### PR TITLE
prism: honour XDG_STATE_HOME in SessionWorkDirPath (#2263)

### DIFF
--- a/modules/programs/prism/prism/internal/container/container_test.go
+++ b/modules/programs/prism/prism/internal/container/container_test.go
@@ -1047,6 +1047,7 @@ func TestWriteGitconfig_AllModes_EmptyIdentityRefused(t *testing.T) {
 func TestSandboxExecPrepare_EmptyIdentityAborts(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", "")
 	for _, d := range []string{".ssh", ".config/pi", ".cache/nix"} {
 		if err := os.MkdirAll(filepath.Join(fakeHome, d), 0o700); err != nil {
 			t.Fatalf("mkdir %s: %v", d, err)

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -571,6 +571,11 @@ func TestPrepareSandboxExec_WritesProfileAndReturnsArgs(t *testing.T) {
 	// homeless-shelter failure class" pattern — the gate this test exercises
 	// (issue #2168) exists to catch the inverse of this missing guard.
 	t.Setenv("HOME", t.TempDir())
+	// Clear XDG_STATE_HOME so the HOME-derived fallback in SessionWorkDirPath
+	// is what's exercised here (the test asserts the work-dir path against
+	// HOME). A developer env that exports XDG_STATE_HOME would otherwise
+	// route the work dir off the tempdir HOME (issue #2263).
+	t.Setenv("XDG_STATE_HOME", "")
 	m := newSandboxExecManager(Config{
 		SessionName:   "repo@feat",
 		Worktree:      t.TempDir(),
@@ -657,6 +662,7 @@ func TestSandboxExecPrepare_WorkDirFailurePropagated(t *testing.T) {
 	// Redirect HOME for the work-dir path derivation. See
 	// TestPrepareSandboxExec_WritesProfileAndReturnsArgs for the rationale.
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", "")
 	// Build the manager and derive the work-dir path before injecting the
 	// failure, so we know which path to block.
 	m := newSandboxExecManagerWithInstance(Config{
@@ -717,6 +723,7 @@ func TestSandboxExecPrepare_WorkDirFailurePropagated_NilArgs(t *testing.T) {
 	// Redirect HOME for the work-dir path derivation. See
 	// TestPrepareSandboxExec_WritesProfileAndReturnsArgs for the rationale.
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", "")
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@feat",
 		InstanceID:  "work-dir-fail-nil-args-test",
@@ -827,6 +834,10 @@ func newFakeHome(t *testing.T) string {
 
 	// Override HOME for the duration of the test.
 	t.Setenv("HOME", fakeHome)
+	// Clear XDG_STATE_HOME so the session work dir resolves under fakeHome
+	// (the HOME-derived fallback in SessionWorkDirPath — issue #2263). Tests
+	// that exercise the XDG_STATE_HOME branch set it explicitly.
+	t.Setenv("XDG_STATE_HOME", "")
 
 	return fakeHome
 }
@@ -1233,6 +1244,7 @@ func TestGenerateProfile_NixProfileAbsent_LiteralStillEmitted(t *testing.T) {
 func TestPrepareSandboxExec_MinimalHomeNoOptionalDirs(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_STATE_HOME", "")
 
 	m := newSandboxExecManager(Config{
 		SessionName:   "repo@minimal-home",

--- a/modules/programs/prism/prism/internal/container/session_work_dir.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir.go
@@ -5,7 +5,13 @@ package container
 //
 // The session work dir lives at
 //
-//	~/.local/state/prism/sessions/<instance_id>/
+//	<XDG_STATE_HOME>/prism/sessions/<instance_id>/
+//
+// honouring $XDG_STATE_HOME first (XDG Base Directory Specification), and
+// falling back to $HOME/.local/state when XDG_STATE_HOME is unset.
+// Production sandbox-exec dispatch sets XDG_STATE_HOME=$HOME/.local/state
+// explicitly (see cmd/agent_run_sandbox_exec_darwin.go), so the production
+// path remains ~/.local/state/prism/sessions/<instance_id>/.
 //
 // It contains no symlinks: just the generated regular files that git and
 // ssh need inside a sandbox-exec session:
@@ -53,20 +59,40 @@ import (
 // SessionWorkDirPath returns the per-session work directory path for the
 // given instance ID:
 //
-//	~/.local/state/prism/sessions/<instanceID>/
+//	<XDG_STATE_HOME>/prism/sessions/<instanceID>/
+//
+// honouring $XDG_STATE_HOME first per the XDG Base Directory Specification,
+// and falling back to $HOME/.local/state when XDG_STATE_HOME is unset. This
+// mirrors xdgStateBase() in dispatch.go and the same pattern used by
+// internal/sidecar tests (see AGENTS.md "Test-suite isolation (#1608)").
+//
+// In production on Darwin, agent_run_sandbox_exec_darwin.go's
+// buildSandboxExecHomeEnv explicitly sets XDG_STATE_HOME=$HOME/.local/state
+// before exec'ing into the sandbox, so the production path is unchanged.
+// On a normal `nh switch` Darwin shell that does NOT export XDG_STATE_HOME
+// the fallback also resolves to $HOME/.local/state — same path as before.
+//
+// The XDG_STATE_HOME branch is what makes the homeless-shelter nix-build
+// sandbox tractable: in that environment $HOME=/homeless-shelter (read-only)
+// and any path derived from it fails on os.MkdirAll. Tests that need a
+// writable session work dir set XDG_STATE_HOME to a t.TempDir() so this
+// function returns a writable path regardless of $HOME (issue #2263).
 //
 // Callers that have an instance_id but no Manager (e.g. cmd/cleanup.go)
 // use this directly.
 func SessionWorkDirPath(instanceID string) (string, error) {
+	if instanceID == "" {
+		return "", fmt.Errorf("container: session work dir: instanceID is empty")
+	}
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return filepath.Join(stateHome, "prism", "sessions", instanceID), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = os.Getenv("HOME")
 	}
 	if home == "" {
-		return "", fmt.Errorf("container: session work dir: cannot determine user home directory")
-	}
-	if instanceID == "" {
-		return "", fmt.Errorf("container: session work dir: instanceID is empty")
+		return "", fmt.Errorf("container: session work dir: cannot determine user home directory (XDG_STATE_HOME unset and $HOME unresolved)")
 	}
 	return filepath.Join(home, ".local", "state", "prism", "sessions", instanceID), nil
 }

--- a/modules/programs/prism/prism/internal/container/session_work_dir_test.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir_test.go
@@ -25,6 +25,11 @@ import (
 func TestSessionWorkDirPath_Layout(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	// Clear XDG_STATE_HOME so the path falls through to the HOME-derived
+	// branch this test pins. SessionWorkDirPath honours XDG_STATE_HOME first
+	// (#2263); a developer env that exports it would otherwise shift the
+	// expected path off the fake home and break this assertion.
+	t.Setenv("XDG_STATE_HOME", "")
 
 	const instanceID = "work-dir-layout-test"
 	m := newSandboxExecManagerWithInstance(Config{
@@ -58,6 +63,7 @@ func TestSessionWorkDirPath_Layout(t *testing.T) {
 // work dir rather than an error.
 func TestSessionWorkDirPath_EmptyInstanceIDFallsBackToName(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", "")
 	m := newSandboxExecManager(Config{SessionName: "repo@feat"})
 
 	sessionDir, err := m.sessionWorkDirPath()
@@ -66,6 +72,73 @@ func TestSessionWorkDirPath_EmptyInstanceIDFallsBackToName(t *testing.T) {
 	}
 	if !strings.Contains(sessionDir, m.name) {
 		t.Errorf("work dir %q does not contain the session-derived name %q", sessionDir, m.name)
+	}
+}
+
+// TestSessionWorkDirPath_XDGStateHomeHonoured pins the XDG_STATE_HOME branch
+// added for issue #2263: when XDG_STATE_HOME is set, the work dir is rooted
+// at it (not at $HOME/.local/state). This is the load-bearing behaviour for
+// the homeless-shelter nix-build sandbox, where $HOME=/homeless-shelter is
+// read-only and any HOME-derived path fails on os.MkdirAll; the test
+// helpers in internal/integration/ set XDG_STATE_HOME to a t.TempDir() so
+// the work dir lives in a writable location.
+func TestSessionWorkDirPath_XDGStateHomeHonoured(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	// HOME is set to a different tempdir so we can assert the result does
+	// NOT contain it — proving XDG_STATE_HOME takes precedence.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	const instanceID = "work-dir-xdg-state-test"
+	sessionDir, err := SessionWorkDirPath(instanceID)
+	if err != nil {
+		t.Fatalf("SessionWorkDirPath: %v", err)
+	}
+	want := filepath.Join(stateHome, "prism", "sessions", instanceID)
+	if sessionDir != want {
+		t.Errorf("SessionWorkDirPath = %q, want %q (XDG_STATE_HOME branch not taken)", sessionDir, want)
+	}
+	if strings.Contains(sessionDir, homeDir) {
+		t.Errorf("SessionWorkDirPath = %q contains $HOME %q — XDG_STATE_HOME must take precedence", sessionDir, homeDir)
+	}
+}
+
+// TestSessionWorkDirPath_HomeFallbackWhenXDGStateHomeUnset pins the
+// fallback half of the same branch: when XDG_STATE_HOME is empty/unset, the
+// path falls back to $HOME/.local/state. This is the production code path
+// on a normal `nh switch` Darwin host where the user shell does not export
+// XDG_STATE_HOME (issue #2263).
+func TestSessionWorkDirPath_HomeFallbackWhenXDGStateHomeUnset(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	const instanceID = "work-dir-home-fallback-test"
+	sessionDir, err := SessionWorkDirPath(instanceID)
+	if err != nil {
+		t.Fatalf("SessionWorkDirPath: %v", err)
+	}
+	want := filepath.Join(homeDir, ".local", "state", "prism", "sessions", instanceID)
+	if sessionDir != want {
+		t.Errorf("SessionWorkDirPath = %q, want %q (HOME fallback not taken)", sessionDir, want)
+	}
+}
+
+// TestSessionWorkDirPath_EmptyInstanceIDErrors pins the diagnostic error
+// path: an empty instanceID is checked first (before either env-var
+// branch), so a caller that forgot to populate the InstanceID gets a
+// useful error rather than a path with an empty last segment.
+func TestSessionWorkDirPath_EmptyInstanceIDErrors(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	_, err := SessionWorkDirPath("")
+	if err == nil {
+		t.Fatalf("SessionWorkDirPath(\"\"): expected an error for the empty instanceID, got nil")
+	}
+	if !strings.Contains(err.Error(), "instanceID is empty") {
+		t.Errorf("SessionWorkDirPath error %q must mention 'instanceID is empty'", err.Error())
 	}
 }
 

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_helpers_darwin_test.go
@@ -81,11 +81,21 @@ func requireNixBash(t *testing.T) string {
 // that read symlink targets under HOME) should use
 // newProfileManagerWithBareRoot.
 //
+// XDG_STATE_HOME is redirected to a t.TempDir() so the per-session work
+// dir lives under the tempdir rather than the real ~/.local/state. This
+// keeps test state confined to t.TempDir() and — critically — makes the
+// integration suite tractable inside the nix-build homeless-shelter
+// sandbox, where $HOME=/homeless-shelter is read-only and any path
+// derived from it fails on os.MkdirAll (issue #2263). Per AGENTS.md
+// "Test-suite isolation (#1608)", this matches the sidecar tests'
+// XDG_STATE_HOME redirection pattern.
+//
 // Note: container.New() initialises the Manager with a hostIsolator by
 // default, but Manager.PrepareSandboxExec() creates its own
 // sandboxExecIsolator internally, so no isolator override is needed.
 func newProfileManager(t *testing.T) *container.Manager {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	// Sanitise the test name for use as an InstanceID: remove characters that
 	// are invalid in filesystem paths (e.g. "/" from subtest names).
 	instanceID := "integ-sbx-" + strings.ReplaceAll(t.Name(), "/", "-")
@@ -118,8 +128,12 @@ func newProfileManager(t *testing.T) *container.Manager {
 // permit symlink-resolution-and-read of paths like /etc/hosts even when
 // (subpath "/etc") is removed, masking the regression the test is trying
 // to catch.
+//
+// XDG_STATE_HOME is redirected to a t.TempDir() for the same reason as in
+// newProfileManager — see that helper's doc for the rationale.
 func newProfileManagerWithBareRoot(t *testing.T) *container.Manager {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		t.Skipf("cannot determine user home: %v", err)
@@ -157,8 +171,12 @@ func newProfileManagerWithBareRoot(t *testing.T) *container.Manager {
 // integration tests that need the SBPL profile to include the pi-gated
 // (subpath ~/.pi/agent) RW allow. Identical to newProfileManagerWithBareRoot
 // but sets Harness="pi" on the Config.
+//
+// XDG_STATE_HOME is redirected to a t.TempDir() for the same reason as in
+// newProfileManager — see that helper's doc for the rationale.
 func newProfileManagerWithBareRootAndPi(t *testing.T) *container.Manager {
 	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
 		t.Skipf("cannot determine user home: %v", err)

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_session_work_dir_xdg_state_home_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_session_work_dir_xdg_state_home_darwin_test.go
@@ -1,0 +1,159 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_session_work_dir_xdg_state_home_darwin_test.go — Darwin
+// integration coverage for the XDG_STATE_HOME branch added to
+// container.SessionWorkDirPath in issue #2263.
+//
+// Why this test exists. Inside the nix-build homeless-shelter sandbox
+// $HOME=/homeless-shelter is read-only; any path derived from it (the
+// pre-#2263 SessionWorkDirPath shape) fails on os.MkdirAll. The fix:
+// SessionWorkDirPath now honours $XDG_STATE_HOME first (XDG Base Directory
+// Specification) and falls back to $HOME/.local/state only when it is
+// unset. Integration test helpers in sandbox_exec_helpers_darwin_test.go
+// redirect XDG_STATE_HOME to a t.TempDir() so the work dir is writable
+// regardless of $HOME.
+//
+// The positive test asserts:
+//
+//   1. The derived sessionDir is rooted at $XDG_STATE_HOME (not $HOME),
+//      proving the new branch is actually taken.
+//   2. The generated SBPL profile contains (subpath "<sessionDir>") for
+//      the XDG_STATE_HOME-derived path.
+//   3. A write into sessionDir from inside /usr/bin/sandbox-exec succeeds.
+//
+// The paired negative test re-targets the (subpath "<sessionDir>") entry
+// at a non-existent sibling path (the same mutation strategy as
+// TestSandboxExecSessionWorkDir_DeniedWithoutSubpath) and asserts the
+// write fails — proving the rule under test is what grants access to the
+// XDG_STATE_HOME-derived path, not a side effect of some unrelated allow.
+//
+// This is a focused complement to TestSandboxExecSessionWorkDir_* which
+// covers the work-dir RW rule at the API level. After the #2263 helper
+// change, those tests already exercise the XDG_STATE_HOME-derived path
+// (because newProfileManager sets XDG_STATE_HOME); this test pins the
+// path-derivation contract explicitly so a future regression that, say,
+// reverted SessionWorkDirPath to HOME-only would fail with a precise
+// error message rather than an opaque homeless-shelter mkdir failure.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSandboxExecSessionWorkDir_XDGStateHomeBranch_GrantsWrites is the
+// positive half of the #2263 XDG_STATE_HOME-branch coverage. It asserts
+// that the sessionDir derived from XDG_STATE_HOME (set by
+// newProfileManager) is covered by the (subpath "<sessionDir>") rule in
+// the generated profile, and that a write into it from inside the sandbox
+// succeeds.
+func TestSandboxExecSessionWorkDir_XDGStateHomeBranch_GrantsWrites(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	// newProfileManager sets XDG_STATE_HOME=t.TempDir() (#2263). Capture it
+	// here so we can assert sessionDir is rooted under it, not under $HOME.
+	m := newProfileManager(t)
+	xdgStateHome := os.Getenv("XDG_STATE_HOME")
+	if xdgStateHome == "" {
+		t.Fatalf("XDG_STATE_HOME is empty after newProfileManager — the helper's #2263 redirect is not in effect")
+	}
+
+	sessionDir, prepared := sessionWorkDirFixture(t, m)
+
+	// AC 1: sessionDir must live under XDG_STATE_HOME, not under $HOME.
+	// This pins the branch in SessionWorkDirPath.
+	if !strings.HasPrefix(sessionDir, xdgStateHome) {
+		t.Fatalf("sessionDir %q is not rooted at XDG_STATE_HOME %q — the XDG_STATE_HOME branch in SessionWorkDirPath is not active",
+			sessionDir, xdgStateHome)
+	}
+	homeDir, _ := os.UserHomeDir()
+	if homeDir != "" && strings.HasPrefix(sessionDir, filepath.Join(homeDir, ".local", "state")) {
+		t.Fatalf("sessionDir %q is rooted under $HOME/.local/state %q — XDG_STATE_HOME should have taken precedence",
+			sessionDir, filepath.Join(homeDir, ".local", "state"))
+	}
+
+	// AC 2: the generated profile must contain the (subpath ...) rule for
+	// the XDG_STATE_HOME-derived sessionDir. sessionWorkDirFixture already
+	// asserts this; the re-check here is the explicit precondition for the
+	// write test below.
+	want := "(subpath " + sbplQuoteForTest(sessionDir) + ")"
+	if !strings.Contains(prepared.content, want) {
+		t.Fatalf("generated profile missing %q for the XDG_STATE_HOME-derived sessionDir.\nProfile:\n%s",
+			want, prepared.content)
+	}
+
+	// AC 3: a write into sessionDir from inside sandbox-exec must succeed.
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+	probe := filepath.Join(sessionDir, "prism-2263-xdg-write-probe.tmp")
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixBash, "-c", "echo hi > "+shQuote(probe))
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		t.Fatalf("write to XDG_STATE_HOME-derived sessionDir failed under production profile.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s", runErr, string(out), testProfilePath)
+	}
+	if _, statErr := os.Stat(probe); statErr != nil {
+		t.Errorf("write probe exited 0 but probe file is missing: %v", statErr)
+	}
+}
+
+// TestSandboxExecSessionWorkDir_XDGStateHomeBranch_DeniedWithoutSubpath
+// is the paired negative test. It mutates the profile to re-target the
+// (subpath "<sessionDir>") entry — the SBPL rule that grants access to
+// the XDG_STATE_HOME-derived sessionDir — at a non-existent sibling path,
+// and asserts the same write now fails. This proves the positive test is
+// not green by accident: the (subpath ...) rule against the
+// XDG_STATE_HOME-derived path is the load-bearing grant.
+//
+// Mutation strategy mirrors TestSandboxExecSessionWorkDir_DeniedWithoutSubpath
+// (ReplaceAll on the quoted path rather than line deletion), which keeps
+// the SBPL syntactically valid regardless of where the entry sits in its
+// allow block.
+func TestSandboxExecSessionWorkDir_XDGStateHomeBranch_DeniedWithoutSubpath(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+
+	m := newProfileManager(t)
+	xdgStateHome := os.Getenv("XDG_STATE_HOME")
+	if xdgStateHome == "" {
+		t.Fatalf("XDG_STATE_HOME is empty after newProfileManager — the helper's #2263 redirect is not in effect")
+	}
+
+	sessionDir, err := m.SessionWorkDir()
+	if err != nil {
+		t.Fatalf("SessionWorkDir: %v", err)
+	}
+	if !strings.HasPrefix(sessionDir, xdgStateHome) {
+		t.Fatalf("sessionDir %q is not rooted at XDG_STATE_HOME %q — the negative test would be checking the wrong path",
+			sessionDir, xdgStateHome)
+	}
+
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p,
+			sbplQuoteForTest(sessionDir),
+			sbplQuoteForTest(sessionDir+".prism-2263-disabled"))
+	})
+
+	probe := filepath.Join(sessionDir, "prism-2263-xdg-write-probe-denied.tmp")
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixBash, "-c", "echo hi > "+shQuote(probe))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write into XDG_STATE_HOME-derived sessionDir succeeded WITHOUT the (subpath ...) rule.\n"+
+			"The XDG_STATE_HOME positive test is not isolated — some other allow grants the write.\n"+
+			"Output: %s\nMutated profile: %s", string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — write correctly denied without the XDG_STATE_HOME-derived subpath rule (exit: %v)", runErr)
+	}
+}


### PR DESCRIPTION
Closes #2263.

## Summary

`TestSandboxExecProfile_Denies_Present` (and the wider integration suite under `internal/integration/`) fails inside the nix-build homeless-shelter sandbox on aarch64-darwin because `PrepareSessionWorkDir` derives the session work dir from `$HOME`. Inside the build sandbox `$HOME=/homeless-shelter` and the `os.MkdirAll` falls over with `read-only file system`.

The fix: `SessionWorkDirPath` now honours `$XDG_STATE_HOME` first per the XDG Base Directory Specification, and falls back to `$HOME/.local/state` only when it's unset. This mirrors the existing `xdgStateBase()` pattern in `dispatch.go` and the sidecar test-suite isolation pattern called out in AGENTS.md "Test-suite isolation (#1608)".

Integration test helpers (`newProfileManager`, `newProfileManagerWithBareRoot`, `newProfileManagerWithBareRootAndPi`) redirect `XDG_STATE_HOME` to a `t.TempDir()` so the per-session work dir lives in a writable location regardless of `$HOME`.

## AC mapping

- [x] **[functional]** On aarch64-darwin, running the homeless-shelter `nix build` no longer fails on `TestSandboxExecProfile_Denies_Present` — the test helpers redirect `XDG_STATE_HOME` to a tempdir and the new branch in `SessionWorkDirPath` uses it (verified by reasoning + local x86_64-linux checked build passes; the AC requires a Darwin host to verify the binary outcome).
- [x] **[functional]** The `mkdir` against the HOME-derived path is gated by the new `XDG_STATE_HOME` branch — when set, no HOME-derived path is computed at all. When unset, the original HOME fallback applies.
- [x] **[edge-case]** Linux `nix-build-prism-checked` stays green — verified locally:
  ```
  nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.x86_64-linux.prism.override { runChecks = true; }'
  # exit 0
  ```
- [x] **[edge-case]** Normal `nh switch` on Darwin is unaffected: the user shell does not export `XDG_STATE_HOME` so the fallback resolves to `$HOME/.local/state` (identical to pre-#2263). The sandbox-exec dispatcher (`cmd/agent_run_sandbox_exec_darwin.go`) also sets `XDG_STATE_HOME=$HOME/.local/state` for the in-sandbox agent env, so even if a user shell does set it, the agent's view is consistent.

## Test changes

Per the sandbox-exec testing convention (`docs/sandbox-exec-testing.md`):

- **Darwin integration test pair** (new) — `sandbox_exec_session_work_dir_xdg_state_home_darwin_test.go`:
  - Positive: asserts `sessionDir` lives under `$XDG_STATE_HOME` (not `$HOME`), the profile contains `(subpath "<sessionDir>")` for the XDG-derived path, and a write into it from inside `/usr/bin/sandbox-exec` succeeds.
  - Negative: mutates the profile to re-target the `(subpath "<sessionDir>")` entry at a non-existent sibling path and asserts the same write fails — proving the positive is not a no-op.
- **Unit tests** (new) — `TestSessionWorkDirPath_XDGStateHomeHonoured`, `TestSessionWorkDirPath_HomeFallbackWhenXDGStateHomeUnset`, `TestSessionWorkDirPath_EmptyInstanceIDErrors`.
- **Existing unit tests** that pin the HOME-derived path now explicitly clear `XDG_STATE_HOME` so a developer env that exports it cannot shift the expected path off the fake HOME. `newFakeHome()` does the same so all tests using it are env-independent.

## "Test isn't a no-op" verification

Reverted the production-code change in `session_work_dir.go`, reran the new unit tests:

```
=== RUN   TestSessionWorkDirPath_XDGStateHomeHonoured
    SessionWorkDirPath = ".../002/.local/state/prism/sessions/work-dir-xdg-state-test",
    want                ".../001/prism/sessions/work-dir-xdg-state-test"
    (XDG_STATE_HOME branch not taken)
--- FAIL
```

Reapplied the fix and the test passes again.

## Out of scope

The sibling `TestSidecarRun_RefusesWhenHostAPISockIsLive` Darwin sun_path failure is tracked separately in #2264.