### PR TITLE
prism: add session_groups.delivered_at to immunise review-group finalisation against agent_status clobbers

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -29,7 +29,7 @@ const (
 	// It must be bumped whenever a new migrateVNtoVN+1 function is added.
 	// A meta-test in db_test.go asserts that this constant equals the count of
 	// migration functions, so forgetting to bump it will fail CI.
-	currentSchemaVersion = 35
+	currentSchemaVersion = 36
 )
 
 // DB wraps a SQLite connection.
@@ -91,7 +91,15 @@ CREATE TABLE IF NOT EXISTS session_groups (
   -- prompt when the detached monitor subprocess dies. Both nullable for
   -- back-compat with the legacy RegisterGroup helper.
   pr_number      TEXT,
-  round          INTEGER
+  round          INTEGER,
+  -- delivered_at is the authoritative end-of-life signal for a review group
+  -- (#2259). It is the epoch-ms timestamp at which prism prompt accepted
+  -- the review-complete delivery for this group, written by review.MonitorFunc
+  -- (happy path) or review.DeliverGroupResults (recovery path). Nullable for
+  -- back-compat with pre-migration rows and for groups whose delivery has
+  -- not yet succeeded; the ORd-in predicate at the read sites means those
+  -- rows are still classified by the existing agent_status roll-up.
+  delivered_at   INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS agent_status (
@@ -657,6 +665,9 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV34ToV35(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV35ToV36(conn, &version); err != nil {
+		return err
+	}
 	if version > currentSchemaVersion {
 		return fmt.Errorf(
 			"db schema version %d is newer than this prism binary (max %d); "+
@@ -704,6 +715,56 @@ func runMigrations(conn *sql.DB) error {
 // The partial WHERE (harness_port IS NOT NULL AND ended_at IS NULL) excludes
 // both NULL/released ports and ended sessions, so that ended sessions' ports
 // can be reclaimed by new sessions without triggering a constraint error.
+// migrateV35ToV36 adds the `delivered_at` column to session_groups
+// (issue #2259). The column is the authoritative end-of-life signal for a
+// review group: it is the epoch-ms timestamp at which the review-complete
+// prompt was successfully accepted by `prism prompt` (either via the happy-
+// path monitor subprocess `review.MonitorFunc`, or via the recovery-watcher
+// primitive `review.DeliverGroupResults`).
+//
+// Pre-fix, group finalisation was derived entirely from a roll-up over
+// `agent_status.state` + `ended_at`. If any process clobbered an
+// agent_status row back to a non-terminal state after delivery (the
+// per-process sidecar-restart anti-pattern in `cmd/sidecar.go`, or the
+// inactivity-watchdog timing race documented in the issue), the four read
+// sites (`db.GroupCompleted`, `review.ActiveReviewGroupForParent` /
+// `isTerminalForGuard`, and `db.ReviewGroupsList`'s `GroupState` rollup)
+// all flipped back to "in-progress" and the parent worker's next
+// `prism review` got refused with "round N already in progress".
+//
+// With this column OR'd into the predicate at all four read sites, a
+// successfully delivered group is permanently classified as terminal — the
+// signal survives any subsequent agent_status mutation. The column is
+// nullable; pre-fix rows continue to be classified by the existing
+// agent_status-based predicate so no backfill is required.
+//
+// The ALTER TABLE is guarded by a pragma_table_info check so the migration
+// is idempotent on fresh databases where the declarative schema block above
+// already includes the column.
+func migrateV35ToV36(conn *sql.DB, version *int) error {
+	if *version >= 36 {
+		return nil
+	}
+	var exists int
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('session_groups') WHERE name = 'delivered_at'`,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("db: migration v35\u2192v36: check delivered_at column: %w", err)
+	}
+	if exists == 0 {
+		if _, err := conn.Exec(
+			`ALTER TABLE session_groups ADD COLUMN delivered_at INTEGER`,
+		); err != nil {
+			return fmt.Errorf("db: migration v35\u2192v36: add delivered_at: %w", err)
+		}
+	}
+	if _, err := conn.Exec(`UPDATE schema_version SET version = 36`); err != nil {
+		return fmt.Errorf("db: migration v35\u2192v36: %w", err)
+	}
+	*version = 36
+	return nil
+}
+
 // migrateV34ToV35 adds the `isolation_mode` column to spawn_inputs
 // (issue #2105). The new column carries the resolved effective isolation
 // mode the session ran under, captured at spawn time after profile /

--- a/modules/programs/prism/prism/internal/db/db_migration_v34_v35_test.go
+++ b/modules/programs/prism/prism/internal/db/db_migration_v34_v35_test.go
@@ -162,8 +162,8 @@ func TestMigration_V34ToV35_BodyRuns_AddsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var n int
@@ -197,8 +197,8 @@ func TestMigration_V34ToV35_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var n int
@@ -234,8 +234,8 @@ func TestMigration_V34ToV35_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version after second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	var n int

--- a/modules/programs/prism/prism/internal/db/db_migration_v35_v36_test.go
+++ b/modules/programs/prism/prism/internal/db/db_migration_v35_v36_test.go
@@ -1,0 +1,316 @@
+package db_test
+
+// Tests for the v35→v36 migration that adds session_groups.delivered_at
+// (issue #2259). The new column is the authoritative end-of-life signal
+// for a review group: GroupCompleted short-circuits to true and
+// ActiveReviewGroupForParent skips the group once delivered_at is set.
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedV35DB creates a v35 DB with the pre-v36 session_groups shape (no
+// delivered_at column). If withDeliveredAt is true, session_groups already
+// has the column (simulates a DB whose declarative schema block added it —
+// the migration's pragma guard must detect this and skip the ALTER TABLE).
+func seedV35DB(t *testing.T, dbPath string, withDeliveredAt bool) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open v35 db: %v", err)
+	}
+	defer rawConn.Close()
+
+	deliveredAtCol := ""
+	if withDeliveredAt {
+		deliveredAtCol = ",\n\t\t  delivered_at INTEGER"
+	}
+
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, harness_session_id TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL,
+		  instance_id TEXT
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		  pr_number TEXT,
+		  round INTEGER` + deliveredAtCol + `
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  isolation_mode TEXT,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'pi',
+		  harness_session_id TEXT, harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  muted INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS sessions (
+		  instance_id        TEXT PRIMARY KEY,
+		  session_name       TEXT NOT NULL,
+		  agent_role         TEXT,
+		  root_agent_name    TEXT,
+		  repo               TEXT NOT NULL,
+		  worktree           TEXT NOT NULL,
+		  harness            TEXT NOT NULL,
+		  harness_session_id TEXT,
+		  group_id           TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  started_at         INTEGER NOT NULL,
+		  ended_at           INTEGER,
+		  end_state          TEXT,
+		  archive_path       TEXT,
+		  prism_version      TEXT,
+		  parent_session     TEXT
+		);
+		CREATE TABLE IF NOT EXISTS pending_merges (
+		  pr INTEGER PRIMARY KEY, session_name TEXT NOT NULL, instance_id TEXT NOT NULL,
+		  queue_position INTEGER NOT NULL, status TEXT NOT NULL, title TEXT, error TEXT,
+		  queued_at INTEGER NOT NULL, last_checked_at INTEGER, merged_at INTEGER, ended_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS spawn_inputs (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    profile_name TEXT, model_flag TEXT, variant_flag TEXT, agent_flag TEXT,
+		    harness_flag TEXT, isolation_flag TEXT, host_mode_flag INTEGER NOT NULL DEFAULT 0,
+		    pr_number INTEGER, branch_flag TEXT, ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+		    isolation_mode TEXT,
+		    model_variant_overrides TEXT, skills_manifest_hash TEXT, prompt_template_hash TEXT,
+		    agent_prompt_hash TEXT, prompt_text TEXT, prompt_source TEXT,
+		    abtest_pair_id TEXT,
+		    extras TEXT,
+		    created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS spawn_outcome (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    end_state TEXT, exit_code INTEGER, duration_ms INTEGER,
+		    interrupted_count INTEGER NOT NULL DEFAULT 0,
+		    compaction_count INTEGER NOT NULL DEFAULT 0,
+		    error_event_count INTEGER NOT NULL DEFAULT 0,
+		    permission_ask_count INTEGER NOT NULL DEFAULT 0,
+		    permission_denied_count INTEGER NOT NULL DEFAULT 0,
+		    doom_loop_count INTEGER NOT NULL DEFAULT 0,
+		    pr_number INTEGER, pr_merged_at INTEGER,
+		    review_group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		    review_verdict TEXT, review_pass_count INTEGER,
+		    review_fail_count INTEGER, review_none_count INTEGER,
+		    rubric_verdict TEXT, rubric_score REAL,
+		    rubric_breakdown TEXT, rubric_grader TEXT,
+		    tokens_input_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_output_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_cache_read_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_cache_write_total INTEGER NOT NULL DEFAULT 0,
+		    cost_usd_total REAL NOT NULL DEFAULT 0,
+		    tool_call_count INTEGER NOT NULL DEFAULT 0,
+		    tool_error_count INTEGER NOT NULL DEFAULT 0,
+		    msg_assistant_count INTEGER NOT NULL DEFAULT 0,
+		    time_to_first_event_ms INTEGER, time_to_finished_ms INTEGER,
+		    computed_at INTEGER NOT NULL,
+		    schema_version INTEGER NOT NULL DEFAULT 1
+		);
+		CREATE TABLE IF NOT EXISTS harness_frames (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, instance_id TEXT,
+		  direction TEXT NOT NULL, type TEXT, payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (35);
+	`)
+	if err != nil {
+		t.Fatalf("seed v35 db: %v", err)
+	}
+}
+
+// TestMigration_V35ToV36_BodyRuns_AddsDeliveredAt exercises the body-runs
+// branch of the v35→v36 migration (issue #2259): a v35 DB without the
+// session_groups.delivered_at column. The pragma_table_info guard returns
+// 0 and the ALTER TABLE ADD COLUMN executes.
+func TestMigration_V35ToV36_BodyRuns_AddsDeliveredAt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v35_body_runs.db")
+	seedV35DB(t, dbPath, false /*withDeliveredAt*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
+	}
+
+	var n int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('session_groups') WHERE name = 'delivered_at'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info delivered_at: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("session_groups.delivered_at missing after v35→v36 (body-runs branch): got %d, want 1", n)
+	}
+
+	// The column must default to NULL on existing rows. Seed a group via
+	// RegisterGroup and check delivered_at is NULL (no backfill).
+	gid, err := d.RegisterGroup("nixos-config@feat-v36")
+	if err != nil {
+		t.Fatalf("RegisterGroup post-migration: %v", err)
+	}
+	var deliveredAt sql.NullInt64
+	if err := d.QueryRow(
+		`SELECT delivered_at FROM session_groups WHERE group_id = ?`, gid,
+	).Scan(&deliveredAt); err != nil {
+		t.Fatalf("read delivered_at on fresh group: %v", err)
+	}
+	if deliveredAt.Valid {
+		t.Errorf("delivered_at on fresh group: got %d, want NULL (no backfill required)", deliveredAt.Int64)
+	}
+}
+
+// TestMigration_V35ToV36_BodySkips_PreExistingColumn exercises the
+// body-skips branch: a v35 DB that ALREADY has the session_groups.delivered_at
+// column. The pragma_table_info guard returns 1 and the ALTER TABLE ADD
+// COLUMN is skipped.
+func TestMigration_V35ToV36_BodySkips_PreExistingColumn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v35_body_skips.db")
+	seedV35DB(t, dbPath, true /*withDeliveredAt*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	var version int
+	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
+	}
+
+	var n int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('session_groups') WHERE name = 'delivered_at'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info delivered_at: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("session_groups.delivered_at count after v35→v36 (body-skips branch): got %d, want 1", n)
+	}
+}
+
+// TestMigration_V35ToV36_Idempotent verifies that re-opening a DB already
+// at v36+ does not error and the column remains.
+func TestMigration_V35ToV36_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v35_idem.db")
+	seedV35DB(t, dbPath, false)
+
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first db.Open: %v", err)
+	}
+	d1.Close()
+
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	var version int
+	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
+		t.Fatalf("read schema_version after second open: %v", err)
+	}
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
+	}
+
+	var n int
+	if err := d2.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('session_groups') WHERE name = 'delivered_at'`,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info delivered_at on second open: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("session_groups.delivered_at count after idempotent open: got %d, want 1", n)
+	}
+}
+
+// TestMigration_V35ToV36_NoBackfill verifies the #2259 edge-case AC:
+// pre-migration session_groups rows (NULL delivered_at) continue to be
+// classified by the existing agent_status-based predicate. A group with
+// all-finished members AND delivered_at NULL must still report done=true
+// via the fallback path — i.e. the new short-circuit does not regress the
+// existing rollup for legacy rows.
+func TestMigration_V35ToV36_NoBackfill(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v35_no_backfill.db")
+	seedV35DB(t, dbPath, false)
+
+	// Pre-seed a v35 group row with a pre-existing finished member.
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	if _, err := rawConn.Exec(
+		`INSERT INTO session_groups (group_id, parent_session, pr_number, round) VALUES (?, ?, ?, ?)`,
+		"legacy-group", "nixos-config@legacy", "1", 1,
+	); err != nil {
+		t.Fatalf("seed legacy session_groups row: %v", err)
+	}
+	if _, err := rawConn.Exec(
+		`INSERT INTO agent_status (session_name, repo, worktree, state, last_seen, group_id)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		"nixos-config@legacy~review-1-goal", "nixos-config", "/wt", "finished", 0, "legacy-group",
+	); err != nil {
+		t.Fatalf("seed legacy agent_status row: %v", err)
+	}
+	rawConn.Close()
+
+	// Open via the real migration path — this will add delivered_at but
+	// leave the legacy row's column as NULL.
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	var deliveredAt sql.NullInt64
+	if err := d.QueryRow(
+		`SELECT delivered_at FROM session_groups WHERE group_id = ?`, "legacy-group",
+	).Scan(&deliveredAt); err != nil {
+		t.Fatalf("read legacy delivered_at: %v", err)
+	}
+	if deliveredAt.Valid {
+		t.Errorf("legacy delivered_at: got %d, want NULL (no backfill required)", deliveredAt.Int64)
+	}
+
+	// The legacy group must still be classified as completed via the
+	// agent_status-based predicate (member is in state=finished).
+	done, err := d.GroupCompleted("legacy-group")
+	if err != nil {
+		t.Fatalf("GroupCompleted on legacy group: %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted on legacy group: got false, want true (delivered_at NULL must fall back to agent_status predicate)")
+	}
+}

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -51,8 +51,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version: got %d, want 36", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1233,8 +1233,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1308,8 +1308,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1860,8 +1860,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1926,8 +1926,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1996,8 +1996,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -2091,8 +2091,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -2184,8 +2184,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2728,8 +2728,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2817,8 +2817,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -3076,6 +3076,179 @@ func TestGroupCompleted_EndedAtIsTerminal(t *testing.T) {
 	}
 	if !done {
 		t.Error("GroupCompleted: got false, want true (ended_at IS NOT NULL must count as terminal even when state=\"interrupted\")")
+	}
+}
+
+// TestGroupCompleted_DeliveredAtIsTerminal verifies the #2259 contract:
+// once session_groups.delivered_at is non-NULL, GroupCompleted returns
+// done=true regardless of any subsequent agent_status mutation. This is
+// what closes the wedge-at-idle failure class where a per-process sidecar
+// restart re-seeded a terminal agent_status row back to "idle" after
+// verdict delivery, causing the parent worker's next `prism review` to be
+// refused with "round N already in progress". With delivered_at set, the
+// short-circuit fires before the agent_status-based predicate is even
+// consulted.
+func TestGroupCompleted_DeliveredAtIsTerminal(t *testing.T) {
+	d := openTestDB(t)
+
+	groupID, err := d.RegisterGroup("nixos-config@delivered")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	// Seed 5 members in non-terminal states (idle + active mix) and
+	// ended_at IS NULL — i.e. the configuration that, pre-#2259, would
+	// have returned done=false from GroupCompleted indefinitely.
+	members := []struct {
+		name  string
+		state string
+	}{
+		{"nixos-config@delivered~review-1-goal", "idle"},
+		{"nixos-config@delivered~review-1-code", "idle"},
+		{"nixos-config@delivered~review-1-security", "active"},
+		{"nixos-config@delivered~review-1-qa", "idle"},
+		{"nixos-config@delivered~review-1-context", "active"},
+	}
+	for _, m := range members {
+		if err := d.UpsertStatus(m.name, "nixos-config", "/wt", m.state, nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q, %q): %v", m.name, m.state, err)
+		}
+		if err := d.SetGroupID(m.name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", m.name, err)
+		}
+	}
+
+	// Sanity: without delivered_at, GroupCompleted must report done=false
+	// because every member is in a non-terminal state.
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted (pre-delivery): %v", err)
+	}
+	if done {
+		t.Fatal("GroupCompleted (pre-delivery): got true, want false (members are non-terminal and delivered_at is NULL)")
+	}
+
+	// Write the authoritative end-of-life signal.
+	if err := d.SetGroupDeliveredAt(groupID); err != nil {
+		t.Fatalf("SetGroupDeliveredAt: %v", err)
+	}
+
+	// Now GroupCompleted must report done=true regardless of member states.
+	done, err = d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted (post-delivery): %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted (post-delivery): got false, want true (delivered_at IS NOT NULL must short-circuit to terminal regardless of member state)")
+	}
+}
+
+// TestSetGroupDeliveredAt_IdempotentFirstWins verifies that calling
+// SetGroupDeliveredAt twice keeps the FIRST timestamp. The deterministic-
+// dedup-ID contract between MonitorFunc and DeliverGroupResults means both
+// can race to deliver for the same group_id; the second call must not
+// overwrite the first delivery's timestamp.
+func TestSetGroupDeliveredAt_IdempotentFirstWins(t *testing.T) {
+	d := openTestDB(t)
+	groupID, err := d.RegisterGroup("nixos-config@idempotent")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	if err := d.SetGroupDeliveredAt(groupID); err != nil {
+		t.Fatalf("SetGroupDeliveredAt (first): %v", err)
+	}
+	var first sql.NullInt64
+	if err := d.QueryRow("SELECT delivered_at FROM session_groups WHERE group_id = ?", groupID).Scan(&first); err != nil {
+		t.Fatalf("read delivered_at (first): %v", err)
+	}
+	if !first.Valid {
+		t.Fatal("delivered_at is NULL after first SetGroupDeliveredAt; want non-NULL")
+	}
+
+	// Sleep a tick to ensure the next UnixMilli() reading would be
+	// observably different if the UPDATE ran.
+	time.Sleep(5 * time.Millisecond)
+
+	if err := d.SetGroupDeliveredAt(groupID); err != nil {
+		t.Fatalf("SetGroupDeliveredAt (second): %v", err)
+	}
+	var second sql.NullInt64
+	if err := d.QueryRow("SELECT delivered_at FROM session_groups WHERE group_id = ?", groupID).Scan(&second); err != nil {
+		t.Fatalf("read delivered_at (second): %v", err)
+	}
+	if !second.Valid {
+		t.Fatal("delivered_at is NULL after second SetGroupDeliveredAt; want non-NULL")
+	}
+	if first.Int64 != second.Int64 {
+		t.Errorf("delivered_at changed across calls: first=%d, second=%d — want the FIRST delivery's timestamp to stick", first.Int64, second.Int64)
+	}
+}
+
+// TestSetGroupDeliveredAt_NoBackfillRequired verifies the #2259 edge-case
+// AC: pre-migration session_groups rows (delivered_at NULL) continue to
+// be classified by the existing agent_status-based predicate. A group
+// with all-terminal members AND delivered_at NULL must still report
+// done=true via the fallback path — i.e. the new short-circuit does not
+// regress the existing rollup for legacy rows.
+func TestSetGroupDeliveredAt_NoBackfillRequired(t *testing.T) {
+	d := openTestDB(t)
+	groupID, err := d.RegisterGroup("nixos-config@legacy")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	for _, name := range []string{
+		"nixos-config@legacy~review-1-goal",
+		"nixos-config@legacy~review-1-code",
+	} {
+		if err := d.UpsertStatus(name, "nixos-config", "/wt", "finished", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", name, err)
+		}
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	// delivered_at intentionally NOT written: simulates a pre-#2259 group.
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted: got false, want true (all members finished, delivered_at NULL must fall back to agent_status predicate)")
+	}
+}
+
+// TestSetGroupDeliveredAt_ActiveMembersStillInProgress verifies the
+// #2259 edge-case AC: a group whose members are still actively running
+// (no terminal states, no delivery) reads as in-progress from
+// GroupCompleted. This guards the negative direction of the short-circuit.
+func TestSetGroupDeliveredAt_ActiveMembersStillInProgress(t *testing.T) {
+	d := openTestDB(t)
+	groupID, err := d.RegisterGroup("nixos-config@still-running")
+	if err != nil {
+		t.Fatalf("RegisterGroup: %v", err)
+	}
+
+	for _, name := range []string{
+		"nixos-config@still-running~review-1-goal",
+		"nixos-config@still-running~review-1-code",
+	} {
+		if err := d.UpsertStatus(name, "nixos-config", "/wt", "active", nil, nil); err != nil {
+			t.Fatalf("UpsertStatus(%q): %v", name, err)
+		}
+		if err := d.SetGroupID(name, groupID); err != nil {
+			t.Fatalf("SetGroupID(%q): %v", name, err)
+		}
+	}
+
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted: %v", err)
+	}
+	if done {
+		t.Error("GroupCompleted: got true, want false (members active, delivered_at NULL)")
 	}
 }
 
@@ -4727,8 +4900,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// Check each row.
@@ -5155,8 +5328,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5430,8 +5603,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5651,8 +5824,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// sessions table must exist.
@@ -5805,8 +5978,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 }
 
@@ -6359,8 +6532,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6417,8 +6590,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6719,8 +6892,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6781,8 +6954,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6940,8 +7113,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6994,8 +7167,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	var startedAt int64
@@ -7148,8 +7321,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -7221,8 +7394,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7357,8 +7530,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7411,8 +7584,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	// spawn_outcome must still exist.
@@ -7526,8 +7699,8 @@ func TestMigration_V23ToV24_CrashRecovery(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&finalVer); err != nil {
 		t.Fatalf("read schema_version after recovery: %v", err)
 	}
-	if finalVer != 35 {
-		t.Errorf("schema_version after recovery: got %d, want 35", finalVer)
+	if finalVer != 36 {
+		t.Errorf("schema_version after recovery: got %d, want 36", finalVer)
 	}
 
 	// Sessions data must be preserved (the two rows seeded by seedV23DB).
@@ -8412,8 +8585,8 @@ func TestMigration_V10ToV11_DropsLegacyOpencodeColumns(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// opencode_sid and opencode_port must be gone from agent_status.
@@ -8496,8 +8669,8 @@ func TestMigration_V10ToV11_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	// Columns must remain dropped.
@@ -8666,8 +8839,8 @@ func TestMigration_V11ToV12_CreatesIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// Index must exist after migration.
@@ -8739,8 +8912,8 @@ func TestMigration_V11ToV12_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	var idxName string
@@ -8840,8 +9013,8 @@ func TestMigration_V16ToV17_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// The pre-existing sessions row must be unchanged.
@@ -8876,8 +9049,8 @@ func TestMigration_V16ToV17_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 }
 
@@ -8968,8 +9141,8 @@ func TestMigration_V18ToV19_CreatesPendingMerges(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var tname string
@@ -9115,8 +9288,8 @@ func TestMigration_V19ToV20_AddsStatusSessionIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var iname string
@@ -9284,8 +9457,8 @@ func TestMigration_V24ToV25_CreatesSpawnInputs(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var tname string
@@ -9486,8 +9659,8 @@ func TestMigration_V25ToV26_DropsHostModeAndBackfillsPodman(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// host_mode column must be gone.
@@ -9585,8 +9758,8 @@ func TestMigration_V25ToV26_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 
 	var hmCount int
@@ -9706,8 +9879,8 @@ func TestMigration_V26ToV27_CreatesHarnessFrames(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var tname string
@@ -9876,8 +10049,8 @@ func TestMigration_V27ToV28_BodyRuns_AddsAbtestPairID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// abtest_pair_id must exist on spawn_inputs.
@@ -9920,8 +10093,8 @@ func TestMigration_V27ToV28_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// The column must still be present — exactly one (not duplicated by a
@@ -10049,8 +10222,8 @@ func TestMigration_V28ToV29_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var startedAt int64
@@ -10083,8 +10256,8 @@ func TestMigration_V28ToV29_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 }
 
@@ -10181,8 +10354,8 @@ func TestMigration_V29ToV30_BodyRuns_AddsParentSession(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	var n int
@@ -10221,8 +10394,8 @@ func TestMigration_V29ToV30_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	// Exactly one parent_session column — not duplicated by re-ADD.
@@ -10352,8 +10525,8 @@ func TestMigration_V30ToV31_AddsPRNumberAndRound(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after migration: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after migration: got %d, want 36", version)
 	}
 
 	for _, col := range []string{"pr_number", "round"} {

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -145,13 +145,24 @@ func (d *DB) GetGroup(groupID string) (*GroupInfo, error) {
 	return &gi, nil
 }
 
-// GroupCompleted reports whether every agent_status row with this group_id has
-// reached a terminal state. A row is considered terminal when EITHER:
+// GroupCompleted reports whether the review group has reached a terminal
+// state. A group is considered terminal when EITHER:
 //
-//   - its `state` is in terminalStates (finished, error, deleted), OR
-//   - its `ended_at` is non-NULL (the session row has been closed by
-//     `prism cleanup`, `prism reset`, or any other lifecycle path that
-//     calls SetEnded / MarkAllEnded).
+//   - its session_groups.delivered_at is non-NULL (#2259) — the
+//     review-complete prompt was successfully accepted by `prism prompt`
+//     for this group, either via the happy-path `review.MonitorFunc` or via
+//     the recovery primitive `review.DeliverGroupResults`. This is the
+//     authoritative end-of-life signal and short-circuits the predicate;
+//     any subsequent mutation of agent_status (including the per-process
+//     sidecar-restart anti-pattern in cmd/sidecar.go that overwrites a
+//     terminal state with `idle`) cannot move the group back to in-progress;
+//     OR
+//   - every agent_status row with this group_id has reached a terminal
+//     state. A row is considered terminal when EITHER its `state` is in
+//     terminalStates (finished, error, deleted), OR its `ended_at` is
+//     non-NULL (the session row has been closed by `prism cleanup`,
+//     `prism reset`, or any other lifecycle path that calls SetEnded /
+//     MarkAllEnded).
 //
 // The `ended_at` arm is what makes the user's escape hatch work. When the
 // user runs `prism cleanup --yes --session <interrupted-agent>` to abandon
@@ -168,12 +179,32 @@ func (d *DB) GetGroup(groupID string) (*GroupInfo, error) {
 // that ends a session row without rewriting state — not just `prism cleanup`,
 // but also `prism reset`'s MarkAllEnded.
 //
-// Returns (true, nil) when all members are terminal (including the case where
-// there are no members yet — caller should guard against that if needed).
-// Returns (false, nil) when at least one member is still running.
+// Returns (true, nil) when delivered_at is set, or when all members are
+// terminal (including the case where there are no members yet — caller
+// should guard against that if needed).
+// Returns (false, nil) when at least one member is still running and the
+// group has not yet been delivered.
 // Returns (false, err) on a database error.
 func (d *DB) GroupCompleted(groupID string) (bool, error) {
-	// Build the NOT IN list for terminal states.
+	// Short-circuit: a group whose delivered_at has been written is
+	// terminal regardless of any subsequent agent_status mutation (#2259).
+	var deliveredAt sql.NullInt64
+	if err := d.conn.QueryRow(
+		`SELECT delivered_at FROM session_groups WHERE group_id = ?`, groupID,
+	).Scan(&deliveredAt); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("db: group completed: read delivered_at: %w", err)
+		}
+		// No session_groups row: caller is operating on an ad-hoc group_id
+		// that was never registered (e.g. some legacy tests). Fall through
+		// to the agent_status-based predicate, which is the back-compat
+		// behaviour.
+	} else if deliveredAt.Valid {
+		return true, nil
+	}
+
+	// Fall back to the agent_status-based predicate for groups that have
+	// not yet been delivered.
 	placeholders := make([]string, len(terminalStates))
 	args := make([]any, 0, 1+len(terminalStates))
 	args = append(args, groupID)
@@ -192,10 +223,77 @@ func (d *DB) GroupCompleted(groupID string) (bool, error) {
 	return nonTerminalCount == 0, nil
 }
 
+// SetGroupDeliveredAt records the epoch-ms timestamp at which the review-
+// complete prompt was successfully accepted by `prism prompt` for this
+// group (#2259). This is the authoritative end-of-life signal read by
+// GroupCompleted, ReviewGroupsList, and the in-progress guard in
+// review.ActiveReviewGroupForParent.
+//
+// The UPDATE is conditional on delivered_at IS NULL so the timestamp
+// reflects the FIRST successful delivery, not the most recent one. A
+// double-delivery race between the monitor and the recovery watcher (see
+// monitor_recovery_race_test.go) thus produces a stable, ordering-
+// independent timestamp.
+//
+// Returns nil when the row exists and is updated, when the row exists but
+// already has delivered_at set (idempotent), or when no row exists for
+// groupID. Returns an error only on a database failure. This is a write-
+// path call site — callers (MonitorFunc, DeliverGroupResults) treat its
+// failures as warnings rather than aborting the delivery, since the prompt
+// has already been accepted by `prism prompt` at the call site.
+func (d *DB) SetGroupDeliveredAt(groupID string) error {
+	if groupID == "" {
+		return fmt.Errorf("db: set group delivered_at: empty group_id")
+	}
+	const q = `UPDATE session_groups
+	           SET delivered_at = ?
+	           WHERE group_id = ? AND delivered_at IS NULL`
+	if _, err := d.conn.Exec(q, time.Now().UnixMilli(), groupID); err != nil {
+		return fmt.Errorf("db: set group delivered_at: %w", err)
+	}
+	return nil
+}
+
+// DeliveredGroupIDsForParent returns the set of group_ids belonging to
+// parentSession whose delivered_at is non-NULL (#2259). Used by
+// review.ActiveReviewGroupForParent to short-circuit the in-progress guard
+// for groups that have already had their review-complete prompt delivered.
+func (d *DB) DeliveredGroupIDsForParent(parentSession string) (map[string]struct{}, error) {
+	const q = `SELECT group_id FROM session_groups
+	           WHERE parent_session = ? AND delivered_at IS NOT NULL`
+	rows, err := d.conn.Query(q, parentSession)
+	if err != nil {
+		return nil, fmt.Errorf("db: delivered group ids for parent: %w", err)
+	}
+	defer rows.Close()
+	result := make(map[string]struct{})
+	for rows.Next() {
+		var gid string
+		if err := rows.Scan(&gid); err != nil {
+			return nil, fmt.Errorf("db: delivered group ids for parent: scan: %w", err)
+		}
+		result[gid] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: delivered group ids for parent: iterate: %w", err)
+	}
+	return result, nil
+}
+
 // GroupResults returns the terminal state and last assistant message for every
 // member of the group, keyed by session_name. It is intended for use after
 // GroupCompleted returns true. Members that are still active are included but
 // their State may be non-terminal.
+//
+// Note: this function is the verdict-aggregation read; it is called once
+// (per delivery) before the group's authoritative end-of-life signal
+// (session_groups.delivered_at, #2259) is written. The delivered_at column
+// is the locking signal for "do not re-aggregate" — callers downstream of
+// the recovery watcher rely on GroupCompleted's delivered_at short-circuit
+// to avoid calling this function a second time once a group has been
+// delivered. Do not consult delivered_at here; do consult it at the
+// monitor-loop and in-progress-guard sites that decide whether to call this
+// function in the first place.
 //
 // Rows whose `ended_at` is non-NULL are intentionally EXCLUDED from the
 // returned map. This is what makes the user's escape hatch flow correctly
@@ -490,7 +588,7 @@ type ReviewGroupSummary struct {
 // ledger. The list is unfiltered — all groups for all parents are returned;
 // the caller filters by parent or repo if desired.
 func (d *DB) ReviewGroupsList(limit int) ([]ReviewGroupSummary, error) {
-	q := `SELECT group_id, parent_session, created_at FROM session_groups
+	q := `SELECT group_id, parent_session, created_at, delivered_at FROM session_groups
 	            ORDER BY created_at DESC`
 	if limit > 0 {
 		q += fmt.Sprintf(" LIMIT %d", limit)
@@ -501,11 +599,19 @@ func (d *DB) ReviewGroupsList(limit int) ([]ReviewGroupSummary, error) {
 	}
 	defer rows.Close()
 
+	// deliveredByGroup records which group_ids have a non-NULL delivered_at
+	// (#2259). The roll-up below maps these to GroupState="completed"
+	// regardless of member state.
+	deliveredByGroup := make(map[string]bool)
 	var out []ReviewGroupSummary
 	for rows.Next() {
 		var s ReviewGroupSummary
-		if scanErr := rows.Scan(&s.GroupID, &s.ParentSession, &s.CreatedAt); scanErr != nil {
+		var deliveredAt sql.NullInt64
+		if scanErr := rows.Scan(&s.GroupID, &s.ParentSession, &s.CreatedAt, &deliveredAt); scanErr != nil {
 			return nil, fmt.Errorf("db: review groups list: scan: %w", scanErr)
+		}
+		if deliveredAt.Valid {
+			deliveredByGroup[s.GroupID] = true
 		}
 		out = append(out, s)
 	}
@@ -564,6 +670,11 @@ ORDER BY group_id ASC, session_name ASC`
 	}
 	for i := range out {
 		switch {
+		case deliveredByGroup[out[i].GroupID]:
+			// delivered_at is the authoritative end-of-life signal (#2259);
+			// a group whose review-complete prompt was delivered is
+			// classified as completed regardless of member state.
+			out[i].GroupState = "completed"
 		case len(out[i].Members) == 0:
 			out[i].GroupState = "empty"
 		case nonTerminalByGroup[out[i].GroupID] == 0:

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 35 {
-		t.Errorf("schema_version after fresh open = %d, want 35", ver)
+	if ver != 36 {
+		t.Errorf("schema_version after fresh open = %d, want 36", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 35 {
-		t.Errorf("schema_version after second open = %d, want 35", ver)
+	if ver != 36 {
+		t.Errorf("schema_version after second open = %d, want 36", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1424,8 +1424,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 35 {
-		t.Errorf("schema_version after second open: got %d, want 35", version)
+	if version != 36 {
+		t.Errorf("schema_version after second open: got %d, want 36", version)
 	}
 }
 

--- a/modules/programs/prism/prism/internal/review/monitor.go
+++ b/modules/programs/prism/prism/internal/review/monitor.go
@@ -258,6 +258,25 @@ func MonitorFunc(opts MonitorOpts) error {
 		return fmt.Errorf("monitor-review: delivery failed and fallback written to %s", fallbackPath)
 	}
 
+	// Write the authoritative end-of-life signal for this review group
+	// (#2259). Once delivered_at is set, GroupCompleted short-circuits to
+	// true and ActiveReviewGroupForParent skips this group, so any
+	// subsequent mutation of agent_status (e.g. the per-process sidecar-
+	// restart anti-pattern in cmd/sidecar.go) cannot flip the parent
+	// worker back into "round N already in progress" refusals.
+	//
+	// Failure is non-fatal: the prompt has already been accepted by
+	// `prism prompt` at this point and the recovery watcher's grace timer
+	// will not re-fire because the worker sidecar's /prompt handler
+	// clears reviewingInFlight. A missing delivered_at write leaves the
+	// system in the pre-fix state (vulnerable to agent_status clobbers)
+	// but does not lose the verdict.
+	if setErr := d.SetGroupDeliveredAt(opts.GroupID); setErr != nil {
+		proglog.Warnf("[prism monitor-review] warning: SetGroupDeliveredAt(%s): %v\n", opts.GroupID, setErr)
+	} else {
+		proglog.Infof("[prism monitor-review] group %s delivered_at recorded\n", opts.GroupID)
+	}
+
 	proglog.Infof("[prism monitor-review] results delivered to %s\n", opts.WorkerSession)
 	return nil
 }
@@ -798,6 +817,18 @@ func StartMonitorProcess(opts MonitorOpts, prismBinary string) error {
 // Only once cleanup (or any other SetEnded path) closes the row does the
 // ended_at arm trip and the guard release.
 func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) {
+	// Skip groups whose review-complete prompt has already been delivered
+	// (#2259): once session_groups.delivered_at is set, the group is
+	// authoritatively complete regardless of any subsequent member-row
+	// mutation. This closes the wedge-at-idle failure class where a per-
+	// process sidecar restart (cmd/sidecar.go) re-seeded an agent_status
+	// row back to a non-terminal state after delivery, leaving the parent
+	// worker permanently refused with "round N already in progress".
+	delivered, err := d.DeliveredGroupIDsForParent(parentSession)
+	if err != nil {
+		return "", fmt.Errorf("active review group: DeliveredGroupIDsForParent: %w", err)
+	}
+
 	members, err := d.GroupMembersForParent(parentSession)
 	if err != nil {
 		return "", fmt.Errorf("active review group: GroupMembersForParent: %w", err)
@@ -807,13 +838,20 @@ func ActiveReviewGroupForParent(d *db.DB, parentSession string) (string, error) 
 	}
 
 	// Group sessions by group_id.
-	// A group is "active" when at least one member is not in a terminal state.
+	// A group is "active" when at least one member is not in a terminal state
+	// AND its session_groups.delivered_at is NULL.
 	groupStates := make(map[string]bool) // group_id → hasActiveMembers
 	for _, m := range members {
 		if m.GroupID == nil {
 			continue
 		}
 		gid := *m.GroupID
+		if _, isDelivered := delivered[gid]; isDelivered {
+			// Already delivered — not active. Do not enter into groupStates
+			// at all so the final scan cannot accidentally classify it as
+			// active on a subsequent member iteration.
+			continue
+		}
 		if !isTerminalForGuard(m) {
 			groupStates[gid] = true
 		} else if _, exists := groupStates[gid]; !exists {

--- a/modules/programs/prism/prism/internal/review/recovery.go
+++ b/modules/programs/prism/prism/internal/review/recovery.go
@@ -180,6 +180,24 @@ func DeliverGroupResults(d *db.DB, groupID, deliveryID string) (*RecoveryDeliver
 		return res, fmt.Errorf("review recovery: deliver to %q: %w", info.ParentSession, delErr)
 	}
 
+	// Write the authoritative end-of-life signal for this review group
+	// (#2259). Once delivered_at is set, GroupCompleted short-circuits to
+	// true and ActiveReviewGroupForParent skips this group, so any
+	// subsequent mutation of agent_status (e.g. the per-process sidecar-
+	// restart anti-pattern in cmd/sidecar.go) cannot flip the parent
+	// worker back into "round N already in progress" refusals on the next
+	// `prism review`.
+	//
+	// Failure is non-fatal: the prompt has already been accepted by the
+	// host-API /prompt handler at this point. A missing delivered_at write
+	// leaves the system in the pre-fix state (vulnerable to agent_status
+	// clobbers) but does not lose the verdict.
+	if setErr := d.SetGroupDeliveredAt(groupID); setErr != nil {
+		proglog.Warnf("[prism review recovery] warning: SetGroupDeliveredAt(%s): %v\n", groupID, setErr)
+	} else {
+		proglog.Infof("[prism review recovery] group %s delivered_at recorded\n", groupID)
+	}
+
 	res.Delivered = true
 	return res, nil
 }

--- a/modules/programs/prism/prism/internal/sidecar/group_delivered_at_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/group_delivered_at_test.go
@@ -1,0 +1,258 @@
+package sidecar
+
+// group_delivered_at_test.go — integration coverage for the #2259
+// delivered_at column.
+//
+// The unit tests under internal/db/ verify that GroupCompleted short-
+// circuits on delivered_at and that SetGroupDeliveredAt is first-write-
+// wins. This file exercises the end-to-end write path:
+//
+//  1. positive — DeliverGroupResults against a fake host-API /prompt
+//     returning 200 must set delivered_at, and ActiveReviewGroupForParent
+//     must immediately return "" (no active group) even though the
+//     agent_status rows are still in non-terminal states.
+//  2. negative — when delivery fails (the worker's host-API socket is
+//     unreachable), delivered_at must remain NULL so the verdict-rerun
+//     path remains available.
+//
+// Both scenarios use sidecartest.NewIsolated per the #1608 convention so
+// no host-side prism state is touched.
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/db"
+	"github.com/prismatic-koi/prism/internal/review"
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// setupDeliveredAtFixture seeds a worker session, registers a review group
+// with 5 active/idle members (no terminal states), and returns the DB and
+// fixture details. Crucially, members are NOT in terminal states — so the
+// pre-#2259 GroupCompleted predicate would return false. The test asserts
+// that delivered_at flips the predicate to true regardless.
+func setupDeliveredAtFixture(t *testing.T, scenarioTag string) (d *db.DB, workerSession, groupID string, sockPath string) {
+	t.Helper()
+
+	workerSession = "prism-test@worker-" + scenarioTag
+	bus := sidecartest.NewIsolated(t, workerSession)
+	d = bus.DB
+
+	// Flip the worker to harness='pi' and state='reviewing' so the
+	// promptdelivery socket-pipe path is exercised.
+	if err := d.QueryRow(
+		`UPDATE agent_status SET harness = 'pi', state = 'reviewing' WHERE session_name = ? RETURNING session_name`,
+		workerSession,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("set harness=pi, state=reviewing: %v", err)
+	}
+
+	const prNumber = "2259"
+	const round = 1
+	var err error
+	groupID, err = d.RegisterGroupWithPR(workerSession, prNumber, round)
+	if err != nil {
+		t.Fatalf("RegisterGroupWithPR: %v", err)
+	}
+
+	// Seed 5 members in NON-terminal states (idle + active). The whole
+	// point of the #2259 fix is that delivered_at must work as a terminal
+	// signal even when the agent_status rollup says the group is still
+	// in-progress (that is the wedged-at-idle reproducer from the issue).
+	memberStates := []struct {
+		role  string
+		state string
+	}{
+		{"review-goal", "idle"},
+		{"review-code", "idle"},
+		{"review-security", "active"},
+		{"review-qa", "idle"},
+		{"review-context", "active"},
+	}
+	for _, m := range memberStates {
+		sessName := workerSession + "~review-1-" + m.role
+		if err := d.UpsertStatus(sessName, "prism-test", "/tmp/worktree", m.state, nil, nil); err != nil {
+			t.Fatalf("upsert agent_status for %s: %v", sessName, err)
+		}
+		if err := d.SetGroupID(sessName, groupID); err != nil {
+			t.Fatalf("SetGroupID for %s: %v", sessName, err)
+		}
+	}
+
+	// Sanity check: pre-delivery GroupCompleted MUST be false (members
+	// are non-terminal). This is the wedged-at-idle reproducer.
+	if done, err := d.GroupCompleted(groupID); err != nil {
+		t.Fatalf("GroupCompleted pre-delivery: %v", err)
+	} else if done {
+		t.Fatalf("GroupCompleted pre-delivery returned true; expected false (members are non-terminal)")
+	}
+	// Sanity check: ActiveReviewGroupForParent must return groupID
+	// because at least one member is non-terminal and delivered_at is
+	// NULL — i.e. the in-progress guard is active.
+	if active, err := review.ActiveReviewGroupForParent(d, workerSession); err != nil {
+		t.Fatalf("ActiveReviewGroupForParent pre-delivery: %v", err)
+	} else if active != groupID {
+		t.Fatalf("ActiveReviewGroupForParent pre-delivery = %q, want %q (in-progress guard should be active)", active, groupID)
+	}
+
+	sockPath, err = session.SidecarHostAPIPath(workerSession)
+	if err != nil {
+		t.Fatalf("resolve sock path: %v", err)
+	}
+	return d, workerSession, groupID, sockPath
+}
+
+// TestDeliverGroupResults_SetsDeliveredAt_UnblocksGuard is the positive
+// integration test for #2259. It mounts a fake /prompt server on the
+// worker's host-API Unix socket that returns 200, calls
+// DeliverGroupResults, and verifies:
+//
+//   - delivered_at is set on the session_groups row.
+//   - ActiveReviewGroupForParent immediately returns "" (no active group)
+//     even though the 5 agent_status members are still idle/active.
+//   - GroupCompleted returns true via the short-circuit.
+//
+// This is the wedged-at-idle reproducer turned green by #2259.
+func TestDeliverGroupResults_SetsDeliveredAt_UnblocksGuard(t *testing.T) {
+	d, workerSession, groupID, sockPath := setupDeliveredAtFixture(t, "delivered-at-positive")
+
+	// Mount a fake /prompt server on the worker's host-API socket. The
+	// promptdelivery socket-pipe path dials this socket; a 200 response
+	// makes DeliverToSessionWithID return nil, which is the success branch
+	// in DeliverGroupResults that writes delivered_at.
+	srv, cleanup := startFakePromptServer(t, sockPath, http.StatusOK, `{"replayed":false}`)
+	defer cleanup()
+	_ = srv
+
+	res, err := review.DeliverGroupResults(d, groupID, review.RecoveryDeliveryID(groupID))
+	if err != nil {
+		t.Fatalf("DeliverGroupResults: %v", err)
+	}
+	if !res.Delivered {
+		t.Fatalf("DeliverGroupResults result: Delivered=false, want true")
+	}
+
+	// delivered_at must now be non-NULL on the session_groups row.
+	var deliveredAt *int64
+	if err := d.QueryRow(
+		`SELECT delivered_at FROM session_groups WHERE group_id = ?`, groupID,
+	).Scan(&deliveredAt); err != nil {
+		t.Fatalf("read delivered_at: %v", err)
+	}
+	if deliveredAt == nil {
+		t.Fatal("delivered_at is NULL after successful DeliverGroupResults; want non-NULL")
+	}
+	// Within a reasonable window of "now" — tiny sanity check that the
+	// value is an epoch-ms not some random integer.
+	nowMs := time.Now().UnixMilli()
+	if *deliveredAt < nowMs-int64(time.Minute/time.Millisecond) || *deliveredAt > nowMs+int64(time.Minute/time.Millisecond) {
+		t.Errorf("delivered_at = %d, want within ±60s of now=%d (epoch-ms)", *deliveredAt, nowMs)
+	}
+
+	// ActiveReviewGroupForParent must now return "" — the in-progress
+	// guard is released even though the 5 members are still in idle/active
+	// states. This is the wedged-at-idle fix in action.
+	active, err := review.ActiveReviewGroupForParent(d, workerSession)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent post-delivery: %v", err)
+	}
+	if active != "" {
+		t.Errorf("ActiveReviewGroupForParent post-delivery = %q, want \"\" (delivered_at must release the in-progress guard regardless of member state)", active)
+	}
+
+	// GroupCompleted must also return true — the short-circuit fires
+	// before the agent_status-based predicate is consulted.
+	done, err := d.GroupCompleted(groupID)
+	if err != nil {
+		t.Fatalf("GroupCompleted post-delivery: %v", err)
+	}
+	if !done {
+		t.Error("GroupCompleted post-delivery = false, want true (delivered_at must short-circuit to terminal)")
+	}
+}
+
+// TestDeliverGroupResults_FailedDelivery_LeavesDeliveredAtNULL is the
+// negative integration test for #2259. When the /prompt server returns
+// 500 (delivery rejected), DeliverGroupResults must NOT write
+// delivered_at — the verdict-rerun path remains available because
+// GroupCompleted still derives from the agent_status predicate.
+func TestDeliverGroupResults_FailedDelivery_LeavesDeliveredAtNULL(t *testing.T) {
+	d, workerSession, groupID, sockPath := setupDeliveredAtFixture(t, "delivered-at-negative")
+
+	// Mount a fake /prompt server that returns 500 on every call.
+	srv, cleanup := startFakePromptServer(t, sockPath, http.StatusInternalServerError, `{"error":"simulated failure"}`)
+	defer cleanup()
+	_ = srv
+
+	res, err := review.DeliverGroupResults(d, groupID, review.RecoveryDeliveryID(groupID))
+	if err == nil {
+		t.Fatal("DeliverGroupResults: got nil error, want non-nil (delivery should have failed)")
+	}
+	if res != nil && res.Delivered {
+		t.Fatalf("DeliverGroupResults result: Delivered=true on a 500 response; want false")
+	}
+
+	// delivered_at must remain NULL on the session_groups row.
+	var deliveredAt *int64
+	if err := d.QueryRow(
+		`SELECT delivered_at FROM session_groups WHERE group_id = ?`, groupID,
+	).Scan(&deliveredAt); err != nil {
+		t.Fatalf("read delivered_at: %v", err)
+	}
+	if deliveredAt != nil {
+		t.Errorf("delivered_at = %d after failed DeliverGroupResults; want NULL so the verdict-rerun path remains available", *deliveredAt)
+	}
+
+	// The in-progress guard must STILL be active (i.e. the agent_status-
+	// based predicate is consulted normally for the unblocked path).
+	active, err := review.ActiveReviewGroupForParent(d, workerSession)
+	if err != nil {
+		t.Fatalf("ActiveReviewGroupForParent post-failure: %v", err)
+	}
+	if active != groupID {
+		t.Errorf("ActiveReviewGroupForParent post-failure = %q, want %q (delivered_at NULL must leave the agent_status predicate authoritative)", active, groupID)
+	}
+}
+
+// startFakePromptServer binds an HTTP server to the given Unix socket path
+// that returns (statusCode, body) for every request. The server is shut
+// down by the returned cleanup function.
+func startFakePromptServer(t *testing.T, sockPath string, statusCode int, body string) (*http.Server, func()) {
+	t.Helper()
+
+	// Ensure the parent directory exists.
+	if idx := strings.LastIndex(sockPath, "/"); idx > 0 {
+		if err := os.MkdirAll(sockPath[:idx], 0o700); err != nil {
+			t.Fatalf("mkdir parent of sock path: %v", err)
+		}
+	}
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sockPath, err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/prompt", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+
+	cleanup := func() {
+		_ = srv.Close()
+		_ = ln.Close()
+	}
+	// Give the listener a brief settling window.
+	time.Sleep(10 * time.Millisecond)
+	return srv, cleanup
+}


### PR DESCRIPTION
Closes #2259.

## What

Adds `session_groups.delivered_at` (epoch ms, nullable, default NULL) as the authoritative end-of-life signal for a review group. The column is OR'd into the existing terminal/completed predicate at all four read sites; it short-circuits whenever the review-complete prompt has been successfully accepted by `prism prompt` for the group.

## Why

Pre-fix, group finalisation was derived entirely from a roll-up over `agent_status.state` + `ended_at`. If any process clobbered an agent_status row back to a non-terminal state after delivery — the per-process sidecar-restart anti-pattern at `cmd/sidecar.go:181-183` is the documented mechanism — all four read sites flipped back to "in-progress" and the parent worker's next `prism review` got refused with "round N already in progress" indefinitely.

With `delivered_at` OR'd in, a successfully delivered group is permanently classified as terminal — the signal survives any subsequent agent_status mutation.

Why a schema column over an in-memory flag: the recovery-watcher path is a separate process from the monitor. Only a persistent column survives across both writers.

## Changes

### Write sites (atomic with delivery acknowledgement)

- `review.MonitorFunc` after `deliverWithRetry` succeeds.
- `review.DeliverGroupResults` after the host-API `/prompt` returns success.

`SetGroupDeliveredAt`'s UPDATE is conditional on `delivered_at IS NULL` so the timestamp reflects the FIRST successful delivery, providing ordering-independent semantics under the monitor/recovery dedup race documented in `monitor_recovery_race_test.go`. Failure is non-fatal (warning log) — the prompt has already been accepted at the call site.

### Read sites (OR'd predicate)

- `db.GroupCompleted` short-circuits to `done=true` when `delivered_at IS NOT NULL`.
- `review.ActiveReviewGroupForParent` / `isTerminalForGuard` skip delivered groups via the new `db.DeliveredGroupIDsForParent` helper.
- `db.ReviewGroupsList` rolls up `GroupState=completed` when `delivered_at IS NOT NULL`.
- `db.GroupResults` gains a code comment naming `delivered_at` as the authoritative end-of-life signal (no behavioural change — the comment names the locking signal for "do not re-aggregate").

### Migration

`migrateV35ToV36` — forward-only, matching the v30→v31 / v34→v35 pattern. Idempotent on fresh DBs via `pragma_table_info` guard. No backfill required — pre-fix rows continue to be classified by the existing agent_status-based predicate.

`currentSchemaVersion` bumped 35 → 36.

### Failed delivery semantics

A failed delivery (all retries exhausted) leaves `delivered_at` NULL — the verdict-rerun path remains available because `GroupCompleted` still derives from the agent_status predicate.

## Tests

Per #1608: all sidecar-path tests use `sidecartest.NewIsolated`, with session names under the `prism-test@` prefix. No host-side prism state is touched.

- `TestGroupCompleted_DeliveredAtIsTerminal` — parallel to `TestGroupCompleted_EndedAtIsTerminal`: 5 idle/active members, `delivered_at` set → `done=true`.
- `TestSetGroupDeliveredAt_IdempotentFirstWins` — verifies the first delivery's timestamp sticks across repeat calls.
- `TestSetGroupDeliveredAt_NoBackfillRequired` — pre-migration rows (NULL `delivered_at`) continue to be classified by the existing agent_status predicate.
- `TestSetGroupDeliveredAt_ActiveMembersStillInProgress` — negative direction: active members + NULL `delivered_at` → `done=false`.
- `TestMigration_V35ToV36_{BodyRuns,BodySkips,Idempotent,NoBackfill}` — schema migration coverage matching the v34→v35 test shape, including the body-skips branch for fresh DBs.
- `TestDeliverGroupResults_SetsDeliveredAt_UnblocksGuard` — sidecar integration: seed 5 non-terminal members, call `DeliverGroupResults` against a fake `/prompt` returning 200, assert `delivered_at` is set and `ActiveReviewGroupForParent` returns `""` immediately. This is the wedged-at-idle reproducer from the issue, turned green.
- `TestDeliverGroupResults_FailedDelivery_LeavesDeliveredAtNULL` — negative integration: `/prompt` returns 500, `delivered_at` remains NULL, in-progress guard remains active.

### No-op verification

Both `TestGroupCompleted_DeliveredAtIsTerminal` and `TestDeliverGroupResults_SetsDeliveredAt_UnblocksGuard` were verified to FAIL with the fix locally removed (short-circuit in `GroupCompleted` disabled, `ActiveReviewGroupForParent` filter disabled — separately), confirming the tests are not vacuous.

## Acceptance criteria

All ACs from the issue's pinned comment are met:

- [x] `session_groups.delivered_at INTEGER` via forward-only v35→v36 migration.
- [x] `delivered_at` written on successful `deliverWithRetry` in `MonitorFunc`.
- [x] `delivered_at` written on successful host-API `/prompt` in `DeliverGroupResults`.
- [x] `db.GroupCompleted` returns `done=true` whenever `delivered_at IS NOT NULL`.
- [x] `ActiveReviewGroupForParent` / `isTerminalForGuard` skips delivered groups.
- [x] `ReviewGroupsList` rolls up `GroupState=completed` when `delivered_at IS NOT NULL`.
- [x] Failed delivery leaves `delivered_at` NULL.
- [x] Pre-migration rows (NULL `delivered_at`) continue to be classified by the existing predicate — no backfill required.
- [x] Active members + NULL `delivered_at` reads as in-progress.
- [x] No `pr_number` filtering introduced in `ReviewGroupsList`.
- [x] All sidecar-path tests use `sidecartest.NewIsolated` (#1608).

## Out of scope (per the issue's investigator findings)

- The per-process sidecar-restart anti-pattern at `cmd/sidecar.go:181-183` that can overwrite a terminal state with `idle` on restart. The `delivered_at` fix immunises the review pipeline against it but does not remove the anti-pattern.
- Coordinator-visible alert / auto-reap for groups with `delivered_at` set but non-terminal members after a grace window. Trivially queryable once the column exists.

## Verification

```bash
# From modules/programs/prism/prism/
go build ./...    # ✓
go test ./...     # ✓ (full suite)
go test ./internal/db/ ./internal/review/ ./internal/sidecar/ -race -count=1  # ✓

# From repo root
nix build .#prism  # ✓
```