### PR TITLE
prism: stub agent-run subcommand in cmd TestMain to fix TestRestoreSession_* flake (#2280)

### DIFF
--- a/modules/programs/prism/prism/cmd/killsidecar_test.go
+++ b/modules/programs/prism/prism/cmd/killsidecar_test.go
@@ -90,11 +90,24 @@ import (
 //     developer hosts, and inside prism worker sandboxes. See
 //     sandbox_env_isolation_test.go for the full rationale.
 //
-//  6. Re-exec stub interception (#2230 class, swept in #2237): production
-//     code reachable from this package re-execs os.Executable() — in tests,
-//     THIS binary — as `<self> sidecar …` / `<self> event …`
-//     (session.SpawnSession paths) and `<self> monitor-review …`
-//     (review.RunAsync → StartMonitorProcess with prismBinary=="").
+//  6. Re-exec stub interception (#2230 class, swept in #2237, extended in
+//     #2280): production code reachable from this package re-execs
+//     os.Executable() — in tests, THIS binary — as `<self> sidecar …` /
+//     `<self> event …` (session.SpawnSession paths) and
+//     `<self> monitor-review …` (review.RunAsync → StartMonitorProcess with
+//     prismBinary=="").  An additional re-exec target reaches this binary
+//     via tmux rather than Go: setupFullLayout (internal/session/session.go)
+//     creates the agent pane with `bwrapIsolator.AgentPaneCmd` /
+//     `sandboxExecIsolator.AgentPaneCmd`, both of which render
+//     `<abs-prism-path> agent-run --session <name>` and hand it to
+//     tmux.NewWindow. In tests `<abs-prism-path>` is the test binary, so
+//     tmux's pane shell invokes `<self> agent-run …` from outside the Go
+//     parent. Without the agent-run arm of the argv check, the subprocess
+//     ran the real cmd/agent_run.go path which calls openAgentRunLog and
+//     creates `$XDG_STATE_HOME/prism/run/<hash>/agent-run.log` after the
+//     test body has returned — racing t.TempDir's RemoveAll and surfacing
+//     as `unlinkat …/prism: directory not empty` (#2280, third instance of
+//     the flake class after #1477 and #1705).
 //     PRISM_TEST_SUBPROCESS=1 short-circuits an explicit stub re-invocation;
 //     the argv check covers paths reached without the env var, exiting
 //     instead of recursively running the suite. The argv check MUST stay
@@ -116,7 +129,7 @@ func TestMain(m *testing.M) {
 		time.Sleep(50 * time.Millisecond)
 		os.Exit(0)
 	}
-	if len(os.Args) > 1 && (os.Args[1] == "sidecar" || os.Args[1] == "event" || os.Args[1] == "monitor-review") {
+	if len(os.Args) > 1 && (os.Args[1] == "sidecar" || os.Args[1] == "event" || os.Args[1] == "monitor-review" || os.Args[1] == "agent-run") {
 		// Re-exec argv defence — see purpose 6 in the doc comment above.
 		os.Exit(0)
 	}

--- a/modules/programs/prism/prism/cmd/reexec_interception_test.go
+++ b/modules/programs/prism/prism/cmd/reexec_interception_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+// Regression guard for TestMain's re-exec stub interception (#2237, extended
+// in #2280).
+//
+// Production code reachable from this package re-execs os.Executable() — in
+// tests, THIS test binary — as `<self> sidecar …` /  `<self> event …`
+// (session.StartSidecarWithOpts and setupFullLayout's status seed) and
+// `<self> monitor-review …` (review.RunAsync → StartMonitorProcess with
+// prismBinary==""). An additional re-exec target reaches this binary via
+// tmux rather than Go: setupFullLayout (internal/session/session.go) creates
+// the agent pane by handing
+// `<abs-prism-path> agent-run --session <name>` to tmux.NewWindow, and tmux
+// invokes the binary from outside the Go parent. Without the agent-run arm
+// of the argv check, the subprocess ran the real cmd/agent_run.go path which
+// calls openAgentRunLog and creates `$XDG_STATE_HOME/prism/run/<hash>/
+// agent-run.log` AFTER the test body has returned — racing t.TempDir's
+// RemoveAll and surfacing as `unlinkat …/prism: directory not empty`
+// (#2280, the third instance of the flake class after #1477 and #1705).
+//
+// This guard execs the test binary the way the production re-exec would —
+// the same argv shapes, no stub env var — and asserts it exits 0
+// immediately with no output. A suite run instead prints test/log output and
+// at minimum a trailing "PASS"/"FAIL", so the empty-output assertion fails
+// if the interception is ever removed (verified non-vacuous against the
+// pre-#2280 binary: the `agent-run …` re-invocation ran the full suite).
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// cmdReexecGuardChildEnv is a recursion brake for the mutated state only: if
+// the TestMain interception is removed, the child invocation below runs the
+// full suite — including this guard. The brake makes the child's copy of the
+// guard skip instead of spawning grandchildren, so the failure is a bounded,
+// visible guard FAIL rather than a fork storm. With the interception in
+// place the child never reaches m.Run() and the brake is inert.
+const cmdReexecGuardChildEnv = "PRISM_CMD_REEXEC_GUARD_CHILD"
+
+// TestReExecInterception_ProductionArgvShapes mirrors the same-named guards
+// in internal/integration and internal/sidecar (#2237). Each case is one
+// production re-exec argv shape that this test binary can be invoked with;
+// the TestMain argv defence in killsidecar_test.go must intercept all of
+// them and exit 0 immediately. Adding a new re-exec target in production
+// without adding it here will let the suite recurse silently — keep the
+// list in sync with the killsidecar_test.go TestMain argv check.
+func TestReExecInterception_ProductionArgvShapes(t *testing.T) {
+	if os.Getenv(cmdReexecGuardChildEnv) == "1" {
+		t.Skip("recursion brake: running inside a guard-spawned child (see cmdReexecGuardChildEnv)")
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		argv []string
+	}{
+		// session.StartSidecarWithOpts (internal/session/sidecar.go).
+		{"sidecar", []string{"sidecar", "--session", "prism-test@reexec-guard", "--harness-url", "http://localhost:0"}},
+		// setupFullLayout's status seed (internal/session/session.go).
+		{"event", []string{"event", "tmux-session-start", "--session", "prism-test@reexec-guard", "--worktree", "/nonexistent/prism-reexec-guard"}},
+		// review.StartMonitorProcess (internal/review/review.go).
+		{"monitor-review", []string{"monitor-review", "--session", "prism-test@reexec-guard"}},
+		// setupFullLayout's tmux-launched agent pane: bwrap / sandbox-exec
+		// AgentPaneCmd renders `<self> agent-run --session <name>` and hands
+		// it to tmux.NewWindow. tmux invokes the binary outside Go's
+		// process tree (#2280).
+		{"agent-run", []string{"agent-run", "--session", "prism-test@reexec-guard"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, self, tc.argv...)
+			// Bound Wait on lingering pipe holders if a mutated run leaves
+			// grandchildren sharing stdout/stderr.
+			cmd.WaitDelay = 5 * time.Second
+			cmd.Env = append(os.Environ(), cmdReexecGuardChildEnv+"=1")
+			out, runErr := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("re-invoked test binary %v did not exit within 30s — TestMain re-exec interception missing; output:\n%s", tc.argv, cmdReexecGuardTruncate(out))
+			}
+			if runErr != nil {
+				t.Fatalf("re-invoked test binary %v = %v, want immediate exit 0 from TestMain interception; output:\n%s", tc.argv, runErr, cmdReexecGuardTruncate(out))
+			}
+			if len(out) != 0 {
+				t.Errorf("re-invoked test binary %v wrote %d bytes — the suite ran instead of TestMain intercepting:\n%s", tc.argv, len(out), cmdReexecGuardTruncate(out))
+			}
+		})
+	}
+}
+
+// cmdReexecGuardTruncate bounds child output in failure messages.
+func cmdReexecGuardTruncate(b []byte) string {
+	const max = 2048
+	if len(b) > max {
+		return string(b[:max]) + "… (truncated)"
+	}
+	return string(b)
+}


### PR DESCRIPTION
Closes #2280

## Summary

Three back-to-back CI runs surfaced the textbook `t.Cleanup` / `t.TempDir` flake
documented in #1477 and #1705: an actor outlives the test body and writes to
the test's `t.TempDir()` after the test returns, racing `RemoveAll` and
surfacing as `unlinkat …/prism: directory not empty`. Reproducible locally
under `go test ./cmd/ -race -count=20 -run TestRestoreSession`.

## Root cause — subprocess, not Go goroutine

The issue title and prior-art analogies assumed a Go-level goroutine
outliving `t.Cleanup`. Reading `cmd/restore.go` and its call graph turned
up a different — but functionally identical — class:

`setupFullLayout` (internal/session/session.go) creates the agent pane via
`bwrapIsolator.AgentPaneCmd` / `sandboxExecIsolator.AgentPaneCmd`, both of
which render `<abs-prism-path> agent-run --session <name>` and hand it to
`tmux.NewWindow`. In tests `<abs-prism-path>` is the test binary, so tmux's
pane shell invokes `<self> agent-run …` from outside the Go parent.

The existing TestMain argv defence (#2237) intercepts `sidecar`, `event`,
and `monitor-review` — but not `agent-run`. So the subprocess ran the real
`cmd/agent_run.go` path which calls `openAgentRunLog` and creates
`$XDG_STATE_HOME/prism/run/<hash>/agent-run.log` AFTER the test body has
returned, racing `t.TempDir`'s `RemoveAll`.

The race is between:

1. `t.Cleanup(KillSidecar)` — fires SIGTERM to the sidecar PID (does NOT
   wait for exit; the sidecar arm is already stubbed and exits 0 anyway).
2. `newCmdTestServer`'s `killFn` — SIGKILLs the tmux server's pgrp and
   asks tmux to kill-server. Tmux's pane subprocesses get SIGHUP via the
   pty-master close but take a non-zero time to actually exit.
3. `t.TempDir`'s `RemoveAll` — walks `<tempdir>/prism/`.

The agent-run subprocess writes to `prism/run/<hash>/agent-run.log`
during (2)→(3) and the late write resurrects entries inside `prism/`,
so the parent `unlinkat(prism/)` returns ENOTEMPTY.

## Fix shape

Matches the canonical pattern established in #2237 for the cmd package:
extend the argv defence in `killsidecar_test.go`'s TestMain to also exit 0
on `agent-run`. **No production code change** — production `agent-run`
continues to do exactly what it does in non-test contexts, because the
check only runs inside the test binary's TestMain. The expanded doc
comment names the new re-exec target and the failure mode it prevents so
future readers understand why the arm exists.

This is not one of the three sync-primitive shapes the issue's AC
proposed (ctx + done channel, sync.WaitGroup, or returned Wait/Close
handle on a Go type), because the actor is a tmux-launched subprocess
rather than a Go-level goroutine — the prism Go code has no handle on it
that a `cancel()` or `Wait()` could observe. The argv-stub is the
established sync primitive for this shape in this repo (#2237).

Also adds `cmd/reexec_interception_test.go`, mirroring the same-named
guards in `internal/integration` and `internal/sidecar` (#2237). It execs
the test binary with the four production argv shapes (sidecar / event /
monitor-review / agent-run) and asserts immediate exit 0 with zero
output. Without the TestMain interception the suite recurses; the
empty-output assertion catches that, and it doubles as a forward-looking
regression guard for any future re-exec target added to this argv check.

## Verification (non-vacuous-test discipline, per AGENTS.md)

| Command | Result |
|---|---|
| `go test ./cmd/ -race -count=50 -run TestRestoreSession` | 50/50 PASS (~206s) |
| `go test ./cmd/ -race -count=20 -run TestRestoreSession` with fix surgically reverted | **5 failures in 20 iters** with the expected `unlinkat …/prism: directory not empty` signature on `TestRestoreSession_BwrapMode_TempFileWritten*` and `TestRestoreSession_BwrapMode_WorkerConfigContent` |
| `go test ./cmd/ -race -count=1 -run TestReExecInterception/agent-run` with fix reverted | **FAIL**: re-invoked test binary wrote bytes (suite ran) |
| `go test ./cmd/ -race -count=1` (full cmd suite) | PASS |
| `go test ./... -race -count=1` (full module) | all packages PASS |
| `nix build .#prism` | OK |

The flake reproduces deterministically on the dev host (NixOS, bwrap
available) at ~20–25% per test per iteration. After the fix the same
loop is clean over 50 iterations.

## Files

- `modules/programs/prism/prism/cmd/killsidecar_test.go` — extend argv
  defence, expand doc comment.
- `modules/programs/prism/prism/cmd/reexec_interception_test.go` —
  new regression guard, mirrors the canonical #2237 pattern.

## Related

- #1477 — `TestTransitionCause_IdleDebounce` (sidecar), same flake class,
  Go-level goroutine.
- #1705 — `TestParityRestore_OrphanedToolCallAndRespawn` (iris/parity),
  same flake class, supervisor goroutine.
- #2237 — established the cmd TestMain argv-defence pattern this PR
  extends.