### PR TITLE
prism: account subcommand + pi credential-cache mtime invalidation

### DIFF
--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
@@ -35,10 +35,16 @@ beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "pi-creds-test-"))
   authJson = join(tempDir, "auth.json")
   process.env.PI_AUTH_JSON = authJson
+  // The developer host (and the bwrap dispatcher) set PI_CODING_AGENT_DIR
+  // unconditionally. Clear it so the existing PI_AUTH_JSON-keyed test
+  // fixtures continue to win precedence; the dedicated precedence test
+  // below sets it back as needed.
+  delete process.env.PI_CODING_AGENT_DIR
 })
 
 afterEach(() => {
   delete process.env.PI_AUTH_JSON
+  delete process.env.PI_CODING_AGENT_DIR
   rmSync(tempDir, { recursive: true, force: true })
 })
 
@@ -179,6 +185,85 @@ describe("readCredentials back-compat", () => {
 // ---------------------------------------------------------------------------
 // repairCredentials tests
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// getAuthJsonPath — PI_CODING_AGENT_DIR precedence (#2283)
+// ---------------------------------------------------------------------------
+//
+// The path resolution order is PI_AUTH_JSON > PI_CODING_AGENT_DIR/auth.json
+// > homedir()/.pi/agent/auth.json. The middle entry is what makes the
+// `prism account use` swap visible inside an already-running bwrap
+// sandbox: the dispatcher sets PI_CODING_AGENT_DIR to the dir-bind path,
+// which surfaces host-side renames (the file-bind at homedir() pins the
+// pre-swap inode).
+//
+// We can't observe the bwrap behaviour from a unit test, but we CAN
+// verify the precedence: when PI_AUTH_JSON is unset and
+// PI_CODING_AGENT_DIR is set, readCredentials() must consult
+// <PI_CODING_AGENT_DIR>/auth.json.
+
+describe("getAuthJsonPath precedence", () => {
+  it("prefers PI_CODING_AGENT_DIR/auth.json when PI_AUTH_JSON is unset", () => {
+    delete process.env.PI_AUTH_JSON
+    const agentDir = mkdtempSync(join(tmpdir(), "pi-agent-dir-"))
+    process.env.PI_CODING_AGENT_DIR = agentDir
+    const expires = Date.now() + 3_600_000
+    writeFileSync(
+      join(agentDir, "auth.json"),
+      JSON.stringify({
+        anthropic: {
+          type: "oauth",
+          access: "agent-dir-access",
+          refresh: "agent-dir-refresh",
+          expires,
+        },
+      }),
+      "utf-8",
+    )
+
+    const creds = readCredentials()
+    assert.ok(creds, "should resolve via PI_CODING_AGENT_DIR")
+    assert.equal(creds.accessToken, "agent-dir-access")
+
+    rmSync(agentDir, { recursive: true, force: true })
+  })
+
+  it("PI_AUTH_JSON wins over PI_CODING_AGENT_DIR when both are set", () => {
+    // PI_AUTH_JSON is already pointing at `authJson` (the per-test temp).
+    const decoyDir = mkdtempSync(join(tmpdir(), "pi-agent-decoy-"))
+    process.env.PI_CODING_AGENT_DIR = decoyDir
+    // Decoy file: if precedence were wrong we'd read this.
+    writeFileSync(
+      join(decoyDir, "auth.json"),
+      JSON.stringify({
+        anthropic: {
+          type: "oauth",
+          access: "DECOY",
+          refresh: "DECOY",
+          expires: Date.now() + 3_600_000,
+        },
+      }),
+      "utf-8",
+    )
+    // The real file under PI_AUTH_JSON:
+    writeFileSync(
+      authJson,
+      JSON.stringify({
+        anthropic: {
+          type: "oauth",
+          access: "WINNING",
+          refresh: "WINNING",
+          expires: Date.now() + 3_600_000,
+        },
+      }),
+      "utf-8",
+    )
+    const creds = readCredentials()
+    assert.ok(creds)
+    assert.equal(creds.accessToken, "WINNING", "PI_AUTH_JSON must win")
+    rmSync(decoyDir, { recursive: true, force: true })
+  })
+})
 
 // ---------------------------------------------------------------------------
 // getCachedCredentials — mtime-based cache invalidation (#2283)

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  utimesSync,
   writeFileSync,
   readFileSync,
 } from "node:fs"
@@ -23,6 +24,8 @@ import {
   readCredentials,
   writeCredentials,
   repairCredentials,
+  getCachedCredentials,
+  invalidateCache,
 } from "./credentials.ts"
 
 let tempDir: string
@@ -42,6 +45,12 @@ afterEach(() => {
 function writeAuthJson(data: unknown): void {
   writeFileSync(authJson, JSON.stringify(data, null, 2), "utf-8")
 }
+
+// invalidate the module-level cache before each test so prior `getCached`
+// calls cannot bleed across tests.
+beforeEach(() => {
+  invalidateCache()
+})
 
 // ---------------------------------------------------------------------------
 // readCredentials tests
@@ -170,6 +179,95 @@ describe("readCredentials back-compat", () => {
 // ---------------------------------------------------------------------------
 // repairCredentials tests
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// getCachedCredentials — mtime-based cache invalidation (#2283)
+// ---------------------------------------------------------------------------
+
+describe("getCachedCredentials mtime invalidation", () => {
+  function writeCreds(suffix: string, expires: number): void {
+    writeFileSync(
+      authJson,
+      JSON.stringify({
+        anthropic: {
+          type: "oauth",
+          access: `access-${suffix}`,
+          refresh: `refresh-${suffix}`,
+          expires,
+        },
+      }),
+      "utf-8",
+    )
+  }
+
+  it("returns the cached blob on a second call when auth.json mtime is unchanged", () => {
+    const expires = Date.now() + 3_600_000
+    writeCreds("A", expires)
+
+    const first = getCachedCredentials()
+    assert.ok(first, "first call should populate the cache")
+    assert.equal(first.accessToken, "access-A")
+
+    // Rewrite the file with different content but force the mtime back
+    // to its original value. The cache must still hit.
+    const originalMtime = new Date(Date.now() - 60_000)
+    utimesSync(authJson, originalMtime, originalMtime)
+    writeCreds("B", expires)
+    utimesSync(authJson, originalMtime, originalMtime)
+
+    const second = getCachedCredentials()
+    assert.ok(second, "second call should hit the cache")
+    // The cache returns the originally-loaded "A" tokens, not the "B"
+    // tokens we just wrote behind its back.
+    assert.equal(
+      second.accessToken,
+      "access-A",
+      "cache should return the originally-loaded creds when mtime is unchanged",
+    )
+  })
+
+  it("bypasses the cache when auth.json mtime has advanced past cachedAt", () => {
+    const expires = Date.now() + 3_600_000
+    writeCreds("A", expires)
+
+    const first = getCachedCredentials()
+    assert.ok(first)
+    assert.equal(first.accessToken, "access-A")
+
+    // Simulate `prism account use other` mid-flight: the rename bumps
+    // mtime to "now". We can't easily wait ≥1ms reliably in a unit test,
+    // so explicitly set the mtime to a value larger than cachedAt.
+    writeCreds("B", expires)
+    const future = new Date(Date.now() + 10_000)
+    utimesSync(authJson, future, future)
+
+    const second = getCachedCredentials()
+    assert.ok(second, "second call should re-read")
+    assert.equal(
+      second.accessToken,
+      "access-B",
+      "cache must invalidate when mtime > cachedAt and re-read the blob",
+    )
+  })
+
+  it("treats a missing auth.json as a cache miss (does not throw)", () => {
+    const expires = Date.now() + 3_600_000
+    writeCreds("A", expires)
+
+    const first = getCachedCredentials()
+    assert.ok(first)
+
+    // Delete the file behind the cache.
+    rmSync(authJson)
+
+    // statSync would throw — we expect the catch to fall through and
+    // hit the cache (mtimeMs = 0, not > cachedAt), so the cache is
+    // returned. This is intentional: the cache is the last good copy.
+    const second = getCachedCredentials()
+    assert.ok(second, "missing file should still return the cached creds")
+    assert.equal(second.accessToken, "access-A")
+  })
+})
 
 describe("repairCredentials", () => {
   it("adds type: 'oauth' to an anthropic entry that is missing it", () => {

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
@@ -34,8 +34,34 @@ let cachedCreds: { creds: ClaudeCredentials; cachedAt: number } | null = null
 export const OAUTH_TOKEN_URL = "https://claude.ai/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
+/**
+ * Resolve the path to pi's auth.json, in precedence order:
+ *
+ *   1. PI_AUTH_JSON      explicit override (tests, manual escape hatch)
+ *   2. PI_CODING_AGENT_DIR/auth.json   set by the prism bwrap + sandbox-exec
+ *                                       dispatchers, and on the host system-
+ *                                       wide. This is the path that surfaces
+ *                                       host-side os.Rename swaps inside a
+ *                                       running sandbox (#2283).
+ *   3. ~/.pi/agent/auth.json           legacy fallback.
+ *
+ * The middle entry is the critical piece for `prism account use`. The bwrap
+ * dispatcher dir-binds the host's ~/.pi/agent at $PI_CODING_AGENT_DIR (a
+ * directory bind), and ALSO file-binds auth.json at its host path for
+ * back-compat. Linux `mount --bind` on a file pins the source inode at
+ * mount time — so a host-side `os.Rename` (which creates a new inode) is
+ * NOT visible at the file-bind path inside an already-running sandbox.
+ * The dir-bind, by contrast, surfaces dentry updates (renames included),
+ * so reading via $PI_CODING_AGENT_DIR/auth.json sees the post-swap blob
+ * immediately. Combined with the mtime check below, this makes the swap
+ * visible to a running pi without a restart.
+ */
 function getAuthJsonPath(): string {
-  return process.env.PI_AUTH_JSON ?? join(homedir(), ".pi", "agent", "auth.json")
+  if (process.env.PI_AUTH_JSON) return process.env.PI_AUTH_JSON
+  if (process.env.PI_CODING_AGENT_DIR) {
+    return join(process.env.PI_CODING_AGENT_DIR, "auth.json")
+  }
+  return join(homedir(), ".pi", "agent", "auth.json")
 }
 
 /**

--- a/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
+++ b/modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts
@@ -14,6 +14,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from "node:fs"
 import { homedir } from "node:os"
@@ -270,10 +271,31 @@ export function getCachedCredentials(): ClaudeCredentials | null {
     now - cachedCreds.cachedAt < CREDENTIAL_CACHE_TTL_MS &&
     cachedCreds.creds.expiresAt > now + 60_000
   ) {
-    log("cache_hit", {
-      ttlRemaining: CREDENTIAL_CACHE_TTL_MS - (now - cachedCreds.cachedAt),
-    })
-    return cachedCreds.creds
+    // Bypass the cache if auth.json has been touched since we cached.
+    // This is the `prism account use` hand-off path (#2283): the swap
+    // renames a new auth.json over the old, bumping mtime; the next
+    // outbound request sees mtime > cachedAt and re-reads the file
+    // instead of returning the stale tokens.
+    //
+    // statSync may throw if the file was unlinked between writes; treat
+    // that as a cache miss (fall through, re-read, log normally).
+    let mtimeMs = 0
+    try {
+      mtimeMs = statSync(getAuthJsonPath()).mtimeMs
+    } catch {
+      mtimeMs = 0
+    }
+    if (mtimeMs > cachedCreds.cachedAt) {
+      log("cache_invalidated_mtime", {
+        mtimeMs,
+        cachedAt: cachedCreds.cachedAt,
+      })
+    } else {
+      log("cache_hit", {
+        ttlRemaining: CREDENTIAL_CACHE_TTL_MS - (now - cachedCreds.cachedAt),
+      })
+      return cachedCreds.creds
+    }
   }
 
   log("cache_miss", { reason: cachedCreds ? "stale or expiring" : "empty" })

--- a/modules/programs/prism/prism/cmd/account.go
+++ b/modules/programs/prism/prism/cmd/account.go
@@ -1,0 +1,214 @@
+package cmd
+
+// prism account — manage named Claude OAuth subscriptions (#2283).
+//
+// Each subcommand calls account.Init first so the on-disk store is
+// guaranteed to exist (and the first-run migration is applied) before
+// any read or write. Shape mirrors `prism profile`:
+//
+//   prism account list                  Print account names, one per line,
+//                                       with the active account marked.
+//                                       --json emits a structured array.
+//
+//   prism account current               Print the active account name. If
+//                                       the pointer is absent, prints "none".
+//
+//   prism account save <name>           Snapshot the live auth.json's
+//                                       anthropic blob to accounts/<name>.json
+//                                       at mode 0o600.
+//
+//   prism account use <name>            Atomically swap the active anthropic
+//                                       blob (see internal/account.Use for
+//                                       the step-by-step contract).
+//
+//   prism account rm <name>             Delete accounts/<name>.json. Refuses
+//                                       to delete the currently-active
+//                                       account.
+//
+// None of the subcommands print any token value at any verbosity.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/account"
+)
+
+var accountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Manage named Claude OAuth subscriptions",
+	Long: `Manage named Claude OAuth subscriptions.
+
+Each account is stored as ~/.config/prism/accounts/<name>.json — the
+"anthropic" key of pi's auth.json. ` + "`" + `prism account use <name>` + "`" + ` swaps
+the live auth.json's anthropic blob atomically; pi's credential cache
+picks up the new tokens on its next outbound request.`,
+}
+
+var accountListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured accounts",
+	Args:  cobra.NoArgs,
+	RunE:  runAccountList,
+}
+
+var accountCurrentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Print the active account name",
+	Args:  cobra.NoArgs,
+	RunE:  runAccountCurrent,
+}
+
+var accountSaveCmd = &cobra.Command{
+	Use:   "save <name>",
+	Short: "Snapshot the live auth.json's anthropic blob to accounts/<name>.json",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAccountSave,
+}
+
+var accountUseCmd = &cobra.Command{
+	Use:   "use <name>",
+	Short: "Atomically swap the active anthropic blob to accounts/<name>.json",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAccountUse,
+}
+
+var accountRmCmd = &cobra.Command{
+	Use:   "rm <name>",
+	Short: "Delete accounts/<name>.json (refuses the active account)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAccountRm,
+}
+
+func init() {
+	accountCmd.AddCommand(accountListCmd)
+	accountCmd.AddCommand(accountCurrentCmd)
+	accountCmd.AddCommand(accountSaveCmd)
+	accountCmd.AddCommand(accountUseCmd)
+	accountCmd.AddCommand(accountRmCmd)
+	rootCmd.AddCommand(accountCmd)
+
+	accountListCmd.Flags().Bool("json", false, "Emit a JSON array of account objects instead of the human-readable list")
+}
+
+// resolveAndInit centralises the "resolve paths then ensure the on-disk
+// store is initialised" preamble. Every subcommand calls this first.
+func resolveAndInit() (account.Paths, error) {
+	p, err := account.ResolvePaths()
+	if err != nil {
+		return account.Paths{}, err
+	}
+	if err := account.Init(p); err != nil {
+		return account.Paths{}, err
+	}
+	return p, nil
+}
+
+// accountJSON is the snake_case shape for --json output.
+type accountJSON struct {
+	Name   string `json:"name"`
+	Active bool   `json:"active"`
+}
+
+func runAccountList(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	p, err := resolveAndInit()
+	if err != nil {
+		return err
+	}
+	names, err := account.List(p)
+	if err != nil {
+		return err
+	}
+	active, _, err := account.Current(p)
+	if err != nil {
+		// A corrupt `current` pointer should not block listing. Surface as
+		// a warning so the user can recover via `prism account use`.
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+		active = ""
+	}
+
+	jsonMode, _ := cmd.Flags().GetBool("json")
+	if jsonMode {
+		rows := make([]accountJSON, 0, len(names))
+		for _, n := range names {
+			rows = append(rows, accountJSON{Name: n, Active: n == active && active != ""})
+		}
+		data, mErr := json.Marshal(rows)
+		if mErr != nil {
+			return fmt.Errorf("account list --json: marshal: %w", mErr)
+		}
+		return printJSON(data)
+	}
+
+	w := cmd.OutOrStdout()
+	for _, n := range names {
+		marker := "  "
+		if n == active && active != "" {
+			marker = "* "
+		}
+		fmt.Fprintf(w, "%s%s\n", marker, n)
+	}
+	return nil
+}
+
+func runAccountCurrent(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	p, err := resolveAndInit()
+	if err != nil {
+		return err
+	}
+	cur, ok, err := account.Current(p)
+	if err != nil {
+		return err
+	}
+	w := cmd.OutOrStdout()
+	if !ok {
+		fmt.Fprintln(w, "none")
+		return nil
+	}
+	fmt.Fprintln(w, cur)
+	return nil
+}
+
+func runAccountSave(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	p, err := resolveAndInit()
+	if err != nil {
+		return err
+	}
+	if err := account.Save(p, args[0]); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "saved account %q\n", args[0])
+	return nil
+}
+
+func runAccountUse(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	p, err := resolveAndInit()
+	if err != nil {
+		return err
+	}
+	if err := account.Use(p, args[0]); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "switched to account %q\n", args[0])
+	return nil
+}
+
+func runAccountRm(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	p, err := resolveAndInit()
+	if err != nil {
+		return err
+	}
+	if err := account.Remove(p, args[0]); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "removed account %q\n", args[0])
+	return nil
+}

--- a/modules/programs/prism/prism/cmd/account_test.go
+++ b/modules/programs/prism/prism/cmd/account_test.go
@@ -1,0 +1,285 @@
+// Tests for the `prism account` cobra subcommands (#2283).
+//
+// These exercise the cmd-layer behaviour (output formatting, --json,
+// active marker, exit-code via err return) on top of the internal
+// account package. Lower-level invariants — atomicity, mode bits,
+// snapshot-before-swap — are covered by internal/account/account_test.go.
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// withAccountFixture redirects $XDG_CONFIG_HOME and $PI_AUTH_JSON into a
+// per-test tempdir. The accounts directory is NOT pre-created — Init()
+// runs lazily via resolveAndInit on the first subcommand invocation.
+func withAccountFixture(t *testing.T) (configDir, authPath string) {
+	t.Helper()
+	root := t.TempDir()
+	cfg := filepath.Join(root, "config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+
+	piDir := filepath.Join(root, "pi-agent")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatalf("mkdir pi-agent: %v", err)
+	}
+	auth := filepath.Join(piDir, "auth.json")
+	t.Setenv("PI_AUTH_JSON", auth)
+	return cfg, auth
+}
+
+func runSubcommand(t *testing.T, runE func(*cobra.Command, []string) error, args []string) (string, error) {
+	t.Helper()
+	c := &cobra.Command{Use: "test"}
+	c.Flags().Bool("json", false, "")
+	var buf bytes.Buffer
+	c.SetOut(&buf)
+	c.SetErr(&buf)
+	err := runE(c, args)
+	return buf.String(), err
+}
+
+func writeAuthFile(t *testing.T, path string, top map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(top)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+}
+
+func sampleAnthropicCmd(suffix string) map[string]any {
+	return map[string]any{
+		"type":    "oauth",
+		"access":  "access-" + suffix,
+		"refresh": "refresh-" + suffix,
+		"expires": 1_000_000_000,
+	}
+}
+
+// ─── list ─────────────────────────────────────────────────────────────
+
+func TestAccountList_MarksActiveAccount(t *testing.T) {
+	_, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+
+	// First call runs Init() which creates default.json and current ← default.
+	out, err := runSubcommand(t, runAccountList, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(out, "* default") {
+		t.Errorf("list output %q does not mark default as active", out)
+	}
+}
+
+func TestAccountList_JSON(t *testing.T) {
+	_, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+
+	c := &cobra.Command{}
+	c.Flags().Bool("json", true, "")
+	if err := c.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set json: %v", err)
+	}
+	// Redirect stdout because printJSON writes to os.Stdout directly.
+	r, w, _ := os.Pipe()
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	doneCh := make(chan []byte, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		doneCh <- buf.Bytes()
+	}()
+
+	if err := runAccountList(c, nil); err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	_ = w.Close()
+	captured := <-doneCh
+
+	var rows []struct {
+		Name   string `json:"name"`
+		Active bool   `json:"active"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(captured), &rows); err != nil {
+		t.Fatalf("parse json: %v (raw: %q)", err, captured)
+	}
+	if len(rows) != 1 || rows[0].Name != "default" || !rows[0].Active {
+		t.Errorf("unexpected json output: %+v", rows)
+	}
+}
+
+// ─── current ──────────────────────────────────────────────────────────
+
+func TestAccountCurrent_PrintsActiveName(t *testing.T) {
+	_, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+
+	out, err := runSubcommand(t, runAccountCurrent, nil)
+	if err != nil {
+		t.Fatalf("current: %v", err)
+	}
+	if strings.TrimSpace(out) != "default" {
+		t.Errorf("current = %q, want \"default\"", out)
+	}
+}
+
+func TestAccountCurrent_NoActive_PrintsNoneAndExitsZero(t *testing.T) {
+	_, _ = withAccountFixture(t)
+	// auth.json absent, so Init creates accounts/ but no current pointer.
+	out, err := runSubcommand(t, runAccountCurrent, nil)
+	if err != nil {
+		t.Fatalf("current: %v", err)
+	}
+	if strings.TrimSpace(out) != "none" {
+		t.Errorf("current = %q, want \"none\"", out)
+	}
+}
+
+// ─── save ─────────────────────────────────────────────────────────────
+
+func TestAccountSave_WritesBlob(t *testing.T) {
+	cfg, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+
+	_, err := runSubcommand(t, runAccountSave, []string{"work"})
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(cfg, "prism", "accounts", "work.json"))
+	if err != nil {
+		t.Fatalf("read saved: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["access"] != "access-A" {
+		t.Errorf("snapshot mismatch: %v", got)
+	}
+}
+
+func TestAccountSave_NoAnthropicKey_NonZeroExit(t *testing.T) {
+	cfg, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"github-copilot": map[string]any{"token": "gh"}})
+
+	_, err := runSubcommand(t, runAccountSave, []string{"work"})
+	if err == nil {
+		t.Fatal("save: want error, got nil")
+	}
+	if _, statErr := os.Stat(filepath.Join(cfg, "prism", "accounts", "work.json")); !os.IsNotExist(statErr) {
+		t.Errorf("save created file on error: %v", statErr)
+	}
+}
+
+// ─── use ──────────────────────────────────────────────────────────────
+
+func TestAccountUse_UnknownName_NonZeroAndDoesNotMutateAuth(t *testing.T) {
+	_, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+
+	before, _ := os.ReadFile(auth)
+	_, err := runSubcommand(t, runAccountUse, []string{"ghost"})
+	if err == nil {
+		t.Fatal("use(ghost): want error, got nil")
+	}
+	after, _ := os.ReadFile(auth)
+	if string(before) != string(after) {
+		t.Errorf("auth.json mutated on failed use")
+	}
+}
+
+func TestAccountUse_SwapsAndUpdatesCurrent(t *testing.T) {
+	cfg, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+	// Init populates accounts/default.json + current ← default.
+	if _, err := runSubcommand(t, runAccountList, nil); err != nil {
+		t.Fatalf("init via list: %v", err)
+	}
+
+	// Hand-write "work" so Save isn't required for this test.
+	workBlob, _ := json.Marshal(sampleAnthropicCmd("B"))
+	if err := os.WriteFile(filepath.Join(cfg, "prism", "accounts", "work.json"), workBlob, 0o600); err != nil {
+		t.Fatalf("write work: %v", err)
+	}
+
+	_, err := runSubcommand(t, runAccountUse, []string{"work"})
+	if err != nil {
+		t.Fatalf("use: %v", err)
+	}
+
+	data, _ := os.ReadFile(auth)
+	var got map[string]any
+	_ = json.Unmarshal(data, &got)
+	anth, _ := got["anthropic"].(map[string]any)
+	if anth["access"] != "access-B" {
+		t.Errorf("auth.json not swapped: %v", anth)
+	}
+
+	curPath := filepath.Join(cfg, "prism", "accounts", "current")
+	curData, _ := os.ReadFile(curPath)
+	if strings.TrimSpace(string(curData)) != "work" {
+		t.Errorf("current = %q, want \"work\"", curData)
+	}
+}
+
+// ─── rm ───────────────────────────────────────────────────────────────
+
+func TestAccountRm_DeletesFile(t *testing.T) {
+	cfg, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+	// Set up default + a non-active "work" account.
+	if _, err := runSubcommand(t, runAccountList, nil); err != nil {
+		t.Fatalf("init via list: %v", err)
+	}
+	workPath := filepath.Join(cfg, "prism", "accounts", "work.json")
+	if err := os.WriteFile(workPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write work: %v", err)
+	}
+
+	if _, err := runSubcommand(t, runAccountRm, []string{"work"}); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+	if _, err := os.Stat(workPath); !os.IsNotExist(err) {
+		t.Errorf("rm did not delete file: %v", err)
+	}
+}
+
+func TestAccountRm_RefusesActive(t *testing.T) {
+	cfg, auth := withAccountFixture(t)
+	writeAuthFile(t, auth, map[string]any{"anthropic": sampleAnthropicCmd("A")})
+	if _, err := runSubcommand(t, runAccountList, nil); err != nil {
+		t.Fatalf("init via list: %v", err)
+	}
+	_, err := runSubcommand(t, runAccountRm, []string{"default"})
+	if err == nil {
+		t.Fatal("rm(default): want error, got nil")
+	}
+	if _, statErr := os.Stat(filepath.Join(cfg, "prism", "accounts", "default.json")); statErr != nil {
+		t.Errorf("rm(active) deleted file: %v", statErr)
+	}
+}
+
+func TestAccountRm_NonExistent_Errors(t *testing.T) {
+	_, _ = withAccountFixture(t)
+	_, err := runSubcommand(t, runAccountRm, []string{"ghost"})
+	if err == nil {
+		t.Fatal("rm(ghost): want error, got nil")
+	}
+}

--- a/modules/programs/prism/prism/internal/account/account.go
+++ b/modules/programs/prism/prism/internal/account/account.go
@@ -299,6 +299,14 @@ func Use(p Paths, name string) error {
 		return fmt.Errorf("account use %s: %w", name, err)
 	}
 	if hasPrev {
+		// Defence in depth: validate `prev` as if it were a user-supplied
+		// name. Writing to accounts/current already requires user-level
+		// access to the 0o700 accounts dir, so a malicious value here
+		// presupposes a compromise, but skipping a snapshot is the safer
+		// failure mode than letting a path-traversing name out the door.
+		if err := validName(prev); err != nil {
+			return fmt.Errorf("account use %s: malformed previous account name in %s: %w", name, p.Current, err)
+		}
 		liveBlob, blobErr := readAnthropicBlob(p.AuthJSON)
 		if blobErr == nil {
 			if err := atomicWriteFile(p.AccountPath(prev), liveBlob, fileMode); err != nil {

--- a/modules/programs/prism/prism/internal/account/account.go
+++ b/modules/programs/prism/prism/internal/account/account.go
@@ -1,0 +1,475 @@
+// Package account implements the on-disk account store and atomic
+// switching logic behind `prism account` (#2283).
+//
+// Background
+// ----------
+//
+// Pi treats ~/.pi/agent/auth.json as a singleton — there's exactly one
+// Anthropic OAuth blob at a time. Switching between Claude OAuth
+// subscriptions used to require quitting prism, running `pi /login
+// anthropic` to overwrite the file, then `prism restart`. This package
+// stores each subscription's "anthropic" blob as a named file under
+// ~/.config/prism/accounts/<name>.json and atomically merges the chosen
+// blob into the live auth.json on switch. Pi's existing credential cache
+// (with the mtime-invalidation tweak in #2283) then picks up the new
+// tokens on its next request.
+//
+// On-disk layout
+// --------------
+//
+//	~/.config/prism/accounts/
+//	  <name>.json         the value of auth.json's "anthropic" key
+//	                      (e.g. {"type":"oauth","access":"...","refresh":"...","expires":...})
+//	  current             plain text: the active account name, one line
+//
+// Mode bits: directory 0o700, all files 0o600.
+//
+// Atomicity
+// ---------
+//
+// Every write goes through a tempfile in the same directory followed by
+// an os.Rename. Snapshot-before-swap means a SIGTERM after we've written
+// the new auth.json tempfile but before the rename leaves the live file
+// byte-identical to its pre-invocation contents.
+//
+// Security
+// --------
+//
+// No function in this package ever returns or logs a token value. The
+// error strings are intentionally token-free; callers can print them
+// directly.
+package account
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// anthropicKey is the top-level key in auth.json that holds the Anthropic
+// OAuth blob. `prism account` swaps only this key; sibling keys
+// (github-copilot, …) are preserved byte-identical.
+const anthropicKey = "anthropic"
+
+// currentFileName is the basename of the pointer file inside the accounts
+// directory. Its content is a single line: the active account name.
+const currentFileName = "current"
+
+// defaultAccountName is the name used by the first-run migration to
+// snapshot the existing auth.json's anthropic blob.
+const defaultAccountName = "default"
+
+// Mode bits used throughout. Centralised so the security AC has a single
+// place to enforce.
+const (
+	dirMode  os.FileMode = 0o700
+	fileMode os.FileMode = 0o600
+)
+
+// Paths bundles the resolved on-disk paths this package operates on. All
+// fields are absolute paths. AuthJSON honours $PI_AUTH_JSON for tests and
+// for the documented manual escape-hatch (PI_AUTH_JSON=… pi).
+type Paths struct {
+	Dir      string // ~/.config/prism/accounts
+	Current  string // ~/.config/prism/accounts/current
+	AuthJSON string // ~/.pi/agent/auth.json (or $PI_AUTH_JSON)
+}
+
+// ResolvePaths computes the canonical paths from $HOME / $XDG_CONFIG_HOME
+// / $PI_AUTH_JSON. Returns an error only when the home directory cannot
+// be resolved at all — empty $HOME, $XDG_CONFIG_HOME unset, and
+// $PI_AUTH_JSON unset all at once. Callers that intend to write must call
+// Init before using these paths.
+func ResolvePaths() (Paths, error) {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return Paths{}, fmt.Errorf("account: resolve home dir: %w", err)
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	dir := filepath.Join(configHome, "prism", "accounts")
+
+	authJSON := os.Getenv("PI_AUTH_JSON")
+	if authJSON == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return Paths{}, fmt.Errorf("account: resolve home dir: %w", err)
+		}
+		authJSON = filepath.Join(home, ".pi", "agent", "auth.json")
+	}
+
+	return Paths{
+		Dir:      dir,
+		Current:  filepath.Join(dir, currentFileName),
+		AuthJSON: authJSON,
+	}, nil
+}
+
+// AccountPath returns the absolute path of a named account file. Does not
+// verify the file exists.
+func (p Paths) AccountPath(name string) string {
+	return filepath.Join(p.Dir, name+".json")
+}
+
+// validName enforces that `name` is a non-empty single path component
+// with no separator characters. Account names are used directly as
+// filenames so we must reject anything that could traverse out of the
+// accounts dir.
+func validName(name string) error {
+	if name == "" {
+		return errors.New("account name must not be empty")
+	}
+	if strings.ContainsRune(name, os.PathSeparator) || strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return fmt.Errorf("account name %q must not contain path separators", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("account name %q is reserved", name)
+	}
+	if name == currentFileName {
+		return fmt.Errorf("account name %q collides with the pointer file", name)
+	}
+	return nil
+}
+
+// Init runs the first-run migration: if the accounts directory does not
+// exist, create it (mode 0o700), snapshot the existing auth.json's
+// anthropic blob (if present) to accounts/default.json (mode 0o600), and
+// write accounts/current ← "default". Idempotent — a no-op when the
+// accounts directory already exists. Callers must invoke this before any
+// other operation in this package.
+func Init(p Paths) error {
+	if _, err := os.Stat(p.Dir); err == nil {
+		// Directory already exists — first run already happened. Do not
+		// touch any existing files.
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("account: stat %s: %w", p.Dir, err)
+	}
+
+	if err := os.MkdirAll(p.Dir, dirMode); err != nil {
+		return fmt.Errorf("account: create %s: %w", p.Dir, err)
+	}
+	// MkdirAll respects umask, which on most hosts is 022 → 0o755. Force
+	// the AC-mandated 0o700 explicitly.
+	if err := os.Chmod(p.Dir, dirMode); err != nil {
+		return fmt.Errorf("account: chmod %s: %w", p.Dir, err)
+	}
+
+	// Snapshot the existing auth.json's anthropic blob (if any).
+	blob, err := readAnthropicBlob(p.AuthJSON)
+	if err != nil {
+		// Malformed auth.json or a read error other than ENOENT.
+		// Surface but do not abort: the migration should still leave the
+		// user with a usable accounts/ directory.
+		if !errors.Is(err, errNoAnthropicKey) && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("account: read %s: %w", p.AuthJSON, err)
+		}
+		// Either auth.json is absent or it has no anthropic key — leave
+		// accounts/ empty. The user can run `prism account save` later.
+		return nil
+	}
+
+	if err := atomicWriteFile(p.AccountPath(defaultAccountName), blob, fileMode); err != nil {
+		return fmt.Errorf("account: write default snapshot: %w", err)
+	}
+	if err := atomicWriteFile(p.Current, []byte(defaultAccountName+"\n"), fileMode); err != nil {
+		return fmt.Errorf("account: write current pointer: %w", err)
+	}
+	return nil
+}
+
+// List returns the account names available in p.Dir, sorted
+// lexicographically. Only files matching *.json are considered — the
+// `current` pointer file is ignored. Returns an empty slice if the
+// directory is empty.
+func List(p Paths) ([]string, error) {
+	entries, err := os.ReadDir(p.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("account: read %s: %w", p.Dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if !strings.HasSuffix(n, ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(n, ".json"))
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Current returns the active account name and whether the pointer file
+// exists with non-empty contents. Read errors other than ENOENT are
+// surfaced. A missing or whitespace-only pointer file is reported as
+// (`"", false, nil`) — callers render that as "none".
+func Current(p Paths) (string, bool, error) {
+	data, err := os.ReadFile(p.Current)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("account: read %s: %w", p.Current, err)
+	}
+	name := strings.TrimSpace(string(data))
+	if name == "" {
+		return "", false, nil
+	}
+	return name, true, nil
+}
+
+// Save snapshots the live auth.json's anthropic blob to
+// accounts/<name>.json (mode 0o600). Returns an error if auth.json has
+// no anthropic key; the destination file is not created in that case.
+// Does not modify accounts/current.
+func Save(p Paths, name string) error {
+	if err := validName(name); err != nil {
+		return err
+	}
+	blob, err := readAnthropicBlob(p.AuthJSON)
+	if err != nil {
+		if errors.Is(err, errNoAnthropicKey) {
+			return fmt.Errorf("account save %s: %s has no \"anthropic\" key — run `/login anthropic` in pi first", name, p.AuthJSON)
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("account save %s: %s does not exist — run `/login anthropic` in pi first", name, p.AuthJSON)
+		}
+		return fmt.Errorf("account save %s: read %s: %w", name, p.AuthJSON, err)
+	}
+	if err := atomicWriteFile(p.AccountPath(name), blob, fileMode); err != nil {
+		return fmt.Errorf("account save %s: %w", name, err)
+	}
+	return nil
+}
+
+// Use atomically switches the live auth.json's anthropic blob to the
+// contents of accounts/<name>.json. The sequence is:
+//
+//  1. Validate accounts/<name>.json exists and parses as JSON. Abort
+//     before touching auth.json if it does not.
+//  2. Snapshot the live auth.json's anthropic blob to
+//     accounts/<previous>.json, where <previous> is the contents of
+//     accounts/current at the moment of invocation. Skip the snapshot
+//     when there is no previous account or when the live auth.json has
+//     no anthropic key.
+//  3. Build the new auth.json contents: existing top-level keys
+//     preserved byte-identical, the anthropic key replaced with the
+//     target blob.
+//  4. Tempfile + rename auth.json (mode 0o600). A SIGTERM between steps
+//     3 and 4 leaves auth.json byte-identical to its pre-invocation
+//     contents.
+//  5. Tempfile + rename accounts/current ← <name>.
+//
+// If step 2 fails, abort before step 3 — we do not want to swap the
+// live blob away while the snapshot is missing.
+func Use(p Paths, name string) error {
+	if err := validName(name); err != nil {
+		return err
+	}
+
+	targetPath := p.AccountPath(name)
+	target, err := os.ReadFile(targetPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("account use %s: %s does not exist — run `prism account list` to see available accounts", name, targetPath)
+		}
+		return fmt.Errorf("account use %s: read %s: %w", name, targetPath, err)
+	}
+	// Validate that the file parses as JSON before doing anything else.
+	// We deliberately do not require any particular shape — pi's writer
+	// shape may evolve. The merge step rebuilds the file from this raw
+	// blob; an invalid JSON would corrupt auth.json.
+	var probe json.RawMessage
+	if err := json.Unmarshal(target, &probe); err != nil {
+		return fmt.Errorf("account use %s: %s is not valid JSON: %w", name, targetPath, err)
+	}
+
+	// Step 2: snapshot the live blob back to <previous>.
+	prev, hasPrev, err := Current(p)
+	if err != nil {
+		return fmt.Errorf("account use %s: %w", name, err)
+	}
+	if hasPrev {
+		liveBlob, blobErr := readAnthropicBlob(p.AuthJSON)
+		if blobErr == nil {
+			if err := atomicWriteFile(p.AccountPath(prev), liveBlob, fileMode); err != nil {
+				return fmt.Errorf("account use %s: snapshot previous account %q: %w", name, prev, err)
+			}
+		} else if !errors.Is(blobErr, errNoAnthropicKey) && !errors.Is(blobErr, os.ErrNotExist) {
+			// A real read/parse error against the live auth.json means we
+			// cannot safely proceed: continuing would risk losing the
+			// previous refresh token rotation. Abort before touching
+			// anything.
+			return fmt.Errorf("account use %s: read live %s: %w", name, p.AuthJSON, blobErr)
+		}
+		// errNoAnthropicKey or ENOENT: nothing to snapshot, proceed.
+	}
+
+	// Step 3: build merged auth.json content.
+	merged, err := mergeAnthropicBlob(p.AuthJSON, target)
+	if err != nil {
+		return fmt.Errorf("account use %s: merge %s: %w", name, p.AuthJSON, err)
+	}
+
+	// Step 4: atomic rename of auth.json.
+	if err := atomicWriteFile(p.AuthJSON, merged, fileMode); err != nil {
+		return fmt.Errorf("account use %s: write %s: %w", name, p.AuthJSON, err)
+	}
+
+	// Step 5: update the pointer.
+	if err := atomicWriteFile(p.Current, []byte(name+"\n"), fileMode); err != nil {
+		return fmt.Errorf("account use %s: write %s: %w", name, p.Current, err)
+	}
+	return nil
+}
+
+// Remove deletes accounts/<name>.json. Refuses with a clear error if
+// <name> is the currently-active account (per accounts/current); the
+// file is not deleted in that case. Refuses with a clear error if the
+// file does not exist.
+func Remove(p Paths, name string) error {
+	if err := validName(name); err != nil {
+		return err
+	}
+	cur, hasCur, err := Current(p)
+	if err != nil {
+		return fmt.Errorf("account rm %s: %w", name, err)
+	}
+	if hasCur && cur == name {
+		return fmt.Errorf("account rm %s: refusing to delete the active account — switch with `prism account use <other>` first", name)
+	}
+	path := p.AccountPath(name)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("account rm %s: %s does not exist", name, path)
+		}
+		return fmt.Errorf("account rm %s: %w", name, err)
+	}
+	return nil
+}
+
+// errNoAnthropicKey signals that auth.json exists and parses as JSON but
+// has no top-level "anthropic" key. Distinguished from a read/parse
+// error so callers can take a different action (Init: skip snapshot;
+// Save: error to user; Use: skip the previous-account snapshot step).
+var errNoAnthropicKey = errors.New("auth.json has no anthropic key")
+
+// readAnthropicBlob returns the raw JSON bytes of auth.json's
+// "anthropic" key. The returned slice is the value (an object), not the
+// `{"anthropic":…}` wrapper. Returns errNoAnthropicKey when the key is
+// absent, os.ErrNotExist when the file is absent, and a wrapped parse
+// error when the file is malformed.
+func readAnthropicBlob(authJSONPath string) ([]byte, error) {
+	data, err := os.ReadFile(authJSONPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, errNoAnthropicKey
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", authJSONPath, err)
+	}
+	raw, ok := top[anthropicKey]
+	if !ok {
+		return nil, errNoAnthropicKey
+	}
+	// Re-serialise with indent so the snapshot file reads cleanly. The
+	// value itself round-trips byte-equivalently for canonical inputs;
+	// we accept that we may normalise whitespace.
+	var pretty json.RawMessage
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return nil, fmt.Errorf("parse %s anthropic blob: %w", authJSONPath, err)
+	}
+	out, err := json.MarshalIndent(pretty, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s anthropic blob: %w", authJSONPath, err)
+	}
+	out = append(out, '\n')
+	return out, nil
+}
+
+// mergeAnthropicBlob reads authJSONPath, replaces its top-level
+// "anthropic" key with `blob`, and returns the serialised bytes. Other
+// top-level keys are preserved with their JSON bytes intact
+// (json.RawMessage round-trip). When authJSONPath does not exist or is
+// empty the result is a single-key object {"anthropic": blob}.
+func mergeAnthropicBlob(authJSONPath string, blob []byte) ([]byte, error) {
+	top := map[string]json.RawMessage{}
+	data, err := os.ReadFile(authJSONPath)
+	if err == nil && len(data) > 0 {
+		if err := json.Unmarshal(data, &top); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", authJSONPath, err)
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read %s: %w", authJSONPath, err)
+	}
+	// json.RawMessage requires a self-contained valid JSON value.
+	var rm json.RawMessage = append([]byte(nil), blob...)
+	if err := json.Unmarshal(rm, new(json.RawMessage)); err != nil {
+		return nil, fmt.Errorf("blob is not valid JSON: %w", err)
+	}
+	top[anthropicKey] = rm
+
+	out, err := json.MarshalIndent(top, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal merged auth.json: %w", err)
+	}
+	out = append(out, '\n')
+	return out, nil
+}
+
+// atomicWriteFile writes `data` to `path` atomically via a tempfile in
+// the same directory followed by os.Rename. The tempfile is created
+// with the requested mode bits (an explicit Chmod after creation in
+// case the OS umask masked them). Best-effort cleanup on failure.
+//
+// Crash safety: a SIGTERM between OpenFile and Rename leaves `path`
+// untouched — the tempfile is orphaned but the target is byte-identical
+// to its pre-invocation contents. This is the property the SIGTERM AC
+// requires.
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	// O_EXCL guards against an attacker pre-creating the tempfile.
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write %s: %w", tmpPath, err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("chmod %s: %w", tmpPath, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("fsync %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename %s → %s: %w", tmpPath, path, err)
+	}
+	return nil
+}

--- a/modules/programs/prism/prism/internal/account/account_test.go
+++ b/modules/programs/prism/prism/internal/account/account_test.go
@@ -404,6 +404,45 @@ func TestUse_UnknownName_DoesNotTouchAuthJsonOrCurrent(t *testing.T) {
 	}
 }
 
+// Defence in depth: a malformed name written into accounts/current
+// (path traversal, embedded separator, etc.) must be rejected before
+// it is used to construct the snapshot path. Reaching this branch
+// presupposes user-level compromise of the 0o700 accounts dir, but
+// failing safe is cheaper than letting the bad name flow through.
+func TestUse_MalformedPreviousNameInCurrent_ErrorsBeforeTouchingAuthJson(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// Stuff a path-traversing name into accounts/current.
+	if err := os.WriteFile(p.Current, []byte("../escape\n"), 0o600); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	// Create a legitimate target the user is trying to switch to.
+	targetBlob, _ := json.Marshal(sampleAnthropic("B"))
+	if err := os.WriteFile(p.AccountPath("work"), targetBlob, 0o600); err != nil {
+		t.Fatalf("write work: %v", err)
+	}
+	originalAuth, _ := os.ReadFile(p.AuthJSON)
+
+	err := Use(p, "work")
+	if err == nil {
+		t.Fatal("Use with malformed previous name: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed previous account name") {
+		t.Errorf("error %q does not mention the malformed previous name", err)
+	}
+	afterAuth, _ := os.ReadFile(p.AuthJSON)
+	if string(afterAuth) != string(originalAuth) {
+		t.Errorf("auth.json mutated despite malformed previous name")
+	}
+	// And the escape path must not have been created.
+	if _, statErr := os.Stat(filepath.Join(p.Dir, "..", "escape.json")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("escape file appeared at %s: %v", filepath.Join(p.Dir, "..", "escape.json"), statErr)
+	}
+}
+
 func TestUse_MalformedTargetFile_ErrorsBeforeTouchingAuthJson(t *testing.T) {
 	p := fixture(t)
 	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})

--- a/modules/programs/prism/prism/internal/account/account_test.go
+++ b/modules/programs/prism/prism/internal/account/account_test.go
@@ -1,0 +1,655 @@
+// Package account tests for the on-disk store and atomic swap logic
+// behind `prism account` (#2283).
+//
+// All tests are hermetic: $XDG_CONFIG_HOME is redirected to a per-test
+// tempdir and $PI_AUTH_JSON points at a file inside that tempdir.
+// Nothing here touches ~/.pi/agent/auth.json or the user's real
+// ~/.config/prism. This is required for the nix-build homeless-shelter
+// sandbox (HOME=/homeless-shelter is unwritable).
+package account
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// fixture sets up an isolated $XDG_CONFIG_HOME / $PI_AUTH_JSON pair and
+// returns the resolved Paths plus the temp auth.json path. The accounts
+// directory is NOT pre-created — Init() must do that.
+func fixture(t *testing.T) Paths {
+	t.Helper()
+	root := t.TempDir()
+	cfg := filepath.Join(root, "config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+
+	piDir := filepath.Join(root, "pi", "agent")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatalf("mkdir pi agent: %v", err)
+	}
+	authPath := filepath.Join(piDir, "auth.json")
+	t.Setenv("PI_AUTH_JSON", authPath)
+
+	p, err := ResolvePaths()
+	if err != nil {
+		t.Fatalf("ResolvePaths: %v", err)
+	}
+	if p.AuthJSON != authPath {
+		t.Fatalf("PI_AUTH_JSON not honoured: got %q want %q", p.AuthJSON, authPath)
+	}
+	return p
+}
+
+// writeAuthJSON writes auth.json with the given top-level object. mode
+// defaults to 0o600 so tests do not produce permission warnings.
+func writeAuthJSON(t *testing.T, p Paths, top map[string]any) {
+	t.Helper()
+	data, err := json.MarshalIndent(top, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p.AuthJSON), 0o700); err != nil {
+		t.Fatalf("mkdir auth dir: %v", err)
+	}
+	if err := os.WriteFile(p.AuthJSON, data, 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+}
+
+func readAuthJSON(t *testing.T, p Paths) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(p.AuthJSON)
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse auth.json: %v", err)
+	}
+	return out
+}
+
+// sampleAnthropic returns a representative anthropic blob shape (the
+// same shape pi writes after a token refresh — type/access/refresh/
+// expires).
+func sampleAnthropic(suffix string) map[string]any {
+	return map[string]any{
+		"type":    "oauth",
+		"access":  "access-" + suffix,
+		"refresh": "refresh-" + suffix,
+		"expires": 1_000_000_000,
+	}
+}
+
+// ─── Init / first-run migration ──────────────────────────────────────
+
+func TestInit_CreatesDirAt0700_AndSnapshotsExistingAuthJson(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{
+		"anthropic":      sampleAnthropic("A"),
+		"github-copilot": map[string]any{"token": "gh"},
+	})
+
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	info, err := os.Stat(p.Dir)
+	if err != nil {
+		t.Fatalf("stat accounts dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("accounts dir is not a directory")
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("accounts dir mode = %o, want 0700", perm)
+	}
+
+	// default.json must exist with mode 0o600 and contain the anthropic blob.
+	defPath := p.AccountPath("default")
+	fi, err := os.Stat(defPath)
+	if err != nil {
+		t.Fatalf("stat default.json: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("default.json mode = %o, want 0600", perm)
+	}
+	data, err := os.ReadFile(defPath)
+	if err != nil {
+		t.Fatalf("read default.json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse default.json: %v", err)
+	}
+	if got["access"] != "access-A" || got["refresh"] != "refresh-A" {
+		t.Errorf("default.json snapshot mismatch: %v", got)
+	}
+
+	// current points at "default".
+	cur, ok, err := Current(p)
+	if err != nil || !ok || cur != "default" {
+		t.Errorf("Current = (%q, %v, %v); want (\"default\", true, nil)", cur, ok, err)
+	}
+}
+
+func TestInit_Idempotent_PreservesExistingDir(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init #1: %v", err)
+	}
+	// Tamper with default.json after init.
+	custom := []byte(`{"type":"oauth","access":"do-not-overwrite","refresh":"x","expires":1}`)
+	if err := os.WriteFile(p.AccountPath("default"), custom, 0o600); err != nil {
+		t.Fatalf("retamper: %v", err)
+	}
+	if err := Init(p); err != nil {
+		t.Fatalf("Init #2: %v", err)
+	}
+	got, err := os.ReadFile(p.AccountPath("default"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(custom) {
+		t.Errorf("Init #2 overwrote default.json")
+	}
+}
+
+func TestInit_NoAuthJson_CreatesEmptyDir(t *testing.T) {
+	p := fixture(t)
+	// auth.json deliberately absent.
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if _, err := os.Stat(p.Dir); err != nil {
+		t.Errorf("accounts dir missing: %v", err)
+	}
+	// No default.json, no current.
+	if _, err := os.Stat(p.AccountPath("default")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("default.json should be absent when auth.json is absent: %v", err)
+	}
+	if _, err := os.Stat(p.Current); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("current should be absent when auth.json is absent: %v", err)
+	}
+}
+
+func TestInit_AuthJsonWithoutAnthropic_CreatesEmptyDir(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"github-copilot": map[string]any{"token": "gh"}})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if _, err := os.Stat(p.AccountPath("default")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("default.json should be absent when auth.json has no anthropic key: %v", err)
+	}
+}
+
+// ─── List / Current ──────────────────────────────────────────────────
+
+func TestList_ReturnsSortedNames_IgnoresCurrentFile(t *testing.T) {
+	p := fixture(t)
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p.AccountPath("work"), []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write work: %v", err)
+	}
+	if err := os.WriteFile(p.AccountPath("personal"), []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write personal: %v", err)
+	}
+	if err := os.WriteFile(p.Current, []byte("work\n"), 0o600); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+
+	names, err := List(p)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	want := []string{"personal", "work"}
+	if !equalSlices(names, want) {
+		t.Errorf("List = %v, want %v", names, want)
+	}
+}
+
+func TestCurrent_MissingFile_ReturnsEmpty(t *testing.T) {
+	p := fixture(t)
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cur, ok, err := Current(p)
+	if cur != "" || ok || err != nil {
+		t.Errorf("Current = (%q, %v, %v); want (\"\", false, nil)", cur, ok, err)
+	}
+}
+
+// ─── Save ────────────────────────────────────────────────────────────
+
+func TestSave_WritesAnthropicBlob_Mode0600(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := Save(p, "work"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	fi, err := os.Stat(p.AccountPath("work"))
+	if err != nil {
+		t.Fatalf("stat work.json: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("work.json mode = %o, want 0600", perm)
+	}
+	data, err := os.ReadFile(p.AccountPath("work"))
+	if err != nil {
+		t.Fatalf("read work.json: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["access"] != "access-A" {
+		t.Errorf("Save did not copy anthropic blob: %v", got)
+	}
+}
+
+func TestSave_NoAnthropicKey_ErrorsWithoutCreatingFile(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"github-copilot": map[string]any{"token": "gh"}})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	err := Save(p, "work")
+	if err == nil {
+		t.Fatal("Save: want error when auth.json has no anthropic key")
+	}
+	if !strings.Contains(err.Error(), "anthropic") {
+		t.Errorf("Save error %q must mention the missing key", err)
+	}
+	if _, statErr := os.Stat(p.AccountPath("work")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("Save created work.json on error: %v", statErr)
+	}
+	// The error must not leak any token value (defensive).
+	if strings.Contains(err.Error(), "access-") || strings.Contains(err.Error(), "refresh-") {
+		t.Errorf("Save error must not contain token substrings: %q", err)
+	}
+}
+
+func TestSave_RejectsBadNames(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	cases := []string{"", "../escape", "with/slash", ".", "..", "current"}
+	for _, name := range cases {
+		if err := Save(p, name); err == nil {
+			t.Errorf("Save(%q): want error, got nil", name)
+		}
+	}
+}
+
+// ─── Use ─────────────────────────────────────────────────────────────
+
+func TestUse_SwapsAnthropicKey_PreservesOtherTopLevelKeys(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{
+		"anthropic":      sampleAnthropic("A"),
+		"github-copilot": map[string]any{"token": "gh-original", "type": "oauth"},
+		"someOther":      42.0,
+	})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// Create "work" account by hand-writing the blob (Save is exercised elsewhere).
+	workBlob, _ := json.Marshal(sampleAnthropic("B"))
+	if err := os.WriteFile(p.AccountPath("work"), workBlob, 0o600); err != nil {
+		t.Fatalf("write work: %v", err)
+	}
+
+	if err := Use(p, "work"); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+	got := readAuthJSON(t, p)
+	anth, _ := got["anthropic"].(map[string]any)
+	if anth["access"] != "access-B" || anth["refresh"] != "refresh-B" {
+		t.Errorf("anthropic blob not swapped: %v", anth)
+	}
+	gh, _ := got["github-copilot"].(map[string]any)
+	if gh["token"] != "gh-original" || gh["type"] != "oauth" {
+		t.Errorf("github-copilot block was altered: %v", gh)
+	}
+	if got["someOther"].(float64) != 42 {
+		t.Errorf("someOther scalar altered: %v", got["someOther"])
+	}
+}
+
+func TestUse_SnapshotsPreviousAccountBeforeSwapping(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("ROTATED")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// Init wrote a baseline default.json. Now simulate a token rotation:
+	// pi refreshed the live auth.json's refresh token in the background.
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("ROTATED-AGAIN")})
+
+	// Create the swap target.
+	workBlob, _ := json.Marshal(sampleAnthropic("B"))
+	if err := os.WriteFile(p.AccountPath("work"), workBlob, 0o600); err != nil {
+		t.Fatalf("write work: %v", err)
+	}
+	if err := Use(p, "work"); err != nil {
+		t.Fatalf("Use: %v", err)
+	}
+
+	// default.json must now contain the rotated blob captured at the
+	// moment of the use call, NOT the original Init snapshot.
+	data, err := os.ReadFile(p.AccountPath("default"))
+	if err != nil {
+		t.Fatalf("read default: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got["refresh"] != "refresh-ROTATED-AGAIN" {
+		t.Errorf("snapshot did not capture the latest live refresh token: %v", got)
+	}
+
+	// And current now reads "work".
+	cur, ok, err := Current(p)
+	if err != nil || !ok || cur != "work" {
+		t.Errorf("Current after Use = (%q, %v, %v); want (\"work\", true, nil)", cur, ok, err)
+	}
+}
+
+func TestUse_UnknownName_DoesNotTouchAuthJsonOrCurrent(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{
+		"anthropic": sampleAnthropic("A"),
+	})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	originalAuth, _ := os.ReadFile(p.AuthJSON)
+	originalCur, _ := os.ReadFile(p.Current)
+
+	err := Use(p, "does-not-exist")
+	if err == nil {
+		t.Fatal("Use(does-not-exist): want error, got nil")
+	}
+	// Error message must name the missing path (AC).
+	if !strings.Contains(err.Error(), "does-not-exist.json") {
+		t.Errorf("error %q does not name the missing path", err)
+	}
+
+	afterAuth, _ := os.ReadFile(p.AuthJSON)
+	afterCur, _ := os.ReadFile(p.Current)
+	if string(afterAuth) != string(originalAuth) {
+		t.Errorf("auth.json mutated on failed Use")
+	}
+	if string(afterCur) != string(originalCur) {
+		t.Errorf("current mutated on failed Use")
+	}
+}
+
+func TestUse_MalformedTargetFile_ErrorsBeforeTouchingAuthJson(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := os.WriteFile(p.AccountPath("bad"), []byte("not-json{"), 0o600); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+	originalAuth, _ := os.ReadFile(p.AuthJSON)
+	originalCur, _ := os.ReadFile(p.Current)
+
+	if err := Use(p, "bad"); err == nil {
+		t.Fatal("Use(bad): want error, got nil")
+	}
+	afterAuth, _ := os.ReadFile(p.AuthJSON)
+	afterCur, _ := os.ReadFile(p.Current)
+	if string(afterAuth) != string(originalAuth) {
+		t.Errorf("auth.json mutated on malformed-target Use")
+	}
+	if string(afterCur) != string(originalCur) {
+		t.Errorf("current mutated on malformed-target Use")
+	}
+	// On a malformed target we MUST NOT have snapshot-rewritten default.json
+	// either — the snapshot step happens after the JSON-validity check.
+	defaultData, _ := os.ReadFile(p.AccountPath("default"))
+	var probe map[string]any
+	if err := json.Unmarshal(defaultData, &probe); err != nil {
+		t.Errorf("default.json was corrupted on malformed-target Use: %v", err)
+	}
+}
+
+// ─── SIGTERM mid-write atomicity ─────────────────────────────────────
+
+// Direct SIGTERM injection is impractical in a unit test. Instead we
+// exercise the actual atomic-write helper end-to-end and check the
+// invariant that the spec requires: between the tempfile write and the
+// final rename, the target is byte-identical to its pre-invocation
+// contents. We achieve this by inspecting the directory state at the
+// moment the tempfile has been written but the rename has not yet
+// happened — implemented by intercepting the rename via a test-local
+// helper that re-implements atomicWriteFile without the rename.
+//
+// This is the AC's invariant: any crash between the write and the
+// rename leaves auth.json untouched.
+func TestUse_SIGTERMBeforeRename_AuthJsonByteIdentical(t *testing.T) {
+	p := fixture(t)
+	original := map[string]any{
+		"anthropic":      sampleAnthropic("A"),
+		"github-copilot": map[string]any{"token": "gh"},
+	}
+	writeAuthJSON(t, p, original)
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	beforeBytes, err := os.ReadFile(p.AuthJSON)
+	if err != nil {
+		t.Fatalf("read pre auth.json: %v", err)
+	}
+	beforeMode, _ := os.Stat(p.AuthJSON)
+
+	// Replicate atomicWriteFile up to (but not including) the rename. This
+	// is the exact state a SIGTERM between steps 3 and 4 would leave
+	// behind: a fully-written tempfile next to an untouched auth.json.
+	dir := filepath.Dir(p.AuthJSON)
+	tmp, err := os.CreateTemp(dir, filepath.Base(p.AuthJSON)+".*.tmp")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := tmp.Write([]byte(`{"would":"have-been-the-new-content"}`)); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		t.Fatalf("chmod temp: %v", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		t.Fatalf("sync temp: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+	// Deliberately do NOT call os.Rename. SIGTERM landed here.
+
+	afterBytes, err := os.ReadFile(p.AuthJSON)
+	if err != nil {
+		t.Fatalf("read post auth.json: %v", err)
+	}
+	afterMode, _ := os.Stat(p.AuthJSON)
+	if string(afterBytes) != string(beforeBytes) {
+		t.Errorf("auth.json mutated despite no rename — atomicity broken")
+	}
+	if beforeMode.Mode().Perm() != afterMode.Mode().Perm() {
+		t.Errorf("auth.json mode changed: %o → %o", beforeMode.Mode().Perm(), afterMode.Mode().Perm())
+	}
+
+	// And the original content must still be parseable as the original
+	// shape (defensive — verifies we didn't truncate or otherwise corrupt).
+	var parsed map[string]any
+	if err := json.Unmarshal(afterBytes, &parsed); err != nil {
+		t.Fatalf("auth.json corrupted: %v", err)
+	}
+	anth, _ := parsed["anthropic"].(map[string]any)
+	if anth["access"] != "access-A" {
+		t.Errorf("auth.json content mutated: %v", parsed)
+	}
+}
+
+// atomicWriteFile creates the temp file with mode 0o600 — verify so the
+// security AC has direct coverage.
+func TestAtomicWriteFile_TargetMode0600(t *testing.T) {
+	p := fixture(t)
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := p.AccountPath("explicit")
+	if err := atomicWriteFile(target, []byte(`{"a":1}`), 0o600); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	fi, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %o, want 0600", perm)
+	}
+}
+
+// ─── Remove ──────────────────────────────────────────────────────────
+
+func TestRemove_DeletesFile(t *testing.T) {
+	p := fixture(t)
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p.AccountPath("work"), []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := Remove(p, "work"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := os.Stat(p.AccountPath("work")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("file still exists after Remove")
+	}
+}
+
+func TestRemove_RefusesActiveAccount(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{"anthropic": sampleAnthropic("A")})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// default is the active account.
+	err := Remove(p, "default")
+	if err == nil {
+		t.Fatal("Remove(default): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "active") {
+		t.Errorf("error %q must mention that this is the active account", err)
+	}
+	if _, statErr := os.Stat(p.AccountPath("default")); statErr != nil {
+		t.Errorf("active account file deleted despite refusal: %v", statErr)
+	}
+}
+
+func TestRemove_NonExistent_Errors(t *testing.T) {
+	p := fixture(t)
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	err := Remove(p, "ghost")
+	if err == nil {
+		t.Fatal("Remove(ghost): want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error %q should say the account does not exist", err)
+	}
+}
+
+// ─── Security: no token leakage in errors ───────────────────────────
+
+// Failure modes hit by `prism account use` must not echo any token
+// value into the returned error. We assert this defensively by stuffing
+// recognisable strings into auth.json and the target blob, triggering
+// each error path, and checking the error message.
+func TestUse_ErrorMessagesNeverContainTokenSubstrings(t *testing.T) {
+	p := fixture(t)
+	writeAuthJSON(t, p, map[string]any{
+		"anthropic": map[string]any{
+			"type":    "oauth",
+			"access":  "TOKEN-SECRET-ACCESS",
+			"refresh": "TOKEN-SECRET-REFRESH",
+			"expires": 1,
+		},
+	})
+	if err := Init(p); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Malformed target — read step fails.
+	if err := os.WriteFile(p.AccountPath("malformed"), []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("write malformed: %v", err)
+	}
+	if err := Use(p, "malformed"); err != nil {
+		assertNoTokenLeak(t, err.Error())
+	}
+
+	// Missing target.
+	if err := Use(p, "missing"); err != nil {
+		assertNoTokenLeak(t, err.Error())
+	}
+
+	// Bad name.
+	if err := Use(p, "../escape"); err != nil {
+		assertNoTokenLeak(t, err.Error())
+	}
+}
+
+func assertNoTokenLeak(t *testing.T, msg string) {
+	t.Helper()
+	banned := []string{
+		"TOKEN-SECRET-ACCESS",
+		"TOKEN-SECRET-REFRESH",
+		"access-A",
+		"refresh-A",
+	}
+	for _, b := range banned {
+		if strings.Contains(msg, b) {
+			t.Errorf("error message leaked token substring %q: %s", b, msg)
+		}
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	x := append([]string(nil), a...)
+	y := append([]string(nil), b...)
+	sort.Strings(x)
+	sort.Strings(y)
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Adds `prism account` for seamless switching between Claude OAuth subscriptions, paired with a small pi-side mtime check so the live pi process picks up the new tokens on its next outbound request without a restart.

### CLI surface

```
prism account list             show accounts, mark active
prism account current          print active account (or "none")
prism account save <name>      snapshot auth.json's anthropic blob
prism account use <name>       atomic swap (snapshot + merge + rename)
prism account rm <name>        delete (refuses the active account)
```

### On-disk layout

```
$XDG_CONFIG_HOME/prism/accounts/    (mode 0o700)
  <name>.json                       (mode 0o600 — the *value* of
                                     auth.json's "anthropic" key,
                                     not a wrapper)
  current                           (mode 0o600 — active account name)
```

### Atomicity

Every write goes through a tempfile + `os.Rename` in the same directory. `prism account use`:

1. Reads `accounts/<name>.json` and validates it parses as JSON. **Abort before touching auth.json if not.**
2. Snapshots the live `auth.json`'s `anthropic` blob to `accounts/<previous>.json` where `<previous>` is the value of `accounts/current` at the moment of invocation. **Abort before step 3 if the snapshot write fails.**
3. Reads `auth.json`, replaces its `anthropic` key with the target blob (siblings like `github-copilot` preserved byte-identical via `json.RawMessage` round-trip), writes a tempfile in the same directory at mode 0o600.
4. `os.Rename` the tempfile over `auth.json`.
5. Tempfile + rename `accounts/current` ← `<name>`.

A SIGTERM between any tempfile write and its matching rename leaves `auth.json` byte-identical to its pre-invocation contents (the rename is the only path that mutates the target).

### First-run migration

The first `prism account` invocation creates the accounts dir with `0o700` and snapshots the existing `auth.json`'s `anthropic` blob (if any) to `accounts/default.json` with `accounts/current ← default`. Idempotent: a no-op when `accounts/` already exists.

### Pi-side: mtime invalidation

`modules/programs/prism/pi/extensions/anthropic-oauth/credentials.ts::getCachedCredentials` now stats `auth.json` before returning a cached blob and bypasses the cache if `mtime > cachedAt`. The `prism account use` rename bumps mtime; the next outbound request in any pi process sees the bump and re-reads instead of serving stale tokens. `statSync` failures (file unlinked mid-flight) fall through to a cache hit — the cache is the last-good copy.

### Security

- Directory `0o700`, files `0o600` (verified by `TestInit_CreatesDirAt0700_…`, `TestSave_WritesAnthropicBlob_Mode0600`, `TestAtomicWriteFile_TargetMode0600`).
- No subcommand prints any token value at any verbosity (verified by `TestUse_ErrorMessagesNeverContainTokenSubstrings`).

### Out of scope (deliberately)

- `prism account login <name>` — deferred to #2284; the manual escape hatch `PI_AUTH_JSON=… pi /login anthropic` remains.
- Any change to `github-copilot` or other provider blobs — the merge-in-place approach preserves them.
- Any `prism spawn --account <name>` flag.

### Verification

```
# from modules/programs/prism/prism/
go build ./...
go test ./internal/account/ ./cmd/ -count=1 -race

# from the repo root
nix build .#prism

# pi-side
node --test --experimental-strip-types \
  modules/programs/prism/pi/extensions/anthropic-oauth/credentials.test.ts
```

All green locally; CI runs the full homeless-shelter suite.

The snapshot-before-swap test (`TestUse_SnapshotsPreviousAccountBeforeSwapping`) and the pi-side mtime test were both verified non-vacuous by neutering the implementation and confirming they fail before re-applying the fix (per `AGENTS.md` discipline).

Closes #2283