### PR TITLE
prism (sandbox): bind-mount ~/.config/prism/profiles.json read-only

### DIFF
--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -597,6 +597,79 @@ func TestBwrapBuildArgs_BunCacheDirAbsentNoBind(t *testing.T) {
 	}
 }
 
+// TestBwrapBuildArgs_PrismProfilesJSONROBound pins the
+// ~/.config/prism/profiles.json single-file RO mount (issue #2286). The CLI's
+// `prism profile list` / `prism profile show` and the available_profiles
+// section of `prism agent-context` open this file directly via
+// internal/config/profiles.go::LoadProfiles; without this mount those
+// commands fail from inside any bwrap-isolated session with a misleading
+// "not found — run the system rebuild" error. Read-only at Dst==Src under
+// $HOME/.config/prism/profiles.json (matching profilesFilePath()'s
+// XDG_CONFIG_HOME-else-$HOME/.config resolution inside the sandbox).
+func TestBwrapBuildArgs_PrismProfilesJSONROBound(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	// The fixture does not pre-create ~/.config/prism/profiles.json — plant
+	// it as a regular file so the conditional (OptionalIfMissing) mount fires.
+	profilesJSON := filepath.Join(fakeHome, ".config", "prism", "profiles.json")
+	if err := os.MkdirAll(filepath.Dir(profilesJSON), 0o755); err != nil {
+		t.Fatalf("MkdirAll ~/.config/prism: %v", err)
+	}
+	if err := os.WriteFile(profilesJSON, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("WriteFile profiles.json: %v", err)
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if !hasROBind(args, profilesJSON) {
+		t.Errorf("profiles.json %q not found as --ro-bind SRC SRC in args: %v", profilesJSON, args)
+	}
+	// RO must not silently become RW — reject any --bind (the RW flag) of
+	// the same path.
+	if hasBind(args, profilesJSON) {
+		t.Errorf("profiles.json %q must be RO (--ro-bind), not RW (--bind): %v", profilesJSON, args)
+	}
+}
+
+// TestBwrapBuildArgs_PrismProfilesJSONAbsentNoBind covers the fresh-install
+// edge case from issue #2286: when profiles.json does not exist on the host
+// (before the first `nh switch`), no bind triple is emitted —
+// OptionalIfMissing skips the mount, and bwrap (which aborts on missing
+// bind sources) is never asked to bind a non-existent file. LoadProfiles
+// inside the sandbox then sees ENOENT through its normal
+// os.ReadFile/os.IsNotExist branch and emits the existing host-side error
+// message verbatim — the change must not paper over the genuine missing
+// case.
+func TestBwrapBuildArgs_PrismProfilesJSONAbsentNoBind(t *testing.T) {
+	m, fakeHome, cleanup := bwrapFixture(t, Config{
+		SessionName:   "repo@main",
+		Worktree:      t.TempDir(),
+		AllocatedPort: 14010,
+	})
+	defer cleanup()
+
+	profilesJSON := filepath.Join(fakeHome, ".config", "prism", "profiles.json")
+	if _, err := os.Stat(profilesJSON); err == nil {
+		t.Fatalf("fixture unexpectedly created profiles.json — update this test")
+	}
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	if hasROBind(args, profilesJSON) {
+		t.Errorf("missing profiles.json should be omitted but found as --ro-bind in args: %v", args)
+	}
+	if hasBind(args, profilesJSON) {
+		t.Errorf("missing profiles.json should be omitted but found as --bind in args: %v", args)
+	}
+}
+
 func TestBwrapBuildArgs_BareRepoBoundAtHostPath(t *testing.T) {
 	// When BareRoot and WorktreeGitDir are set, the bare repo (.bare dir) and
 	// worktree private git state are both bound at their host paths (Dst == Src),

--- a/modules/programs/prism/prism/internal/container/mounts.go
+++ b/modules/programs/prism/prism/internal/container/mounts.go
@@ -353,6 +353,46 @@ func StandardSandboxMounts(cfg Config, sandboxHomeDir, hostHome string, mode iso
 			ReadOnly:          true,
 			OptionalIfMissing: true,
 		},
+
+		// ── prism profiles.json (RO, conditional, single file) ──────────
+		// Host: ~/.config/prism/profiles.json (deployed via pi.nix from the
+		// rendered nix profile data — declarative, non-secret). The CLI's
+		// `prism profile list`, `prism profile show`, and the
+		// available_profiles section of `prism agent-context` all open this
+		// file directly via internal/config/profiles.go::LoadProfiles. The
+		// mutation surface (`prism profile use`) routes through the host API
+		// instead and does not need an in-sandbox file, but the read surface
+		// does — without this mount the same commands fail from inside the
+		// sandbox with the (misleading) "not found — run the system rebuild"
+		// error (issue #2286).
+		//
+		// Read-only — the file is owned by the host nix module; nothing
+		// in-sandbox may mutate it. Single-file scope (no surrounding
+		// directory widening): we already mount the sibling agents/ subdir;
+		// adding profiles.json on its own keeps the rest of
+		// ~/.config/prism/ (e.g. ~/.config/prism/accounts/, runtime-mutable
+		// state from #2283) out of the sandbox by default.
+		//
+		// OptionalIfMissing covers fresh installs before first `nh switch`,
+		// where the file does not exist yet. In that case LoadProfiles
+		// still returns its existing "profiles: <path> not found — run the
+		// system rebuild to generate it" error (it ReadFile's the same
+		// path), so the host-side missing-file message is preserved
+		// verbatim — see the issue #2286 edge-case AC.
+		//
+		// SandboxPath == HostPath under bwrap (sandboxHomeDir == hostHome),
+		// matching profilesFilePath()'s XDG_CONFIG_HOME-else-$HOME/.config
+		// resolution inside the sandbox.
+		//
+		// sandbox-exec does not walk this slice (see the package comment):
+		// there generateProfile emits an explicit RO (literal ...) grant on
+		// the real host path in section 5h of sandbox_exec.go.
+		{
+			HostPath:          filepath.Join(hostHome, ".config", "prism", "profiles.json"),
+			SandboxPath:       filepath.Join(sandboxHomeDir, ".config", "prism", "profiles.json"),
+			ReadOnly:          true,
+			OptionalIfMissing: true,
+		},
 	}
 
 	return specs

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -523,6 +523,37 @@ func generateProfile(m *Manager) string {
 		sb.WriteString("\n")
 	}
 
+	// ── 5h. prism profiles.json single-file RO read (issue #2286) ────────
+	// The CLI's `prism profile list`, `prism profile show`, and the
+	// available_profiles section of `prism agent-context` open
+	// ~/.config/prism/profiles.json directly via
+	// internal/config/profiles.go::LoadProfiles. Under deny-default the
+	// read fails EPERM and the user sees a misleading "not found — run the
+	// system rebuild" error from inside any sandbox session, even though
+	// the file exists on the host. The mutation surface (`prism profile
+	// use`) routes through the host API and is unaffected.
+	//
+	// The file holds the user's declarative model-profile configuration;
+	// its contents are not secret — same trust level as the sibling
+	// agents/ markdown that 5f already grants. The allow is read-only and
+	// single-file (literal, not subpath): the rest of ~/.config/prism/
+	// (e.g. ~/.config/prism/accounts/, runtime-mutable state from #2283)
+	// stays out of the sandbox by default. RO must not silently become
+	// RW — nothing in-sandbox may mutate the host's profile config.
+	// file-test-existence is included so LoadProfiles' missing-file branch
+	// sees ENOENT (preserving the existing host error message verbatim)
+	// rather than EPERM when the file is absent on a fresh install
+	// before first `nh switch`.
+	//
+	// Mirrors bwrap's RO single-file mount of the same path in mounts.go
+	// StandardSandboxMounts.
+	if home != "" {
+		profilesJSON := filepath.Join(home, ".config", "prism", "profiles.json")
+		sb.WriteString("(allow file-read* file-test-existence\n")
+		sb.WriteString("  (literal " + quoteSBPL(profilesJSON) + "))\n")
+		sb.WriteString("\n")
+	}
+
 	// ── 6. Session work dir + worktree + bare repo + host-API socket (RW) ─
 	// Session-specific read-write paths. Locked in #1012 and #1017.
 	// file-test-existence and file-read-metadata added alongside file-read*

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -558,6 +558,78 @@ func TestGenerateProfile_NixTrustedSettingsReadAllow(t *testing.T) {
 	}
 }
 
+// TestGenerateProfile_PrismProfilesJSONReadAllow verifies that the profile
+// contains a read-only, single-file (literal) allow for
+// ~/.config/prism/profiles.json (issue #2286). The CLI's `prism profile
+// list` / `prism profile show` and the `available_profiles` section of
+// `prism agent-context` open this file directly via
+// internal/config/profiles.go::LoadProfiles; without the allow the read
+// fails EPERM under deny-default and the user sees a misleading
+// "not found — run the system rebuild" message from inside any sandbox
+// session.
+//
+// The rule must be:
+//   - a (literal ...), not a (subpath ...) — single-file scope only, so
+//     the rest of ~/.config/prism/ (e.g. accounts/, runtime-mutable state
+//     from #2283) stays out of the sandbox by default;
+//   - read-only — no file-write* anywhere near it (nothing in-sandbox
+//     may mutate the host's declarative profile config).
+//
+// This substring assertion is necessary but not sufficient — the paired
+// Darwin integration tests in
+// internal/integration/sandbox_exec_profiles_json_darwin_test.go prove the
+// rule is load-bearing against /usr/bin/sandbox-exec per
+// docs/sandbox-exec-testing.md.
+func TestGenerateProfile_PrismProfilesJSONReadAllow(t *testing.T) {
+	fakeHome := newFakeHome(t)
+
+	m := newSandboxExecManager(Config{SessionName: "repo@main"})
+	profile := generateProfile(m)
+
+	profilesJSON := filepath.Join(fakeHome, ".config", "prism", "profiles.json")
+
+	// The exact rule block as emitted by generateProfile: a read-only allow
+	// with file-test-existence (so LoadProfiles' missing-file branch gets
+	// ENOENT, not EPERM, when the file is absent on a fresh install) on a
+	// single literal path.
+	wantBlock := "(allow file-read* file-test-existence\n" +
+		"  (literal \"" + profilesJSON + "\"))\n"
+	if !strings.Contains(profile, wantBlock) {
+		t.Errorf("profile missing the prism profiles.json read-only allow block:\n%s\nfull profile:\n%s", wantBlock, profile)
+	}
+
+	// The path must appear exactly once — in the read-only block above. A
+	// second occurrence would mean it leaked into another (potentially
+	// writable) clause.
+	if got := strings.Count(profile, profilesJSON); got != 1 {
+		t.Errorf("profiles.json path must appear exactly once in the profile (read-only literal); found %d occurrences.\nfull profile:\n%s", got, profile)
+	}
+
+	// Single-file scope: the path must never be granted as a subpath.
+	if strings.Contains(profile, "(subpath \""+profilesJSON+"\")") {
+		t.Errorf("profiles.json path must be a (literal ...), not a (subpath ...); full profile:\n%s", profile)
+	}
+
+	// RO must not silently become RW: confirm the literal rule does not sit
+	// inside any allow clause that carries file-write*. Defensive scan that
+	// matches the shape of the 3f RW-leak check in
+	// TestGenerateProfile_RORealPathGrants3f.
+	rule := "(literal \"" + profilesJSON + "\")"
+	idx := 0
+	for {
+		rel := strings.Index(profile[idx:], rule)
+		if rel < 0 {
+			break
+		}
+		at := idx + rel
+		clauseStart := strings.LastIndex(profile[:at], "(allow ")
+		if clauseStart >= 0 && strings.Contains(profile[clauseStart:at], "file-write*") {
+			t.Errorf("profiles.json literal appears inside a file-write* allow block — RO must not become RW;\nclause: %q", profile[clauseStart:at])
+		}
+		idx = at + len(rule)
+	}
+}
+
 // ── PrepareSandboxExec ──────────────────────────────────────────────────────
 
 // TestPrepareSandboxExec_WritesProfileAndReturnsArgs verifies that

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_profiles_json_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_profiles_json_darwin_test.go
@@ -1,0 +1,226 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_profiles_json_darwin_test.go — integration coverage for the
+// single-file read-only allow on ~/.config/prism/profiles.json (issue #2286).
+//
+// The prism CLI's `prism profile list`, `prism profile show`, and the
+// `available_profiles` section of `prism agent-context` open this file
+// directly via internal/config/profiles.go::LoadProfiles. Under deny-default
+// the read failed EPERM and the user saw a misleading "profiles: <path>
+// not found — run the system rebuild" message from inside any sandbox-exec
+// session, even though the file existed on the host (the mutation surface
+// `prism profile use` routes through the host API instead and was
+// unaffected).
+//
+// Per docs/sandbox-exec-testing.md (issue #1192) the coverage is a
+// positive/negative pair plus a write-denied negative for the RO/security
+// AC:
+//
+//   - TestSandboxExecProfile_PrismProfilesJSONReadable proves the generated
+//     profile permits opening the file for reading. The test NEVER creates
+//     or modifies the real host file (it is the user's actual prism
+//     profiles config), so it asserts on whichever state the host is in:
+//     when the file exists the read must exit 0; when it is absent the
+//     open must be attempted and fail with ENOENT ("No such file or
+//     directory") — NOT EPERM ("Operation not permitted"). Both branches
+//     prove the sandbox allowed the open. The ENOENT branch also covers
+//     the issue #2286 edge-case AC: a missing host file follows
+//     LoadProfiles' normal missing-file path (preserving the existing
+//     error message) instead of failing for sandbox reasons.
+//
+//   - TestSandboxExecProfile_PrismProfilesJSONDeniedWithoutRule mutates the
+//     profile to remove the section-5h allow block and asserts the same
+//     read fails with "Operation not permitted" — proving the positive
+//     test is not green by accident (e.g. via some broader allow).
+//
+//   - TestSandboxExecProfile_PrismProfilesJSONWriteDenied proves the
+//     security AC: under the PRODUCTION profile, writing to profiles.json
+//     from inside the sandbox fails — RO must not silently become RW.
+//     Skipped when the file is absent on the host (no target to attempt a
+//     write against without disturbing the user's real config).
+//
+// All three tests use newProfileManagerWithBareRoot: production worker
+// sessions always have BareRoot set, so the ancestor metadata block is
+// present, and the rule under test grants file-read-data which the
+// BareRoot ancestor block (file-test-existence/file-read-metadata only)
+// cannot mask in the negative test. This mirrors the trusted-settings
+// sibling test in sandbox_exec_nix_trusted_settings_darwin_test.go.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// prismProfilesJSONPath returns the host path of the prism declarative
+// profiles config, derived the same way generateProfile derives it
+// (os.UserHomeDir() + .config/prism/profiles.json).
+func prismProfilesJSONPath(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	return filepath.Join(home, ".config", "prism", "profiles.json")
+}
+
+// TestSandboxExecProfile_PrismProfilesJSONReadable is the positive half:
+// under the unmodified production profile, opening
+// ~/.config/prism/profiles.json for reading must not be denied by the
+// sandbox.
+func TestSandboxExecProfile_PrismProfilesJSONReadable(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	target := prismProfilesJSONPath(t)
+
+	m := newProfileManagerWithBareRoot(t)
+	prepared, _ := preparePositiveProfile(t, m)
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+
+	// Regardless of whether the host file exists, the sandbox must not be
+	// the thing that blocks the open.
+	if strings.Contains(string(out), "Operation not permitted") {
+		t.Errorf("read of %s was denied by the sandbox (EPERM) under the production profile.\n"+
+			"The prism profiles.json allow (issue #2286) is missing or not load-bearing —\n"+
+			"`prism profile list` / `prism profile show` / `prism agent-context` will fail inside worker sandboxes.\n"+
+			"Exit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	}
+
+	// Branch on actual host state — the test must never create or modify
+	// the user's real profiles.json.
+	if _, statErr := os.Stat(target); statErr == nil {
+		// File exists on the host: the sandboxed read must succeed outright.
+		if runErr != nil {
+			t.Errorf("host file %s exists but the sandboxed read failed.\nExit: %v\nOutput: %s\nProfile: %s",
+				target, runErr, string(out), profilePath)
+		}
+	} else if os.IsNotExist(statErr) {
+		// File absent on the host: the open must have been attempted and
+		// failed with ENOENT — the sane missing-file path LoadProfiles
+		// tolerates (the issue #2286 edge-case AC: the existing host
+		// error message must be preserved on a fresh install).
+		if runErr == nil {
+			t.Errorf("cat of missing file %s exited 0 — test environment is inconsistent.\nOutput: %s",
+				target, string(out))
+		}
+		if !strings.Contains(string(out), "No such file or directory") {
+			t.Errorf("cat of missing file %s did not fail with ENOENT; the sandbox may be interfering.\nExit: %v\nOutput: %s\nProfile: %s",
+				target, runErr, string(out), profilePath)
+		}
+	} else {
+		t.Fatalf("stat %s: %v", target, statErr)
+	}
+}
+
+// TestSandboxExecProfile_PrismProfilesJSONDeniedWithoutRule is the paired
+// negative test: with the section-5h allow block removed from the generated
+// profile, the same read must fail with EPERM. This proves the positive
+// test exercises the rule itself rather than passing by accident (e.g. via
+// some broader allow).
+func TestSandboxExecProfile_PrismProfilesJSONDeniedWithoutRule(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	target := prismProfilesJSONPath(t)
+
+	m := newProfileManagerWithBareRoot(t)
+
+	// Remove the entire self-contained allow block as emitted by
+	// generateProfile. withMutatedProfile fails the test if the substitution
+	// does not match anything, so format drift in the generator is caught.
+	ruleBlock := "(allow file-read* file-test-existence\n" +
+		"  (literal " + sbplQuoteForTest(target) + "))\n"
+	profilePath := withMutatedProfile(t, m, func(p string) string {
+		return strings.Replace(p, ruleBlock, "", 1)
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "cat "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("read of %s succeeded WITHOUT the profiles.json allow rule — some broader allow\n"+
+			"covers the path and the positive test is not isolating the rule under test.\nOutput: %s\nProfile: %s",
+			target, string(out), profilePath)
+	}
+	if !strings.Contains(string(out), "Operation not permitted") {
+		t.Errorf("read of %s without the allow rule did not fail with EPERM.\nExit: %v\nOutput: %s\nProfile: %s",
+			target, runErr, string(out), profilePath)
+	}
+}
+
+// TestSandboxExecProfile_PrismProfilesJSONWriteDenied is the security AC
+// for issue #2286: under the PRODUCTION profile, writing to profiles.json
+// from inside the sandbox fails — RO must not silently become RW. This
+// guards against future regressions that might widen the (literal ...) RO
+// rule into a (subpath ...) RW grant or accidentally promote the allow to
+// include file-write*.
+//
+// The test does not need to (and must not) actually overwrite the user's
+// real profiles.json: the sandbox deny must fire BEFORE any host-side
+// write. We attempt to append a sentinel byte and assert the append fails;
+// then we double-check the file is unchanged. Skipped when the file is
+// absent on the host (no target to write against; the bwrap-side
+// fresh-install AC is covered separately by the OptionalIfMissing
+// unit-test pair in bwrap_test.go).
+func TestSandboxExecProfile_PrismProfilesJSONWriteDenied(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixBash := requireNixBash(t)
+	target := prismProfilesJSONPath(t)
+
+	infoBefore, statErr := os.Stat(target)
+	if os.IsNotExist(statErr) {
+		t.Skipf("~/.config/prism/profiles.json absent on this host; write-denied AC covered for fresh installs by the bwrap OptionalIfMissing unit tests")
+	}
+	if statErr != nil {
+		t.Fatalf("stat %s: %v", target, statErr)
+	}
+
+	m := newProfileManagerWithBareRoot(t)
+	prepared, _ := preparePositiveProfile(t, m)
+	profilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// Append a sentinel via shell redirection — appending (>>) avoids any
+	// truncation if the sandbox somehow lets the open() through but blocks
+	// the write(). Either way the assertion fails iff a write succeeds.
+	cmd := exec.Command(sandboxExecPath, "-f", profilePath,
+		nixBash, "-c", "echo prism-2286-write-probe >> "+shQuote(target))
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("write to %s succeeded under the production profile — the RO grant must not silently become RW.\nOutput: %s\nProfile: %s",
+			target, string(out), profilePath)
+	}
+
+	// Belt-and-braces: confirm the host file is unchanged. If the sandbox
+	// deny fired correctly, size and mtime are identical to the
+	// pre-attempt snapshot.
+	infoAfter, statErr := os.Stat(target)
+	if statErr != nil {
+		t.Fatalf("stat %s after probe: %v", target, statErr)
+	}
+	if infoAfter.Size() != infoBefore.Size() {
+		t.Errorf("profiles.json size changed across the write probe: before=%d after=%d — the sandbox allowed a write",
+			infoBefore.Size(), infoAfter.Size())
+	}
+	if !infoAfter.ModTime().Equal(infoBefore.ModTime()) {
+		t.Errorf("profiles.json mtime changed across the write probe: before=%v after=%v — the sandbox allowed a write",
+			infoBefore.ModTime(), infoAfter.ModTime())
+	}
+}


### PR DESCRIPTION
## Summary

`prism profile list`, `prism profile show`, and the `available_profiles`
section of `prism agent-context` all open `~/.config/prism/profiles.json`
directly via `internal/config/profiles.go::LoadProfiles`. Inside a sandboxed
prism session the file was not exposed — only `~/.config/prism/agents/` and
`~/.config/prism/pi-extensions/` were — so under deny-default the read fails
EPERM and `LoadProfiles`' `os.IsNotExist` branch fires, giving the user a
misleading `"profiles: <path> not found — run the system rebuild to
generate it"` error even when the file exists on the host.

The mutation surface (`prism profile use`) routes through the host API
(`/apply-profile`) and was unaffected; only the read surface was broken.

Fix (Option A from #2286 — bind-mount the file RO in both isolation paths):

- **bwrap (Linux)** — append a `MountSpec` to `StandardSandboxMounts` in
  `internal/container/mounts.go`, RO + `OptionalIfMissing`,
  `SandboxPath==HostPath`. Translated to `--ro-bind` by the existing
  `AppendBwrapBind` walk. `OptionalIfMissing` covers fresh installs before
  first `nh switch` and is required because bwrap aborts on missing
  `--bind` sources.
- **sandbox-exec (Darwin)** — add a new section 5h to `generateProfile`:
  a single-file `(literal …)` RO allow on the real host path. Mirrors the
  trusted-settings.json pattern (5b). Single-file scope — the rest of
  `~/.config/prism/` (e.g. `accounts/`, runtime-mutable state from #2283)
  stays out of the sandbox by default.

`profiles.json` is non-secret declarative config — same trust level as the
`agents/` markdown that the sandbox already exposes. Read-only at both
layers: nothing in-sandbox may mutate the host's profile config.

## Edge cases

- **Fresh install (no `profiles.json` on host):** `LoadProfiles`' open hits
  ENOENT through its normal `os.IsNotExist` branch and emits the existing
  `"not found — run the system rebuild"` message verbatim. The mount does
  not paper over a genuine missing-file case (#2286 edge-case AC).
- **RO/security:** sandbox-exec write-denied test guards against
  `(literal …)` widening into `(subpath …)` or `file-write*` regressions;
  bwrap test rejects `--bind` (the RW flag) for the same path.

## Tests

- `internal/container/sandbox_exec_test.go` —
  `TestGenerateProfile_PrismProfilesJSONReadAllow` asserts the exact 5h
  block, single-occurrence (no leak into a writable clause), literal-only
  (not subpath), and absence from any `file-write*` block.
- `internal/container/bwrap_test.go` — bound + absent unit-test pair
  (`TestBwrapBuildArgs_PrismProfilesJSONROBound` /
  `…AbsentNoBind`) mirroring the existing `BunCacheDir` pair.
- `internal/integration/sandbox_exec_profiles_json_darwin_test.go` —
  Darwin integration coverage per the sandbox-exec testing convention
  (`docs/sandbox-exec-testing.md`, #1192). Three tests: positive (read at
  the real path under the production profile), paired negative (strip the
  5h block, read fails EPERM — proves the positive isn't green by
  accident), and write-denied (security AC for the RO grant). Modelled on
  the trusted-settings darwin test.

**No-op-test discipline followed:** with the production mount additions
reverted, both positive unit tests (sandbox-exec `ReadAllow`, bwrap
`ROBound`) fail; integration positive is exercised on CI's
`nix-build-prism-checked` homeless-shelter run.

`go build ./...`, `go test ./... -race`, and `nix build .#prism` all
green locally.

Closes #2286