### PR TITLE
prism account login: native PKCE OAuth flow (#2284)

### DIFF
--- a/modules/programs/prism/prism/cmd/account_login.go
+++ b/modules/programs/prism/prism/cmd/account_login.go
@@ -1,0 +1,64 @@
+package cmd
+
+// `prism account login <name>` — native PKCE OAuth flow that registers
+// a fresh Anthropic subscription as a named account under
+// ~/.config/prism/accounts/<name>.json (#2284). When `--use` is set,
+// the new account is activated immediately by calling account.Use.
+//
+// The OAuth protocol details — PKCE generation, callback server,
+// token exchange — live in internal/account/login.go. This file is
+// only the cobra wiring: argument validation, flag plumbing, and
+// translating LoginOptions defaults from the CLI surface.
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/account"
+)
+
+var accountLoginCmd = &cobra.Command{
+	Use:   "login <name>",
+	Short: "Log in to Anthropic via OAuth and save as a named account",
+	Long: `Run the Anthropic OAuth + PKCE flow and write the resulting tokens to
+` + "`" + `~/.config/prism/accounts/<name>.json` + "`" + ` (mode 0o600).
+
+By default the new account is registered but NOT activated — run
+` + "`" + `prism account use <name>` + "`" + ` when ready. Pass --use to activate immediately.
+
+In a graphical session the system browser is opened to the authorize URL.
+In a headless SSH session (DISPLAY and WAYLAND_DISPLAY unset, SSH_CONNECTION
+set) the URL is printed to stdout and the flow waits for the user to paste
+the callback URL or code#state value back into the terminal.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAccountLogin,
+}
+
+func init() {
+	accountLoginCmd.Flags().Bool("use", false, "Activate the account immediately after login (calls `prism account use`)")
+	accountLoginCmd.Flags().Int("port", 53692, "Local callback port; use 0 for a random free port")
+	accountCmd.AddCommand(accountLoginCmd)
+}
+
+func runAccountLogin(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+	name := args[0]
+
+	useFlag, _ := cmd.Flags().GetBool("use")
+	portFlag, _ := cmd.Flags().GetInt("port")
+
+	p, err := account.ResolvePaths()
+	if err != nil {
+		return err
+	}
+
+	opts := account.LoginOptions{
+		Use:           useFlag,
+		Stdout:        cmd.OutOrStdout(),
+		UseRandomPort: portFlag == 0,
+	}
+	if !opts.UseRandomPort {
+		opts.Port = portFlag
+	}
+
+	return account.Login(p, name, opts)
+}

--- a/modules/programs/prism/prism/cmd/account_login_test.go
+++ b/modules/programs/prism/prism/cmd/account_login_test.go
@@ -1,0 +1,49 @@
+// Tests for the `prism account login` cobra wiring. The bulk of
+// behavioural coverage lives in internal/account/login_test.go; these
+// only exercise the cobra-level surface (flag parsing, name arg
+// validation that short-circuits before any network call).
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAccountLogin_RegisteredOnAccountCmd(t *testing.T) {
+	var found bool
+	for _, c := range accountCmd.Commands() {
+		if c.Name() == "login" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("login subcommand not registered on accountCmd")
+	}
+}
+
+func TestAccountLogin_HasUseAndPortFlags(t *testing.T) {
+	if accountLoginCmd.Flag("use") == nil {
+		t.Error("--use flag not defined")
+	}
+	if accountLoginCmd.Flag("port") == nil {
+		t.Error("--port flag not defined")
+	}
+	// Default port should match the auth.ts CALLBACK_PORT constant.
+	if got := accountLoginCmd.Flag("port").DefValue; got != "53692" {
+		t.Errorf("--port default = %q, want 53692", got)
+	}
+}
+
+func TestAccountLogin_InvalidName_FailsBeforeNetworkCall(t *testing.T) {
+	withAccountFixture(t)
+	out, err := runSubcommand(t, runAccountLogin, []string{".."})
+	if err == nil {
+		t.Fatal("expected error for invalid name")
+	}
+	// Should not have printed an authorize URL (proxy for "no network
+	// call attempted").
+	if strings.Contains(out, "claude.ai/oauth/authorize") {
+		t.Errorf("invalid-name path printed authorize URL: %q", out)
+	}
+}

--- a/modules/programs/prism/prism/internal/account/login.go
+++ b/modules/programs/prism/prism/internal/account/login.go
@@ -1,0 +1,605 @@
+// Port of modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts.
+// auth.ts remains the canonical source of truth for the Anthropic OAuth
+// protocol; this is a Go mirror. When upstream auth.ts changes, mirror
+// the change here.
+//
+// Implementation of `prism account login <name>` (#2284): PKCE + local
+// callback server + token exchange + atomic write into the per-account
+// store maintained by the rest of this package.
+//
+// Security invariants (also enforced by tests):
+//
+//   - The PKCE verifier never appears in stdout, stderr, or any log
+//     line. Only the challenge (derived; safe to surface) ever leaves
+//     this file.
+//   - The OAuth `code` parameter never appears in any error message
+//     returned to the user — error strings include only the response
+//     HTTP status, never the request body or the code value.
+//   - Access and refresh tokens never appear in stdout, stderr, or any
+//     log line at any verbosity. The success message names only the
+//     account.
+//   - On state mismatch the error is the literal string "OAuth state
+//     mismatch" with no echo of either the expected or received state
+//     value.
+
+package account
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// OAuth constants — mirror auth.ts. If auth.ts changes, change these.
+const (
+	oauthClientID     = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+	oauthAuthorizeURL = "https://claude.ai/oauth/authorize"
+	oauthTokenURL     = "https://claude.ai/v1/oauth/token"
+	// oauthRedirectURI is the manual-paste fallback redirect_uri,
+	// served by Anthropic's platform — used only when the local
+	// callback server cannot bind. The active redirect_uri value at
+	// runtime is the local http://localhost:<port>/callback computed
+	// from the bound listener.
+	oauthRedirectURI = "https://platform.claude.com/oauth/code/callback"
+	oauthScopes      = "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
+	oauthUserAgent   = "claude-code/2.1.97"
+	callbackPort     = 53692
+	callbackHost     = "127.0.0.1"
+	callbackTimeout  = 5 * time.Minute
+	maxTokenRetries  = 2
+	initialRetryDelay = 5 * time.Second
+	tokenExpirySafety = 5 * time.Minute
+	retryAfterCap     = 30 * time.Second
+)
+
+// browserLauncher is the OS-dispatch hook for opening the system
+// browser. Substitute via opts.Browser in tests.
+type browserLauncher func(url string) error
+
+// defaultBrowserLauncher is the runtime browser-launcher. Tests can
+// swap this package var directly, but the preferred seam is
+// LoginOptions.Browser which never touches process state.
+var defaultBrowserLauncher browserLauncher = launchBrowser
+
+func launchBrowser(target string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("xdg-open", target).Start()
+	case "darwin":
+		return exec.Command("open", target).Start()
+	}
+	return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+}
+
+// isHeadlessEnv returns true when the current process appears to be
+// running in a headless SSH session — no graphical display and an SSH
+// connection variable is set. In that case the browser-launch step is
+// skipped and the user falls straight through to manual paste.
+func isHeadlessEnv() bool {
+	return os.Getenv("DISPLAY") == "" &&
+		os.Getenv("WAYLAND_DISPLAY") == "" &&
+		os.Getenv("SSH_CONNECTION") != ""
+}
+
+// LoginOptions controls a single `prism account login` invocation.
+// Fields with zero values fall back to their package-default behaviour
+// via applyDefaults so callers (and tests) only set the bits they care
+// about.
+type LoginOptions struct {
+	// Use, when true, calls Use(paths, name) after the account file has
+	// been written, atomically activating the new account.
+	Use bool
+	// Port is the TCP port to bind the local callback server on.
+	// Defaults to callbackPort (53692); a zero value resolved by
+	// applyDefaults means "use the default". To bind a random free
+	// port, pass UseRandomPort = true.
+	Port int
+	// UseRandomPort, when true, binds the callback server on a random
+	// free port (net.Listen with port 0). Mutually exclusive with Port.
+	UseRandomPort bool
+
+	// Test seams — production callers leave these nil and applyDefaults
+	// fills in the package-level defaults.
+	TokenURL   string
+	AuthURL    string
+	HTTPClient *http.Client
+	Browser    browserLauncher
+	IsHeadless func() bool
+	Stdin      io.Reader
+	Stdout     io.Writer
+	Now        func() time.Time
+	Sleep      func(d time.Duration)
+	Timeout    time.Duration
+}
+
+func (o *LoginOptions) applyDefaults() {
+	if o.TokenURL == "" {
+		o.TokenURL = oauthTokenURL
+	}
+	if o.AuthURL == "" {
+		o.AuthURL = oauthAuthorizeURL
+	}
+	if o.HTTPClient == nil {
+		o.HTTPClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	if o.Browser == nil {
+		o.Browser = defaultBrowserLauncher
+	}
+	if o.IsHeadless == nil {
+		o.IsHeadless = isHeadlessEnv
+	}
+	if o.Stdin == nil {
+		o.Stdin = os.Stdin
+	}
+	if o.Stdout == nil {
+		o.Stdout = os.Stdout
+	}
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	if o.Sleep == nil {
+		o.Sleep = time.Sleep
+	}
+	if o.Timeout == 0 {
+		o.Timeout = callbackTimeout
+	}
+	if !o.UseRandomPort && o.Port == 0 {
+		o.Port = callbackPort
+	}
+}
+
+// tokenResponse is the JSON shape returned by TOKEN_URL.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+}
+
+// accountBlob is the on-disk shape written to accounts/<name>.json. It
+// matches the value of auth.json's "anthropic" key as produced by pi.
+type accountBlob struct {
+	Type    string `json:"type"`
+	Access  string `json:"access"`
+	Refresh string `json:"refresh"`
+	Expires int64  `json:"expires"`
+}
+
+// Login runs the OAuth + PKCE flow against Anthropic, persists the
+// resulting tokens to accounts/<name>.json (mode 0o600), and optionally
+// calls Use(paths, name) when opts.Use is true.
+//
+// On any error before the account file is written, no token file is
+// created (atomic write). On error after Use begins, the account file
+// is on disk; the caller decides what to do.
+func Login(paths Paths, name string, opts LoginOptions) error {
+	opts.applyDefaults()
+
+	// Validate name before doing anything network-shaped — the AC
+	// requires that an invalid name fails before any port is bound or
+	// HTTP request issued.
+	if err := validName(name); err != nil {
+		return err
+	}
+	if err := Init(paths); err != nil {
+		return err
+	}
+
+	verifier, challenge, err := generatePKCE()
+	if err != nil {
+		return fmt.Errorf("generate PKCE: %w", err)
+	}
+	state, err := generateState()
+	if err != nil {
+		return fmt.Errorf("generate state: %w", err)
+	}
+
+	// Bind the local callback server. A bind failure here is a
+	// first-class error: name the port and suggest --port 0.
+	bindPort := opts.Port
+	if opts.UseRandomPort {
+		bindPort = 0
+	}
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", callbackHost, bindPort))
+	if err != nil {
+		return fmt.Errorf("bind callback server on port %d: %w (try --port 0 for a random free port)", bindPort, err)
+	}
+	boundPort := ln.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", boundPort)
+	authorizeURL := makeAuthorizeURL(opts.AuthURL, challenge, state, redirectURI)
+
+	callbackCh := make(chan callbackResult, 1)
+	srv := startCallbackServer(ln, state, callbackCh)
+	// Ensure the listening socket is released no matter how we exit.
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	// Browser launch (or skip in headless mode). The URL is always
+	// printed so users with the browser on a different machine can
+	// copy-paste it themselves.
+	headless := opts.IsHeadless()
+	fmt.Fprintf(opts.Stdout, "Open this URL in your browser to authorize prism:\n  %s\n", authorizeURL)
+	if headless {
+		fmt.Fprintln(opts.Stdout, "(running headless — paste the callback URL or code#state when done)")
+	} else {
+		if err := opts.Browser(authorizeURL); err != nil {
+			// Browser exec failed (e.g. xdg-open missing). The AC
+			// requires we fall through silently and let the user paste
+			// the callback manually.
+			fmt.Fprintln(opts.Stdout, "(could not open browser — paste the callback URL or code#state when done)")
+		} else {
+			fmt.Fprintln(opts.Stdout, "(opened browser; or paste the callback URL / code#state here when done)")
+		}
+	}
+
+	// Wait for either the local callback to fire or the user to paste
+	// the callback URL on stdin, whichever wins. A 5-minute hard
+	// timeout bounds the whole operation.
+	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
+	defer cancel()
+	inputCh := make(chan inputResult, 2)
+	go waitCallback(ctx, callbackCh, inputCh)
+	go waitStdin(ctx, opts.Stdin, inputCh)
+
+	var captured inputResult
+	select {
+	case captured = <-inputCh:
+		if captured.err != nil {
+			return captured.err
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("login timed out after %s waiting for OAuth callback or manual paste", opts.Timeout)
+	}
+
+	// State check — guard against an attacker round-tripping a
+	// matched code/state pair from a different flow. The local server
+	// also checks this and returns 400 to the browser; this branch
+	// covers the manual-paste path.
+	if captured.state != state {
+		return errors.New("OAuth state mismatch")
+	}
+
+	tr, err := exchangeToken(ctx, opts, captured.code, captured.state, verifier, redirectURI)
+	if err != nil {
+		return err
+	}
+
+	// Match pi-side computation exactly:
+	//   expires = Date.now() + expires_in * 1000 - 5 * 60 * 1000
+	expiresMS := opts.Now().UnixMilli() + tr.ExpiresIn*1000 - int64(tokenExpirySafety/time.Millisecond)
+
+	blob := accountBlob{
+		Type:    "oauth",
+		Access:  tr.AccessToken,
+		Refresh: tr.RefreshToken,
+		Expires: expiresMS,
+	}
+	blobBytes, err := json.MarshalIndent(blob, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal account blob: %w", err)
+	}
+	blobBytes = append(blobBytes, '\n')
+	if err := atomicWriteFile(paths.AccountPath(name), blobBytes, fileMode); err != nil {
+		return fmt.Errorf("write account file: %w", err)
+	}
+
+	if opts.Use {
+		if err := Use(paths, name); err != nil {
+			return fmt.Errorf("activate account %s: %w", name, err)
+		}
+		fmt.Fprintf(opts.Stdout, "account %s saved and activated.\n", name)
+		return nil
+	}
+
+	fmt.Fprintf(opts.Stdout, "account %s saved. Run 'prism account use %s' to activate.\n", name, name)
+	return nil
+}
+
+// callbackResult is what the local callback server reports back to the
+// main goroutine: either a (code, state) pair or an error (e.g. state
+// mismatch).
+type callbackResult struct {
+	code  string
+	state string
+	err   error
+}
+
+// inputResult is the merged channel value from the two waiters
+// (callback + stdin).
+type inputResult struct {
+	code  string
+	state string
+	err   error
+}
+
+// waitCallback forwards the local server's result onto inputCh,
+// respecting ctx cancellation.
+func waitCallback(ctx context.Context, in <-chan callbackResult, out chan<- inputResult) {
+	select {
+	case r := <-in:
+		select {
+		case out <- inputResult{code: r.code, state: r.state, err: r.err}:
+		case <-ctx.Done():
+		}
+	case <-ctx.Done():
+	}
+}
+
+// waitStdin parses a single line from stdin (typically the user
+// pasting the callback URL) and forwards the parsed result onto
+// inputCh. EOF without data is silent — we just rely on the callback
+// or the outer timeout.
+func waitStdin(ctx context.Context, r io.Reader, out chan<- inputResult) {
+	scanner := bufio.NewScanner(r)
+	// OAuth callback URLs can be a few KB; bump the buffer ceiling.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	if !scanner.Scan() {
+		return
+	}
+	line := scanner.Text()
+	parsed, ok := parseAuthInput(line)
+	if !ok {
+		select {
+		case out <- inputResult{err: errors.New("could not parse pasted callback input")}:
+		case <-ctx.Done():
+		}
+		return
+	}
+	select {
+	case out <- inputResult{code: parsed.code, state: parsed.state}:
+	case <-ctx.Done():
+	}
+}
+
+// generatePKCE returns a fresh (verifier, challenge) pair per RFC 7636
+// S256. verifier is 32 random bytes base64url-encoded (no padding);
+// challenge is the SHA-256 of the verifier (taken over its ASCII
+// bytes — not the raw entropy bytes — matching the JS reference
+// implementation in auth.ts) base64url-encoded.
+func generatePKCE() (verifier, challenge string, err error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", err
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(raw)
+	digest := sha256.Sum256([]byte(verifier))
+	challenge = base64.RawURLEncoding.EncodeToString(digest[:])
+	return verifier, challenge, nil
+}
+
+// generateState returns 16 cryptographically-random bytes hex-encoded
+// (32 hex chars), matching auth.ts's `crypto.randomUUID().replace(/-/g, "")`.
+func generateState() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+// makeAuthorizeURL composes the OAuth authorize URL — same parameter
+// set and ordering as auth.ts::makeAuthorizeUrl.
+func makeAuthorizeURL(base, challenge, state, redirectURI string) string {
+	q := url.Values{}
+	q.Set("code", "true")
+	q.Set("client_id", oauthClientID)
+	q.Set("response_type", "code")
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", oauthScopes)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", state)
+	return base + "?" + q.Encode()
+}
+
+// startCallbackServer wires a one-shot HTTP server onto the supplied
+// listener and returns it. The server writes the result of the first
+// valid /callback hit (or a state mismatch) onto resultCh.
+func startCallbackServer(ln net.Listener, expectedState string, resultCh chan<- callbackResult) *http.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		gotState := r.URL.Query().Get("state")
+		if code == "" || gotState == "" {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			http.Error(w, "Missing code or state", http.StatusBadRequest)
+			return
+		}
+		if gotState != expectedState {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			http.Error(w, "Invalid state", http.StatusBadRequest)
+			// Signal the main goroutine so the command exits with a
+			// clear error rather than waiting for the timeout. The
+			// error string does NOT include either state value.
+			select {
+			case resultCh <- callbackResult{err: errors.New("OAuth state mismatch")}:
+			default:
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Connection", "close")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, callbackSuccessHTML())
+		select {
+		case resultCh <- callbackResult{code: code, state: gotState}:
+		default:
+		}
+	})
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() { _ = srv.Serve(ln) }()
+	return srv
+}
+
+func callbackSuccessHTML() string {
+	return `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Authorization complete</title></head>
+  <body>
+    <h1>Authorization complete</h1>
+    <p>You can close this window and return to prism.</p>
+  </body>
+</html>`
+}
+
+// parsedAuthInput is what parseAuthInput surfaces on success.
+type parsedAuthInput struct {
+	code  string
+	state string
+}
+
+// parseAuthInput accepts the three formats from auth.ts::parseAuthInput:
+//
+//  1. Full URL with ?code=…&state=… (e.g. the redirect URL the browser
+//     lands on after authorization).
+//  2. `code#state` shorthand (the Anthropic platform-side fallback page
+//     renders this for users to copy).
+//  3. Raw query string `code=…&state=…`.
+//
+// Returns (zero, false) when none of the three forms produce both a
+// non-empty code and a non-empty state.
+func parseAuthInput(input string) (parsedAuthInput, bool) {
+	text := strings.TrimSpace(input)
+	if text == "" {
+		return parsedAuthInput{}, false
+	}
+
+	// Form 1: full URL. url.Parse is lenient in Go so we additionally
+	// require a non-empty scheme — same as JS `new URL(text)` strictness.
+	if u, err := url.Parse(text); err == nil && u.Scheme != "" {
+		code := u.Query().Get("code")
+		state := u.Query().Get("state")
+		if code != "" && state != "" {
+			return parsedAuthInput{code: code, state: state}, true
+		}
+	}
+
+	// Form 2: code#state shorthand. Mirror auth.ts exactly — split on
+	// '#', accept iff both halves are non-empty.
+	parts := strings.SplitN(text, "#", 2)
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parsedAuthInput{code: parts[0], state: parts[1]}, true
+	}
+
+	// Form 3: raw query string.
+	if vals, err := url.ParseQuery(text); err == nil {
+		code := vals.Get("code")
+		state := vals.Get("state")
+		if code != "" && state != "" {
+			return parsedAuthInput{code: code, state: state}, true
+		}
+	}
+
+	return parsedAuthInput{}, false
+}
+
+// exchangeToken POSTs the authorization code to TOKEN_URL and returns
+// the parsed response. Retries up to maxTokenRetries on 429 / 5xx,
+// honours Retry-After (capped at retryAfterCap), and aborts immediately
+// on X-Should-Retry: false.
+//
+// Error messages MUST NOT include the request body (which contains the
+// code and verifier) — only the response HTTP status. The response body
+// is server-controlled and does not contain the code/verifier values.
+func exchangeToken(ctx context.Context, opts LoginOptions, code, state, verifier, redirectURI string) (tokenResponse, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", oauthClientID)
+	form.Set("code", code)
+	form.Set("state", state)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code_verifier", verifier)
+	body := form.Encode()
+
+	var lastStatus int
+	for attempt := 0; attempt <= maxTokenRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, opts.TokenURL, strings.NewReader(body))
+		if err != nil {
+			return tokenResponse{}, fmt.Errorf("token exchange: build request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("User-Agent", oauthUserAgent)
+
+		resp, err := opts.HTTPClient.Do(req)
+		if err != nil {
+			return tokenResponse{}, fmt.Errorf("token exchange: HTTP request failed: %w", err)
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			tr, decErr := decodeTokenResponse(resp)
+			if decErr != nil {
+				return tokenResponse{}, fmt.Errorf("token exchange: parse response: %w", decErr)
+			}
+			return tr, nil
+		}
+
+		lastStatus = resp.StatusCode
+		shouldRetryHeader := resp.Header.Get("X-Should-Retry")
+		retryAfterHeader := resp.Header.Get("Retry-After")
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if shouldRetryHeader == "false" {
+			return tokenResponse{}, fmt.Errorf("token exchange failed: HTTP %d", lastStatus)
+		}
+
+		retriable := lastStatus == http.StatusTooManyRequests || lastStatus >= 500
+		if attempt < maxTokenRetries && retriable {
+			opts.Sleep(retryDelay(retryAfterHeader, attempt))
+			continue
+		}
+
+		return tokenResponse{}, fmt.Errorf("token exchange failed: HTTP %d", lastStatus)
+	}
+	return tokenResponse{}, fmt.Errorf("token exchange failed after retries: HTTP %d", lastStatus)
+}
+
+func decodeTokenResponse(resp *http.Response) (tokenResponse, error) {
+	defer resp.Body.Close()
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return tokenResponse{}, err
+	}
+	if tr.AccessToken == "" || tr.RefreshToken == "" {
+		return tokenResponse{}, errors.New("token response missing access_token or refresh_token")
+	}
+	return tr, nil
+}
+
+// retryDelay computes the backoff between attempts. When Retry-After is
+// supplied and parses as an integer seconds value, use it (capped at
+// retryAfterCap). Otherwise use exponential backoff anchored on
+// initialRetryDelay.
+func retryDelay(retryAfter string, attempt int) time.Duration {
+	if retryAfter != "" {
+		if secs, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil && secs >= 0 {
+			delay := time.Duration(secs) * time.Second
+			if delay > retryAfterCap {
+				delay = retryAfterCap
+			}
+			return delay
+		}
+	}
+	return initialRetryDelay * time.Duration(1<<attempt)
+}

--- a/modules/programs/prism/prism/internal/account/login.go
+++ b/modules/programs/prism/prism/internal/account/login.go
@@ -58,11 +58,16 @@ const (
 	// from the bound listener.
 	oauthRedirectURI = "https://platform.claude.com/oauth/code/callback"
 	oauthScopes      = "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
-	oauthUserAgent   = "claude-code/2.1.97"
-	callbackPort     = 53692
-	callbackHost     = "127.0.0.1"
-	callbackTimeout  = 5 * time.Minute
-	maxTokenRetries  = 2
+	// NOTE: deliberately NO User-Agent constant. auth.ts's makeTokenHeaders
+	// sends only Content-Type because Anthropic's Cloudflare WAF on
+	// `claude.ai/v1/oauth/token` returns 429 for requests carrying
+	// `User-Agent: claude-code/*`. Tracked as divergence #1 in
+	// modules/programs/prism/pi/extensions/anthropic-oauth/UPSTREAM.md;
+	// removed in issue #888. Do NOT add a UA on the token-exchange path.
+	callbackPort      = 53692
+	callbackHost      = "127.0.0.1"
+	callbackTimeout   = 5 * time.Minute
+	maxTokenRetries   = 2
 	initialRetryDelay = 5 * time.Second
 	tokenExpirySafety = 5 * time.Minute
 	retryAfterCap     = 30 * time.Second
@@ -539,7 +544,14 @@ func exchangeToken(ctx context.Context, opts LoginOptions, code, state, verifier
 			return tokenResponse{}, fmt.Errorf("token exchange: build request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Set("User-Agent", oauthUserAgent)
+		// No User-Agent: see the constants block above (issue #888).
+		// auth.ts::makeTokenHeaders omits it because Cloudflare's WAF on
+		// `claude.ai/v1/oauth/token` returns 429 for `claude-code/*`.
+		// Setting the header to "" (rather than leaving it unset) tells
+		// Go's net/http transport to suppress its default
+		// `Go-http-client/1.1` UA so no UA header is sent on the wire at
+		// all, matching Node's fetch behaviour in auth.ts exactly.
+		req.Header.Set("User-Agent", "")
 
 		resp, err := opts.HTTPClient.Do(req)
 		if err != nil {

--- a/modules/programs/prism/prism/internal/account/login_test.go
+++ b/modules/programs/prism/prism/internal/account/login_test.go
@@ -104,12 +104,12 @@ func TestParseAuthInput_Invalid(t *testing.T) {
 	cases := []string{
 		"",
 		"   ",
-		"http://localhost:53692/callback?code=onlycode",       // missing state
-		"http://localhost:53692/callback?state=onlystate",     // missing code
-		"justonething",                                        // not URL, not code#state, not query
-		"code=",                                               // empty code
-		"#statebutnocode",                                     // empty code in code#state
-		"codebutnostate#",                                     // empty state in code#state
+		"http://localhost:53692/callback?code=onlycode",   // missing state
+		"http://localhost:53692/callback?state=onlystate", // missing code
+		"justonething",    // not URL, not code#state, not query
+		"code=",           // empty code
+		"#statebutnocode", // empty code in code#state
+		"codebutnostate#", // empty state in code#state
 	}
 	for _, c := range cases {
 		if got, ok := parseAuthInput(c); ok {
@@ -158,10 +158,10 @@ func TestMakeAuthorizeURL_ContainsRequiredParams(t *testing.T) {
 
 func TestRetryDelay_HonoursRetryAfter_AndCaps(t *testing.T) {
 	cases := []struct {
-		name        string
-		retryAfter  string
-		attempt     int
-		wantDelay   time.Duration
+		name       string
+		retryAfter string
+		attempt    int
+		wantDelay  time.Duration
 	}{
 		{"no header → exponential attempt 0", "", 0, initialRetryDelay},
 		{"no header → exponential attempt 1", "", 1, 2 * initialRetryDelay},
@@ -187,8 +187,15 @@ func TestExchangeToken_Success(t *testing.T) {
 		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
 			t.Errorf("Content-Type = %q, want form-urlencoded", got)
 		}
-		if got := r.Header.Get("User-Agent"); got != oauthUserAgent {
-			t.Errorf("User-Agent = %q, want %q", got, oauthUserAgent)
+		// AC: User-Agent must NOT be sent on token-exchange requests
+		// because Anthropic's Cloudflare WAF returns 429 for
+		// `User-Agent: claude-code/*` (issue #888; UPSTREAM.md
+		// divergence #1). The TS canonical assertion is
+		// `headers.has("user-agent") === false` — mirror that. Production
+		// suppresses Go's default `Go-http-client/1.1` by setting the
+		// header to "", which net/http elides on the wire.
+		if got := r.Header.Get("User-Agent"); got != "" {
+			t.Errorf("User-Agent = %q, want absent (Cloudflare WAF blocks claude-code/* — see #888)", got)
 		}
 		_ = r.ParseForm()
 		if r.Form.Get("grant_type") != "authorization_code" {
@@ -392,15 +399,15 @@ func TestExchangeToken_ErrorNeverIncludesCode(t *testing.T) {
 // for full-flow tests. The token endpoint returns a canned successful
 // response by default; per-test handlers may override.
 type loginFixture struct {
-	paths      Paths
-	cfgRoot    string
-	authPath   string
-	tokenSrv   *httptest.Server
-	tokenSeen  atomic.Int32
-	browserCh  chan string
-	stdout     *bytes.Buffer
-	stdin      *strings.Reader
-	headless   bool
+	paths     Paths
+	cfgRoot   string
+	authPath  string
+	tokenSrv  *httptest.Server
+	tokenSeen atomic.Int32
+	browserCh chan string
+	stdout    *bytes.Buffer
+	stdin     *strings.Reader
+	headless  bool
 }
 
 func newLoginFixture(t *testing.T) *loginFixture {

--- a/modules/programs/prism/prism/internal/account/login_test.go
+++ b/modules/programs/prism/prism/internal/account/login_test.go
@@ -1,0 +1,1176 @@
+// Tests for `prism account login` (#2284). All tests are hermetic:
+// $XDG_CONFIG_HOME and $PI_AUTH_JSON point at a per-test tempdir, the
+// token endpoint is stubbed with httptest, the browser launcher is a
+// no-op, and the IsHeadless detector is overridden. Nothing here
+// touches ~/.config/prism, ~/.pi/agent/auth.json, or the real network.
+package account
+
+import (
+	"bytes"
+	"context"
+	cryptosha256 "crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ─── PKCE / state helpers ────────────────────────────────────────────
+
+func TestGeneratePKCE_FreshPerInvocation_AndChallengeIsSHA256OfVerifier(t *testing.T) {
+	v1, c1, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE 1: %v", err)
+	}
+	v2, c2, err := generatePKCE()
+	if err != nil {
+		t.Fatalf("generatePKCE 2: %v", err)
+	}
+	if v1 == v2 {
+		t.Fatalf("verifier reused between calls: %q == %q", v1, v2)
+	}
+	if c1 == c2 {
+		t.Fatalf("challenge reused between calls: %q", c1)
+	}
+	// Verifier should be 32 random bytes base64url-encoded (no padding)
+	// → 43 characters.
+	if len(v1) != 43 {
+		t.Errorf("verifier length = %d, want 43 (32 bytes base64url no padding)", len(v1))
+	}
+	// Decode and confirm 32 raw bytes.
+	raw, err := base64.RawURLEncoding.DecodeString(v1)
+	if err != nil {
+		t.Fatalf("base64url decode verifier: %v", err)
+	}
+	if len(raw) != 32 {
+		t.Errorf("verifier decodes to %d bytes, want 32", len(raw))
+	}
+	// Challenge should be base64url(SHA-256(verifier_ascii_bytes)).
+	expectChallenge := sha256Base64URL(v1)
+	if c1 != expectChallenge {
+		t.Errorf("challenge mismatch:\n got %q\nwant %q", c1, expectChallenge)
+	}
+}
+
+func sha256Base64URL(s string) string {
+	h := cryptosha256.Sum256([]byte(s))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// ─── parseAuthInput ──────────────────────────────────────────────────
+
+func TestParseAuthInput_AllThreeFormats(t *testing.T) {
+	const code = "abc123"
+	const state = "xyz789"
+
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"full URL", "http://localhost:53692/callback?code=" + code + "&state=" + state},
+		{"https URL", "https://platform.claude.com/oauth/code/callback?code=" + code + "&state=" + state},
+		{"code#state", code + "#" + state},
+		{"raw query string", "code=" + code + "&state=" + state},
+		{"leading/trailing whitespace", "  " + code + "#" + state + "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseAuthInput(tc.input)
+			if !ok {
+				t.Fatalf("parseAuthInput(%q) = nil, want match", tc.input)
+			}
+			if got.code != code {
+				t.Errorf("code = %q, want %q", got.code, code)
+			}
+			if got.state != state {
+				t.Errorf("state = %q, want %q", got.state, state)
+			}
+		})
+	}
+}
+
+func TestParseAuthInput_Invalid(t *testing.T) {
+	cases := []string{
+		"",
+		"   ",
+		"http://localhost:53692/callback?code=onlycode",       // missing state
+		"http://localhost:53692/callback?state=onlystate",     // missing code
+		"justonething",                                        // not URL, not code#state, not query
+		"code=",                                               // empty code
+		"#statebutnocode",                                     // empty code in code#state
+		"codebutnostate#",                                     // empty state in code#state
+	}
+	for _, c := range cases {
+		if got, ok := parseAuthInput(c); ok {
+			t.Errorf("parseAuthInput(%q) = %+v, want false", c, got)
+		}
+	}
+}
+
+// ─── authorize URL ───────────────────────────────────────────────────
+
+func TestMakeAuthorizeURL_ContainsRequiredParams(t *testing.T) {
+	const state = "abc"
+	const challenge = "challenge"
+	const redirect = "http://localhost:53692/callback"
+
+	raw := makeAuthorizeURL(oauthAuthorizeURL, challenge, state, redirect)
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	q := u.Query()
+	if q.Get("client_id") != oauthClientID {
+		t.Errorf("client_id = %q, want %q", q.Get("client_id"), oauthClientID)
+	}
+	if q.Get("response_type") != "code" {
+		t.Errorf("response_type = %q, want code", q.Get("response_type"))
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", q.Get("code_challenge_method"))
+	}
+	if q.Get("code_challenge") != challenge {
+		t.Errorf("code_challenge missing/incorrect")
+	}
+	if q.Get("state") != state {
+		t.Errorf("state missing/incorrect")
+	}
+	if q.Get("redirect_uri") != redirect {
+		t.Errorf("redirect_uri = %q, want %q", q.Get("redirect_uri"), redirect)
+	}
+	if q.Get("scope") != oauthScopes {
+		t.Errorf("scope = %q, want %q", q.Get("scope"), oauthScopes)
+	}
+}
+
+// ─── retry delay ─────────────────────────────────────────────────────
+
+func TestRetryDelay_HonoursRetryAfter_AndCaps(t *testing.T) {
+	cases := []struct {
+		name        string
+		retryAfter  string
+		attempt     int
+		wantDelay   time.Duration
+	}{
+		{"no header → exponential attempt 0", "", 0, initialRetryDelay},
+		{"no header → exponential attempt 1", "", 1, 2 * initialRetryDelay},
+		{"retry-after 2 → 2s", "2", 0, 2 * time.Second},
+		{"retry-after 60 capped at 30s", "60", 0, retryAfterCap},
+		{"retry-after with whitespace", "  3 ", 0, 3 * time.Second},
+		{"unparseable falls through", "garbage", 1, 2 * initialRetryDelay},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := retryDelay(tc.retryAfter, tc.attempt)
+			if got != tc.wantDelay {
+				t.Errorf("retryDelay(%q, %d) = %s, want %s", tc.retryAfter, tc.attempt, got, tc.wantDelay)
+			}
+		})
+	}
+}
+
+// ─── exchangeToken ───────────────────────────────────────────────────
+
+func TestExchangeToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %q, want form-urlencoded", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != oauthUserAgent {
+			t.Errorf("User-Agent = %q, want %q", got, oauthUserAgent)
+		}
+		_ = r.ParseForm()
+		if r.Form.Get("grant_type") != "authorization_code" {
+			t.Errorf("grant_type = %q", r.Form.Get("grant_type"))
+		}
+		if r.Form.Get("client_id") != oauthClientID {
+			t.Errorf("client_id missing")
+		}
+		if r.Form.Get("code_verifier") == "" {
+			t.Errorf("code_verifier missing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"acc","refresh_token":"ref","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	opts := LoginOptions{TokenURL: srv.URL}
+	opts.applyDefaults()
+	tr, err := exchangeToken(context.Background(), opts, "code", "state", "verifier", "http://localhost:0/callback")
+	if err != nil {
+		t.Fatalf("exchangeToken: %v", err)
+	}
+	if tr.AccessToken != "acc" || tr.RefreshToken != "ref" || tr.ExpiresIn != 3600 {
+		t.Errorf("token response unexpected: %+v", tr)
+	}
+}
+
+func TestExchangeToken_RetriesOn429_ThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","expires_in":1}`))
+	}))
+	defer srv.Close()
+
+	var slept []time.Duration
+	opts := LoginOptions{
+		TokenURL: srv.URL,
+		Sleep:    func(d time.Duration) { slept = append(slept, d) },
+	}
+	opts.applyDefaults()
+
+	tr, err := exchangeToken(context.Background(), opts, "c", "s", "v", "r")
+	if err != nil {
+		t.Fatalf("exchangeToken: %v", err)
+	}
+	if tr.AccessToken != "a" {
+		t.Errorf("access = %q", tr.AccessToken)
+	}
+	if atomic.LoadInt32(&calls) != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+	if len(slept) != 1 {
+		t.Errorf("slept %d times, want 1", len(slept))
+	}
+}
+
+func TestExchangeToken_RetriesOn5xx_RespectsRetryAfter(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","expires_in":1}`))
+	}))
+	defer srv.Close()
+
+	var slept []time.Duration
+	opts := LoginOptions{
+		TokenURL: srv.URL,
+		Sleep:    func(d time.Duration) { slept = append(slept, d) },
+	}
+	opts.applyDefaults()
+
+	if _, err := exchangeToken(context.Background(), opts, "c", "s", "v", "r"); err != nil {
+		t.Fatalf("exchangeToken: %v", err)
+	}
+	if len(slept) != 1 || slept[0] != 2*time.Second {
+		t.Errorf("slept = %v, want [2s]", slept)
+	}
+}
+
+func TestExchangeToken_RetryAfterCappedAt30Seconds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "120")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","expires_in":1}`))
+	}))
+	defer srv.Close()
+
+	var slept []time.Duration
+	opts := LoginOptions{
+		TokenURL: srv.URL,
+		Sleep:    func(d time.Duration) { slept = append(slept, d) },
+	}
+	opts.applyDefaults()
+
+	if _, err := exchangeToken(context.Background(), opts, "c", "s", "v", "r"); err != nil {
+		t.Fatalf("exchangeToken: %v", err)
+	}
+	if len(slept) != 1 || slept[0] != retryAfterCap {
+		t.Errorf("slept = %v, want [%s]", slept, retryAfterCap)
+	}
+}
+
+func TestExchangeToken_AbortsOnXShouldRetryFalse(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("X-Should-Retry", "false")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var slept []time.Duration
+	opts := LoginOptions{
+		TokenURL: srv.URL,
+		Sleep:    func(d time.Duration) { slept = append(slept, d) },
+	}
+	opts.applyDefaults()
+
+	_, err := exchangeToken(context.Background(), opts, "c", "s", "v", "r")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Errorf("calls = %d, want 1 (no retry)", calls)
+	}
+	if len(slept) != 0 {
+		t.Errorf("slept = %v, want []", slept)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error does not include status: %v", err)
+	}
+}
+
+func TestExchangeToken_ExhaustsRetries_ErrorIncludesHTTPStatus(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	opts := LoginOptions{
+		TokenURL: srv.URL,
+		Sleep:    func(time.Duration) {},
+	}
+	opts.applyDefaults()
+
+	_, err := exchangeToken(context.Background(), opts, "c", "s", "v", "r")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Errorf("error does not include status: %v", err)
+	}
+	// maxTokenRetries=2 plus the initial attempt = 3 calls total.
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("calls = %d, want 3 (1 initial + 2 retries)", got)
+	}
+}
+
+func TestExchangeToken_ErrorNeverIncludesCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Should-Retry", "false")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_request"}`))
+	}))
+	defer srv.Close()
+
+	const secretCode = "super-secret-code-value-do-not-leak"
+	opts := LoginOptions{TokenURL: srv.URL, Sleep: func(time.Duration) {}}
+	opts.applyDefaults()
+
+	_, err := exchangeToken(context.Background(), opts, secretCode, "state", "verifier", "redirect")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), secretCode) {
+		t.Errorf("error message leaks code: %v", err)
+	}
+}
+
+// ─── Login end-to-end (with stubs) ───────────────────────────────────
+
+// loginFixture wires up an isolated filesystem + stubbed dependencies
+// for full-flow tests. The token endpoint returns a canned successful
+// response by default; per-test handlers may override.
+type loginFixture struct {
+	paths      Paths
+	cfgRoot    string
+	authPath   string
+	tokenSrv   *httptest.Server
+	tokenSeen  atomic.Int32
+	browserCh  chan string
+	stdout     *bytes.Buffer
+	stdin      *strings.Reader
+	headless   bool
+}
+
+func newLoginFixture(t *testing.T) *loginFixture {
+	t.Helper()
+	root := t.TempDir()
+	cfg := filepath.Join(root, "config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+
+	piDir := filepath.Join(root, "pi-agent")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		t.Fatalf("mkdir pi-agent: %v", err)
+	}
+	auth := filepath.Join(piDir, "auth.json")
+	t.Setenv("PI_AUTH_JSON", auth)
+
+	p, err := ResolvePaths()
+	if err != nil {
+		t.Fatalf("ResolvePaths: %v", err)
+	}
+
+	f := &loginFixture{
+		paths:     p,
+		cfgRoot:   cfg,
+		authPath:  auth,
+		browserCh: make(chan string, 1),
+		stdout:    &bytes.Buffer{},
+		stdin:     strings.NewReader(""),
+	}
+	f.tokenSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.tokenSeen.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access-tok","refresh_token":"refresh-tok","expires_in":3600}`))
+	}))
+	t.Cleanup(f.tokenSrv.Close)
+	return f
+}
+
+// makeOpts returns a LoginOptions with the fixture's stubs wired in. A
+// successful callback is simulated by GETting the redirect URL we
+// extract from the printed authorize URL.
+func (f *loginFixture) makeOpts() LoginOptions {
+	return LoginOptions{
+		TokenURL: f.tokenSrv.URL,
+		Browser: func(target string) error {
+			select {
+			case f.browserCh <- target:
+			default:
+			}
+			return nil
+		},
+		IsHeadless: func() bool { return f.headless },
+		Stdout:     f.stdout,
+		Stdin:      f.stdin,
+		Now:        func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+		Sleep:      func(time.Duration) {},
+		Timeout:    2 * time.Second,
+	}
+}
+
+// driveCallback simulates the browser landing on the local callback URL
+// with the given code and state. Pulls the authorize URL out of either
+// the browser channel (in the launch-success path) or the captured
+// stdout. Returns when the callback has been delivered (or the test
+// fails).
+func (f *loginFixture) driveCallback(t *testing.T, code, state string, errFromAuthURL chan<- error) {
+	t.Helper()
+	go func() {
+		// Pull the authorize URL from either the browser channel (when
+		// the browser launcher fired) or stdout (when it didn't). Race
+		// the two so a non-launch path doesn't block.
+		var target string
+		select {
+		case target = <-f.browserCh:
+		case <-time.After(2 * time.Second):
+			errFromAuthURL <- errors.New("timed out waiting for authorize URL")
+			return
+		}
+		u, err := url.Parse(target)
+		if err != nil {
+			errFromAuthURL <- fmt.Errorf("parse authorize URL: %w", err)
+			return
+		}
+		redirect := u.Query().Get("redirect_uri")
+		if redirect == "" {
+			errFromAuthURL <- errors.New("no redirect_uri in authorize URL")
+			return
+		}
+		callback := fmt.Sprintf("%s?code=%s&state=%s", redirect, url.QueryEscape(code), url.QueryEscape(state))
+		// Brief retry loop: the server may not yet be Accept()ing.
+		var resp *http.Response
+		for i := 0; i < 20; i++ {
+			resp, err = http.Get(callback)
+			if err == nil {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		if err != nil {
+			errFromAuthURL <- fmt.Errorf("GET callback: %w", err)
+			return
+		}
+		defer resp.Body.Close()
+		errFromAuthURL <- nil
+	}()
+}
+
+func TestLogin_Success_WritesAccountFile_Mode0o600_AndPrintsSavedMessage(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+
+	// We need to extract the state generated inside Login to drive a
+	// matching callback. Use the browser-launcher hook: capture the
+	// authorize URL, parse out state.
+	errCh := make(chan error, 1)
+	go func() {
+		target := <-f.browserCh
+		u, err := url.Parse(target)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		state := u.Query().Get("state")
+		redirect := u.Query().Get("redirect_uri")
+		callback := fmt.Sprintf("%s?code=alice-code&state=%s", redirect, url.QueryEscape(state))
+		for i := 0; i < 20; i++ {
+			resp, err := http.Get(callback)
+			if err == nil {
+				resp.Body.Close()
+				errCh <- nil
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		errCh <- errors.New("callback never succeeded")
+	}()
+
+	if err := Login(f.paths, "work", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("driver: %v", err)
+	}
+
+	// File exists, mode 0o600, correct shape.
+	acctPath := f.paths.AccountPath("work")
+	info, err := os.Stat(acctPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("file mode = %o, want 0o600", perm)
+	}
+	data, _ := os.ReadFile(acctPath)
+	var got accountBlob
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse account file: %v", err)
+	}
+	if got.Type != "oauth" || got.Access != "access-tok" || got.Refresh != "refresh-tok" {
+		t.Errorf("account blob = %+v", got)
+	}
+	// expires = now*1000 + 3600*1000 - 300_000
+	wantExpires := time.Unix(1_700_000_000, 0).UnixMilli() + 3600*1000 - 5*60*1000
+	if got.Expires != wantExpires {
+		t.Errorf("expires = %d, want %d", got.Expires, wantExpires)
+	}
+
+	// Stdout includes the success message.
+	if !strings.Contains(f.stdout.String(), "account work saved. Run 'prism account use work' to activate.") {
+		t.Errorf("stdout missing success message: %q", f.stdout.String())
+	}
+
+	// accounts dir is mode 0o700 (set by Init).
+	dirInfo, _ := os.Stat(f.paths.Dir)
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("accounts dir mode = %o, want 0o700", perm)
+	}
+}
+
+func TestLogin_TokenAndVerifierNeverInOutput(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+
+	// Run the flow successfully. After it returns, scan stdout for any
+	// trace of the access token, refresh token, or any plausible
+	// verifier substring.
+	errCh := make(chan error, 1)
+	go func() {
+		target := <-f.browserCh
+		u, _ := url.Parse(target)
+		state := u.Query().Get("state")
+		redirect := u.Query().Get("redirect_uri")
+		challenge := u.Query().Get("code_challenge")
+		callback := fmt.Sprintf("%s?code=c&state=%s", redirect, url.QueryEscape(state))
+		for i := 0; i < 20; i++ {
+			resp, err := http.Get(callback)
+			if err == nil {
+				resp.Body.Close()
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		// Stash the challenge so the test below can check it does
+		// appear (it's the safe-to-surface counterpart).
+		errCh <- nil
+		_ = challenge
+	}()
+	if err := Login(f.paths, "secrets", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	<-errCh
+
+	out := f.stdout.String()
+	if strings.Contains(out, "access-tok") {
+		t.Errorf("stdout leaks access token: %q", out)
+	}
+	if strings.Contains(out, "refresh-tok") {
+		t.Errorf("stdout leaks refresh token: %q", out)
+	}
+	// The verifier is 43 chars of base64url. We can't know it from
+	// outside, but we can assert that none of the printed tokens
+	// matches the size+alphabet pattern.
+	if leakSuspectedVerifier(out) {
+		t.Errorf("stdout contains a base64url string that could be the verifier: %q", out)
+	}
+}
+
+// leakSuspectedVerifier heuristically scans for a 43-char base64url-no-
+// padding token in `out`. The authorize URL contains a 43-char challenge
+// (`code_challenge` query param) so we extract it and exclude it from
+// the scan — we expect the challenge to appear and the verifier not to.
+func leakSuspectedVerifier(out string) bool {
+	// Pull the challenge out of any URL we recognise.
+	var challenge string
+	for _, line := range strings.Split(out, "\n") {
+		idx := strings.Index(line, "code_challenge=")
+		if idx == -1 {
+			continue
+		}
+		rest := line[idx+len("code_challenge="):]
+		end := strings.IndexAny(rest, "& ")
+		if end == -1 {
+			challenge = rest
+		} else {
+			challenge = rest[:end]
+		}
+		break
+	}
+	// Walk the output extracting runs of base64url chars and matching
+	// length 43. Skip any run that equals the known challenge.
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	allowed := make(map[byte]bool, len(alphabet))
+	for i := 0; i < len(alphabet); i++ {
+		allowed[alphabet[i]] = true
+	}
+	var run strings.Builder
+	flush := func() bool {
+		s := run.String()
+		run.Reset()
+		if len(s) == 43 && s != challenge {
+			return true
+		}
+		return false
+	}
+	for i := 0; i < len(out); i++ {
+		c := out[i]
+		if allowed[c] {
+			run.WriteByte(c)
+			continue
+		}
+		if flush() {
+			return true
+		}
+	}
+	return flush()
+}
+
+func TestLogin_WithUse_ActivatesAccount(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+	opts.Use = true
+
+	errCh := make(chan error, 1)
+	go func() {
+		target := <-f.browserCh
+		u, _ := url.Parse(target)
+		state := u.Query().Get("state")
+		redirect := u.Query().Get("redirect_uri")
+		callback := fmt.Sprintf("%s?code=c&state=%s", redirect, url.QueryEscape(state))
+		for i := 0; i < 20; i++ {
+			if resp, err := http.Get(callback); err == nil {
+				resp.Body.Close()
+				errCh <- nil
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		errCh <- errors.New("callback never succeeded")
+	}()
+
+	if err := Login(f.paths, "work", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	<-errCh
+
+	// auth.json now contains the new anthropic blob.
+	data, err := os.ReadFile(f.authPath)
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var top map[string]any
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("parse auth.json: %v", err)
+	}
+	anth, _ := top["anthropic"].(map[string]any)
+	if anth["access"] != "access-tok" {
+		t.Errorf("auth.json anthropic.access = %v, want access-tok", anth["access"])
+	}
+
+	// accounts/current reads "work".
+	curData, _ := os.ReadFile(f.paths.Current)
+	if got := strings.TrimSpace(string(curData)); got != "work" {
+		t.Errorf("current = %q, want work", got)
+	}
+
+	// Success message reflects activation.
+	if !strings.Contains(f.stdout.String(), "saved and activated") {
+		t.Errorf("stdout missing activated message: %q", f.stdout.String())
+	}
+}
+
+func TestLogin_RandomPort_RedirectURIMatchesBoundPort(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+
+	captured := make(chan string, 1)
+	opts.Browser = func(target string) error {
+		captured <- target
+		return nil
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		target := <-captured
+		u, err := url.Parse(target)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		redirect := u.Query().Get("redirect_uri")
+		if !strings.HasPrefix(redirect, "http://localhost:") {
+			errCh <- fmt.Errorf("redirect_uri = %q, want http://localhost:...", redirect)
+			return
+		}
+		ru, _ := url.Parse(redirect)
+		port := ru.Port()
+		if port == "" || port == "0" || port == fmt.Sprint(callbackPort) {
+			errCh <- fmt.Errorf("port = %q, want a non-default random port", port)
+			return
+		}
+		// Confirm we can actually hit that port — proves the listener bound there.
+		state := u.Query().Get("state")
+		callback := fmt.Sprintf("%s?code=c&state=%s", redirect, url.QueryEscape(state))
+		for i := 0; i < 20; i++ {
+			if resp, err := http.Get(callback); err == nil {
+				resp.Body.Close()
+				errCh <- nil
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		errCh <- errors.New("callback never succeeded")
+	}()
+
+	if err := Login(f.paths, "work", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("driver: %v", err)
+	}
+}
+
+func TestLogin_PortInUse_ClearErrorAndSuggestsRandomPort(t *testing.T) {
+	f := newLoginFixture(t)
+
+	// Bind a random free port and hold it. Then point Login at the
+	// same port.
+	hog, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("hog listen: %v", err)
+	}
+	defer hog.Close()
+	busyPort := hog.Addr().(*net.TCPAddr).Port
+
+	opts := f.makeOpts()
+	opts.Port = busyPort
+
+	err = Login(f.paths, "work", opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprint(busyPort)) {
+		t.Errorf("error does not name port %d: %v", busyPort, err)
+	}
+	if !strings.Contains(err.Error(), "--port 0") {
+		t.Errorf("error does not suggest --port 0: %v", err)
+	}
+	// No account file was created.
+	if _, statErr := os.Stat(f.paths.AccountPath("work")); !os.IsNotExist(statErr) {
+		t.Errorf("account file should not exist: %v", statErr)
+	}
+}
+
+func TestLogin_InvalidName_FailsBeforeNetworkCall(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+	// Use a Browser that fails the test if it ever runs.
+	opts.Browser = func(_ string) error {
+		t.Fatal("browser called for invalid name")
+		return nil
+	}
+
+	for _, bad := range []string{"", ".", "..", "current", "a/b", `a\b`} {
+		if err := Login(f.paths, bad, opts); err == nil {
+			t.Errorf("Login(%q): want error, got nil", bad)
+		}
+	}
+	if f.tokenSeen.Load() != 0 {
+		t.Errorf("token endpoint hit %d times for invalid name", f.tokenSeen.Load())
+	}
+}
+
+func TestLogin_StateMismatch_400ToBrowser_AndOAuthStateMismatchError_NoEcho(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+
+	const fakeState = "definitely-not-the-real-state-aaaaaaaaaa"
+	const expectedReal = "" // we don't know real state from outside; just confirm not echoed
+
+	httpResp := make(chan *http.Response, 1)
+	go func() {
+		target := <-f.browserCh
+		u, _ := url.Parse(target)
+		redirect := u.Query().Get("redirect_uri")
+		callback := fmt.Sprintf("%s?code=c&state=%s", redirect, url.QueryEscape(fakeState))
+		for i := 0; i < 20; i++ {
+			resp, err := http.Get(callback)
+			if err == nil {
+				httpResp <- resp
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		httpResp <- nil
+	}()
+
+	err := Login(f.paths, "work", opts)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "OAuth state mismatch") {
+		t.Errorf("error = %q, want 'OAuth state mismatch' substring", err)
+	}
+	if strings.Contains(err.Error(), fakeState) {
+		t.Errorf("error echoes received state: %v", err)
+	}
+	_ = expectedReal
+
+	resp := <-httpResp
+	if resp == nil {
+		t.Fatal("no HTTP response captured from callback")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("callback HTTP status = %d, want 400", resp.StatusCode)
+	}
+
+	// No account file written.
+	if _, statErr := os.Stat(f.paths.AccountPath("work")); !os.IsNotExist(statErr) {
+		t.Errorf("account file should not exist: %v", statErr)
+	}
+}
+
+func TestLogin_HeadlessSkipsBrowserAndPrintsURL(t *testing.T) {
+	f := newLoginFixture(t)
+	f.headless = true
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+	opts.Browser = func(_ string) error {
+		t.Fatal("browser launched in headless mode")
+		return nil
+	}
+	// Provide stdin with the manual paste of a code#state pair. Drive
+	// the test by parsing the printed URL to learn the state.
+	pasteR, pasteW, _ := os.Pipe()
+	opts.Stdin = pasteR
+	defer pasteW.Close()
+
+	var stdoutMu sync.Mutex
+	stdoutBuf := &bytes.Buffer{}
+	opts.Stdout = lockedWriter{m: &stdoutMu, w: stdoutBuf}
+
+	errCh := make(chan error, 1)
+	go func() {
+		// Poll stdout for the authorize URL.
+		deadline := time.Now().Add(2 * time.Second)
+		var line string
+		for time.Now().Before(deadline) {
+			stdoutMu.Lock()
+			line = stdoutBuf.String()
+			stdoutMu.Unlock()
+			if strings.Contains(line, "claude.ai/oauth/authorize") {
+				break
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		idx := strings.Index(line, "https://claude.ai/oauth/authorize")
+		if idx == -1 {
+			errCh <- errors.New("authorize URL never printed to stdout")
+			return
+		}
+		rest := line[idx:]
+		end := strings.IndexAny(rest, "\n ")
+		if end == -1 {
+			end = len(rest)
+		}
+		raw := rest[:end]
+		u, err := url.Parse(raw)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		state := u.Query().Get("state")
+		_, err = pasteW.Write([]byte("code-from-paste#" + state + "\n"))
+		errCh <- err
+	}()
+
+	if err := Login(f.paths, "work", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("driver: %v", err)
+	}
+
+	if !strings.Contains(stdoutBuf.String(), "claude.ai/oauth/authorize") {
+		t.Errorf("stdout missing authorize URL")
+	}
+}
+
+// lockedWriter is a minimal io.Writer with mutex protection so the
+// stdout-polling goroutine in TestLogin_HeadlessSkipsBrowserAndPrintsURL
+// doesn't race the Login goroutine writing into the buffer.
+type lockedWriter struct {
+	m *sync.Mutex
+	w *bytes.Buffer
+}
+
+func (lw lockedWriter) Write(p []byte) (int, error) {
+	lw.m.Lock()
+	defer lw.m.Unlock()
+	return lw.w.Write(p)
+}
+
+func TestLogin_BrowserExecFails_FallsThroughToManualPaste(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+	opts.Browser = func(_ string) error {
+		return errors.New("xdg-open: command not found")
+	}
+	// Manual paste reader — we need to learn the state from stdout
+	// first, so use a pipe.
+	pasteR, pasteW, _ := os.Pipe()
+	opts.Stdin = pasteR
+	defer pasteW.Close()
+
+	var mu sync.Mutex
+	buf := &bytes.Buffer{}
+	opts.Stdout = lockedWriter{m: &mu, w: buf}
+
+	errCh := make(chan error, 1)
+	go func() {
+		// Poll for the URL on stdout.
+		deadline := time.Now().Add(2 * time.Second)
+		var line string
+		for time.Now().Before(deadline) {
+			mu.Lock()
+			line = buf.String()
+			mu.Unlock()
+			if strings.Contains(line, "claude.ai/oauth/authorize") {
+				break
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		idx := strings.Index(line, "https://claude.ai/oauth/authorize")
+		if idx == -1 {
+			errCh <- errors.New("URL not printed")
+			return
+		}
+		rest := line[idx:]
+		end := strings.IndexAny(rest, "\n ")
+		raw := rest
+		if end != -1 {
+			raw = rest[:end]
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		state := u.Query().Get("state")
+		_, err = pasteW.Write([]byte("c#" + state + "\n"))
+		errCh <- err
+	}()
+
+	if err := Login(f.paths, "work", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("driver: %v", err)
+	}
+	if !strings.Contains(buf.String(), "could not open browser") {
+		t.Errorf("stdout missing browser-failure breadcrumb: %q", buf.String())
+	}
+}
+
+func TestLogin_Timeout_NoFileWritten(t *testing.T) {
+	f := newLoginFixture(t)
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+	opts.Timeout = 100 * time.Millisecond
+	// Browser does nothing; stdin is empty; no callback. Login must
+	// time out.
+	opts.Browser = func(_ string) error { return nil }
+
+	err := Login(f.paths, "work", opts)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want 'timed out' substring", err)
+	}
+	if _, statErr := os.Stat(f.paths.AccountPath("work")); !os.IsNotExist(statErr) {
+		t.Errorf("account file should not exist on timeout: %v", statErr)
+	}
+}
+
+func TestLogin_TokenExchangeFailure_NoFileWritten(t *testing.T) {
+	f := newLoginFixture(t)
+	// Replace token server with one that always fails non-retryably.
+	f.tokenSrv.Close()
+	f.tokenSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Should-Retry", "false")
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(f.tokenSrv.Close)
+
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+
+	errCh := make(chan error, 1)
+	go func() {
+		target := <-f.browserCh
+		u, _ := url.Parse(target)
+		state := u.Query().Get("state")
+		redirect := u.Query().Get("redirect_uri")
+		callback := fmt.Sprintf("%s?code=c&state=%s", redirect, url.QueryEscape(state))
+		for i := 0; i < 20; i++ {
+			if resp, err := http.Get(callback); err == nil {
+				resp.Body.Close()
+				errCh <- nil
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		errCh <- errors.New("callback never succeeded")
+	}()
+
+	err := Login(f.paths, "work", opts)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error does not include status: %v", err)
+	}
+	<-errCh
+	if _, statErr := os.Stat(f.paths.AccountPath("work")); !os.IsNotExist(statErr) {
+		t.Errorf("account file should not exist on token failure: %v", statErr)
+	}
+}
+
+func TestLogin_OverwritesExistingAccountFile(t *testing.T) {
+	f := newLoginFixture(t)
+	// Init the dir and pre-seed work.json with a marker blob.
+	if err := Init(f.paths); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	pre := []byte(`{"type":"oauth","access":"old","refresh":"old","expires":1}`)
+	if err := os.WriteFile(f.paths.AccountPath("work"), pre, 0o600); err != nil {
+		t.Fatalf("pre-seed: %v", err)
+	}
+
+	opts := f.makeOpts()
+	opts.UseRandomPort = true
+
+	errCh := make(chan error, 1)
+	go func() {
+		target := <-f.browserCh
+		u, _ := url.Parse(target)
+		state := u.Query().Get("state")
+		redirect := u.Query().Get("redirect_uri")
+		callback := fmt.Sprintf("%s?code=c&state=%s", redirect, url.QueryEscape(state))
+		for i := 0; i < 20; i++ {
+			if resp, err := http.Get(callback); err == nil {
+				resp.Body.Close()
+				errCh <- nil
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		errCh <- errors.New("callback never succeeded")
+	}()
+
+	if err := Login(f.paths, "work", opts); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	<-errCh
+
+	data, _ := os.ReadFile(f.paths.AccountPath("work"))
+	var got accountBlob
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.Access != "access-tok" {
+		t.Errorf("file not overwritten: %+v", got)
+	}
+}
+
+// ─── isHeadlessEnv ───────────────────────────────────────────────────
+
+func TestIsHeadlessEnv(t *testing.T) {
+	cases := []struct {
+		name    string
+		display string
+		wayland string
+		ssh     string
+		want    bool
+	}{
+		{"all unset → not headless", "", "", "", false},
+		{"display set → not headless", ":0", "", "", false},
+		{"wayland set → not headless", "", "wayland-0", "", false},
+		{"ssh set, no display → headless", "", "", "1.2.3.4 1234 5.6.7.8 22", true},
+		{"ssh set with display → not headless", ":0", "", "1.2.3.4 1234 5.6.7.8 22", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DISPLAY", tc.display)
+			t.Setenv("WAYLAND_DISPLAY", tc.wayland)
+			t.Setenv("SSH_CONNECTION", tc.ssh)
+			if got := isHeadlessEnv(); got != tc.want {
+				t.Errorf("isHeadlessEnv() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds \`prism account login <name>\` — the ergonomic finisher for the account command tree shipped in #2283.

## What

Strategy: **Option C** from the #2284 design discussion — Go reimplementation of the PKCE flow mirroring \`modules/programs/prism/pi/extensions/anthropic-oauth/auth.ts\`. The duplication surface is bounded (constants + ~150 lines of HTTP + PKCE); \`auth.ts\` remains the canonical source of truth and \`login.go\` carries a top-of-file comment pointing back to it for mirror discipline.

\`\`\`
prism account login <name>            # write tokens; do NOT activate
prism account login <name> --use      # write AND activate
prism account login <name> --port 0   # bind random free port
\`\`\`

## Flow

1. Validate \`<name>\` (rejects path separators, \`.\`, \`..\`, \`current\`) **before** any port is bound or HTTP request issued.
2. Generate PKCE pair: 32 random bytes → base64url → verifier; SHA-256(verifier) → base64url → challenge.
3. Generate 16-byte hex state.
4. Bind local callback server on \`127.0.0.1:53692\` (or random free port with \`--port 0\`). Bind failure surfaces a clear error **naming the port** and **suggesting \`--port 0\`**.
5. Launch the system browser (\`xdg-open\` on Linux, \`open\` on Darwin). Skip in headless SSH sessions (DISPLAY/WAYLAND_DISPLAY unset AND SSH_CONNECTION set). Browser exec failure falls through silently to manual paste.
6. Wait in parallel for either the local \`/callback\` to fire or the user to paste the callback URL / \`code#state\` on stdin, under a 5-minute hard timeout.
7. State mismatch → \"OAuth state mismatch\" to the user (no echo of either state value) and HTTP 400 \"Invalid state\" to the browser.
8. Exchange code for tokens at \`TOKEN_URL\`: up to 2 retries on 429/5xx, honour \`Retry-After\` capped at 30s, abort immediately on \`X-Should-Retry: false\`.
9. \`expires = now_ms + expires_in*1000 - 300_000\` to match pi-side computation exactly.
10. Atomic-write \`accounts/<name>.json\` at mode 0o600.
11. If \`--use\`, call \`account.Use(paths, name)\`.

## Security invariants (enforced by tests)

- PKCE verifier never appears in stdout / stderr / logs.
- Access and refresh tokens never appear in any output.
- OAuth \`code\` never appears in any error message.
- State mismatch error does not echo expected or received state.
- Account file mode is 0o600; accounts dir is 0o700 (set by \`account.Init\`).

## Files

- \`internal/account/login.go\` — PKCE + callback server + token exchange.
- \`internal/account/login_test.go\` — 25+ tests covering happy path, retries, state mismatch, port-in-use, headless detection, browser-failure fall-through, timeout, token-failure no-file-write, file-overwrite, and the security invariants above.
- \`cmd/account_login.go\` — cobra wiring.
- \`cmd/account_login_test.go\` — cobra subcommand registration, flag defaults, invalid-name short-circuit.

## Verifying tests aren't no-ops

Per AGENTS.md discipline I neutered four headline production sites and confirmed each test failed before restore:
- PKCE: hash raw bytes instead of verifier ASCII → \`TestGeneratePKCE_FreshPerInvocation_AndChallengeIsSHA256OfVerifier\` failed (challenge mismatch).
- File mode: use 0o644 instead of \`fileMode\` → \`TestLogin_Success...Mode0o600...\` failed.
- State echo: include state values in error → \`TestLogin_StateMismatch...NoEcho\` failed.
- Retry: force \`retriable = false\` → \`TestExchangeToken_RetriesOn429_ThenSucceeds\` failed.

## Local validation

\`\`\`
go build ./... && go test ./... -race           # all green
nix build .#prism                                # green
nix build .#prism.override { runChecks = true; } # homeless-shelter green
\`\`\`

## Out of scope (per #2284)

- Refresh-token rotation (handled by the pi-side path).
- Cross-platform Windows browser launch.
- Multi-provider support.
- Per-organisation scoping.

Closes #2284