### PR TITLE
AGENTS.md: document gofmt -l . in the prism Go pre-PR self-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ Both jobs must pass before merge. They live in `.github/workflows/pr-gate.yml`. 
 
 ```bash
 # From modules/programs/prism/prism/
+gofmt -l .
 go build ./...
 go test ./...
 
@@ -71,7 +72,7 @@ go test ./...
 nix build .#prism
 ```
 
-This catches build/test failures fast. The full homeless-shelter signal is then exercised by CI on the PR.
+This catches build/test failures fast. The full homeless-shelter signal is then exercised by CI on the PR. `gofmt -l .` matches the `gofmt check` step in `pr-gate.yml` (added in #2282) — list mode (`-l`) shows what would change without mutating; once you're ready to fix any reported files, re-run with `-w .`.
 
 **Test-suite isolation (issue #1608).** The test suite under `modules/programs/prism/prism/internal/sidecar/` is fully isolated from host bus / DB / tmux state:
 


### PR DESCRIPTION
Closes #2290.

`pr-gate.yml` has enforced `gofmt -l .` across `modules/programs/prism/prism/` since #2282 (commit `d242c03c`), but the "Prism Go-source and `.nix` changes" section of `AGENTS.md` still only documented `go build ./...` and `go test ./...` as the local pre-PR self-check. Workers without that signal lose a CI cycle to a gate they had no warning about — the Opus leg of the abtest on #2284 hit exactly this.

## Change

Single edit: add `gofmt -l .` to the "Local pre-PR self-check (recommended)" block in `AGENTS.md`, alongside the existing `go build ./...` and `go test ./...`. Includes a one-line rationale pointing at the `gofmt check` step in `pr-gate.yml` so future readers understand the link to CI. List mode (`-l`) is intentional per the issue ACs — shows what would change without mutating.

## ACs

- [x] [functional] `gofmt -l .` documented in the pre-PR self-check, run from `modules/programs/prism/prism/`, alongside `go build ./...` and `go test ./...`.
- [x] [functional] Uses `-l` (list mode), not `-w` (write mode).
- [x] [functional] One-line rationale points at the `gofmt check` step in `pr-gate.yml`.

## Out of scope (per #2290)

- Adding `goimports`, `staticcheck`, or any other tool not currently enforced by CI.
- Updating custom agent prompts under `modules/programs/prism/agents/`.
- Re-running gofmt across the codebase (already done in #2282).

## Testing

Markdown-only change. No `go build` / `go test` / `nix build` required, and the path doesn't match `pr-gate.yml`'s prism-touching filter so `go-tests` / `nix-build-prism-checked` won't trigger.