### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781242433,
-        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
+        "lastModified": 1781715441,
+        "narHash": "sha256-yyui90BUxu+A/NjUBO2RV9ubrC0lc/ECzuy2aWGnNEA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
+        "rev": "ee9c7b96c90bbb23620544201e26de92858b9ce3",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305496,
-        "narHash": "sha256-g8Vv4Qfc7n+lgov97REu3X6BeJtvYY0hlSUZR1GrGQQ=",
+        "lastModified": 1781751568,
+        "narHash": "sha256-hZAbXoNA4nCSaIJJLGl/EdErFtlnAS06jEp4oO7Qp6s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c87a39aa979acc4848016d2220c6238390d84779",
+        "rev": "5bcff43156c0eebe68759338b7879c8e1b2e2bd0",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1781328464,
-        "narHash": "sha256-j9uBlHI0eJ9zWU9IlF6SlBBPdeJu30hcvar31IRKHpw=",
+        "lastModified": 1781761764,
+        "narHash": "sha256-JsYqAFwGp4U6UhHnlI3RC65H7evEyVLRIKCzcUPn9sg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a722a7155bfc9fbe657f28d26b71860d95324bc",
+        "rev": "96649ec14f40ab996df8761ca7790a538afa83c6",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1780952837,
-        "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
+        "lastModified": 1781509190,
+        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e820eb4a444b46a19b2e03e8dfd2359439ff30fe",
+        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/27740018197

## Closure diff: navi

```
alsa-lib: -506.9 KiB
aquamarine: 0.12.0 → 0.12.1
atkmm: 2.28.4 → 2.28.5
attica: 6.26.0 → 6.27.0
breeze-icons: 6.26.0 → 6.27.0, -162.4 KiB
bullet: 3.25 → ∅, -31.1 MiB
chromium: 149.0.7827.102 → 149.0.7827.114
chromium-unwrapped: 149.0.7827.102 → 149.0.7827.114
claude-code: 2.1.175 → 2.1.179, 1.8 MiB
cloudflared: 2026.5.2 → 2026.6.0, 24.1 KiB
cni-plugins: 1.9.0 → 1.9.1, 99.3 KiB
curl: -275.1 KiB
deno: 2.8.2 → 2.8.3, 963.0 KiB
dnsmasq: 2.92rel2 → 2.93, 29.7 KiB
doxygen: 1.16.1 → ∅, -29.3 MiB
efl: 1.28.1 → ∅, -78.3 MiB
electron: 40.10.2, 41.7.1 → 40.10.3, 41.7.2
electron-unwrapped: 40.10.2, 41.7.1 → 40.10.3, 41.7.2, 12.0 KiB
extra-cmake-modules: 6.26.0 → 6.27.0
fc: ∅ → 53-user-aliases.conf
frameworkintegration: 6.26.0 → 6.27.0
gh: 2.93.0 → 2.94.0, 331.4 KiB
gimp: 121.0 KiB
gnome-icon-theme: 3.12.0 → ∅, -11.2 MiB
gtk-engine-murrine: 0.98.2 → ∅, -309.7 KiB
home-configuration-reference: 9.3 KiB
humanity-icon-theme: 0.6.16 → ∅, -23.9 MiB
hyprland: 0.55.3 → 0.55.4
initrd-linux: 7.0.12 → 7.1, 79.7 KiB
k9s: 0.50.18 → 0.51.0, 2.9 MiB
karchive: 6.26.0 → 6.27.0
kauth: 6.26.0 → 6.27.0, 18.2 KiB
kbookmarks: 6.26.0 → 6.27.0
kcmutils: 6.26.0 → 6.27.0, 8.3 KiB
kcodecs: 6.26.0 → 6.27.0
kcolorscheme: 6.26.0 → 6.27.0
kcompletion: 6.26.0 → 6.27.0
kconfig: 6.26.0 → 6.27.0, 20.9 KiB
kconfigwidgets: 6.26.0 → 6.27.0
kcoreaddons: 6.26.0 → 6.27.0, 97.0 KiB
kcrash: 6.26.0 → 6.27.0
kdbusaddons: 6.26.0 → 6.27.0
kdoctools: 6.26.0 → 6.27.0
kglobalaccel: 6.26.0 → 6.27.0
kguiaddons: 6.26.0 → 6.27.0, 42.3 KiB
ki18n: 6.26.0 → 6.27.0
kiconthemes: 6.26.0 → 6.27.0
kio: 6.26.0 → 6.27.0, 197.2 KiB
kirigami: 6.26.0 → 6.27.0, 183.4 KiB
kitemviews: 6.26.0 → 6.27.0
kitty: 0.47.2 → 0.47.4, 559.3 KiB
kjobwidgets: 6.26.0 → 6.27.0
knewstuff: 6.26.0 → 6.27.0
knotifications: 6.26.0 → 6.27.0
kpackage: 6.26.0 → 6.27.0
krb5: -2.0 MiB
kservice: 6.26.0 → 6.27.0
ktextwidgets: 6.26.0 → 6.27.0
kwallet: 6.26.0 → 6.27.0, 29.3 KiB
kwidgetsaddons: 6.26.0 → 6.27.0, 12.5 KiB
kwindowsystem: 6.26.0 → 6.27.0
kxmlgui: 6.26.0 → 6.27.0, 35.4 KiB
lcms2: -342.7 KiB
libidn2: -53.2 KiB
libkrun: 1.17.4 → 1.18.1, 772.4 KiB
libkrunfw: 5.3.0 → 5.5.0, 128.0 KiB
libnfs: 5.0.2 → 5.0.3, 27.2 KiB
libraw: -341.7 KiB
librsvg: -235.7 KiB
libssh2: -83.6 KiB
linux: 7.0.12 → 7.1, 1.4 MiB
mint-x-icons: 1.7.6 → ∅, -108.6 MiB
neovim: 0.12.2 → 0.12.3
neovim-unwrapped: 0.12.2 → 0.12.3, 63.6 KiB
networkmanager.conf: ∅ → ε
nixos-firewall: ε → ∅
nixos-firewall-tool: ∅ → 26.11
nixos-manual: 17.2 KiB
nixos-system-navi: 26.11.20260610.9ae611a → 26.11.20260616.567a49d
nspr: -571.2 KiB
nss: -1.4 MiB
openjpeg: -79.1 KiB
openrazer: 3.12.3-7.0.12 → 3.12.3-7.1
oxygen-icons: 6.2.0 → 6.27.0
poppler-glib: -1.7 MiB
python3.13-curl-cffi: 0.14.0 → 0.15.0, 203.6 KiB
qqc2-desktop-style: 6.26.0 → 6.27.0
ripgrep: -6.2 MiB
sdl2-compat: -2.4 MiB
solid: 6.26.0 → 6.27.0, 22.3 KiB
sonnet: 6.26.0 → 6.27.0, 15.6 KiB
source: 824.3 KiB
syncthing: 2.0.15 → 2.1.0, 80.2 KiB
syndication: 6.26.0 → 6.27.0
tree-sitter-c-neovim: 0.12.2 → 0.12.3
tree-sitter-lua-neovim: 0.12.2 → 0.12.3
tree-sitter-markdown-neovim: 0.12.2 → 0.12.3
tree-sitter-markdown_inline-neovim: 0.12.2 → 0.12.3
tree-sitter-query-neovim: 0.12.2 → 0.12.3
tree-sitter-vim-neovim: 0.12.2 → 0.12.3
tree-sitter-vimdoc-neovim: 0.12.2 → 0.12.3
ubuntu-themes: 24.04 → ∅, -38.9 MiB
uwsm: 0.26.4 → 0.26.5
vimplugin-leap.nvim: 0-unstable-2026-05-17 → 0-unstable-2026-06-10
vimplugin-nvim-lspconfig: 2.9.0 → 2.10.0, 35.5 KiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-05-15 → 1.17.0-unstable-2026-06-08
xdotool: 3.20211022.1 → 4.20260303.1
xfsprogs: 6.19.0 → 7.0.1, 156.9 KiB
yq-go: 4.53.2 → 4.53.3, 8.7 KiB
yt-dlp: 2026.03.17 → 2026.06.09, -2.3 MiB
```

## Closure diff: tui

```
alsa-lib: -506.9 KiB
aquamarine: 0.12.0 → 0.12.1
atkmm: 2.28.4 → 2.28.5
attica: 6.26.0 → 6.27.0
bootspec: 2.0.0 → ∅, -1.9 MiB
breeze-icons: 6.26.0 → 6.27.0, -162.4 KiB
bullet: 3.25 → ∅, -31.1 MiB
chromium: 149.0.7827.102 → 149.0.7827.114
chromium-unwrapped: 149.0.7827.102 → 149.0.7827.114
claude-code: 2.1.175 → 2.1.179, 1.8 MiB
cloudflared: 2026.5.2 → 2026.6.0, 24.1 KiB
cni-plugins: 1.9.0 → 1.9.1, 99.3 KiB
curl: -275.1 KiB
deno: 2.8.2 → 2.8.3, 963.0 KiB
dnsmasq: 2.92rel2 → 2.93, 29.7 KiB
doxygen: 1.16.1 → ∅, -29.3 MiB
efl: 1.28.1 → ∅, -78.3 MiB
electron: 40.10.2, 41.7.1 → 40.10.3, 41.7.2
electron-unwrapped: 40.10.2, 41.7.1 → 40.10.3, 41.7.2, 12.0 KiB
extra-cmake-modules: 6.26.0 → 6.27.0
fc: ∅ → 53-user-aliases.conf
frameworkintegration: 6.26.0 → 6.27.0
gh: 2.93.0 → 2.94.0, 331.4 KiB
gimp: 121.0 KiB
gnome-icon-theme: 3.12.0 → ∅, -11.2 MiB
gtk-engine-murrine: 0.98.2 → ∅, -309.7 KiB
home-configuration-reference: 9.3 KiB
humanity-icon-theme: 0.6.16 → ∅, -23.9 MiB
hyprland: 0.55.3 → 0.55.4
initrd-linux: 7.0.12 → 7.1, 16.2 KiB
k9s: 0.50.18 → 0.51.0, 2.9 MiB
karchive: 6.26.0 → 6.27.0
kauth: 6.26.0 → 6.27.0, 18.2 KiB
kbookmarks: 6.26.0 → 6.27.0
kcmutils: 6.26.0 → 6.27.0, 8.3 KiB
kcodecs: 6.26.0 → 6.27.0
kcolorscheme: 6.26.0 → 6.27.0
kcompletion: 6.26.0 → 6.27.0
kconfig: 6.26.0 → 6.27.0, 20.9 KiB
kconfigwidgets: 6.26.0 → 6.27.0
kcoreaddons: 6.26.0 → 6.27.0, 97.0 KiB
kcrash: 6.26.0 → 6.27.0
kdbusaddons: 6.26.0 → 6.27.0
kdoctools: 6.26.0 → 6.27.0
kglobalaccel: 6.26.0 → 6.27.0
kguiaddons: 6.26.0 → 6.27.0, 42.3 KiB
ki18n: 6.26.0 → 6.27.0
kiconthemes: 6.26.0 → 6.27.0
kio: 6.26.0 → 6.27.0, 197.2 KiB
kirigami: 6.26.0 → 6.27.0, 183.4 KiB
kitemviews: 6.26.0 → 6.27.0
kitty: 0.47.2 → 0.47.4, 559.3 KiB
kjobwidgets: 6.26.0 → 6.27.0
knewstuff: 6.26.0 → 6.27.0
knotifications: 6.26.0 → 6.27.0
kpackage: 6.26.0 → 6.27.0
krb5: -748.1 KiB
kservice: 6.26.0 → 6.27.0
ktextwidgets: 6.26.0 → 6.27.0
kwallet: 6.26.0 → 6.27.0, 29.3 KiB
kwidgetsaddons: 6.26.0 → 6.27.0, 12.5 KiB
kwindowsystem: 6.26.0 → 6.27.0
kxmlgui: 6.26.0 → 6.27.0, 35.4 KiB
lcms2: -342.7 KiB
libidn2: -53.2 KiB
libkrun: 1.17.4 → 1.18.1, 772.4 KiB
libkrunfw: 5.3.0 → 5.5.0, 128.0 KiB
libnfs: 5.0.2 → 5.0.3, 27.2 KiB
libraw: -341.7 KiB
librsvg: -235.7 KiB
libssh2: -83.6 KiB
linux: 7.0.12 → 7.1, 1.4 MiB
mint-x-icons: 1.7.6 → ∅, -108.6 MiB
neovim: 0.12.2 → 0.12.3
neovim-unwrapped: 0.12.2 → 0.12.3, 63.6 KiB
networkmanager.conf: ∅ → ε
nixos-firewall: ε → ∅
nixos-firewall-tool: ∅ → 26.11
nixos-manual: 17.2 KiB
nixos-system-tui: 26.11.20260610.9ae611a → 26.11.20260616.567a49d
nspr: -571.2 KiB
nss: -1.4 MiB
openjpeg: -79.1 KiB
openrazer: 3.12.3-7.0.12 → 3.12.3-7.1
oxygen-icons: 6.2.0 → 6.27.0
poppler-glib: -1.7 MiB
python3.13-curl-cffi: 0.14.0 → 0.15.0, 203.6 KiB
qqc2-desktop-style: 6.26.0 → 6.27.0
ripgrep: -6.2 MiB
sdl2-compat: -2.4 MiB
solid: 6.26.0 → 6.27.0, 22.3 KiB
sonnet: 6.26.0 → 6.27.0, 15.6 KiB
source: 824.3 KiB
syncthing: 2.0.15 → 2.1.0, 80.2 KiB
syndication: 6.26.0 → 6.27.0
tree-sitter-c-neovim: 0.12.2 → 0.12.3
tree-sitter-lua-neovim: 0.12.2 → 0.12.3
tree-sitter-markdown-neovim: 0.12.2 → 0.12.3
tree-sitter-markdown_inline-neovim: 0.12.2 → 0.12.3
tree-sitter-query-neovim: 0.12.2 → 0.12.3
tree-sitter-vim-neovim: 0.12.2 → 0.12.3
tree-sitter-vimdoc-neovim: 0.12.2 → 0.12.3
ubuntu-themes: 24.04 → ∅, -38.9 MiB
uwsm: 0.26.4 → 0.26.5
vimplugin-leap.nvim: 0-unstable-2026-05-17 → 0-unstable-2026-06-10
vimplugin-nvim-lspconfig: 2.9.0 → 2.10.0, 35.5 KiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-05-15 → 1.17.0-unstable-2026-06-08
xdotool: 3.20211022.1 → 4.20260303.1
xfsprogs: 6.19.0 → 7.0.1, 156.9 KiB
yq-go: 4.53.2 → 4.53.3, 8.7 KiB
yt-dlp: 2026.03.17 → 2026.06.09, -2.3 MiB
```