### PR TITLE
prism: migrate four sandbox-exec tests to XDG_STATE_HOME (test-only)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_test.go
+++ b/modules/programs/prism/prism/cmd/agent_run_test.go
@@ -442,10 +442,18 @@ func containsAt(s, substr string) bool {
 // Manager.PrepareSandboxExec pass validation when the on-disk profile is
 // present.
 func TestValidateSandboxExecArgs_OK(t *testing.T) {
-	// PrepareSandboxExec derives the staging HOME from os.UserHomeDir(); in
-	// the nix build sandbox $HOME is /homeless-shelter (unwritable). Redirect
-	// to a tempdir so the staging-home MkdirAll succeeds. AGENTS.md § "the
-	// homeless-shelter failure class" + issue #2168.
+	// PrepareSandboxExec creates the per-session work dir and writes the
+	// ssh-config / gitconfig / allowed_signers files into it. Since PR #2277,
+	// sessionWorkDirPath honours $XDG_STATE_HOME first and falls back to
+	// $HOME/.local/state — so on a developer machine whose shell exports
+	// XDG_STATE_HOME=$HOME/.local/state, setting HOME alone does not
+	// redirect the work dir off the host's real state tree (issue #2295).
+	// Redirect both: XDG_STATE_HOME so the session work dir lands in a
+	// tempdir, and HOME so home-derived MkdirAlls (e.g. ~/.local/share/pi/
+	// prism-sessions/<name>) succeed inside the homeless-shelter nix-build
+	// sandbox (AGENTS.md § "the homeless-shelter failure class" + issue
+	// #2168).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	m := container.New(container.Config{
 		SessionName:   "repo@feat",
@@ -476,8 +484,10 @@ func TestValidateSandboxExecArgs_OK(t *testing.T) {
 // when the profile-temp file is missing or unreadable, validation returns a
 // clear error containing the path and the underlying stat error.
 func TestValidateSandboxExecArgs_MissingProfile(t *testing.T) {
-	// Redirect HOME for the sandbox-exec staging-home path derivation. See
-	// TestValidateSandboxExecArgs_OK for the rationale.
+	// Redirect $XDG_STATE_HOME and $HOME so PrepareSandboxExec writes into
+	// tempdirs rather than the host's real state tree. See
+	// TestValidateSandboxExecArgs_OK for the rationale (issue #2295).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	m := container.New(container.Config{
 		SessionName:   "repo@gone",

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_test.go
@@ -355,8 +355,17 @@ func TestGenerateProfile_V3CryptexAndTmpRules(t *testing.T) {
 // worktree, and bare repo as (allow file-read* file-write* (subpath ...))
 // clauses when the Manager has InstanceID, Worktree, and BareRoot set.
 func TestGenerateProfile_SessionWorkDirAndWorktreeRules(t *testing.T) {
-	fakeHome := t.TempDir()
-	t.Setenv("HOME", fakeHome)
+	// Drive the work-dir base via $XDG_STATE_HOME (issue #2295). Since
+	// PR #2277, sessionWorkDirPath honours XDG_STATE_HOME first and falls
+	// back to $HOME/.local/state only when XDG_STATE_HOME is unset; setting
+	// HOME alone does not control where the work dir lands on a developer
+	// machine whose shell exports XDG_STATE_HOME. We also point HOME at a
+	// tempdir so any home-derived carve-outs in the profile do not leak the
+	// host's real home into test output. Matches the established pattern in
+	// pi_invocation_resume_test.go.
+	fakeStateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", fakeStateHome)
+	t.Setenv("HOME", t.TempDir())
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@main",
 		Worktree:    "/tmp/fake-worktree",
@@ -380,8 +389,8 @@ func TestGenerateProfile_SessionWorkDirAndWorktreeRules(t *testing.T) {
 		t.Errorf("profile missing bare repo path /tmp/fake-bare; full profile:\n%s", profile)
 	}
 	// The per-session work dir subpath must be present (namespaced by
-	// InstanceID).
-	sessionDir := filepath.Join(fakeHome, ".local", "state", "prism", "sessions", "test-instance-id")
+	// InstanceID). Resolved from $XDG_STATE_HOME per PR #2277.
+	sessionDir := filepath.Join(fakeStateHome, "prism", "sessions", "test-instance-id")
 	if !strings.Contains(profile, "(subpath "+quoteSBPL(sessionDir)+")") {
 		t.Errorf("profile missing the session work dir subpath %q; full profile:\n%s", sessionDir, profile)
 	}
@@ -392,8 +401,11 @@ func TestGenerateProfile_SessionWorkDirAndWorktreeRules(t *testing.T) {
 // (subpath <sessionDir>/home) grant — the per-session writable scope is
 // exactly the work-dir (subpath <sessionDir>) rule from PR #2221.
 func TestGenerateProfile_NoStagingHomeGrant(t *testing.T) {
-	fakeHome := t.TempDir()
-	t.Setenv("HOME", fakeHome)
+	// Drive the work-dir base via $XDG_STATE_HOME (issue #2295). See
+	// TestGenerateProfile_SessionWorkDirAndWorktreeRules for the rationale.
+	fakeStateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", fakeStateHome)
+	t.Setenv("HOME", t.TempDir())
 	m := newSandboxExecManagerWithInstance(Config{
 		SessionName: "repo@main",
 		Worktree:    "/tmp/fake-worktree",
@@ -401,7 +413,7 @@ func TestGenerateProfile_NoStagingHomeGrant(t *testing.T) {
 	})
 	profile := generateProfile(m)
 
-	sessionDir := filepath.Join(fakeHome, ".local", "state", "prism", "sessions", "test-instance-id")
+	sessionDir := filepath.Join(fakeStateHome, "prism", "sessions", "test-instance-id")
 	stagingHome := filepath.Join(sessionDir, "home")
 
 	// The legacy staging-home path must not appear anywhere in the profile —


### PR DESCRIPTION
## Summary

PR #2277 changed `internal/container/dispatch.go::xdgStateBase` and `SessionWorkDirPath` to resolve in this order:

1. `$XDG_STATE_HOME` if set
2. `$HOME/.local/state` as fallback

Four unit tests were not migrated when #2277 landed and still drove the work-dir base via `t.Setenv("HOME", ...)`:

- `internal/container.TestGenerateProfile_SessionWorkDirAndWorktreeRules`
- `internal/container.TestGenerateProfile_NoStagingHomeGrant`
- `cmd.TestValidateSandboxExecArgs_OK`
- `cmd.TestValidateSandboxExecArgs_MissingProfile`

On a developer machine whose shell exports `XDG_STATE_HOME` (e.g. the default `~/.local/state`), the HOME override does NOT redirect the work dir off the host's real state tree — production code consults XDG_STATE_HOME first. The PR-gate CI (`nix-build-prism-checked`) does not catch this because the homeless-shelter nix sandbox happens to satisfy the broken expectation by accident; the four tests reproduce on a real dev machine with a populated `~/.local/state`.

## Fix shape

Migrate the four tests to `t.Setenv("XDG_STATE_HOME", t.TempDir())`, mirroring the established pattern already used in `internal/container/pi_invocation_resume_test.go`, `pi_invocation_test.go`, `hostapi_path_roundtrip_test.go`, and `container_test.go`. `HOME` is still set to a tempdir in each test because:

- `generateProfile()` reads `os.UserHomeDir()` for home-derived carve-outs (`~/.aws/`, `~/.cache/`, etc.) — keeping HOME at a tempdir avoids leaking the developer's real home into test output and assertions;
- `PrepareSandboxExec` calls home-derived `MkdirAll`s (e.g. `~/.local/share/pi/prism-sessions/<name>`) that must succeed inside the homeless-shelter nix-build sandbox.

The two `internal/container` tests preserve their original semantic property: the per-session work-dir subpath is present in the profile, and the legacy staging-HOME `(subpath <sessionDir>/home)` grant is absent. The two `cmd` tests still exercise `validateSandboxExecArgs` against the `PrepareSandboxExec`-produced args along the OK and missing-profile paths.

**No production code change.** `xdgStateBase` and `sessionWorkDirPath` are correct as of #2277.

## Verification

From `modules/programs/prism/prism/`:

- `gofmt -l .` — clean
- `go build ./...` — green
- `go test ./...` — green (full suite, all packages)

From the repo root:

- `nix build .#prism` — green

Vacuous-pass check: reverting only the test diff locally (production code unchanged) and re-running the four named tests reproduces the original failures; re-applying the diff turns them green.

## Composition

Rebased on top of `main` post-#2294 (sandbox-exec keychain re-grant). The two PRs touch disjoint test functions in `sandbox_exec_test.go`; no conflict.

## Acceptance criteria

- [x] [functional] `go test ./...` from `modules/programs/prism/prism/` exits 0 on a developer machine with a populated `~/.local/state`. All four named tests pass.
- [x] [functional] The four tests assert the same semantic property they asserted before #2277.
- [x] [edge-case] No change to `internal/container/dispatch.go::xdgStateBase`, `sessionWorkDirPath`, or any other production code path.
- [x] [functional] `gofmt -l .` clean over `modules/programs/prism/prism/`.
- [x] [functional] `nix build .#prism` green from repo root.

Closes #2295
