### PR TITLE
docs(coordinator): forbid merging external PRs in Case 1

### DIFF
--- a/modules/programs/prism/agents/coordinator.md
+++ b/modules/programs/prism/agents/coordinator.md
@@ -205,6 +205,17 @@ Wait for the finish notification from that spawned session before reporting back
 to the user. The spawned session will run `prism review`, handle any blocking
 issues, and summarise the findings. Your role is to relay the outcome.
 
+> **Do NOT `prism merge` the PR.** A PR authored by someone outside our agent
+> fleet is not ours to land — the author and their maintainer chain decide
+> when it merges. Operational tell: a session spawned via `prism pr <number>`
+> is review-only because the PR existed before the session, so the session
+> did not author it. A session spawned via `prism spawn` that then opened a
+> PR is ours.
+
+"Done" for Case 1 is: read the review outcome, summarise it back to the user,
+optionally clean up the review session, stop. Do not run `gh pr view` looking
+for metadata to sense-check. Do not enqueue `prism merge`.
+
 ### Case 2: Worker has self-reviewed and handed off
 
 > **Anti-pattern: do not act on PR-open alone.** Observing a PR in `gh pr list`,
@@ -240,6 +251,10 @@ When a spawned agent opens a PR and announces completion:
 ---
 
 ## Merge and cleanup
+
+> **Applies to Case 2 only.** Only enqueue a PR that was authored by a worker
+> you spawned. For Case 1 PRs (external authors), stop after relaying the
+> review outcome — do not run `prism merge`.
 
 Once the sense-check passes, enqueue the PR in the merge queue and continue with other work. The queue handles CI waits, rebases, and the merge itself; you act on the bus notification when the merge lands or fails.
 


### PR DESCRIPTION
## Context

This morning the `helm-charts@main` coordinator was asked to review PR #15 on
the helm-charts repo — a PR opened by an external author, not by one of our
spawned workers. The coordinator correctly spawned a review session via
`prism pr 15 --prompt 'review this PR'`, the review passed 5/5 on round 2, and
then the coordinator slid straight into the Case 2 path: ran `gh pr view`,
sense-checked the metadata, ran `prism merge 15`, and the queue merged the PR
into upstream `main`. We don't merge other people's PRs — we review and relay.

The user's directive (verbatim):

> don't prism merge another persons pr just review, only do a prism merge if
> the pr was our own

## What this PR changes

Documentation-only edit to `modules/programs/prism/agents/coordinator.md`:

1. **Case 1 (review-only)** now explicitly forbids `prism merge`, gives the
   operational tell so a coordinator can self-check (`prism pr <n>` =
   review-only; `prism spawn` that then opened a PR = ours), and restates
   what "done" looks like (relay outcome, optional cleanup, stop).
2. **Merge and cleanup** section opens with a precondition that scopes it to
   Case 2 (worker-authored PRs only).

Diff is small (15 lines added, 0 removed) and surgical — no formatting churn,
no reflow of unrelated paragraphs.

## Out of scope

- `modules/programs/prism/skills/prism/SKILL.md` — its review section is
  already correctly scoped.
- `modules/programs/prism/agents/worker.md` — unchanged.
- No prism Go source touched.