### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781715441,
-        "narHash": "sha256-yyui90BUxu+A/NjUBO2RV9ubrC0lc/ECzuy2aWGnNEA=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ee9c7b96c90bbb23620544201e26de92858b9ce3",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781751568,
-        "narHash": "sha256-hZAbXoNA4nCSaIJJLGl/EdErFtlnAS06jEp4oO7Qp6s=",
+        "lastModified": 1781906751,
+        "narHash": "sha256-6Ld1PqmptFtFKblE+SynhRgyBApUWcmrISetWqWHeeo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5bcff43156c0eebe68759338b7879c8e1b2e2bd0",
+        "rev": "37f21dfa5d27e71b75bacd9418b156f9265e312e",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1781761764,
-        "narHash": "sha256-JsYqAFwGp4U6UhHnlI3RC65H7evEyVLRIKCzcUPn9sg=",
+        "lastModified": 1781933520,
+        "narHash": "sha256-RG9fbzqqV8VqtKgEScRlPXMftmj/1mS2DZTcM6uBlCY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "96649ec14f40ab996df8761ca7790a538afa83c6",
+        "rev": "5c8b56a21030a527cbec0a6691635370a28c5fc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/27861990884

## Closure diff: navi

```
hm_fontconfigconf.d10hmfonts.conf: ε → ∅
hm_fontconfigconf.d52hmdefaultfonts.conf: ε → ∅
hm_hmfontconfigdefaultfonts.xml: ∅ → ε
hm_hmfontconfigfonts.xml: ∅ → ε
```

## Closure diff: tui

```
hm_fontconfigconf.d10hmfonts.conf: ε → ∅
hm_fontconfigconf.d52hmdefaultfonts.conf: ε → ∅
hm_hmfontconfigdefaultfonts.xml: ∅ → ε
hm_hmfontconfigfonts.xml: ∅ → ε
```