### PR TITLE
prism review: resolve PR base ref instead of hardcoding origin/main

### DIFF
--- a/modules/programs/prism/prism/cmd/review.go
+++ b/modules/programs/prism/prism/cmd/review.go
@@ -16,7 +16,7 @@ package cmd
 //	--harness <name>    Runtime harness (default: "pi")
 //	--timeout <dur>     Per-agent timeout (default: 10m)
 //	--only <csv>        Run only the named agents (e.g. review-goal,review-code)
-//	--rebase            Inline-rebase onto origin/main (fetch + rebase + force-push) before review
+//	--rebase            Inline-rebase onto the PR's base ref (fetch + rebase + force-push) before review
 
 import (
 	"fmt"
@@ -62,7 +62,7 @@ func init() {
 	reviewCmd.Flags().Int("diff-inline-max", 0,
 		"Max diff lines to inline in agent prompts (0 = use PRISM_REVIEW_DIFF_INLINE_MAX env var or default 500)")
 	reviewCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
-	reviewCmd.Flags().Bool("rebase", false, "Fetch origin/main, rebase HEAD onto it, and force-push before running the review")
+	reviewCmd.Flags().Bool("rebase", false, "Fetch the PR's base ref (default origin/main), rebase HEAD onto it, and force-push before running the review")
 	reviewCmd.Flags().Bool("wait", false, "Block until the review group reaches a terminal state (all-PASS, any-FAIL, or no-start)")
 	reviewCmd.Flags().Duration("wait-timeout", defaultReviewWaitTimeout, "Timeout for --wait. Ignored when --wait is not set.")
 	reviewCmd.Flags().Bool("json", false, "Emit the terminal verdict as a JSON object on stdout (only useful with --wait). Suppresses textual output.")
@@ -207,19 +207,29 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return prStateErr
 	}
 
-	// Pre-flight rebase gate (#1518). Runs BEFORE any review-agent sessions
-	// are spawned and BEFORE any DB rows are written for this round, so a
-	// gate failure (refusal, fetch failure, conflict abort, missing upstream)
-	// cannot increment the review-cycle counter — that counter is derived
-	// from per-agent session rows by review.NextRoundNumber, and no such
-	// rows exist on the gate-failure path.
+	// Pre-flight rebase gate (#1518, #2304). Runs BEFORE any review-agent
+	// sessions are spawned and BEFORE any DB rows are written for this round,
+	// so a gate failure (refusal, fetch failure, conflict abort, missing
+	// upstream) cannot increment the review-cycle counter — that counter is
+	// derived from per-agent session rows by review.NextRoundNumber, and no
+	// such rows exist on the gate-failure path.
 	//
-	// Strict ancestor check: `git merge-base --is-ancestor origin/main HEAD`.
+	// Strict ancestor check: `git merge-base --is-ancestor <remote>/<base> HEAD`.
+	// The PR's actual base ref is discovered via `gh pr view --json baseRefName`
+	// (issue #2304) so PRs targeting non-main bases (long-lived integration
+	// branches, release branches, environment branches) are checked against
+	// the correct upstream. On any lookup failure (gh missing, unauthenticated,
+	// network error, no PR for branch, empty baseRefName) we fall back
+	// silently to "main" — preserving today's behaviour for invocations not
+	// tied to a discoverable PR.
+	//
 	// On --rebase, the gate also performs fetch + rebase + force-push inline;
 	// on rebase conflict it aborts the rebase and restores HEAD before
 	// returning a non-zero error. Never leaves the worktree mid-rebase.
+	baseBranch := review.ResolvePRBaseRef(prNumber) // "" on any failure → Preflight defaults to "main"
 	if gateErr := review.Preflight(review.PreflightOpts{
 		Worktree:   worktree,
+		Branch:     baseBranch,
 		Rebase:     rebaseFlag,
 		OnProgress: progressLineEager,
 	}); gateErr != nil {

--- a/modules/programs/prism/prism/docs/invariants/session-lifecycle.md
+++ b/modules/programs/prism/prism/docs/invariants/session-lifecycle.md
@@ -131,7 +131,7 @@ to all of them. The valid isolation modes referenced below are `bwrap`,
 - Two sessions on the same branch are rejected by the git worktree machinery: only one worktree may be checked out for a branch at a time.
 - The per-session run directory under `$XDG_STATE_HOME/prism/run/<sessionDirHash>/` (12-hex SHA-256 prefix of the session name) is unique per session; the host-API socket, the harness pipe socket, and the `agent-run.log` are not shared between sessions.
 - The merge queue is serial: only one PR is in flight at a time per coordinator, regardless of how many `prism merge` invocations have been made.
-- `prism review` is gated behind a one-shot `git fetch origin main` + strict `git merge-base --is-ancestor origin/main HEAD` check before any review agents are spawned; on refusal no agents spawn and the cycle counter does not increment. `prism review --rebase` performs fetch + rebase + force-push inline and on conflict aborts the rebase and exits non-zero, never leaving the worktree mid-rebase.
+- `prism review` is gated behind a one-shot `git fetch origin <base>` + strict `git merge-base --is-ancestor origin/<base> HEAD` check before any review agents are spawned, where `<base>` is the PR's `baseRefName` resolved via `gh pr view <pr> --json baseRefName` (falls back silently to `main` on any lookup failure — gh missing, network error, unauthenticated, no PR for the branch, or empty `baseRefName` — #2304). On refusal no agents spawn and the cycle counter does not increment. `prism review --rebase` performs fetch + rebase + force-push against the resolved base ref inline and on conflict aborts the rebase and exits non-zero, never leaving the worktree mid-rebase.
 
 ## Transports / isolation modes
 

--- a/modules/programs/prism/prism/internal/review/base_ref.go
+++ b/modules/programs/prism/prism/internal/review/base_ref.go
@@ -1,0 +1,81 @@
+package review
+
+// base_ref.go — resolve a PR's base branch name via `gh pr view`.
+//
+// Issue #2304: the pre-flight rebase gate (preflight.go) refuses the review
+// when HEAD is not a descendant of `origin/main`, hardcoding "main". This is
+// correct for PRs targeting main but wrong for PRs targeting any other base
+// branch — long-lived integration branches, release branches, environment
+// branches, etc. — and `--rebase` against the wrong base is a silent footgun.
+//
+// The fix is to discover the PR's actual base ref before invoking Preflight,
+// and pass it through PreflightOpts.Branch. This file provides the discovery
+// helper. The discovery is best-effort: any failure (gh missing, network
+// error, unauthenticated, PR not found, empty baseRefName) returns "" and the
+// caller falls back silently to the existing "main" default. The fallback
+// preserves today's behaviour for invocations not tied to a discoverable PR
+// and never surfaces a warning that would scare the operator.
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// baseRefRunner is the test seam for invoking `gh pr view --json baseRefName`.
+// Production code uses realGHForBaseRef (which shells out via the runGH helper
+// in context.go); tests inject a scripted runner that returns canned values.
+type baseRefRunner interface {
+	// run executes `gh pr view <prNumber> --json baseRefName` and returns
+	// its stdout body and any underlying error. On non-zero gh exit, err is
+	// non-nil and the stdout body should be ignored.
+	run(prNumber string) (stdout string, err error)
+}
+
+// realGHForBaseRef shells out via the existing runGH helper in context.go.
+// It uses the same 30-second timeout and process plumbing as the rest of the
+// review package's gh calls (no second gh client introduced).
+type realGHForBaseRef struct{}
+
+func (realGHForBaseRef) run(prNumber string) (string, error) {
+	return runGH("pr", "view", prNumber, "--json", "baseRefName")
+}
+
+// baseRefJSON is the minimal JSON shape we need from
+// `gh pr view <pr> --json baseRefName`. Defined locally rather than reusing
+// prViewJSON from context.go because we only need one field and want a tight
+// contract for this helper.
+type baseRefJSON struct {
+	BaseRefName string `json:"baseRefName"`
+}
+
+// ResolvePRBaseRef returns the PR's base branch name (e.g. "main",
+// "eks-pipeline"), or "" on any failure. The caller treats "" as
+// "fall back to the default base" — typically "main". This is the public
+// entry point used by cmd/review.go.
+//
+// Resolution is best-effort and silent: a missing gh binary, network failure,
+// unauthenticated session, non-existent PR, or an empty baseRefName all
+// collapse to "" without surfacing a warning. Surfacing a scary warning on
+// every invocation that isn't tied to a discoverable PR would be noise; the
+// rebase-gate guarantees its own clear messaging when the resolved base is
+// genuinely wrong.
+func ResolvePRBaseRef(prNumber string) string {
+	return resolvePRBaseRefWithRunner(prNumber, realGHForBaseRef{})
+}
+
+// resolvePRBaseRefWithRunner is the test entry point. ResolvePRBaseRef wires
+// in the real gh runner; tests inject a scripted baseRefRunner.
+func resolvePRBaseRefWithRunner(prNumber string, runner baseRefRunner) string {
+	if strings.TrimSpace(prNumber) == "" {
+		return ""
+	}
+	stdout, err := runner.run(prNumber)
+	if err != nil {
+		return ""
+	}
+	var info baseRefJSON
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &info); jsonErr != nil {
+		return ""
+	}
+	return strings.TrimSpace(info.BaseRefName)
+}

--- a/modules/programs/prism/prism/internal/review/preflight.go
+++ b/modules/programs/prism/prism/internal/review/preflight.go
@@ -3,15 +3,22 @@ package review
 // preflight.go — pre-flight rebase gate for `prism review`.
 //
 // Issue #1518: Reviews regularly produce noisy findings of the form "you should
-// also update X" when X landed on main after the branch was cut. A pre-flight
-// ancestor check on origin/main catches this in one fetch, before any agent
-// spawns, and either refuses the review or (with --rebase) fixes it inline.
+// also update X" when X landed on the base branch after the feature branch was
+// cut. A pre-flight ancestor check on the PR's base ref catches this in one
+// fetch, before any agent spawns, and either refuses the review or (with
+// --rebase) fixes it inline.
 //
-// The gate is a snapshot at review-spawn time. It is not continuous — main can
-// advance during a review run; we do not chase that. This is consistent with
-// how CI works.
+// Issue #2304: The base branch is configurable via PreflightOpts.Branch and is
+// resolved at the call site from `gh pr view --json baseRefName` so PRs
+// targeting non-main bases are checked against the correct upstream. The
+// default remains "main" when no branch is supplied — preserving today's
+// behaviour for invocations not tied to a discoverable PR.
 //
-// Strict ancestor check via `git merge-base --is-ancestor origin/main HEAD`.
+// The gate is a snapshot at review-spawn time. It is not continuous — the base
+// can advance during a review run; we do not chase that. This is consistent
+// with how CI works.
+//
+// Strict ancestor check via `git merge-base --is-ancestor <remote>/<base> HEAD`.
 // No "files-touched-in-common" / loose variant — that breaks on renames,
 // deletes, and cross-cutting helper introductions and gives different verdicts
 // in equivalent situations.
@@ -82,30 +89,30 @@ func (realGit) run(worktree string, args ...string) (string, string, int, error)
 // PreflightError is returned by Preflight when the gate refuses the review.
 // It carries a Refused flag so callers can distinguish gate refusals from
 // infrastructure errors (fetch failure, missing upstream) — both must exit
-// non-zero, but only refusal carries the "behind main" rebase guidance.
+// non-zero, but only refusal carries the "behind <base>" rebase guidance.
 type PreflightError struct {
 	// Msg is the user-facing error message, ready to display.
 	Msg string
-	// Refused is true when the gate refused because origin/main is not an
-	// ancestor of HEAD. False for infrastructure errors (fetch failure,
-	// missing upstream, conflict abort).
+	// Refused is true when the gate refused because the resolved base ref is
+	// not an ancestor of HEAD. False for infrastructure errors (fetch
+	// failure, missing upstream, conflict abort).
 	Refused bool
 	// CommitsBehind is the number of commits HEAD is behind the remote
-	// branch (origin/main..HEAD vs HEAD..origin/main). Populated only when
-	// Refused is true. Zero otherwise.
+	// branch (HEAD..<remote>/<base>). Populated only when Refused is true.
+	// Zero otherwise.
 	CommitsBehind int
 }
 
 func (e *PreflightError) Error() string { return e.Msg }
 
-// Preflight runs the rebase gate. It returns nil when origin/main is an
-// ancestor of HEAD (the review may proceed). On any failure (fetch failure,
-// missing upstream, behind-main refusal, rebase conflict) it returns a
-// *PreflightError with a ready-to-display message; the caller should print it
-// to stderr and exit non-zero. Preflight does not spawn any review agents and
-// does not touch the prism DB, so a Preflight failure cannot affect the
-// review-cycle counter (the counter is derived from per-agent session rows
-// written by RunAsync).
+// Preflight runs the rebase gate. It returns nil when the resolved base ref
+// (<remote>/<branch>, defaulting to origin/main) is an ancestor of HEAD (the
+// review may proceed). On any failure (fetch failure, missing upstream,
+// behind-base refusal, rebase conflict) it returns a *PreflightError with a
+// ready-to-display message; the caller should print it to stderr and exit
+// non-zero. Preflight does not spawn any review agents and does not touch the
+// prism DB, so a Preflight failure cannot affect the review-cycle counter
+// (the counter is derived from per-agent session rows written by RunAsync).
 func Preflight(opts PreflightOpts) error {
 	if opts.Worktree == "" {
 		return &PreflightError{Msg: "prism review: preflight: worktree path is required"}
@@ -156,23 +163,26 @@ func Preflight(opts PreflightOpts) error {
 
 	remoteRef := remote + "/" + branch
 
-	// Step 3: verify the remote ref now exists (catches the "no origin/main
+	// Step 3: verify the remote ref now exists (catches the "no <remote>/<base>
 	// configured" case where fetch is silently a no-op because the remote
-	// itself does not advertise main, or the local checkout has no origin).
+	// itself does not advertise the requested branch, or the local checkout
+	// has no such remote). This must NOT silently retry against "main" — if
+	// the resolved base is missing upstream, the operator needs to know.
 	if _, stderr, code, _ := runner.run(opts.Worktree, "rev-parse", "--verify", remoteRef); code != 0 {
 		return &PreflightError{Msg: fmt.Sprintf(`prism review: no %s ref configured.
 
 After 'git fetch %s %s' the ref %s is still not present. The branch has no
-upstream main configured (this is unusual but possible in local-only setups).
+upstream %s configured (this is unusual but possible in local-only setups
+or when the base branch has been deleted upstream).
 
 Configure the remote:
 
     git remote add %s <url>
     git fetch %s %s
 
-Or, if origin already exists, ensure it advertises a 'main' branch.
+Or, if %s already exists, ensure it advertises a '%s' branch.
 
-git stderr: %s`, remoteRef, remote, branch, remoteRef, remote, remote, branch, strings.TrimSpace(stderr))}
+git stderr: %s`, remoteRef, remote, branch, remoteRef, branch, remote, remote, branch, remote, branch, strings.TrimSpace(stderr))}
 	}
 
 	// Step 4 (optional): inline rebase. We do this BEFORE the ancestor check so
@@ -243,14 +253,17 @@ git stderr (truncated):
 		// Up to date — proceed.
 		return nil
 	case 1:
-		// Not an ancestor — refuse with a clear message.
+		// Not an ancestor — refuse with a clear message. The refusal names the
+		// resolved base ref in the "N commits behind …" line and in the
+		// suggested `git fetch` / `git rebase` commands so a worker on a PR
+		// targeting a non-main base sees the right ref to act on (#2304).
 		behind := countCommitsBehind(runner, opts.Worktree, remoteRef)
 		return &PreflightError{
 			Refused:       true,
 			CommitsBehind: behind,
 			Msg: fmt.Sprintf(`prism review: branch is %s behind %s
 
-main has advanced since this branch was cut. Reviewers will see drift
+%s has advanced since this branch was cut. Reviewers will see drift
 that is not part of your change. Rebase first:
 
     git fetch %s %s
@@ -259,7 +272,7 @@ that is not part of your change. Rebase first:
 
 Or rerun with --rebase to do this inline (only safe if your local branch
 has no uncommitted or local-only state worth preserving).`,
-				pluralCommits(behind), remoteRef, remote, branch, remoteRef),
+				pluralCommits(behind), remoteRef, branch, remote, branch, remoteRef),
 		}
 	default:
 		// Unknown ref or other git failure.

--- a/modules/programs/prism/prism/internal/review/preflight_test.go
+++ b/modules/programs/prism/prism/internal/review/preflight_test.go
@@ -386,6 +386,305 @@ func TestPreflight_WorktreeRequired(t *testing.T) {
 	}
 }
 
+// ── base-ref resolver tests (#2304) ───────────────────────────────────────────
+
+// fakeBaseRefRunner is a scripted baseRefRunner for unit-testing
+// resolvePRBaseRefWithRunner. It captures the PR numbers it was called with
+// so tests can assert the resolver did (or didn't) actually invoke gh.
+type fakeBaseRefRunner struct {
+	stdout string
+	err    error
+	calls  []string
+}
+
+func (f *fakeBaseRefRunner) run(prNumber string) (string, error) {
+	f.calls = append(f.calls, prNumber)
+	return f.stdout, f.err
+}
+
+// TestResolvePRBaseRef_Success verifies that the resolver returns the
+// baseRefName from a successful gh response. This is the happy path that
+// drives a PR-aware base-branch in the rebase gate (#2304 AC "base-ref
+// resolution from PR metadata").
+func TestResolvePRBaseRef_Success(t *testing.T) {
+	fr := &fakeBaseRefRunner{
+		stdout: `{"baseRefName":"eks-pipeline"}` + "\n",
+	}
+	got := resolvePRBaseRefWithRunner("1234", fr)
+	if got != "eks-pipeline" {
+		t.Errorf("ResolvePRBaseRef: got %q, want %q", got, "eks-pipeline")
+	}
+	if len(fr.calls) != 1 || fr.calls[0] != "1234" {
+		t.Errorf("ResolvePRBaseRef: expected one gh call with PR %q; got %v", "1234", fr.calls)
+	}
+}
+
+// TestResolvePRBaseRef_SuccessMainBase verifies the main-targeting case
+// returns "main". Ensures the resolver does not collapse "main" to "" — the
+// preflight default mechanism handles the "" → "main" fallback separately.
+func TestResolvePRBaseRef_SuccessMainBase(t *testing.T) {
+	fr := &fakeBaseRefRunner{stdout: `{"baseRefName":"main"}`}
+	got := resolvePRBaseRefWithRunner("42", fr)
+	if got != "main" {
+		t.Errorf("ResolvePRBaseRef: got %q, want %q", got, "main")
+	}
+}
+
+// TestResolvePRBaseRef_GHFailureFallsBack verifies the silent-fallback
+// contract: a gh failure (network error, unauthenticated, PR not found, gh
+// missing) collapses to "" so the caller defaults to "main". This is the
+// [edge-case] AC: preflight falls back silently to origin/main without a
+// scary warning.
+func TestResolvePRBaseRef_GHFailureFallsBack(t *testing.T) {
+	fr := &fakeBaseRefRunner{err: errors.New("gh: Could not resolve to a PullRequest with the number of 9999")}
+	got := resolvePRBaseRefWithRunner("9999", fr)
+	if got != "" {
+		t.Errorf("ResolvePRBaseRef: expected \"\" on gh failure; got %q", got)
+	}
+}
+
+// TestResolvePRBaseRef_EmptyBaseFallsBack verifies that gh succeeding with
+// an empty baseRefName is treated the same as a lookup failure — required by
+// the [edge-case] AC "empty baseRefName falls back to origin/main".
+func TestResolvePRBaseRef_EmptyBaseFallsBack(t *testing.T) {
+	fr := &fakeBaseRefRunner{stdout: `{"baseRefName":""}`}
+	got := resolvePRBaseRefWithRunner("7", fr)
+	if got != "" {
+		t.Errorf("ResolvePRBaseRef: expected \"\" on empty baseRefName; got %q", got)
+	}
+}
+
+// TestResolvePRBaseRef_MalformedJSONFallsBack verifies that an unparseable gh
+// response is treated as a lookup failure. Defends against a future gh output
+// schema change silently producing the wrong base ref.
+func TestResolvePRBaseRef_MalformedJSONFallsBack(t *testing.T) {
+	fr := &fakeBaseRefRunner{stdout: `not json`}
+	got := resolvePRBaseRefWithRunner("7", fr)
+	if got != "" {
+		t.Errorf("ResolvePRBaseRef: expected \"\" on malformed JSON; got %q", got)
+	}
+}
+
+// TestResolvePRBaseRef_EmptyPRNumberSkipsGH verifies that an empty PR number
+// does not invoke gh at all. Defence in depth — guards against `prism review`
+// invocations that somehow forwarded an empty positional arg.
+func TestResolvePRBaseRef_EmptyPRNumberSkipsGH(t *testing.T) {
+	fr := &fakeBaseRefRunner{stdout: `{"baseRefName":"main"}`}
+	got := resolvePRBaseRefWithRunner("", fr)
+	if got != "" {
+		t.Errorf("ResolvePRBaseRef: expected \"\" for empty PR; got %q", got)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("ResolvePRBaseRef: expected no gh call for empty PR; got %v", fr.calls)
+	}
+}
+
+// ── Preflight tests against a non-main base branch (#2304) ────────────────────
+
+// TestPreflight_NonMainBaseRefusalNamesResolvedRef verifies that when the
+// caller supplies a non-main Branch, the refusal message names the resolved
+// ref in the "N commits behind …" line, the "<base> has advanced" line, and
+// in the suggested `git fetch` / `git rebase` commands. The hardcoded
+// origin/main from #1518 must NOT appear (#2304 AC: refusal message
+// references the resolved ref).
+func TestPreflight_NonMainBaseRefusalNamesResolvedRef(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin eks-pipeline", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/eks-pipeline", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("merge-base --is-ancestor origin/eks-pipeline HEAD", scriptedResponse{exitCode: 1}).
+		on("rev-list --count HEAD..origin/eks-pipeline", scriptedResponse{stdout: "3\n", exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		Branch:    "eks-pipeline",
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight: expected refusal for behind-base branch, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if !pe.Refused {
+		t.Errorf("Preflight: expected Refused=true; got %+v", pe)
+	}
+	if pe.CommitsBehind != 3 {
+		t.Errorf("Preflight: expected CommitsBehind=3; got %d", pe.CommitsBehind)
+	}
+	for _, want := range []string{
+		"3 commits",
+		"behind origin/eks-pipeline",
+		"eks-pipeline has advanced",
+		"git fetch origin eks-pipeline",
+		"git rebase origin/eks-pipeline",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight: non-main refusal message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+	// Defence in depth: the message must NOT reference origin/main when the
+	// resolved base is something else. A leaked "origin/main" or stray "main"
+	// reference is the #2304 footgun.
+	for _, mustNot := range []string{
+		"origin/main",
+		"behind main",
+		"git rebase origin/main",
+	} {
+		if strings.Contains(pe.Msg, mustNot) {
+			t.Errorf("Preflight: non-main refusal message must not contain %q; got:\n%s", mustNot, pe.Msg)
+		}
+	}
+	// Sanity: the ancestor check must have run against the resolved ref, not
+	// against the hardcoded origin/main.
+	if !fg.called("merge-base --is-ancestor origin/eks-pipeline HEAD") {
+		t.Errorf("Preflight: expected merge-base against origin/eks-pipeline; calls=%v", fg.calls)
+	}
+	if fg.called("merge-base --is-ancestor origin/main HEAD") {
+		t.Errorf("Preflight: merge-base against origin/main must NOT run when Branch=eks-pipeline; calls=%v", fg.calls)
+	}
+}
+
+// TestPreflight_NonMainBaseRebaseTargetsResolvedRef verifies that --rebase
+// against a PR with a non-main base rebases onto the resolved ref (not
+// origin/main) and force-pushes the result. This is the #2304 footgun: a
+// rebase onto the wrong base silently pulls in unrelated commits and inflates
+// the PR's apparent diff.
+func TestPreflight_NonMainBaseRebaseTargetsResolvedRef(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin eks-pipeline", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/eks-pipeline", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("rebase origin/eks-pipeline", scriptedResponse{exitCode: 0}).
+		on("push --force-with-lease", scriptedResponse{exitCode: 0}).
+		on("merge-base --is-ancestor origin/eks-pipeline HEAD", scriptedResponse{exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		Branch:    "eks-pipeline",
+		Rebase:    true,
+		gitRunner: fg,
+	})
+	if err != nil {
+		t.Fatalf("Preflight (--rebase, non-main base): unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"fetch origin eks-pipeline",
+		"rebase origin/eks-pipeline",
+		"push --force-with-lease",
+		"merge-base --is-ancestor origin/eks-pipeline HEAD",
+	} {
+		if !fg.called(want) {
+			t.Errorf("Preflight (--rebase, non-main): expected %q to be called; calls=%v", want, fg.calls)
+		}
+	}
+	// Defence in depth: a rebase against origin/main must NEVER fire when
+	// the PR's base is something else — this is the silent-footgun class
+	// the issue calls out.
+	for _, mustNot := range []string{
+		"fetch origin main",
+		"rebase origin/main",
+		"merge-base --is-ancestor origin/main HEAD",
+	} {
+		if fg.called(mustNot) {
+			t.Errorf("Preflight (--rebase, non-main): origin/main op %q must NOT run when Branch=eks-pipeline; calls=%v", mustNot, fg.calls)
+		}
+	}
+}
+
+// TestPreflight_NonMainBaseMissingUpstreamSurfacesResolvedRef verifies that
+// when the resolved base ref does not exist after fetch (e.g. base branch
+// deleted upstream), the missing-upstream error names the resolved ref —
+// preflight does NOT silently retry against main (#2304 AC "resolved base
+// ref missing" edge case).
+func TestPreflight_NonMainBaseMissingUpstreamSurfacesResolvedRef(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin eks-pipeline", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/eks-pipeline", scriptedResponse{
+			stderr:   "fatal: Needed a single revision",
+			exitCode: 128,
+		})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		Branch:    "eks-pipeline",
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight: expected missing-upstream error for non-main base, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if pe.Refused {
+		t.Errorf("Preflight: missing-upstream (non-main) must not be Refused=true; got %+v", pe)
+	}
+	for _, want := range []string{
+		"no origin/eks-pipeline ref configured",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight: missing-upstream (non-main) message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+	// Defence in depth: must not silently retry against main.
+	if fg.called("fetch origin main") || fg.called("rev-parse --verify origin/main") {
+		t.Errorf("Preflight: missing-upstream (non-main) must NOT retry against main; calls=%v", fg.calls)
+	}
+}
+
+// TestPreflight_NonMainBaseRebaseConflictAbortsAndRestores verifies the
+// rebase-conflict abort/restore guarantee holds for non-main bases — the
+// worktree is never left mid-rebase, mirroring the same-restoration
+// guarantee the original gate provides against main (#2304 AC "on --rebase
+// conflict against a non-main base, the rebase is aborted, HEAD restored").
+func TestPreflight_NonMainBaseRebaseConflictAbortsAndRestores(t *testing.T) {
+	fg := newFakeGit().
+		on("rev-parse HEAD", scriptedResponse{stdout: "deadbeef\n", exitCode: 0}).
+		on("fetch origin eks-pipeline", scriptedResponse{exitCode: 0}).
+		on("rev-parse --verify origin/eks-pipeline", scriptedResponse{stdout: "abc123\n", exitCode: 0}).
+		on("rebase origin/eks-pipeline", scriptedResponse{
+			stderr:   "CONFLICT (content): Merge conflict in foo.txt",
+			exitCode: 1,
+		}).
+		on("rebase --abort", scriptedResponse{exitCode: 0}).
+		on("reset --hard deadbeef", scriptedResponse{exitCode: 0})
+
+	err := Preflight(PreflightOpts{
+		Worktree:  "/fake/worktree",
+		Branch:    "eks-pipeline",
+		Rebase:    true,
+		gitRunner: fg,
+	})
+	if err == nil {
+		t.Fatal("Preflight (--rebase conflict, non-main): expected error, got nil")
+	}
+	var pe *PreflightError
+	if !errors.As(err, &pe) {
+		t.Fatalf("Preflight: error is not *PreflightError: %T %v", err, err)
+	}
+	if pe.Refused {
+		t.Errorf("Preflight (--rebase conflict, non-main): must not be Refused=true; got %+v", pe)
+	}
+	if !fg.called("rebase --abort") {
+		t.Errorf("Preflight (--rebase conflict, non-main): expected `rebase --abort`; calls=%v", fg.calls)
+	}
+	if !fg.called("reset --hard deadbeef") {
+		t.Errorf("Preflight (--rebase conflict, non-main): expected `reset --hard deadbeef`; calls=%v", fg.calls)
+	}
+	// Recovery commands must name the resolved base, not origin/main.
+	for _, want := range []string{
+		"git fetch origin eks-pipeline",
+		"git rebase origin/eks-pipeline",
+	} {
+		if !strings.Contains(pe.Msg, want) {
+			t.Errorf("Preflight (--rebase conflict, non-main): recovery message missing %q; got:\n%s", want, pe.Msg)
+		}
+	}
+}
+
 // ── integration test against a real local git repo ────────────────────────────
 
 // TestPreflight_RealGit_AncestorPasses creates a real local git repo with two

--- a/modules/programs/prism/skills/prism/SKILL.md
+++ b/modules/programs/prism/skills/prism/SKILL.md
@@ -228,17 +228,20 @@ on all-PASS, non-zero on any FAIL / no-start / timeout. See the `--wait`
 section above for the full contract (exit codes, Ctrl-C semantic, idempotent
 observation).
 
-### Pre-flight rebase gate (`prism review` refuses when behind `origin/main`)
+### Pre-flight rebase gate (`prism review` refuses when behind the PR's base branch)
 
 Before spawning any review agents, `prism review` runs a **one-shot pre-flight
-check**:
+check** against the PR's actual base ref (resolved via
+`gh pr view <pr> --json baseRefName`; falls back silently to `origin/main`
+when the lookup fails or no PR is discoverable — #2304):
 
-1. `git fetch origin main` (one network round-trip).
-2. Strict ancestor check: `git merge-base --is-ancestor origin/main HEAD`.
-3. If `origin/main` is an ancestor of `HEAD`: proceed unchanged.
+1. `git fetch origin <base>` (one network round-trip).
+2. Strict ancestor check: `git merge-base --is-ancestor origin/<base> HEAD`.
+3. If `origin/<base>` is an ancestor of `HEAD`: proceed unchanged.
 4. If not: refuse, exit non-zero, **no agents spawn**, and **no cycle counter
    increment**. The error message names the number of commits behind and the
-   recommended fix:
+   recommended fix. For a PR targeting `main` the rendered message looks
+   like:
 
    ```
    prism review: branch is N commits behind origin/main
@@ -250,26 +253,37 @@ check**:
    Or rerun with --rebase to do this inline.
    ```
 
+   For a PR targeting (say) `eks-pipeline`, the `main` references are
+   substituted with the resolved base ref:
+
+   ```
+   prism review: branch is N commits behind origin/eks-pipeline
+
+       git fetch origin eks-pipeline
+       git rebase origin/eks-pipeline
+       git push --force-with-lease
+   ```
+
 The `--rebase` flag is the inline opt-in fix:
 
 ```bash
 prism review <pr> --rebase
 ```
 
-It performs the fetch + rebase + force-push inline and then proceeds to the
-review against the rebased HEAD. If the rebase produces conflicts, the rebase
-is aborted, the worktree is restored to the original `HEAD`, and the command
-exits non-zero — never leaves the worktree mid-rebase. Resolve conflicts
-manually and re-run.
+It performs the fetch + rebase + force-push inline against the resolved base
+ref (not hardcoded `origin/main`) and then proceeds to the review against the
+rebased HEAD. If the rebase produces conflicts, the rebase is aborted, the
+worktree is restored to the original `HEAD`, and the command exits non-zero —
+never leaves the worktree mid-rebase. Resolve conflicts manually and re-run.
 
 **Why this gate exists.** Reviewers regularly produce noisy findings of the
-form "you should also update X" when X landed on `main` after the branch was
-cut. A simple rebase makes the diff smaller and the finding disappear, but
-discovering this from a FAIL verdict burns a full 5-agent cycle. The gate
-catches drift in one fetch, before any agent spawns.
+form "you should also update X" when X landed on the base branch after the
+feature branch was cut. A simple rebase makes the diff smaller and the
+finding disappear, but discovering this from a FAIL verdict burns a full
+5-agent cycle. The gate catches drift in one fetch, before any agent spawns.
 
-**Cycle-counter contract.** Gate failures (behind-main refusal, fetch failure,
-missing `origin/main`, rebase conflict abort) **do not increment** the
+**Cycle-counter contract.** Gate failures (behind-base refusal, fetch failure,
+missing `origin/<base>`, rebase conflict abort) **do not increment** the
 review-cycle counter. They are the same category as "round already in
 progress" / pure-infrastructure failures / ran-but-no-parseable-verdict
 rounds (#1995): no full set of parseable verdicts was produced, so the
@@ -279,8 +293,8 @@ available before the LOOP-LIMIT footer fires.
 
 Rounds that **do not count** toward the 3-cycle limit:
 
-- **Pre-flight gate refusals** — behind-main, fetch failure, missing
-  `origin/main`, rebase conflict abort. No agents spawned.
+- **Pre-flight gate refusals** — behind-base, fetch failure, missing
+  `origin/<base>`, rebase conflict abort. No agents spawned.
 - **Round-already-in-progress refusals** — a prior review is still
   active for the same parent. No agents spawned.
 - **Pure-infrastructure failures** — every agent failed to start


### PR DESCRIPTION
Closes #2304.

## What

`prism review`'s pre-flight rebase gate hardcoded `origin/main` regardless of the PR's actual base branch. For PRs targeting non-`main` bases (long-lived integration branches, release branches, environment branches) the gate refused on irrelevant divergence and `--rebase` silently injected unrelated `main` commits into the branch — inflating the diff against the actual base.

## Approach

Discover the PR's base via `gh pr view <pr> --json baseRefName` before invoking `review.Preflight`, and pass it through `PreflightOpts.Branch`. Fall back silently to `main` on any lookup failure (gh missing, network error, unauthenticated, no PR for branch, empty `baseRefName`) so invocations not tied to a discoverable PR keep today's behaviour. No noisy warning on the fallback path — the gate is best-effort about base-ref detection.

Threaded the resolved base through:

- `remoteRef := remote + "/" + branch` (already configurable, just never populated by the call site)
- the refusal message body — `"main has advanced"` → `"<base> has advanced"`
- the missing-upstream message body — drops the hardcoded "main" wording
- the `--rebase` target — already flowed through `remoteRef`, but now from a non-`main` value

When the resolved base is `main`, output is byte-for-byte identical to the pre-fix behaviour (verified by re-running the existing pre-#2304 tests).

## Files

- `internal/review/base_ref.go` (new) — `ResolvePRBaseRef(prNumber) string` plus a `baseRefRunner` test seam, following the same shape as `pr_existence.go`.
- `cmd/review.go` — call the resolver before `Preflight`, pass result through `Branch`.
- `internal/review/preflight.go` — substitute hardcoded `"main"` in user-facing message bodies with the resolved `branch`.
- `internal/review/preflight_test.go` — 7 new tests covering AC items (a) – (d) plus non-main missing-upstream and non-main rebase-conflict.

## Tests

```
gofmt -l .            # clean
go build ./...        # clean
go test ./...         # all packages pass (review pkg has 20/20 preflight+resolver tests)
nix build .#prism     # green
```

Verified the new refusal-naming test catches the bug by reverting just the preflight.go text changes — the test correctly fails on the unchanged code with:

```
Preflight: non-main refusal message missing "eks-pipeline has advanced"
```

CI `nix-build-prism-checked` will exercise the homeless-shelter suite.

## AC mapping

- functional: non-main PR → fetches `<remote>/<base>`, ancestor check against that ref → covered by `TestPreflight_NonMainBaseRefusalNamesResolvedRef` (negative path)
- functional: base=main → byte-for-byte identical → covered by the pre-existing tests staying green
- functional: refusal message names resolved ref → covered, asserts `"eks-pipeline has advanced"` + must-not-contain `"origin/main"`
- functional: `--rebase` targets resolved ref → covered by `TestPreflight_NonMainBaseRebaseTargetsResolvedRef`
- edge: gh failure → fallback to main → covered by `TestResolvePRBaseRef_GHFailureFallsBack`
- edge: empty `baseRefName` → fallback → covered by `TestResolvePRBaseRef_EmptyBaseFallsBack`
- edge: resolved base ref missing after fetch → clear `prism review: no <remote>/<base> ref configured` → covered by `TestPreflight_NonMainBaseMissingUpstreamSurfacesResolvedRef`
- edge: `--rebase` conflict on non-main base → abort + restore → covered by `TestPreflight_NonMainBaseRebaseConflictAbortsAndRestores`
- functional: preflight_test.go tests use an injected seam → `fakeBaseRefRunner` (no real `gh` call)
