### PR TITLE
mergequeue: distinguish external merge from prism-driven (#2298)

### DIFF
--- a/modules/programs/prism/prism/internal/mergequeue/spawn_outcome_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/spawn_outcome_test.go
@@ -91,7 +91,7 @@ func TestSucceedAndNotify_PersistsPRMergedAt(t *testing.T) {
 	// Capture the wall-clock right before invoking succeedAndNotify so the
 	// assertion below has a tight upper bound on the persisted value.
 	wantAtLeast := time.Now().UnixMilli()
-	w.succeedAndNotify(context.Background(), head)
+	w.succeedAndNotify(context.Background(), head, mergeOutcomePrismDriven, nil)
 	wantAtMost := time.Now().UnixMilli()
 
 	// The worker's spawn_outcome row must now carry a pr_merged_at value.
@@ -150,7 +150,7 @@ func TestSucceedAndNotify_NoWorkerRow_SkipsPRMergedAt(t *testing.T) {
 	}
 
 	w := New(d, coordIID, coordSession, http.DefaultClient)
-	w.succeedAndNotify(context.Background(), head)
+	w.succeedAndNotify(context.Background(), head, mergeOutcomePrismDriven, nil)
 
 	// pending_merges must still have transitioned to merged.
 	pm, err := d.PendingMergeByPR(pr)

--- a/modules/programs/prism/prism/internal/mergequeue/watcher.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher.go
@@ -212,9 +212,13 @@ func (w *Watcher) tick(ctx context.Context) {
 		return
 	}
 
-	// PR already merged (shouldn't happen, but handle it gracefully).
+	// PR observed as already MERGED on a fresh poll. The merge was performed
+	// by an external actor (human via GitHub UI, another tool, or a tab racing
+	// the watcher) — prism did NOT execute the merge mutation. Notify the
+	// coordinator with an honest-signal message that distinguishes this from
+	// a prism-driven merge (#2298).
 	if prInfo.State == "MERGED" || prInfo.isMerged() {
-		w.succeedAndNotify(ctx, head)
+		w.succeedAndNotify(ctx, head, mergeOutcomeExternal, prInfo)
 		return
 	}
 
@@ -296,16 +300,19 @@ func (w *Watcher) tryMerge(ctx context.Context, head *db.PendingMerge) {
 	out, err := w.runGH(ctx, "pr", "merge", fmt.Sprintf("%d", head.PR), "--squash")
 	if err == nil {
 		log.Printf("[mergequeue] PR #%d merged successfully", head.PR)
-		w.succeedAndNotify(ctx, head)
+		w.succeedAndNotify(ctx, head, mergeOutcomePrismDriven, nil)
 		return
 	}
 
 	// First: reconcile by checking the PR's actual state. Some "errors" are
 	// races where the PR did merge — trusting the observed state is more
-	// reliable than pattern-matching error strings.
+	// reliable than pattern-matching error strings. This is still a
+	// prism-driven merge (we issued the mutation; it errored but the merge
+	// took effect), so the notification distinguishes the reconciliation
+	// breadcrumb from the external-merge case (#2298).
 	if state := w.checkPRMergedState(ctx, head.PR); state == "MERGED" {
 		log.Printf("[mergequeue] PR #%d merge mutation errored but PR is MERGED — reconciling as success", head.PR)
-		w.succeedAndNotify(ctx, head)
+		w.succeedAndNotify(ctx, head, mergeOutcomeReconciled, nil)
 		return
 	}
 
@@ -345,8 +352,42 @@ func (w *Watcher) checkPRMergedState(ctx context.Context, pr int) string {
 	return v.State
 }
 
+// mergeOutcome identifies which of the three success paths called
+// succeedAndNotify. The DB transition is identical for all three (the
+// pending_merges row terminates as 'merged'); the values only steer the
+// notification text rendered for the coordinator. Introduced in #2298 so the
+// coordinator can distinguish an externally-merged PR (the watcher saw a
+// fait-accompli MERGED state on a fresh poll) from a prism-driven merge.
+type mergeOutcome int
+
+const (
+	// mergeOutcomePrismDriven — gh pr merge --squash returned err == nil and
+	// the merge commit was created by prism's own mutation. Canonical case;
+	// existing notification text is preserved byte-for-byte.
+	mergeOutcomePrismDriven mergeOutcome = iota
+
+	// mergeOutcomeExternal — fresh poll observed state=MERGED before prism
+	// attempted any mutation. The merge was performed by a human via the
+	// GitHub UI, by another tool, or by a tab racing the watcher. The
+	// coordinator notification names the merger and does NOT instruct
+	// `prism cleanup`, because prism did not perform the merge.
+	mergeOutcomeExternal
+
+	// mergeOutcomeReconciled — gh pr merge --squash returned a non-nil error
+	// but checkPRMergedState revealed the PR is MERGED. This is the in-flight
+	// race recovery from #1645 — the mutation took effect despite the error.
+	// Still a prism-driven merge (we issued the mutation) so the coordinator
+	// is told to `git pull` + `prism cleanup`, with a reconciliation
+	// breadcrumb appended.
+	mergeOutcomeReconciled
+)
+
 // succeedAndNotify transitions head to merged and notifies the coordinator.
-func (w *Watcher) succeedAndNotify(ctx context.Context, head *db.PendingMerge) {
+// outcome selects which of the three notification variants is rendered (see
+// mergeOutcome). prInfoForExternal supplies mergedBy/mergedAt when
+// outcome == mergeOutcomeExternal; ignored otherwise. Pass nil when the
+// caller does not have a prInfo (prism-driven and reconciled paths).
+func (w *Watcher) succeedAndNotify(ctx context.Context, head *db.PendingMerge, outcome mergeOutcome, prInfoForExternal *prInfo) {
 	// Capture mergedAt at the same instant TerminateMerge persists it, so the
 	// spawn_outcome.pr_merged_at write reflects the canonical wall-clock the
 	// merge-queue row carries. Using time.Now() here (and inside TerminateMerge)
@@ -380,22 +421,80 @@ func (w *Watcher) succeedAndNotify(ctx context.Context, head *db.PendingMerge) {
 		log.Printf("[mergequeue] PR #%d: no worker spawn_outcome row carries pr_number=%d — skipping pr_merged_at persistence", head.PR, head.PR)
 	}
 
-	// Look up the worker session's archive_path from the sessions table.
-	archivePath := w.lookupWorkerArchivePath(head)
-	var notifyText string
-	if archivePath != "" {
-		notifyText = fmt.Sprintf(
-			"PR #%d merged. Archive: %s. Run `git pull` in @main and `prism cleanup` the worker session.",
-			head.PR, archivePath,
+	notifyText := w.renderSuccessNotifyText(head, outcome, prInfoForExternal)
+	log.Printf("[mergequeue] %s", notifyText)
+	w.notify(ctx, head.SessionName, head.InstanceID, notifyText)
+}
+
+// renderSuccessNotifyText composes the coordinator notification text for one
+// of the three success outcomes (#2298). The prism-driven and reconciled
+// variants include the worker session's archive_path when one is recorded;
+// the external variant omits the archive path because prism did not perform
+// the merge and the coordinator should not run `prism cleanup`.
+func (w *Watcher) renderSuccessNotifyText(head *db.PendingMerge, outcome mergeOutcome, prInfoForExternal *prInfo) string {
+	switch outcome {
+	case mergeOutcomeExternal:
+		return renderExternalMergeNotifyText(head.PR, prInfoForExternal)
+	case mergeOutcomeReconciled:
+		archivePath := w.lookupWorkerArchivePath(head)
+		if archivePath != "" {
+			return fmt.Sprintf(
+				"PR #%d merged. (Reconciled — gh mutation errored but PR is MERGED.) Archive: %s. Run `git pull` in @main and `prism cleanup` the worker session.",
+				head.PR, archivePath,
+			)
+		}
+		return fmt.Sprintf(
+			"PR #%d merged. (Reconciled — gh mutation errored but PR is MERGED.) Run `git pull` in @main and `prism cleanup` the worker session.",
+			head.PR,
 		)
-	} else {
-		notifyText = fmt.Sprintf(
+	default: // mergeOutcomePrismDriven
+		archivePath := w.lookupWorkerArchivePath(head)
+		if archivePath != "" {
+			return fmt.Sprintf(
+				"PR #%d merged. Archive: %s. Run `git pull` in @main and `prism cleanup` the worker session.",
+				head.PR, archivePath,
+			)
+		}
+		return fmt.Sprintf(
 			"PR #%d merged. Run `git pull` in @main and `prism cleanup` the worker session.",
 			head.PR,
 		)
 	}
-	log.Printf("[mergequeue] %s", notifyText)
-	w.notify(ctx, head.SessionName, head.InstanceID, notifyText)
+}
+
+// renderExternalMergeNotifyText composes the external-merge notification text
+// (#2298). The merger field is emitted as "merged by @<login>" when login is
+// available, falling back to a login-less form when gh returned mergedBy=null
+// or an empty login. The merge timestamp is included when present in prInfo.
+// The text deliberately omits `prism cleanup` because prism did not perform
+// the merge.
+func renderExternalMergeNotifyText(pr int, prInfo *prInfo) string {
+	var login, mergedAt string
+	if prInfo != nil {
+		if prInfo.MergedBy != nil {
+			login = strings.TrimSpace(prInfo.MergedBy.Login)
+		}
+		if prInfo.MergedAt != nil {
+			mergedAt = strings.TrimSpace(*prInfo.MergedAt)
+		}
+	}
+
+	var detail string
+	switch {
+	case login != "" && mergedAt != "":
+		detail = fmt.Sprintf(" (merged by @%s at %s)", login, mergedAt)
+	case login != "":
+		detail = fmt.Sprintf(" (merged by @%s)", login)
+	case mergedAt != "":
+		detail = fmt.Sprintf(" (merged at %s)", mergedAt)
+	default:
+		detail = ""
+	}
+
+	return fmt.Sprintf(
+		"PR #%d was already merged externally%s. No action taken by prism. Run `git pull` if needed.",
+		pr, detail,
+	)
 }
 
 // failAndNotify transitions head to failed and notifies the coordinator.
@@ -589,12 +688,25 @@ func buildNotifyBody(text string, status *db.Status) map[string]any {
 // the field list never regresses to use the (invalid) "merged" field again —
 // `gh pr view` rejects unknown JSON fields with a non-zero exit, so an invalid
 // field name silently breaks the entire merge-queue watcher (see #1014 fallout).
-const prInfoJSONFields = "state,mergedAt,mergeStateStatus,statusCheckRollup,reviewDecision"
+//
+// `mergedBy` was added in #2298 so the external-merge notification can name the
+// human (or bot) who clicked Squash-and-merge before the watcher's mutation.
+const prInfoJSONFields = "state,mergedAt,mergedBy,mergeStateStatus,statusCheckRollup,reviewDecision"
+
+// userRef is the shape `gh pr view --json mergedBy` returns: an object with a
+// `login` field. Null in JSON unmarshals to a nil *userRef.
+type userRef struct {
+	Login string `json:"login"`
+}
 
 // prInfo holds the fields we care about from `gh pr view --json`.
 type prInfo struct {
-	State             string       `json:"state"`
-	MergedAt          *string      `json:"mergedAt"`
+	State    string  `json:"state"`
+	MergedAt *string `json:"mergedAt"`
+	// MergedBy identifies the GitHub user who clicked Squash-and-merge. nil
+	// when the PR is unmerged or when gh returned mergedBy=null. Consumed by
+	// the external-merge notification path (#2298).
+	MergedBy          *userRef     `json:"mergedBy"`
 	MergeStateStatus  string       `json:"mergeStateStatus"`
 	StatusCheckRollup []checkEntry `json:"statusCheckRollup"`
 	// ReviewDecision is the PR's review decision from GitHub: "REVIEW_REQUIRED",

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -490,7 +490,7 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 		return
 	}
 	if prInfoVal.State == "MERGED" || prInfoVal.isMerged() {
-		fw.watcher.succeedAndNotify(ctx, head)
+		fw.watcher.succeedAndNotify(ctx, head, mergeOutcomeExternal, prInfoVal)
 		return
 	}
 
@@ -498,7 +498,7 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 	case "CLEAN":
 		out, mergeErr := fw.mergeFn(ctx, head.PR)
 		if mergeErr == nil {
-			fw.watcher.succeedAndNotify(ctx, head)
+			fw.watcher.succeedAndNotify(ctx, head, mergeOutcomePrismDriven, nil)
 			return
 		}
 		// First: reconcile by checking the PR's actual state.
@@ -507,7 +507,7 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 			reconciledState = fw.checkMergedStateFn(ctx, head.PR)
 		}
 		if reconciledState == "MERGED" {
-			fw.watcher.succeedAndNotify(ctx, head)
+			fw.watcher.succeedAndNotify(ctx, head, mergeOutcomeReconciled, nil)
 			return
 		}
 		// Second: keyword-based branch-moved-race check.
@@ -548,7 +548,7 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 		if requiredChecksAllPassed(prInfoVal.StatusCheckRollup, required) {
 			out, mergeErr := fw.mergeFn(ctx, head.PR)
 			if mergeErr == nil {
-				fw.watcher.succeedAndNotify(ctx, head)
+				fw.watcher.succeedAndNotify(ctx, head, mergeOutcomePrismDriven, nil)
 				return
 			}
 			// First: reconcile state.
@@ -557,7 +557,7 @@ func (fw *fakeWatcher) processHead(ctx context.Context) {
 				reconciledState = fw.checkMergedStateFn(ctx, head.PR)
 			}
 			if reconciledState == "MERGED" {
-				fw.watcher.succeedAndNotify(ctx, head)
+				fw.watcher.succeedAndNotify(ctx, head, mergeOutcomeReconciled, nil)
 				return
 			}
 			// Second: keyword check.
@@ -1516,6 +1516,7 @@ func TestPRInfoJSONFields_NoMergedField(t *testing.T) {
 	}
 	hasMergedAt := false
 	hasReviewDecision := false
+	hasMergedBy := false
 	for _, f := range fields {
 		if f == "mergedAt" {
 			hasMergedAt = true
@@ -1523,12 +1524,18 @@ func TestPRInfoJSONFields_NoMergedField(t *testing.T) {
 		if f == "reviewDecision" {
 			hasReviewDecision = true
 		}
+		if f == "mergedBy" {
+			hasMergedBy = true
+		}
 	}
 	if !hasMergedAt {
 		t.Errorf("prInfoJSONFields must include 'mergedAt' to detect merged state. Got: %q", prInfoJSONFields)
 	}
 	if !hasReviewDecision {
 		t.Errorf("prInfoJSONFields must include 'reviewDecision' to detect review-required blocks (#1357). Got: %q", prInfoJSONFields)
+	}
+	if !hasMergedBy {
+		t.Errorf("prInfoJSONFields must include 'mergedBy' to name the merger in the external-merge notification (#2298). Got: %q", prInfoJSONFields)
 	}
 }
 
@@ -2336,6 +2343,369 @@ func TestWatcher_GenuineFailure_NoRegression(t *testing.T) {
 	}
 	if row.Status != "failed" {
 		t.Errorf("status: got %q, want failed (genuine error must not reconcile as merged)", row.Status)
+	}
+}
+
+// ── succeedAndNotify variant rendering tests (issue #2298) ──────────────────
+
+// extractNotifyText pulls the parts[0].text string out of the most recent
+// JSON body the capturing server received. Test-only helper.
+func extractNotifyText(t *testing.T, body []byte) string {
+	t.Helper()
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("extractNotifyText: unmarshal: %v", err)
+	}
+	parts, _ := parsed["parts"].([]interface{})
+	if len(parts) == 0 {
+		t.Fatal("extractNotifyText: notification body has no parts")
+	}
+	part, _ := parts[0].(map[string]interface{})
+	text, _ := part["text"].(string)
+	return text
+}
+
+// TestWatcher_ExternalMerge_NotifyTextDistinguishedAndNamesByLogin verifies
+// AC1 (#2298): when the pre-poll early-return fires (prInfo.State == "MERGED"
+// or prInfo.isMerged()), the notification text identifies the PR as merged
+// externally, names the merger by GitHub login, includes the merge
+// timestamp, and does NOT instruct the coordinator to run `prism cleanup`.
+func TestWatcher_ExternalMerge_NotifyTextDistinguishedAndNamesByLogin(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-ext-merge"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-ext-merge")
+
+	if _, err := d.EnqueueMerge(2200, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	mergedAt := "2026-06-16T22:32:47Z"
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{
+				State:    "MERGED",
+				MergedAt: &mergedAt,
+				MergedBy: &userRef{Login: "b-h-mck"},
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			t.Fatal("external merge path must not invoke gh pr merge")
+			return nil, nil
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator")
+	}
+	text := extractNotifyText(t, srv.lastBody)
+
+	if !strings.Contains(text, "PR #2200") {
+		t.Errorf("notification text %q does not mention 'PR #2200'", text)
+	}
+	if !strings.Contains(text, "merged externally") {
+		t.Errorf("notification text %q does not contain 'merged externally' — external-merge case must be distinguished from prism-driven", text)
+	}
+	if !strings.Contains(text, "@b-h-mck") {
+		t.Errorf("notification text %q does not name merger @b-h-mck", text)
+	}
+	if !strings.Contains(text, mergedAt) {
+		t.Errorf("notification text %q does not include merge timestamp %q", text, mergedAt)
+	}
+	if strings.Contains(text, "prism cleanup") {
+		t.Errorf("notification text %q must NOT instruct `prism cleanup` for external merges — prism did not perform the merge", text)
+	}
+
+	// Row must still terminate as merged (DB state unchanged from current behaviour).
+	row, err := d.PendingMergeByPR(2200)
+	if err != nil {
+		t.Fatalf("PendingMergeByPR: %v", err)
+	}
+	if row.Status != "merged" {
+		t.Errorf("status: got %q, want merged (DB transition unchanged for external case)", row.Status)
+	}
+}
+
+// TestWatcher_ExternalMerge_MergedByNullDegradesGracefully verifies AC4
+// (#2298): when gh returns mergedBy=null (or an empty login), the
+// external-merge notification still emits successfully — the merger field
+// degrades gracefully rather than blocking the notification.
+func TestWatcher_ExternalMerge_MergedByNullDegradesGracefully(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-ext-merge-null"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-ext-merge-null")
+
+	if _, err := d.EnqueueMerge(2201, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	mergedAt := "2026-06-17T09:00:00Z"
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			// MergedBy is nil — gh returned "mergedBy": null.
+			return &prInfo{
+				State:    "MERGED",
+				MergedAt: &mergedAt,
+				MergedBy: nil,
+			}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator — mergedBy=nil must not block notification")
+	}
+	text := extractNotifyText(t, srv.lastBody)
+
+	if !strings.Contains(text, "PR #2201") {
+		t.Errorf("notification text %q does not mention 'PR #2201'", text)
+	}
+	if !strings.Contains(text, "merged externally") {
+		t.Errorf("notification text %q does not contain 'merged externally'", text)
+	}
+	if strings.Contains(text, "@") {
+		t.Errorf("notification text %q contains '@' — with mergedBy=nil the merger should be omitted, not emitted as an empty handle", text)
+	}
+	if !strings.Contains(text, mergedAt) {
+		t.Errorf("notification text %q does not include merge timestamp %q (graceful degrade must still surface mergedAt when present)", text, mergedAt)
+	}
+	if strings.Contains(text, "prism cleanup") {
+		t.Errorf("notification text %q must NOT instruct `prism cleanup` for external merges", text)
+	}
+}
+
+// TestWatcher_PrismDrivenMerge_NotifyTextUnchanged_NoArchive verifies AC2
+// (#2298): when tryMerge succeeds via `gh pr merge --squash` and no worker
+// archive_path is recorded, the notification text matches the existing
+// `PR #N merged. Run \`git pull\` ...` form byte-for-byte. Non-regression
+// for the canonical case.
+func TestWatcher_PrismDrivenMerge_NotifyTextUnchanged_NoArchive(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-prism-merge-noarch"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-prism-merge-noarch")
+
+	if _, err := d.EnqueueMerge(2210, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+
+	fw.processHead(context.Background())
+
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator")
+	}
+	text := extractNotifyText(t, srv.lastBody)
+
+	want := "PR #2210 merged. Run `git pull` in @main and `prism cleanup` the worker session."
+	if text != want {
+		t.Errorf("prism-driven notification (no archive) text mismatch —\n got:  %q\n want: %q", text, want)
+	}
+}
+
+// TestWatcher_PrismDrivenMerge_NotifyTextUnchanged_WithArchive verifies AC2
+// (#2298): when tryMerge succeeds and a worker archive_path is recorded, the
+// notification text matches the existing
+// `PR #N merged. Archive: <path>. Run \`git pull\` ...` form byte-for-byte.
+func TestWatcher_PrismDrivenMerge_NotifyTextUnchanged_WithArchive(t *testing.T) {
+	d := openTestDB(t)
+	coordInstanceID := "inst-coord-arch"
+	coordSession := "myrepo@main"
+	coordRepo := "owner/myrepo"
+
+	// Seed an agent_status row for notification routing.
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, coordSession, coordInstanceID, port, "sid-coord-arch")
+
+	// Seed both a coordinator sessions row (so lookupWorkerArchivePath can
+	// resolve the coordinator's repo via instance_id) and a worker session
+	// whose archive_path will be surfaced in the notification.
+	coordSess := db.Session{
+		InstanceID:  coordInstanceID,
+		SessionName: coordSession,
+		Repo:        coordRepo,
+		Worktree:    "/tmp/coord-wt-arch",
+		Harness:     "pi",
+	}
+	if err := d.InsertSession(coordSess); err != nil {
+		t.Fatalf("insert coordinator session: %v", err)
+	}
+	seedWorkerSession(t, d, "worker-inst-arch-2211", "myrepo@2211", coordRepo,
+		"/archives/myrepo-2211.tar.gz")
+
+	if _, err := d.EnqueueMerge(2211, coordSession, coordInstanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, coordInstanceID, coordSession, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) { return nil, nil },
+		func(_ context.Context, pr int) error { return nil },
+	)
+	// Pin the watcher's repo so lookupWorkerArchivePath has a non-empty scope.
+	fw.watcher.repo = coordRepo
+
+	fw.processHead(context.Background())
+
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator")
+	}
+	text := extractNotifyText(t, srv.lastBody)
+
+	want := "PR #2211 merged. Archive: /archives/myrepo-2211.tar.gz. Run `git pull` in @main and `prism cleanup` the worker session."
+	if text != want {
+		t.Errorf("prism-driven notification (with archive) text mismatch —\n got:  %q\n want: %q", text, want)
+	}
+}
+
+// TestWatcher_Reconciled_NotifyTextIncludesReconciledNote verifies AC3
+// (#2298): when tryMerge errors but checkPRMergedState returns MERGED, the
+// notification text indicates the merge was reconciled from an errored
+// mutation AND still instructs `git pull` + `prism cleanup` (this IS a
+// prism-driven merge, just with a recovery breadcrumb). The text is distinct
+// from both the canonical and the external cases.
+func TestWatcher_Reconciled_NotifyTextIncludesReconciledNote(t *testing.T) {
+	d := openTestDB(t)
+	instanceID := "inst-reconciled-text"
+	session := "myrepo@main"
+
+	srv := newCapturingServer(t)
+	port := parsePort(t, srv.URL)
+	seedCoordinator(t, d, session, instanceID, port, "sid-reconciled-text")
+
+	if _, err := d.EnqueueMerge(2220, session, instanceID, nil); err != nil {
+		t.Fatalf("EnqueueMerge: %v", err)
+	}
+
+	fw := newFakeWatcher(d, instanceID, session, srv.Client(),
+		func(_ context.Context, pr int) (*prInfo, error) {
+			return &prInfo{State: "OPEN", MergeStateStatus: "CLEAN"}, nil
+		},
+		func(_ context.Context, pr int) ([]byte, error) {
+			return []byte("GraphQL: Merge already in progress (mergePullRequest)"),
+				fmt.Errorf("exit status 1")
+		},
+		func(_ context.Context, pr int) error { return nil },
+	)
+	fw.checkMergedStateFn = func(_ context.Context, pr int) string { return "MERGED" }
+
+	fw.processHead(context.Background())
+
+	if srv.called == 0 {
+		t.Fatal("no notification sent to coordinator")
+	}
+	text := extractNotifyText(t, srv.lastBody)
+
+	if !strings.Contains(text, "PR #2220") {
+		t.Errorf("notification text %q does not mention 'PR #2220'", text)
+	}
+	if !strings.Contains(text, "Reconciled") {
+		t.Errorf("notification text %q does not contain reconciliation breadcrumb — reconciled case must be distinct from canonical case", text)
+	}
+	if !strings.Contains(text, "prism cleanup") {
+		t.Errorf("notification text %q does not instruct `prism cleanup` — reconciled case is still a prism-driven merge", text)
+	}
+	if strings.Contains(text, "merged externally") {
+		t.Errorf("notification text %q contains 'merged externally' — reconciled case must NOT be mistaken for external merge", text)
+	}
+}
+
+// TestRenderExternalMergeNotifyText_NilPrInfo verifies the table of
+// degraded-info renderings: with prInfo == nil the text emits with no
+// merger detail and still avoids the `prism cleanup` instruction. Pure
+// rendering test (no DB, no notify) so we can pin the exact strings.
+func TestRenderExternalMergeNotifyText_NilPrInfo(t *testing.T) {
+	got := renderExternalMergeNotifyText(42, nil)
+	want := "PR #42 was already merged externally. No action taken by prism. Run `git pull` if needed."
+	if got != want {
+		t.Errorf("renderExternalMergeNotifyText(42, nil) =\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestRenderExternalMergeNotifyText_LoginAndTimestamp pins the happy-path
+// rendering used by AC1.
+func TestRenderExternalMergeNotifyText_LoginAndTimestamp(t *testing.T) {
+	ts := "2026-06-16T22:32:47Z"
+	info := &prInfo{
+		MergedAt: &ts,
+		MergedBy: &userRef{Login: "b-h-mck"},
+	}
+	got := renderExternalMergeNotifyText(15, info)
+	want := "PR #15 was already merged externally (merged by @b-h-mck at 2026-06-16T22:32:47Z). No action taken by prism. Run `git pull` if needed."
+	if got != want {
+		t.Errorf("renderExternalMergeNotifyText —\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestRenderExternalMergeNotifyText_LoginOnly verifies the case where gh
+// returned mergedBy but mergedAt is unset (defensive — should not normally
+// happen on a MERGED PR but we still want to render gracefully).
+func TestRenderExternalMergeNotifyText_LoginOnly(t *testing.T) {
+	info := &prInfo{
+		MergedAt: nil,
+		MergedBy: &userRef{Login: "someone"},
+	}
+	got := renderExternalMergeNotifyText(99, info)
+	want := "PR #99 was already merged externally (merged by @someone). No action taken by prism. Run `git pull` if needed."
+	if got != want {
+		t.Errorf("renderExternalMergeNotifyText —\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestRenderExternalMergeNotifyText_TimestampOnly verifies the case where gh
+// returned mergedAt but mergedBy=null — still emits a useful breadcrumb.
+func TestRenderExternalMergeNotifyText_TimestampOnly(t *testing.T) {
+	ts := "2026-06-17T09:00:00Z"
+	info := &prInfo{
+		MergedAt: &ts,
+		MergedBy: nil,
+	}
+	got := renderExternalMergeNotifyText(123, info)
+	want := "PR #123 was already merged externally (merged at 2026-06-17T09:00:00Z). No action taken by prism. Run `git pull` if needed."
+	if got != want {
+		t.Errorf("renderExternalMergeNotifyText —\n got:  %q\n want: %q", got, want)
+	}
+}
+
+// TestRenderExternalMergeNotifyText_EmptyLogin verifies that a mergedBy
+// object with an empty login string (rare but possible — e.g. a deleted
+// account) is treated identically to mergedBy=nil: no "@" is emitted.
+func TestRenderExternalMergeNotifyText_EmptyLogin(t *testing.T) {
+	ts := "2026-06-17T09:00:00Z"
+	info := &prInfo{
+		MergedAt: &ts,
+		MergedBy: &userRef{Login: ""},
+	}
+	got := renderExternalMergeNotifyText(456, info)
+	want := "PR #456 was already merged externally (merged at 2026-06-17T09:00:00Z). No action taken by prism. Run `git pull` if needed."
+	if got != want {
+		t.Errorf("renderExternalMergeNotifyText —\n got:  %q\n want: %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #2298.

## Problem

The merge-queue watcher emits the same `PR #N merged. Run \`git pull\` ... \`prism cleanup\` the worker session.` notification text for **all three** success paths in the polling loop:

1. **Pre-poll early-return** (watcher.go ~217) — observed `state=MERGED` on a fresh poll. The merge was performed by an external actor (human via GitHub UI, another tool, or a tab racing the watcher). **prism did NOT execute the merge mutation.**
2. **`gh pr merge --squash` succeeded** (watcher.go ~299) — the canonical prism-driven case.
3. **`gh pr merge --squash` errored but `checkPRMergedState` returned MERGED** (watcher.go ~308) — the in-flight race recovery from #1645. Still prism-driven, just with a recovery breadcrumb.

The coordinator can't tell (1) from (2)/(3), so a watcher race against an external merger surfaces in the event log indistinguishable from a real prism-driven merge. The full repro (helm-charts PR #15, b-h-mck via GitHub UI) is on issue #2298.

## Entry-point shape (AC #6)

Chose **(a) — typed enum parameter on `succeedAndNotify`** over the alternatives:

- **(b) three distinct entry points** — would have required two new helper functions, more diff, more shuffling of the existing function. Not necessary because the DB-write path is identical for all three outcomes.
- **(c) switch on observed state inside `succeedAndNotify`** — awkward because the reconciliation path doesn't have a fresh `prInfo` (only the string returned by `checkPRMergedState`). Threading `prInfo` through to all three sites would be misleading: only the external case has access to a `prInfo` that reflects the merge.
- **(a) typed `mergeOutcome` enum + optional `*prInfo`** — smallest signature change. Three call sites pass an explicit constant; one helper switches on the constant; only the external case carries a `prInfo`. Minimal blast radius against the existing structure.

## Rendered text variants

All three are pinned by tests.

| Path | Text |
| --- | --- |
| **External** (AC1, AC4) | `PR #N was already merged externally (merged by @<login> at <timestamp>). No action taken by prism. Run \`git pull\` if needed.` — `prism cleanup` deliberately omitted; mergedBy/mergedAt degrade gracefully (login omitted when nil/empty, timestamp omitted when absent, both omitted falls back to bare \`PR #N was already merged externally. No action taken by prism. Run \`git pull\` if needed.\`) |
| **Prism-driven** (AC2) | `PR #N merged. [Archive: <path>. ]Run \`git pull\` in @main and \`prism cleanup\` the worker session.` — unchanged from current behaviour, pinned byte-for-byte by two new tests |
| **Reconciled** (AC3) | `PR #N merged. (Reconciled — gh mutation errored but PR is MERGED.) [Archive: <path>. ]Run \`git pull\` in @main and \`prism cleanup\` the worker session.` — distinct from both, still instructs \`prism cleanup\` because the merge IS prism-driven |

## Out of scope (explicit non-goals from the spec)

- **Schema migration for a `merged_externally` row status.** The issue body proposes it as a deeper change; this PR does not touch the DB schema. Notification distinction is the load-bearing fix.
- **Refusing to enqueue PRs not authored by a known session.** Larger policy question.
- **Coordinator docs / agent prompts.** Already handled by #2297.
- **The `cmd/merge.go:496-497` enqueue-time guard** is unchanged (AC7 verified).

## Test coverage

In `internal/mergequeue/watcher_test.go`:

- `TestWatcher_ExternalMerge_NotifyTextDistinguishedAndNamesByLogin` — AC1, full happy path with mergedBy + mergedAt populated.
- `TestWatcher_ExternalMerge_MergedByNullDegradesGracefully` — AC4 edge case, `mergedBy=nil` and the notification still fires without leaking a bare \`@\` into the text.
- `TestWatcher_PrismDrivenMerge_NotifyTextUnchanged_NoArchive` — AC2 (no archive path).
- `TestWatcher_PrismDrivenMerge_NotifyTextUnchanged_WithArchive` — AC2 (archive path present); byte-for-byte string comparison.
- `TestWatcher_Reconciled_NotifyTextIncludesReconciledNote` — AC3, asserts reconciled breadcrumb is present, still instructs \`prism cleanup\`, and does NOT contain \`merged externally\`.
- `TestRenderExternalMergeNotifyText_{NilPrInfo,LoginAndTimestamp,LoginOnly,TimestampOnly,EmptyLogin}` — pure-render unit tests pinning every cell of the (mergedBy × mergedAt) degrade table.
- `TestPRInfoJSONFields_NoMergedField` extended to assert \`mergedBy\` is present in the field list — guards against a future field-list edit silently losing the merger name.

No-op-test discipline applied: temporarily reverted the rendering switch to always emit the canonical text and re-ran the new tests; all three watcher-level distinction tests fail with the exact text mismatch they're written to catch. Then re-applied the fix.

## Quality gates run locally

From \`modules/programs/prism/prism/\`:

\`\`\`
gofmt -l .                       # clean
go build ./...                   # clean
go test ./...                    # all packages green
go test -race ./internal/mergequeue/   # green
\`\`\`

From the repo root:

\`\`\`
nix build .#prism                # produced result/bin/prism
\`\`\`

CI gates that apply: \`go-tests\` (race-enabled, Linux + bwrap) and \`nix-build-prism-checked\` (homeless-shelter sandbox).