### PR TITLE
hyprland: fix workspace-autoswitch handler (use window.close callback arg)

### DIFF
--- a/modules/desktop/hyprland/default.nix
+++ b/modules/desktop/hyprland/default.nix
@@ -428,31 +428,75 @@ in
                   # close event. Same observable behaviour, no daemon,
                   # no socat, no per-event subprocess fork.
                   #
-                  # Event name and workspace introspection verified
-                  # against the type stubs shipped with hyprland 0.55.1:
-                  #   - `HL.EventName` includes "window.close" (the lua
-                  #     binding of the legacy `closewindow` IPC event)
-                  #     in `share/hypr/stubs/hl.meta.lua`.
-                  #   - `hl.get_active_workspace()` returns an
-                  #     `HL.Workspace` with `id : integer` and
-                  #     `is_empty : boolean` fields. Per the type stubs,
-                  #     `is_empty` is true iff the workspace has no
-                  #     tracked windows — equivalent to the original
-                  #     script's `windows == 0` check via the IPC JSON.
-                  #   - The workspace-switch dispatcher is
-                  #     `hl.dsp.focus({ workspace = "previous" })`, the
-                  #     same form used by every numbered-workspace
-                  #     keybind above (see comment near `SUPER + 1`).
-                  #     `"previous"` matches the existing script's
-                  #     post-#1954 dispatch and is monitor-/numbering-
-                  #     independent (last-focused workspace, not `m-1`).
+                  # Timing supersedes the first cut of this handler (PR
+                  # #1968) which queried `hl.get_active_workspace().is_empty`
+                  # synchronously and silently never fired. Tracing the
+                  # hyprland 0.55.4 source:
+                  #   - `window.close` is emitted at
+                  #     src/desktop/view/Window.cpp:2323 inside
+                  #     `CWindow::unmapWindow()`.
+                  #   - The closing window is detached from its
+                  #     workspace's layout space only LATER in the same
+                  #     function, at Window.cpp:2392 via
+                  #     `g_layoutManager->removeTarget(m_target)` →
+                  #     `LayoutManager.cpp:24-26` → `ITarget::assignToSpace(nullptr)`
+                  #     at `Target.cpp:25-26`, which calls
+                  #     `m_space->remove(...)`.
+                  #   - `is_empty` is `getWindows() == 0`
+                  #     (`LuaWorkspace.cpp:131-132`), and `getWindows()`
+                  #     iterates `m_space->targets()`
+                  #     (`Workspace.cpp:438-461`).
+                  # So at the synchronous lua callback the closing
+                  # window is still in `m_space->targets()`, `is_empty`
+                  # is false, and the old guard never matched. The old
+                  # socat daemon worked accidentally — it shelled out to
+                  # `hyprctl activeworkspace -j` with subprocess
+                  # latency, and the IPC `closewindow` was queried
+                  # post-removal anyway.
+                  #
+                  # Fix: receive the closing window via the callback
+                  # argument (the lua event dispatch pushes the window
+                  # as arg 1, see `LuaEventHandler.cpp:92`), read its
+                  # `.workspace` (per `HL.Window` stub line 745 in
+                  # `share/hypr/stubs/hl.meta.lua`), and check
+                  # `ws.windows == 1` — the closing window IS the one
+                  # remaining target, so a count of exactly 1 means
+                  # this close empties the workspace. The `ws.active`
+                  # gate preserves the original semantic that we only
+                  # auto-switch when the closing window's workspace is
+                  # the active one (the legacy `hyprctl activeworkspace`
+                  # query was implicit-active by construction).
+                  #
+                  # All four lua symbols used below are present in the
+                  # type stubs shipped with hyprland 0.55.4
+                  # (`share/hypr/stubs/hl.meta.lua`):
+                  #   - `HL.EventName` includes "window.close" (line 19).
+                  #   - `HL.Window.workspace : HL.Workspace|nil` (line 745).
+                  #   - `HL.Workspace.active : boolean` (line 758).
+                  #   - `HL.Workspace.id : integer` (line 765).
+                  #   - `HL.Workspace.windows : integer` (line 775).
+                  # The workspace-switch dispatcher is
+                  # `hl.dsp.focus({ workspace = "previous" })`, the
+                  # same form used by every numbered-workspace keybind
+                  # below. `"previous"` is monitor-/numbering-
+                  # independent (last-focused workspace).
+                  #
+                  # Nil-guards on `win` and `win.workspace` keep the
+                  # callback total in any teardown corner where the
+                  # closing window's workspace pointer is already
+                  # cleared — the handler no-ops rather than raising a
+                  # lua error.
                   {
                     _args = [
                       "window.close"
                       (mkLuaInline ''
-                        function()
-                          local ws = hl.get_active_workspace()
-                          if ws ~= nil and ws.id ~= 1 and ws.is_empty then
+                        function(win)
+                          if win == nil then return end
+                          local ws = win.workspace
+                          if ws == nil then return end
+                          if not ws.active then return end
+                          if ws.id == 1 then return end
+                          if ws.windows == 1 then
                             hl.dispatch(hl.dsp.focus({ workspace = "previous" }))
                           end
                         end


### PR DESCRIPTION
## What

Fix the workspace-autoswitch-on-last-window-close behaviour, which was
silently broken after PR #1968 ported the legacy socat daemon to a native
`hl.on("window.close", ...)` lua handler. The handler was firing, but its
synchronous `is_empty` check on `hl.get_active_workspace()` always
returned false at callback time, so the workspace-switch dispatch never
ran.

## Root cause — source evidence chain (hyprland 0.55.4)

Path: `/nix/store/cr4vq0w7dn9i5m19847mrl99rm24vsba-source/` (or
`nix build --no-link '.#nixosConfigurations.navi.pkgs.hyprland.src'`).

1. `window.close` is emitted at
   **`src/desktop/view/Window.cpp:2323`** inside `CWindow::unmapWindow()`:
   ```cpp
   Event::bus()->m_events.window.close.emit(m_self.lock());
   ```
2. The closing window is detached from its workspace's layout space only
   **later in the same function**, at
   **`src/desktop/view/Window.cpp:2392`**:
   ```cpp
   g_layoutManager->removeTarget(m_target);
   ```
3. `CLayoutManager::removeTarget` at
   **`src/layout/LayoutManager.cpp:24-26`** calls
   `target->assignToSpace(nullptr)`.
4. `ITarget::assignToSpace(nullptr)` at
   **`src/layout/target/Target.cpp:25-26`** calls
   `m_space->remove(m_self.lock())` — that's the line that actually drops
   the window from `m_space->targets()`.
5. `is_empty` on `HL.Workspace` is
   **`src/config/lua/objects/LuaWorkspace.cpp:131-132`**:
   ```cpp
   else if (key == "is_empty")
       lua_pushboolean(L, ws->getWindows() == 0);
   ```
6. `CWorkspace::getWindows()` at
   **`src/desktop/Workspace.cpp:438-461`** iterates
   `m_space->targets()`.

So at the synchronous lua callback (step 1) the closing window is still
in `m_space->targets()` — `getWindows()` returns ≥ 1 and `is_empty` is
false. The dispatch never fires. The old socat daemon worked because it
shelled out to `hyprctl activeworkspace -j` with subprocess latency, and
the legacy IPC `closewindow` event was queried post-removal anyway.

The callback receives the closing window as arg 1 (see
**`src/config/lua/LuaEventHandler.cpp:92`**), giving us a robust handle
to the closing window's own workspace independent of timing.

## Option chosen

**Option B from the spec — keep `window.close`, reframe the check using
the callback argument.**

Why B over A (switch to `window.destroy`):

- `window.destroy` fires from `removeWindowFromVectorSafe` in
  `src/Compositor.cpp:885`, only after the window has finished its
  fade-out animation. Between `window.close` and `window.destroy`,
  `unmapWindow` runs its own focus-fallback logic (lines 2400–2425),
  which may switch focus to a candidate window. Querying
  `hl.get_active_workspace()` at `window.destroy` time is fragile
  because the active workspace may no longer be the one whose last
  window just closed.
- Option B counts windows on the *closing window's own workspace*, with
  the closing window itself still attached. The predicate "this close
  empties the workspace" is a property of the close event itself,
  independent of any focus-state shuffling hyprland does later.

## The new handler

```lua
hl.on("window.close", function(win)
  if win == nil then return end
  local ws = win.workspace
  if ws == nil then return end
  if not ws.active then return end
  if ws.id == 1 then return end
  if ws.windows == 1 then
    hl.dispatch(hl.dsp.focus({ workspace = "previous" }))
  end
end)
```

The `ws.windows == 1` check works because the closing window is still
attached to `m_space->targets()` when the lua callback runs (see steps
1–4 above), so a count of exactly 1 means the closing window is the
only target — closing it empties the workspace.

`ws.active` preserves the original `hl.get_active_workspace()` semantic
(only fire when the closing window's workspace is the active one — a
background-window close on a non-active workspace shouldn't yank focus).

`ws.id ~= 1` preserves the existing workspace-1 guard.

Nil guards on `win` and `win.workspace` keep the callback total in any
teardown corner where the window-pointer or workspace-pointer is already
cleared — the handler no-ops rather than raising a lua error.

## Stub verification (AC5)

All four lua symbols are present in
`share/hypr/stubs/hl.meta.lua` shipped with the locked `pkgs.hyprland`
0.55.4 (`/nix/store/rv2dda5jgqr8vxd4ljp7vxmklmficxcm-hyprland-0.55.4`):

- `HL.EventName` includes `"window.close"` — line 19.
- `HL.Window.workspace : HL.Workspace|nil` — line 745.
- `HL.Workspace.active : boolean` — line 758.
- `HL.Workspace.id : integer` — line 765.
- `HL.Workspace.windows : integer` — line 775.

## Rendered lua (AC6)

`nix build` of
`.#nixosConfigurations.navi.config.home-manager.users.ben.xdg.configFile."hypr/hyprland.lua".source`
produces `/nix/store/5nmy5w06l58dvs986p75dnj41sls4l2m-hm_hyprhyprland.lua`,
which contains verbatim:

```lua
hl.on("window.close", (function(win)
  if win == nil then return end
  local ws = win.workspace
  if ws == nil then return end
  if not ws.active then return end
  if ws.id == 1 then return end
  if ws.windows == 1 then
    hl.dispatch(hl.dsp.focus({ workspace = "previous" }))
  end
end
))
```

No stale references to `get_active_workspace()` or `is_empty` remain in
the rendered file (greped). The surrounding comment block in
`modules/desktop/hyprland/default.nix` is updated to supersede the
PR #1968 claim that `window.close` + `is_empty` is the correct shape.

## Builds (AC7)

Both toplevel builds succeed from the worktree root:

- `nix build --no-link .#nixosConfigurations.navi.config.system.build.toplevel` ✓
- `nix build --no-link .#nixosConfigurations.tui.config.system.build.toplevel` ✓

## Runtime caveat

Per the spec's "Out of scope" section, this worker is bwrap-isolated and
has no live hyprland to test against. **Runtime behavioural verification
happens on Ben's live session post-merge** — same pattern as the recent
Darwin helm caveat on PR #2311. The static rendering and toplevel builds
above are the gates this PR can offer.

## Files

- `modules/desktop/hyprland/default.nix` — only file touched.

Supersedes the workspace-autoswitch handler introduced in #1968.
