### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782423922,
-        "narHash": "sha256-qPNd6lUohHP5gcJhqQ7rLV87RwIx0xYR2A4Frb9Zjc4=",
+        "lastModified": 1782522538,
+        "narHash": "sha256-CvOaUvJ+mXlxU3m2cPWKcOAhtKETsPUYhq+Xa5ewBp4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d320ab301cfaaca7d32514f13815d19d109f5f4",
+        "rev": "8d8a6cc50ddc60748791a14ee1163c865ec57635",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {
@@ -121,11 +121,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1782464691,
-        "narHash": "sha256-pBqzHxpDWzg+UC144opDEhkiCSlznur5AzQLh1z6+fA=",
+        "lastModified": 1782625347,
+        "narHash": "sha256-Jk1bzoynhAdsIzxQH3nqIVnj2X2QcoPDoOclbB8vdY0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bdccc39dd2a9923b24cb9b947cb0c5dec7d5a9d5",
+        "rev": "126015c9f35181565b8c30c5e220547f3fc056d2",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1782335603,
-        "narHash": "sha256-sZkQH1CkiZtdvcaLx4sGQD9Q9h+A8qB04DRpqQCN530=",
+        "lastModified": 1782498288,
+        "narHash": "sha256-8/X3yyTXiE82b38n32ItbOqfWOVBl+gKa8fILyZfR4Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "03c72920da828594fae523aaef96f33dff10b340",
+        "rev": "3cac626ec5e3703e835f227687e88aa9e2f25701",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Run report

https://github.com/prismatic-koi/nixos-config/actions/runs/28312972694

## Closure diff: navi

```
aardvark-dns: 1.17.1 → 2.0.0, -290.2 KiB
abseil-cpp: -3.3 MiB
acl: -125.2 KiB
alsa-lib: -1.8 MiB
alsa-topology-conf: -336.1 KiB
alsa-ucm-conf: -841.8 KiB
at-spi2-core: 2.60.1 → ∅, -2.2 MiB
attr: -90.5 KiB
audit: 4.1.2-unstable-2025-09-06 → ∅, -420.4 KiB
avahi: -1.6 MiB
bash: -1.8 MiB
bind: 9.20.23 → 9.20.24, 9.2 KiB
blas: 8.8 KiB
bluez: -10.1 MiB
breeze: 6.6.5 → 6.7.1, 1.4 MiB
brotli: -961.9 KiB
bubblewrap: -102.6 KiB
bzip2: -86.9 KiB
cairo: -2.1 MiB
cdparanoia-iii: -366.9 KiB
chromium: 149.0.7827.114 → 149.0.7827.196
chromium-unwrapped: 149.0.7827.114 → 149.0.7827.196, 119.7 KiB
cjson: -72.3 KiB
claude-code: 2.1.191 → 2.1.193, 1.1 MiB
cloudflared: 2026.6.0 → 2026.6.1
coreutils: -1.7 MiB
cracklib: -803.0 KiB
cryptsetup: -2.7 MiB
cups: -4.7 MiB
curl: -1.2 MiB
dav1d: -2.5 MiB
db: -3.5 MiB
dbus: -461.6 KiB
dconf: -324.5 KiB
dejavu-fonts-minimal: -742.6 KiB
e2fsprogs: 1.47.3 → 1.47.4
electron: 41.7.2 → 42.4.0
electron-unwrapped: 41.7.2 → 42.4.0, 36.6 MiB
elfutils: -4.0 MiB
ell: -658.7 KiB
etc-fuse.conf: ε → ∅
expat: 2.8.0 → ∅, -305.2 KiB
fastfetch: -2.3 MiB
fastfetch-unwrapped: ∅ → 2.64.2, 4.7 MiB
fdk-aac: -1.6 MiB
ffado: -3.1 MiB
ffmpeg: 8.1 → 8.1.1
ffmpeg-headless: 8.1 → ∅, -33.7 MiB
fftw-double: 3.3.10 → ∅, -3.9 MiB
fftw-single: 3.3.10 → ∅, -4.1 MiB
file: -10.4 MiB
flac: -778.8 KiB
flatpak: 1.16.6 → 1.18.0, 782.7 KiB
fontconfig: -1.6 MiB
freetype: 2.14.2 → ∅, -2.2 MiB
fribidi: -162.5 KiB
fuse: 2.9.9 → ∅, -99.1 KiB
gcc: -10.0 MiB
gdbm: -448.6 KiB
gdk-pixbuf: -2.8 MiB
getent-glibc: 2.42-61 → 2.42-67
gh: 2.94.0 → 2.95.0, 453.3 KiB
ghostscript-with-X: 10.07.0 → 10.07.1, 37.6 KiB
giflib: -407.5 KiB
glib: -15.3 MiB
glibc: 2.42-61 → ∅, -33.5 MiB
glibc-locales: 2.42-61 → 2.42-67
glibc-multi: 2.42-61 → 2.42-67
glibmm: -4.2 MiB
gmp-with-cxx: -1.5 MiB
gnum4: -1.1 MiB
gnutls: -3.6 MiB
go: 1.26.3 → 1.26.4, -11.3 KiB
gobject-introspection: -1.2 MiB
graphene: -182.5 KiB
graphite2: -228.0 KiB
gsettings-desktop-schemas: -6.2 MiB
gst-plugins-base: -8.8 MiB
gstreamer: -5.9 MiB
gtest: -842.0 KiB
gtk+3: -41.6 MiB
harfbuzz: -3.7 MiB
hwdata: -9.9 MiB
hwdb.bin: 113.3 KiB
icu4c: ∅ → 78.3, 7.2 MiB
ijs: 10.07.0 → 10.07.1
imagemagick: 7.1.2-23 → 7.1.2-24, 8.4 KiB
initrd-linux: 7.1 → 7.1.1, 591.8 KiB
iso-codes: -22.6 MiB
json-c: -244.8 KiB
json-glib: -662.9 KiB
kbd: -2.7 MiB
kdecoration: 6.6.5 → 6.7.1
kexec-tools: -262.5 KiB
keyutils: -41.8 KiB
kio: 35.3 KiB
kmod: -325.6 KiB
krb5: 1.22.1 → ∅, -2.7 MiB
kubectl: 1.36.1 → 1.36.2
kubernetes-helm: 4.2.0 → 4.2.2, 179.2 KiB
kwallet: 14.1 KiB
lame: -348.7 KiB
lapack: 8.8 KiB
lcms2: -484.3 KiB
ldacBT: -88.7 KiB
lerc: -842.4 KiB
libXNVCtrl: 595.80 → 595.84
libadwaita: 1.9.0 → 1.9.1
libaec: 1.1.6 → 1.1.7
libao: -123.7 KiB
libaom: -8.4 MiB
libapparmor: -590.5 KiB
libappindicator-gtk3: -89.7 KiB
libarchive: -949.8 KiB
libass: -253.1 KiB
libavc1394: -145.7 KiB
libbluray: -1.1 MiB
libbpf: -2.1 MiB
libcamera: -6.1 MiB
libcanberra: -251.2 KiB
libcap: -73.4 KiB
libcap-ng: -166.7 KiB
libcbor: -83.6 KiB
libconfig: -398.1 KiB
libcupsfilters: 450.3 KiB
libdaemon: -41.0 KiB
libdatrie: -42.2 KiB
libdbusmenu-gtk3: -632.5 KiB
libde265: 1.0.18 → 1.1.1, 73.9 KiB
libdeflate: -458.6 KiB
libdrm: -1.8 MiB
libebur128: -54.2 KiB
libepoxy: -1.7 MiB
libevent: -861.7 KiB
libffi: -72.1 KiB
libfido2: -1.1 MiB
libfreeaptx: -55.5 KiB
libgcrypt: 1.11.2 → ∅, -1.7 MiB
libglvnd: -2.5 MiB
libgpg-error: -885.0 KiB
libheif: 1.21.2 → 1.23.0, 300.9 KiB
libical: -3.9 MiB
libidn2: -359.5 KiB
libiec61883: -154.8 KiB
libjack2: -420.7 KiB
libjpeg-turbo: -2.0 MiB
libkrun: 1.18.1 → 1.19.0, 98.4 KiB
liblc3: -175.1 KiB
libmad: -142.5 KiB
libmicrohttpd: -260.4 KiB
libmpg123: -1.1 MiB
libmysofa: -1.3 MiB
libnotify: -111.2 KiB
libogg: -47.0 KiB
libopenmpt: -2.9 MiB
libopus: -501.2 KiB
libpciaccess: -172.0 KiB
libpng-apng: 1.6.56 → ∅, -273.3 KiB
libpsl: -114.9 KiB
libpulseaudio: -4.7 MiB
libpwquality: -382.5 KiB
libraw1394: -196.5 KiB
librist: -422.9 KiB
libsamplerate: -1.5 MiB
libseccomp: -193.8 KiB
libselinux: -690.2 KiB
libsigc++: -42.0 KiB
libsndfile: -644.6 KiB
libsoup: -1.2 MiB
libssh: -682.3 KiB
libssh2: -326.6 KiB
libsysprof-capture: 50.0 → ∅, -271.8 KiB
libtasn1: -95.8 KiB
libthai: -637.0 KiB
libtheora: -675.4 KiB
libtiff: -739.2 KiB
libtool: -57.0 KiB
libtpms: -1.1 MiB
libunistring: -2.0 MiB
libunwind: -267.6 KiB
libusb: -158.0 KiB
libuv: -271.9 KiB
libva: -353.6 KiB
libva-minimal: -254.3 KiB
libvmaf: -2.7 MiB
libvorbis: -1.1 MiB
libvpx: -8.9 MiB
libwebp: -3.4 MiB
libwmf: 0.2.13 → 0.2.15
libx11: -2.6 MiB
libxau: -27.1 KiB
libxcb: -1.4 MiB
libxcomposite: -25.1 KiB
libxcrypt: -141.0 KiB
libxcursor: -78.0 KiB
libxdamage: -17.9 KiB
libxdmcp: -31.2 KiB
libxext: -93.7 KiB
libxfixes: -33.9 KiB
libxft: -151.0 KiB
libxi: -87.7 KiB
libxinerama: -21.7 KiB
libxkbcommon: -1.0 MiB
libxml++: -299.8 KiB
libxml2: 2.15.2 → ∅, -1.4 MiB
libxrandr: -62.6 KiB
libxrender: -53.2 KiB
libxscrnsaver: -32.9 KiB
libxtst: -117.6 KiB
libxv: -31.4 KiB
libyaml: -143.9 KiB
lilv: -380.8 KiB
linux: 7.1 → 7.1.1, -21.3 KiB
linux-firmware: 20260519 → 20260622, 17.0 MiB
linux-pam: -1.8 MiB
lttng-ust: -1.8 MiB
lua-language-server: 3.18.1 → 3.18.2
lvm2: -443.7 KiB
lz4: -256.0 KiB
lzo: -159.7 KiB
mailcap: -116.6 KiB
mbedtls: -12.7 MiB
mdadm: 4.4 → 4.6, 13.8 KiB
mesa: 26.1.2 → 26.1.3, 159.4 KiB
mesa-libgbm: -58.2 KiB
mpdecimal: -220.9 KiB
mpg123: -1.1 MiB
ncurses: -3.7 MiB
netavark: 1.17.2 → 2.0.0, -158.2 KiB
nettle: -723.5 KiB
nghttp2: -225.3 KiB
nghttp3: -227.7 KiB
ngtcp2: -484.3 KiB
nixos-manual: 90.3 KiB
nixos-system-navi: 26.11.20260616.567a49d → 26.11.20260626.e73de5b
nodejs: 22.22.3, 24.15.0 → 22.23.1, 24.16.0, 46.9 KiB
nodejs-slim: 22.22.3, 24.15.0 → 22.23.1, 24.16.0, 1.4 MiB
nspr: -349.8 KiB
nss: -4.0 MiB
numactl: -269.9 KiB
ocl-icd: -609.3 KiB
openapv: 0.2.1.2 → ∅, -719.7 KiB
openblas: 0.3.32 → 0.3.33
openexr: 3.4.10 → 3.4.11
openfec: -204.4 KiB
openjpeg: -1.6 MiB
openrazer: 3.12.3-7.1 → 3.12.3-7.1.1
openssl: -8.9 MiB
opentofu: 1.12.1 → 1.12.3, 8.0 KiB
opusfile: -124.6 KiB
orc: -844.3 KiB
p11-kit: -5.7 MiB
pango: -917.4 KiB
pcre2: -2.0 MiB
pcsclite: -107.3 KiB
perl: 32.5 KiB
perl5.42.0-HTTP-Daemon: 6.16 → 6.17
pi-coding-agent: 0.79.1 → 0.79.8, 14.5 MiB
pipewire: -16.7 MiB
pixman: -858.3 KiB
podman: 5.8.2 → 5.8.3, 30.5 KiB
polkitd.conf: ∅ → ε
prismlauncher-unwrapped: 26.5 KiB
procps: -3.0 MiB
publicsuffix-list: 0-unstable-2026-03-26 → ∅, -326.7 KiB
python3: -126.9 MiB
python3.12-pyjwt: 2.12.1 → 2.13.0
python3.13-aiodns: 4.0.0 → 4.0.4, 8.1 KiB
python3.13-python-xlib: ∅ → 0.33, 2.1 MiB
python3.13-xlib: 0.33 → ∅, -2.1 MiB
qrencode: -62.6 KiB
qt5compat: 6.11.0 → 6.11.1, 18.4 KiB
qtbase: 5.15.18, 6.11.0, 6.11.0-only-plugins → 5.15.19, 6.11.1, 6.11.1-only-plugins, 245.1 KiB
qtcharts: 6.11.0 → 6.11.1
qtdeclarative: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 420.8 KiB
qtimageformats: 6.11.0 → 6.11.1
qtmultimedia: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 120.3 KiB
qtnetworkauth: 6.11.0 → 6.11.1, 10.9 KiB
qtpositioning: 6.11.0 → 6.11.1
qtquick3d: 6.11.0 → 6.11.1, 38.1 KiB
qtquickcontrols: 5.15.18 → 5.15.19
qtserialport: 6.11.0 → 6.11.1
qtshadertools: 6.11.0 → 6.11.1
qtspeech: 6.11.0 → 6.11.1
qtsvg: 5.15.18, 6.11.0 → 5.15.19, 6.11.1
qttools: 6.11.0 → 6.11.1, 66.3 KiB
qttranslations: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 50.3 KiB
qtwayland: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 105.0 KiB
qtwebchannel: 5.15.18, 6.11.0 → 5.15.19, 6.11.1
qtwebengine: 6.11.0 → 6.11.1, 149.4 KiB
qtwebsockets: 6.11.0 → 6.11.1
qtx11extras: 5.15.18 → 5.15.19
readline: -494.5 KiB
ripgrep: -6.2 MiB
roc-toolkit: -7.9 MiB
rsync: 3.4.1 → 3.4.4, 20.5 KiB
runc: 1.4.2 → 1.4.3, 8.7 KiB
sbc: -276.9 KiB
sd-switch: 0.6.3 → 0.6.4, 49.9 KiB
sdl3: 3.4.8 → 3.4.10, 24.4 KiB
security-wrapper-fusermount-x86_64-unknown-linux: ε → ∅, -70.0 KiB
security-wrapper-fusermount3-x86_64-unknown-linux: ε → ∅, -70.0 KiB
serd: -137.3 KiB
shotcut: 13.0 KiB
signal-desktop: 8.13.0 → 8.15.0, 921.1 KiB
simdjson: 4.6.0 → 4.6.4, 24.1 KiB
socat: -860.2 KiB
solid: 26.3 KiB
sord: -99.5 KiB
source: 1.4 MiB
sox-unstable: -701.6 KiB
soxr: -298.4 KiB
spandsp: -983.9 KiB
speech-dispatcher: -488.3 KiB
speex: -133.7 KiB
speexdsp: -78.5 KiB
sqlite: -5.6 MiB
sratom: -47.2 KiB
srt: -6.8 MiB
strace: 7.0 → 7.1, 17.5 KiB
svt-av1: -8.1 MiB
systemd: 260.1 → ∅, -59.6 MiB
systemd-minimal: 260.1 → ∅, -20.0 MiB
systemd-minimal-libs: 260.1 → ∅, -4.0 MiB
tinysparql: -4.7 MiB
tpm2-tss: -3.2 MiB
tremor-unstable: -132.7 KiB
tsx: 4.21.0 → 4.22.4, 279.8 KiB
tzdata: -2.0 MiB
unbound: 1.25.0 → ∅, -1.1 MiB
util-linux-minimal: -2.4 MiB
v4l-utils: -782.0 KiB
vid.stab: -552.5 KiB
vimplugin-copilot.lua: 2.0.4 → 3.0.0, 149.0 MiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-08 → 1.17.0-unstable-2026-06-15
vulkan-loader: -683.8 KiB
wavpack: -547.0 KiB
wayland: -264.1 KiB
webrtc-audio-processing: -1.2 MiB
wireplumber: 0.5.14 → 0.5.15, 216.1 KiB
x264: -2.4 MiB
x265: -23.7 MiB
xgcc: -193.0 KiB
xkeyboard-config: -10.3 MiB
xorgproto: -1.6 MiB
xvidcore: -786.7 KiB
xz: -837.8 KiB
yyjson: 0.12.0 → ∅, -639.4 KiB
zimg: -758.8 KiB
zix: -142.0 KiB
zlib: -278.8 KiB
zstd: -1.1 MiB
zvbi: -1.0 MiB
```

## Closure diff: tui

```
aardvark-dns: 1.17.1 → 2.0.0, -290.2 KiB
abseil-cpp: -3.3 MiB
acl: -125.2 KiB
alsa-lib: -1.8 MiB
alsa-topology-conf: -336.1 KiB
alsa-ucm-conf: -841.8 KiB
at-spi2-core: 2.60.1 → ∅, -2.2 MiB
attr: -90.5 KiB
audit: 4.1.2-unstable-2025-09-06 → ∅, -420.4 KiB
avahi: -1.6 MiB
bash: -1.8 MiB
bind: 9.20.23 → 9.20.24, 9.2 KiB
blas: 8.8 KiB
bluez: -10.1 MiB
breeze: 6.6.5 → 6.7.1, 1.4 MiB
brotli: -961.9 KiB
bubblewrap: -102.6 KiB
bzip2: -86.9 KiB
cairo: -2.1 MiB
cdparanoia-iii: -366.9 KiB
chromium: 149.0.7827.114 → 149.0.7827.196
chromium-unwrapped: 149.0.7827.114 → 149.0.7827.196, 119.7 KiB
cjson: -72.3 KiB
claude-code: 2.1.191 → 2.1.193, 1.1 MiB
cloudflared: 2026.6.0 → 2026.6.1
coreutils: -1.7 MiB
cracklib: -803.0 KiB
cryptsetup: -2.7 MiB
cups: -4.7 MiB
curl: -1.2 MiB
dav1d: -2.5 MiB
db: -3.5 MiB
dbus: -461.6 KiB
dconf: -324.5 KiB
dejavu-fonts-minimal: -742.6 KiB
e2fsprogs: 1.47.3 → 1.47.4
electron: 41.7.2 → 42.4.0
electron-unwrapped: 41.7.2 → 42.4.0, 36.6 MiB
elfutils: -4.0 MiB
ell: -658.7 KiB
etc-fuse.conf: ε → ∅
expat: 2.8.0 → ∅, -305.2 KiB
fastfetch: -2.3 MiB
fastfetch-unwrapped: ∅ → 2.64.2, 4.7 MiB
fdk-aac: -1.6 MiB
ffado: -3.1 MiB
ffmpeg: 8.1 → 8.1.1
ffmpeg-headless: 8.1 → ∅, -33.7 MiB
fftw-double: 3.3.10 → ∅, -3.9 MiB
fftw-single: 3.3.10 → ∅, -4.1 MiB
file: -10.4 MiB
flac: -778.8 KiB
flatpak: 1.16.6 → 1.18.0, 782.7 KiB
fontconfig: -1.6 MiB
freetype: 2.14.2 → ∅, -2.2 MiB
fribidi: -162.5 KiB
fuse: 2.9.9 → ∅, -165.0 KiB
gcc: -10.0 MiB
gdbm: -448.6 KiB
gdk-pixbuf: -2.8 MiB
getent-glibc: 2.42-61 → 2.42-67
gh: 2.94.0 → 2.95.0, 453.3 KiB
ghostscript-with-X: 10.07.0 → 10.07.1, 37.6 KiB
giflib: -407.5 KiB
glib: -15.3 MiB
glibc: 2.42-61 → ∅, -33.5 MiB
glibc-locales: 2.42-61 → 2.42-67
glibc-multi: 2.42-61 → 2.42-67
glibmm: -4.2 MiB
gmp-with-cxx: -1.5 MiB
gnum4: -1.1 MiB
gnutls: -3.6 MiB
go: 1.26.3 → 1.26.4, -11.3 KiB
gobject-introspection: -1.2 MiB
graphene: -182.5 KiB
graphite2: -228.0 KiB
gsettings-desktop-schemas: -6.2 MiB
gst-plugins-base: -8.8 MiB
gstreamer: -5.9 MiB
gtest: -842.0 KiB
gtk+3: -41.6 MiB
harfbuzz: -3.7 MiB
hwdata: -9.9 MiB
hwdb.bin: 113.3 KiB
icu4c: ∅ → 78.3, 7.2 MiB
ijs: 10.07.0 → 10.07.1
imagemagick: 7.1.2-23 → 7.1.2-24, 8.4 KiB
initrd-linux: 7.1 → 7.1.1, 15.3 KiB
iso-codes: -22.6 MiB
json-c: -244.8 KiB
json-glib: -662.9 KiB
kbd: -2.7 MiB
kdecoration: 6.6.5 → 6.7.1
kexec-tools: -262.5 KiB
keyutils: -41.8 KiB
kio: 35.3 KiB
kmod: -325.6 KiB
krb5: 1.22.1 → ∅, -2.7 MiB
kubectl: 1.36.1 → 1.36.2
kubernetes-helm: 4.2.0 → 4.2.2, 179.2 KiB
kwallet: 14.1 KiB
lame: -348.7 KiB
lapack: 8.8 KiB
lcms2: -484.3 KiB
ldacBT: -88.7 KiB
lerc: -842.4 KiB
libXNVCtrl: 595.80 → 595.84
libadwaita: 1.9.0 → 1.9.1
libaec: 1.1.6 → 1.1.7
libao: -123.7 KiB
libaom: -8.4 MiB
libapparmor: -590.5 KiB
libappindicator-gtk3: -89.7 KiB
libarchive: -949.8 KiB
libass: -253.1 KiB
libavc1394: -145.7 KiB
libbluray: -1.1 MiB
libbpf: -2.1 MiB
libcamera: -6.1 MiB
libcanberra: -251.2 KiB
libcap: -73.4 KiB
libcap-ng: -166.7 KiB
libcbor: -83.6 KiB
libconfig: -398.1 KiB
libcupsfilters: 450.3 KiB
libdaemon: -41.0 KiB
libdatrie: -42.2 KiB
libdbusmenu-gtk3: -632.5 KiB
libde265: 1.0.18 → 1.1.1, 73.9 KiB
libdeflate: -458.6 KiB
libdrm: -1.8 MiB
libebur128: -54.2 KiB
libepoxy: -1.7 MiB
libevent: -861.7 KiB
libffi: -72.1 KiB
libfido2: -1.1 MiB
libfreeaptx: -55.5 KiB
libgcrypt: 1.11.2 → ∅, -1.7 MiB
libglvnd: -2.5 MiB
libgpg-error: -885.0 KiB
libheif: 1.21.2 → 1.23.0, 300.9 KiB
libical: -3.9 MiB
libidn2: -359.5 KiB
libiec61883: -154.8 KiB
libjack2: -420.7 KiB
libjpeg-turbo: -2.0 MiB
libkrun: 1.18.1 → 1.19.0, 98.4 KiB
liblc3: -175.1 KiB
libmad: -142.5 KiB
libmicrohttpd: -260.4 KiB
libmpg123: -1.1 MiB
libmysofa: -1.3 MiB
libnotify: -111.2 KiB
libogg: -47.0 KiB
libopenmpt: -2.9 MiB
libopus: -501.2 KiB
libpciaccess: -172.0 KiB
libpng-apng: 1.6.56 → ∅, -273.3 KiB
libpsl: -114.9 KiB
libpulseaudio: -4.7 MiB
libpwquality: -382.5 KiB
libraw1394: -196.5 KiB
librist: -422.9 KiB
libsamplerate: -1.5 MiB
libseccomp: -193.8 KiB
libselinux: -690.2 KiB
libsigc++: -42.0 KiB
libsndfile: -644.6 KiB
libsoup: -1.2 MiB
libssh: -682.3 KiB
libssh2: -326.6 KiB
libsysprof-capture: 50.0 → ∅, -271.8 KiB
libtasn1: -95.8 KiB
libthai: -637.0 KiB
libtheora: -675.4 KiB
libtiff: -739.2 KiB
libtool: -57.0 KiB
libtpms: -1.1 MiB
libunistring: -2.0 MiB
libunwind: -267.6 KiB
libusb: -158.0 KiB
libuv: -271.9 KiB
libva: -353.6 KiB
libva-minimal: -254.3 KiB
libvmaf: -2.7 MiB
libvorbis: -1.1 MiB
libvpx: -8.9 MiB
libwebp: -3.4 MiB
libwmf: 0.2.13 → 0.2.15
libx11: -2.6 MiB
libxau: -27.1 KiB
libxcb: -1.4 MiB
libxcomposite: -25.1 KiB
libxcrypt: -141.0 KiB
libxcursor: -78.0 KiB
libxdamage: -17.9 KiB
libxdmcp: -31.2 KiB
libxext: -93.7 KiB
libxfixes: -33.9 KiB
libxft: -151.0 KiB
libxi: -87.7 KiB
libxinerama: -21.7 KiB
libxkbcommon: -1.0 MiB
libxml++: -299.8 KiB
libxml2: 2.15.2 → ∅, -1.4 MiB
libxrandr: -62.6 KiB
libxrender: -53.2 KiB
libxscrnsaver: -32.9 KiB
libxtst: -117.6 KiB
libxv: -31.4 KiB
libyaml: -143.9 KiB
lilv: -380.8 KiB
linux: 7.1 → 7.1.1, -21.3 KiB
linux-firmware: 20260519 → 20260622, 17.0 MiB
linux-pam: -1.8 MiB
lttng-ust: -1.8 MiB
lua-language-server: 3.18.1 → 3.18.2
lvm2: -443.7 KiB
lz4: -256.0 KiB
lzo: -159.7 KiB
mailcap: -116.6 KiB
mbedtls: -12.7 MiB
mdadm: 4.4 → 4.6, 13.8 KiB
mesa: 26.1.2 → 26.1.3, 159.4 KiB
mesa-libgbm: -58.2 KiB
mpdecimal: -220.9 KiB
mpg123: -1.1 MiB
ncurses: -3.7 MiB
netavark: 1.17.2 → 2.0.0, -158.2 KiB
nettle: -723.5 KiB
nghttp2: -225.3 KiB
nghttp3: -227.7 KiB
ngtcp2: -484.3 KiB
nixos-manual: 90.3 KiB
nixos-system-tui: 26.11.20260616.567a49d → 26.11.20260626.e73de5b
nodejs: 22.22.3, 24.15.0 → 22.23.1, 24.16.0, 46.9 KiB
nodejs-slim: 22.22.3, 24.15.0 → 22.23.1, 24.16.0, 1.4 MiB
nspr: -349.8 KiB
nss: -4.0 MiB
numactl: -269.9 KiB
ocl-icd: -609.3 KiB
openapv: 0.2.1.2 → ∅, -719.7 KiB
openblas: 0.3.32 → 0.3.33
openexr: 3.4.10 → 3.4.11
openfec: -204.4 KiB
openjpeg: -1.6 MiB
openrazer: 3.12.3-7.1 → 3.12.3-7.1.1
openssl: -8.9 MiB
opentofu: 1.12.1 → 1.12.3, 8.0 KiB
opusfile: -124.6 KiB
orc: -844.3 KiB
p11-kit: -5.7 MiB
pango: -917.4 KiB
pcre2: -2.0 MiB
pcsclite: -107.3 KiB
perl: 32.5 KiB
perl5.42.0-HTTP-Daemon: 6.16 → 6.17
pi-coding-agent: 0.79.1 → 0.79.8, 14.5 MiB
pipewire: -16.7 MiB
pixman: -858.3 KiB
podman: 5.8.2 → 5.8.3, 30.5 KiB
polkitd.conf: ∅ → ε
prismlauncher-unwrapped: 26.5 KiB
procps: -3.0 MiB
publicsuffix-list: 0-unstable-2026-03-26 → ∅, -326.7 KiB
pv: 1.10.5 → 1.11.0, 23.9 KiB
python3: -126.9 MiB
python3.12-pyjwt: 2.12.1 → 2.13.0
python3.13-aiodns: 4.0.0 → 4.0.4, 8.1 KiB
python3.13-python-xlib: ∅ → 0.33, 2.1 MiB
python3.13-xlib: 0.33 → ∅, -2.1 MiB
qrencode: -62.6 KiB
qt5compat: 6.11.0 → 6.11.1, 18.4 KiB
qtbase: 5.15.18, 6.11.0, 6.11.0-only-plugins → 5.15.19, 6.11.1, 6.11.1-only-plugins, 245.1 KiB
qtcharts: 6.11.0 → 6.11.1
qtdeclarative: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 420.8 KiB
qtimageformats: 6.11.0 → 6.11.1
qtmultimedia: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 120.3 KiB
qtnetworkauth: 6.11.0 → 6.11.1, 10.9 KiB
qtpositioning: 6.11.0 → 6.11.1
qtquick3d: 6.11.0 → 6.11.1, 38.1 KiB
qtquickcontrols: 5.15.18 → 5.15.19
qtserialport: 6.11.0 → 6.11.1
qtshadertools: 6.11.0 → 6.11.1
qtspeech: 6.11.0 → 6.11.1
qtsvg: 5.15.18, 6.11.0 → 5.15.19, 6.11.1
qttools: 6.11.0 → 6.11.1, 66.3 KiB
qttranslations: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 50.3 KiB
qtwayland: 5.15.18, 6.11.0 → 5.15.19, 6.11.1, 105.0 KiB
qtwebchannel: 5.15.18, 6.11.0 → 5.15.19, 6.11.1
qtwebengine: 6.11.0 → 6.11.1, 149.4 KiB
qtwebsockets: 6.11.0 → 6.11.1
qtx11extras: 5.15.18 → 5.15.19
readline: -494.5 KiB
ripgrep: -6.2 MiB
roc-toolkit: -7.9 MiB
rsync: 3.4.1 → 3.4.4, 20.5 KiB
runc: 1.4.2 → 1.4.3, 8.7 KiB
sbc: -276.9 KiB
sd-switch: 0.6.3 → 0.6.4, 49.9 KiB
sdl3: 3.4.8 → 3.4.10, 24.4 KiB
security-wrapper-fusermount-x86_64-unknown-linux: ε → ∅, -70.0 KiB
security-wrapper-fusermount3-x86_64-unknown-linux: ε → ∅, -70.0 KiB
serd: -137.3 KiB
shotcut: 13.0 KiB
signal-desktop: 8.13.0 → 8.15.0, 921.1 KiB
simdjson: 4.6.0 → 4.6.4, 24.1 KiB
socat: -860.2 KiB
solid: 26.3 KiB
sord: -99.5 KiB
source: 1.4 MiB
sox-unstable: -701.6 KiB
soxr: -298.4 KiB
spandsp: -983.9 KiB
speech-dispatcher: -488.3 KiB
speex: -133.7 KiB
speexdsp: -78.5 KiB
sqlite: -5.6 MiB
sratom: -47.2 KiB
srt: -6.8 MiB
strace: 7.0 → 7.1, 17.5 KiB
svt-av1: -8.1 MiB
systemd: 260.1 → ∅, -59.6 MiB
systemd-minimal: 260.1 → ∅, -20.0 MiB
systemd-minimal-libs: 260.1 → ∅, -4.0 MiB
tinysparql: -4.7 MiB
tpm2-tss: -3.2 MiB
tremor-unstable: -132.7 KiB
tsx: 4.21.0 → 4.22.4, 279.8 KiB
tzdata: -2.0 MiB
unbound: 1.25.0 → ∅, -1.1 MiB
util-linux-minimal: -2.4 MiB
v4l-utils: -782.0 KiB
vid.stab: -552.5 KiB
vimplugin-copilot.lua: 2.0.4 → 3.0.0, 149.0 MiB
vimplugin-nvim-tree.lua: 1.17.0-unstable-2026-06-08 → 1.17.0-unstable-2026-06-15
vulkan-loader: -683.8 KiB
wavpack: -547.0 KiB
wayland: -264.1 KiB
webrtc-audio-processing: -1.2 MiB
wireplumber: 0.5.14 → 0.5.15, 216.1 KiB
x264: -2.4 MiB
x265: -23.7 MiB
xgcc: -193.0 KiB
xkeyboard-config: -10.3 MiB
xorgproto: -1.6 MiB
xvidcore: -786.7 KiB
xz: -837.8 KiB
yyjson: 0.12.0 → ∅, -639.4 KiB
zimg: -758.8 KiB
zix: -142.0 KiB
zlib: -278.8 KiB
zstd: -1.1 MiB
zvbi: -1.0 MiB
```