### PR TITLE
prism: add internal/podmanproxy default-deny socket filter (Step 1 of #2317)

### DIFF
--- a/modules/programs/prism/prism/internal/podmanproxy/audit.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/audit.go
@@ -1,0 +1,73 @@
+package podmanproxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// auditLine is the per-request structured log entry written to
+// Config.AuditWriter. Field order in the JSON output is fixed by
+// encoding/json's struct-field iteration order, which gives a stable
+// shape for downstream log consumers.
+//
+// AC reference (#2318): "Every accepted and rejected request emits
+// exactly one line to the configured audit io.Writer with fields
+// timestamp, method, endpoint, decision, reason as JSON."
+type auditLine struct {
+	Timestamp string `json:"timestamp"`
+	Method    string `json:"method"`
+	Endpoint  string `json:"endpoint"`
+	Decision  string `json:"decision"`
+	Reason    string `json:"reason"`
+}
+
+// auditDecision* constants name the values the `decision` audit field
+// may take. There are exactly two: every request is either an allow or
+// a deny — upstream availability is NOT a separate decision; an allowed
+// request whose upstream is unreachable still audits as "allow".
+const (
+	auditAllow = "allow"
+	auditDeny  = "deny"
+)
+
+// emitAudit writes a single JSON line to Config.AuditWriter describing
+// the policy outcome for r. It is safe for concurrent use by multiple
+// goroutines: writes are serialised by p.auditMu so two simultaneous
+// audit lines never interleave on the wire.
+//
+// emitAudit is called exactly once per request. The placement of those
+// calls in serveHTTP is the source of truth for the "exactly one line
+// per request" AC — do not add additional call sites from inside the
+// upstream-error handler or any downstream policy helper.
+func (p *Proxy) emitAudit(r *http.Request, decision, reason string) {
+	if p.cfg.AuditWriter == nil {
+		return
+	}
+
+	clock := p.cfg.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+
+	line := auditLine{
+		Timestamp: clock().UTC().Format(time.RFC3339Nano),
+		Method:    r.Method,
+		Endpoint:  r.URL.RequestURI(),
+		Decision:  decision,
+		Reason:    reason,
+	}
+
+	encoded, err := json.Marshal(line)
+	if err != nil {
+		// auditLine has only string fields, so json.Marshal cannot
+		// fail in practice; on the impossible path, drop the line
+		// rather than poisoning the log with garbage.
+		return
+	}
+	encoded = append(encoded, '\n')
+
+	p.auditMu.Lock()
+	defer p.auditMu.Unlock()
+	_, _ = p.cfg.AuditWriter.Write(encoded)
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/doc.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/doc.go
@@ -43,6 +43,35 @@
 // fields all live on containers/create, so the endpoint allowlist alone
 // is sufficient.
 //
+// # Bind-source symlink resolution and residual TOCTOU
+//
+// The bind-source allowlist check resolves symlinks (via
+// filepath.EvalSymlinks) on both the requested source and the
+// allowlist entries before the prefix comparison. This closes the
+// purely-lexical bypass where an agent with write access to a path
+// inside an allowed prefix could plant a symlink to /etc/passwd (or
+// any other forbidden host path) and have the kernel follow it when
+// runc mounts the bind.
+//
+// A residual TOCTOU window remains: the symlink resolution runs at
+// policy time, mount(2) runs in podman/runc some milliseconds later.
+// The agent can race the gap by swapping a safe symlink for a
+// dangerous one between the two moments. For v1 this residual is
+// acceptable because (a) the agent is otherwise sandboxed, (b) the
+// bind target inside the container is fixed at create time so a
+// changed symlink cannot retarget the agent's reach, and (c) the
+// sandbox layer (bwrap / sandbox-exec) sits in front of the proxy.
+// Closing the window properly requires either kernel-level fs
+// freezing or filesystem snapshots, both out of scope for a Step-1
+// library PR.
+//
+// Step 3 (sidecar wiring) and later should evaluate mounting the
+// per-session scratch directory with `nosymfollow` (Linux) or the
+// equivalent SBPL restriction (Darwin) where the platform permits.
+// That moves the TOCTOU mitigation from this proxy into the
+// surrounding sandbox profile, which is the correct architectural
+// home for it.
+//
 // # JSON error envelope
 //
 // Every synthesised error response (denial or upstream-unavailable) uses

--- a/modules/programs/prism/prism/internal/podmanproxy/doc.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/doc.go
@@ -43,6 +43,16 @@
 //     to the upstream unmodified). A future docker-API field that
 //     introduces an escape vector is rejected by default until it
 //     is explicitly admitted.
+//   - Value-level: for admitted enumerable fields (Mount.Type,
+//     NetworkMode, PidMode/IpcMode/UTSMode/UsernsMode/CgroupnsMode,
+//     LogConfig.Type), the value MUST match an explicit literal
+//     allowlist; NetworkMode additionally accepts a user-defined
+//     name regex. Anything outside the allowlist denies. This
+//     closes the cycle-6 "deny-list pattern at the value layer"
+//     class, sibling of the cycle-5 field-layer inversion. Value
+//     allowlists live in policy.go alongside the inspector
+//     functions (e.g. checkNetworkMode, checkLogConfigType) and
+//     are the canonical security spec for enumerable values.
 //   - Query-level: PUT containers/{id}/archive requires its `path`
 //     query parameter to fall under the same prefix allowlist as
 //     bind sources.

--- a/modules/programs/prism/prism/internal/podmanproxy/doc.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/doc.go
@@ -1,0 +1,58 @@
+// Package podmanproxy implements a default-deny HTTP filter proxy for the
+// docker / podman REST API socket.
+//
+// The proxy is a self-contained library with no prism-specific imports
+// beyond the standard library. It is intended to be embedded by a longer-
+// running owner (for example, the per-session prism sidecar — Step 3 of
+// the train tracked by issue #2317) which wires it up to a per-session
+// Unix socket and the host's real podman socket. This package itself
+// performs no session bookkeeping, no DB writes, and no isolation-mode
+// reasoning — those concerns live in the caller.
+//
+// # Threat model
+//
+// The proxy is the security boundary between an untrusted agent that
+// controls one end of the socket and the host's real container API on
+// the other end. The escapes the proxy is designed to block are listed
+// in #2317 §4: host-path bind mounts, --privileged, host network / pid /
+// ipc / uts / userns modes, cap-add SYS_ADMIN / SYS_PTRACE / etc., host
+// device passthrough, podman cp exfiltration, and raw-socket fallback
+// (the only socket exposed to the agent IS the filter).
+//
+// # Default-deny
+//
+// Every request is denied unless it matches an explicit allow rule.
+// Three classes of allow are enforced:
+//
+//   - Endpoint-level: any path/method pair that does not appear in the
+//     allowlist returns 403 with a friendly JSON envelope that names the
+//     rejected endpoint.
+//   - Body-level: containers/create requests are parsed and their
+//     HostConfig.* fields are checked. Any Binds source outside the
+//     configured prefix allowlist, any Mounts of type "bind" outside the
+//     allowlist, any Privileged: true, any host {Network,Pid,Ipc,UTS,Userns}
+//     mode, any non-empty Devices, any CapAdd entry outside the cap
+//     allowlist, or any resource cap above the configured upper bound
+//     returns 403.
+//   - Query-level: PUT containers/{id}/archive requires its `path` query
+//     parameter to fall under the same prefix allowlist as bind sources.
+//
+// Streaming endpoints — /containers/{id}/attach, /exec/{id}/start, and
+// the follow=1 variant of /containers/{id}/logs — are forwarded without
+// body parsing. They have no JSON body to inspect and the dangerous
+// fields all live on containers/create, so the endpoint allowlist alone
+// is sufficient.
+//
+// # JSON error envelope
+//
+// Every synthesised error response (denial or upstream-unavailable) uses
+// the docker-compatible envelope:
+//
+//	{"message": "..."}
+//
+// This shape is the lowest common denominator across the docker CLI,
+// podman, and the various Go client libraries (containers/buildah,
+// docker/docker, fsouza/go-dockerclient). The upstream-unavailable
+// envelope additionally carries actionable text naming the platform
+// commands the operator should run to bring the socket back up.
+package podmanproxy

--- a/modules/programs/prism/prism/internal/podmanproxy/doc.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/doc.go
@@ -19,23 +19,52 @@
 // device passthrough, podman cp exfiltration, and raw-socket fallback
 // (the only socket exposed to the agent IS the filter).
 //
-// # Default-deny
+// # Default-deny — endpoint, body, and field layers
 //
 // Every request is denied unless it matches an explicit allow rule.
-// Three classes of allow are enforced:
+// Four classes of allow are enforced (the field-level layer was
+// added in cycle 5 of #2326 after cycles 2/3/4 each surfaced a
+// HostConfig field that the previous permissive parser silently
+// forwarded):
 //
-//   - Endpoint-level: any path/method pair that does not appear in the
-//     allowlist returns 403 with a friendly JSON envelope that names the
-//     rejected endpoint.
-//   - Body-level: containers/create requests are parsed and their
-//     HostConfig.* fields are checked. Any Binds source outside the
-//     configured prefix allowlist, any Mounts of type "bind" outside the
-//     allowlist, any Privileged: true, any host {Network,Pid,Ipc,UTS,Userns}
-//     mode, any non-empty Devices, any CapAdd entry outside the cap
-//     allowlist, or any resource cap above the configured upper bound
-//     returns 403.
-//   - Query-level: PUT containers/{id}/archive requires its `path` query
-//     parameter to fall under the same prefix allowlist as bind sources.
+//   - Endpoint-level: any path/method pair that does not appear in
+//     the allowlist returns 403 with a friendly JSON envelope that
+//     names the rejected endpoint.
+//   - Body-level: containers/create / containers/{id}/update /
+//     containers/{id}/exec / volumes/create / networks/create
+//     bodies are parsed and policy-checked.
+//   - Field-level: every parsed body runs with
+//     json.Decoder.DisallowUnknownFields(). The typed struct for
+//     each body shape (hostConfig, containerCreateBody,
+//     containerExecBody, volumeCreateBody, networkCreateBody) is
+//     the security spec — every admitted field is annotated as
+//     INSPECTED (policy-checked), DENIED (rejected when non-empty),
+//     or FORWARDED (admitted as opaque json.RawMessage and passed
+//     to the upstream unmodified). A future docker-API field that
+//     introduces an escape vector is rejected by default until it
+//     is explicitly admitted.
+//   - Query-level: PUT containers/{id}/archive requires its `path`
+//     query parameter to fall under the same prefix allowlist as
+//     bind sources.
+//
+// # Field admission process for Step 3+
+//
+// When a workflow in Step 3 or later surfaces a HostConfig (or
+// top-level / exec / update / volume / network) field that the
+// current allowlist does not admit, the request fails with a 403
+// containing "unknown field <Name>" in the message. The process for
+// admitting a new field:
+//
+//  1. File an issue describing the workflow and the field.
+//  2. Audit the field against the parent issue's threat table
+//     (#2317 §4). Classify as INSPECTED / DENIED / FORWARDED.
+//  3. Open a PR that adds the field to the appropriate struct in
+//     policy.go with a rationale comment matching the existing
+//     style. INSPECTED additions need a policy check + a non-vacuous
+//     test pair (positive + revert-and-watch-fail).
+//  4. The struct definition is the canonical spec; reviewers should
+//     audit by reading the struct, not by guessing what the proxy
+//     admits.
 //
 // Streaming endpoints — /containers/{id}/attach, /exec/{id}/start, and
 // the follow=1 variant of /containers/{id}/logs — are forwarded without

--- a/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
@@ -49,6 +49,15 @@ const (
 	// bypass where an agent creates a non-privileged container and
 	// then exec's into it with Privileged: true.
 	endpointPolicyExec
+
+	// endpointPolicyVolumeCreate means "read body, parse as JSON,
+	// reject local-driver bind-volumes". Used for POST volumes/create.
+	// Closes the bypass where an agent creates a named volume that is
+	// functionally a host bind (Driver=local + DriverOpts={type=none,
+	// device=/host/path, o=bind}) and then references it from a
+	// subsequent containers/create body via the named-volume path that
+	// bindSource() does NOT host-check.
+	endpointPolicyVolumeCreate
 )
 
 // normalisePath strips a leading docker/podman API version segment and
@@ -264,9 +273,11 @@ func classifyPOST(normPath string) endpointKind {
 	}
 
 	// Network and volume create / connect / disconnect.
-	switch normPath {
-	case "networks/create", "volumes/create":
+	if normPath == "networks/create" {
 		return endpointAllow
+	}
+	if normPath == "volumes/create" {
+		return endpointPolicyVolumeCreate
 	}
 	switch {
 	case matchPath(normPath, "networks/+/connect"),

--- a/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
@@ -25,6 +25,41 @@ const (
 	// path that body-inspecting endpoints take. It exists as a separate
 	// constant for clarity: the AC explicitly calls out attach / exec /
 	// follow=logs as endpoints that must not parse a body.
+	//
+	// # Streaming-endpoint body audit (cycle 6)
+	//
+	// The endpoints in this class are forwarded WITHOUT body
+	// inspection. The cycle-6 audit confirmed each one is safe to
+	// admit without parsing:
+	//
+	// - POST /containers/{id}/attach
+	//     The body is empty (the endpoint upgrades the connection
+	//     to a hijacked bidirectional stream for stdin/stdout/stderr).
+	//     No JSON to inspect, no policy fields. Forward.
+	//
+	// - POST /exec/{id}/start
+	//     The body, when present, is a small JSON object with two
+	//     audited fields: Detach (bool; backgrounds the exec) and
+	//     Tty (bool; allocates a tty). Neither is an escape —
+	//     Tty=true is terminal allocation, Detach=true backgrounds.
+	//     A POST with NO body or an empty object {} is equally
+	//     valid. Per coordinator directive (cycle 6) any future
+	//     additional field surfaced on this body should be audited
+	//     and either admitted with a rationale (move to
+	//     endpointPolicyExec-style strict-parse) or denied via the
+	//     same allowlist discipline as the other body-bearing
+	//     endpoints. The current Detach/Tty pair has no JSON inversion
+	//     because docker/podman accept many other shapes at this
+	//     surface across versions and the bytes are tiny; the
+	//     conservative read is "the dangerous fields all live on
+	//     containers/create / containers/{id}/exec (which IS
+	//     inverted)".
+	//
+	// - GET /containers/{id}/logs
+	//     Body is empty. Query parameters: follow (bool), stdout
+	//     (bool), stderr (bool), since (int), until (int),
+	//     timestamps (bool), tail (int). All safe enums/integers;
+	//     no host-path or command-injection surface. Forward.
 	endpointAllowStreaming
 
 	// endpointPolicyCreate means "read body, parse as JSON, apply the

--- a/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
@@ -58,6 +58,15 @@ const (
 	// subsequent containers/create body via the named-volume path that
 	// bindSource() does NOT host-check.
 	endpointPolicyVolumeCreate
+
+	// endpointPolicyNetworkCreate runs the schema-inversion pass on
+	// POST networks/create. No fields are currently INSPECTED — the
+	// network-mode escape lives on HostConfig.NetworkMode of a
+	// container, not on the network definition. The kind exists so a
+	// future docker-API addition cannot silently introduce an escape
+	// via this endpoint without explicit admission in
+	// networkCreateBody.
+	endpointPolicyNetworkCreate
 )
 
 // normalisePath strips a leading docker/podman API version segment and
@@ -274,7 +283,7 @@ func classifyPOST(normPath string) endpointKind {
 
 	// Network and volume create / connect / disconnect.
 	if normPath == "networks/create" {
-		return endpointAllow
+		return endpointPolicyNetworkCreate
 	}
 	if normPath == "volumes/create" {
 		return endpointPolicyVolumeCreate

--- a/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
@@ -36,6 +36,19 @@ const (
 	// against the bind-source allowlist before forwarding". Used for
 	// PUT containers/{id}/archive (the podman cp write endpoint).
 	endpointPolicyArchive
+
+	// endpointPolicyUpdate means "read body, parse as JSON, apply the
+	// resource-cap policy in update-context mode (absent fields
+	// allowed)". Used for POST containers/{id}/update. Closes the
+	// bypass where an agent creates a container with valid caps and
+	// then updates them to 0 (= unlimited) after the fact.
+	endpointPolicyUpdate
+
+	// endpointPolicyExec means "read body, parse as JSON, reject
+	// Privileged=true". Used for POST containers/{id}/exec. Closes the
+	// bypass where an agent creates a non-privileged container and
+	// then exec's into it with Privileged: true.
+	endpointPolicyExec
 )
 
 // normalisePath strips a leading docker/podman API version segment and
@@ -222,11 +235,14 @@ func classifyPOST(normPath string) endpointKind {
 		return endpointAllowStreaming
 	}
 
-	// Exec create / resize. The exec body carries Cmd, Env, etc., but
-	// no HostConfig — so no body inspection is required.
-	switch {
-	case matchPath(normPath, "containers/+/exec"),
-		matchPath(normPath, "exec/+/resize"):
+	// Exec create has its own Privileged field that grants extra
+	// capabilities to the exec process — body inspection is required
+	// (review-security PR #2326 round 2). Exec resize is a small
+	// tty-resize op with no security-relevant body.
+	if matchPath(normPath, "containers/+/exec") {
+		return endpointPolicyExec
+	}
+	if matchPath(normPath, "exec/+/resize") {
 		return endpointAllow
 	}
 
@@ -258,12 +274,12 @@ func classifyPOST(normPath string) endpointKind {
 		return endpointAllow
 	}
 
-	// Container update is permitted — its body cannot introduce binds
-	// (those are fixed at create time) and resource fields are bounded
-	// by the host kernel. If a future docker API change adds a binds-
-	// equivalent field to /update, that classification flips.
+	// Container update accepts Memory, CpuQuota, NanoCpus, etc. — an
+	// agent that creates with valid caps could otherwise POST update
+	// with Memory=0 to remove the cap (review-security PR #2326 round 2).
+	// Body inspection is required.
 	if matchPath(normPath, "containers/+/update") {
-		return endpointAllow
+		return endpointPolicyUpdate
 	}
 
 	return endpointDeny

--- a/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
@@ -1,0 +1,289 @@
+package podmanproxy
+
+import (
+	"strings"
+)
+
+// endpointKind classifies a request after the path/method allowlist has
+// been consulted. The serveHTTP dispatcher uses this to decide whether
+// to forward the request as-is, body-inspect first, query-inspect first,
+// or reject outright.
+type endpointKind int
+
+const (
+	// endpointDeny is the default. The request matched no allow rule.
+	endpointDeny endpointKind = iota
+
+	// endpointAllow means "forward to the upstream socket without any
+	// further inspection". The endpoint is in the allowlist and has no
+	// known dangerous fields.
+	endpointAllow
+
+	// endpointAllowStreaming means "forward without body parsing". This
+	// is identical to endpointAllow in terms of permission, but the
+	// dispatcher uses it to short-circuit the read-body-into-buffer
+	// path that body-inspecting endpoints take. It exists as a separate
+	// constant for clarity: the AC explicitly calls out attach / exec /
+	// follow=logs as endpoints that must not parse a body.
+	endpointAllowStreaming
+
+	// endpointPolicyCreate means "read body, parse as JSON, apply the
+	// containers/create HostConfig policy before forwarding". Used for
+	// POST containers/create.
+	endpointPolicyCreate
+
+	// endpointPolicyArchive means "inspect the `path` query parameter
+	// against the bind-source allowlist before forwarding". Used for
+	// PUT containers/{id}/archive (the podman cp write endpoint).
+	endpointPolicyArchive
+)
+
+// normalisePath strips a leading docker/podman API version segment and
+// an optional libpod/ prefix from p, returning the canonical endpoint
+// path WITHOUT a leading slash. Examples:
+//
+//	"/v1.41/containers/json"        -> "containers/json"
+//	"/v5.0.0/libpod/containers/x"   -> "containers/x"
+//	"/libpod/containers/create"     -> "containers/create"
+//	"/containers/create"            -> "containers/create"
+//	"/"                             -> ""
+//	"//double"                      -> "" (deny — defence in depth)
+//	""                              -> ""
+//
+// The result is the canonical identifier used by classifyRequest and
+// the audit log's policy-rule names. A double-slash or non-leading-slash
+// input deliberately returns the empty string so it falls into the
+// default-deny branch of classifyRequest rather than producing an
+// ambiguous endpoint match.
+func normalisePath(p string) string {
+	if !strings.HasPrefix(p, "/") {
+		return ""
+	}
+	if strings.HasPrefix(p, "//") {
+		return ""
+	}
+	rest := strings.TrimPrefix(p, "/")
+	// Optional version segment, e.g. "v1.41" or "v5.0.0".
+	if i := strings.Index(rest, "/"); i > 0 {
+		if isVersionSegment(rest[:i]) {
+			rest = rest[i+1:]
+		}
+	}
+	// Optional libpod/ namespace prefix (podman-native API).
+	rest = strings.TrimPrefix(rest, "libpod/")
+	return rest
+}
+
+// isVersionSegment reports whether s looks like a docker/podman API
+// version path component: a leading 'v' followed by one or more
+// dot-separated digit runs. "v1", "v1.41", "v5.0.0" all match;
+// "version", "v", "v1a" do not.
+func isVersionSegment(s string) bool {
+	if len(s) < 2 || s[0] != 'v' {
+		return false
+	}
+	for _, c := range s[1:] {
+		if (c < '0' || c > '9') && c != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+// matchPath is a tiny pattern matcher: '+' matches exactly one
+// non-empty path segment. There are no other meta-characters — this
+// is not a regex engine, just a way to spell "containers/<id>/start"
+// without inventing dozens of named-capture rules.
+func matchPath(path, pattern string) bool {
+	ps := strings.Split(path, "/")
+	qs := strings.Split(pattern, "/")
+	if len(ps) != len(qs) {
+		return false
+	}
+	for i, q := range qs {
+		if q == "+" {
+			if ps[i] == "" {
+				return false
+			}
+			continue
+		}
+		if q != ps[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// classifyRequest applies the endpoint allowlist to the (method, normalised
+// path) pair. The default-deny branch is the LAST return — every allow
+// rule is an explicit positive match above it.
+//
+// The classification covers the docker / podman REST API surface that
+// an agent legitimately needs for the workflows described in #2317 §1:
+// container lifecycle (run / stop / rm), image pull, exec, build,
+// network / volume create. Endpoints outside this surface are denied
+// even if they are technically read-only — the proxy's job is to be
+// narrow, not exhaustive.
+//
+// When this function returns endpointPolicyCreate or endpointPolicyArchive
+// the caller MUST apply the corresponding body / query policy before
+// forwarding. When it returns endpointAllowStreaming the caller MUST NOT
+// attempt to read the body for inspection.
+func classifyRequest(method, normPath string) endpointKind {
+	if normPath == "" {
+		return endpointDeny
+	}
+
+	switch method {
+	case "GET":
+		return classifyGET(normPath)
+	case "HEAD":
+		if normPath == "_ping" {
+			return endpointAllow
+		}
+		return endpointDeny
+	case "POST":
+		return classifyPOST(normPath)
+	case "PUT":
+		return classifyPUT(normPath)
+	case "DELETE":
+		return classifyDELETE(normPath)
+	}
+	return endpointDeny
+}
+
+func classifyGET(normPath string) endpointKind {
+	// Read-only system endpoints.
+	switch normPath {
+	case "_ping", "info", "version", "events", "system/df", "system/info":
+		return endpointAllow
+	case "containers/json", "images/json", "networks", "volumes",
+		"images/search", "exec", "secrets", "configs":
+		// Listing read-only.
+		return endpointAllow
+	}
+
+	// Specific container read-paths.
+	switch {
+	case matchPath(normPath, "containers/+/json"),
+		matchPath(normPath, "containers/+/stats"),
+		matchPath(normPath, "containers/+/top"),
+		matchPath(normPath, "containers/+/changes"),
+		matchPath(normPath, "containers/+/export"),
+		matchPath(normPath, "containers/+/archive"):
+		return endpointAllow
+	case matchPath(normPath, "containers/+/logs"):
+		// /logs is GET-only and may stream when follow=1. The body
+		// inspection path does not apply (there is no request body).
+		return endpointAllowStreaming
+	}
+
+	// Image / network / volume / exec inspect.
+	switch {
+	case matchPath(normPath, "images/+/json"),
+		matchPath(normPath, "images/+/history"),
+		matchPath(normPath, "images/+/get"),
+		matchPath(normPath, "networks/+"),
+		matchPath(normPath, "volumes/+"),
+		matchPath(normPath, "exec/+/json"):
+		return endpointAllow
+	}
+
+	return endpointDeny
+}
+
+func classifyPOST(normPath string) endpointKind {
+	// Body-inspected: this is the one and only endpoint where the
+	// entire HostConfig policy is enforced.
+	if normPath == "containers/create" {
+		return endpointPolicyCreate
+	}
+
+	// Lifecycle ops on an existing container — no body fields can
+	// re-introduce host binds or privileged execution.
+	switch {
+	case matchPath(normPath, "containers/+/start"),
+		matchPath(normPath, "containers/+/stop"),
+		matchPath(normPath, "containers/+/kill"),
+		matchPath(normPath, "containers/+/restart"),
+		matchPath(normPath, "containers/+/pause"),
+		matchPath(normPath, "containers/+/unpause"),
+		matchPath(normPath, "containers/+/wait"),
+		matchPath(normPath, "containers/+/rename"),
+		matchPath(normPath, "containers/+/resize"):
+		return endpointAllow
+	}
+
+	// Streaming endpoints: no body parsing — see endpointAllowStreaming
+	// comment for the rationale.
+	switch {
+	case matchPath(normPath, "containers/+/attach"),
+		matchPath(normPath, "exec/+/start"):
+		return endpointAllowStreaming
+	}
+
+	// Exec create / resize. The exec body carries Cmd, Env, etc., but
+	// no HostConfig — so no body inspection is required.
+	switch {
+	case matchPath(normPath, "containers/+/exec"),
+		matchPath(normPath, "exec/+/resize"):
+		return endpointAllow
+	}
+
+	// Prune ops.
+	switch normPath {
+	case "containers/prune", "images/prune", "networks/prune", "volumes/prune", "build/prune":
+		return endpointAllow
+	}
+
+	// Image lifecycle.
+	switch normPath {
+	case "images/create", "images/load", "build", "commit":
+		return endpointAllow
+	}
+	switch {
+	case matchPath(normPath, "images/+/tag"),
+		matchPath(normPath, "images/+/push"):
+		return endpointAllow
+	}
+
+	// Network and volume create / connect / disconnect.
+	switch normPath {
+	case "networks/create", "volumes/create":
+		return endpointAllow
+	}
+	switch {
+	case matchPath(normPath, "networks/+/connect"),
+		matchPath(normPath, "networks/+/disconnect"):
+		return endpointAllow
+	}
+
+	// Container update is permitted — its body cannot introduce binds
+	// (those are fixed at create time) and resource fields are bounded
+	// by the host kernel. If a future docker API change adds a binds-
+	// equivalent field to /update, that classification flips.
+	if matchPath(normPath, "containers/+/update") {
+		return endpointAllow
+	}
+
+	return endpointDeny
+}
+
+func classifyPUT(normPath string) endpointKind {
+	if matchPath(normPath, "containers/+/archive") {
+		return endpointPolicyArchive
+	}
+	return endpointDeny
+}
+
+func classifyDELETE(normPath string) endpointKind {
+	switch {
+	case matchPath(normPath, "containers/+"),
+		matchPath(normPath, "images/+"),
+		matchPath(normPath, "networks/+"),
+		matchPath(normPath, "volumes/+"),
+		matchPath(normPath, "exec/+"):
+		return endpointAllow
+	}
+	return endpointDeny
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/handler.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/handler.go
@@ -48,6 +48,9 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case endpointPolicyExec:
 		p.handlePolicyExec(w, r)
 
+	case endpointPolicyVolumeCreate:
+		p.handlePolicyVolumeCreate(w, r)
+
 	case endpointDeny:
 		fallthrough
 	default:
@@ -120,6 +123,29 @@ func (p *Proxy) handlePolicyUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	dec := p.inspectUpdate(body)
+	if !dec.allow {
+		p.emitAudit(r, auditDeny, dec.reason)
+		writeJSONError(w, dec.status, dec.message)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	p.emitAudit(r, auditAllow, dec.reason)
+	p.upstream.ServeHTTP(w, r)
+}
+
+// handlePolicyVolumeCreate is the body-inspecting branch for POST
+// /volumes/create. Same shape as handlePolicyUpdate: read body,
+// inspect for the local-driver bind-volume escape, restore body and
+// forward on allow.
+func (p *Proxy) handlePolicyVolumeCreate(w http.ResponseWriter, r *http.Request) {
+	body, readDec := p.readBoundedBody(w, r)
+	if !readDec.allow {
+		p.emitAudit(r, auditDeny, readDec.reason)
+		writeJSONError(w, readDec.status, readDec.message)
+		return
+	}
+	dec := p.inspectVolumeCreate(body)
 	if !dec.allow {
 		p.emitAudit(r, auditDeny, dec.reason)
 		writeJSONError(w, dec.status, dec.message)

--- a/modules/programs/prism/prism/internal/podmanproxy/handler.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/handler.go
@@ -1,0 +1,102 @@
+package podmanproxy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// serveHTTP is the proxy's single HTTP handler. The control flow is:
+//
+//  1. Normalise the request path; reject anything that does not look
+//     like a docker / podman REST path.
+//  2. Classify the (method, path) pair against the endpoint allowlist.
+//  3. For endpoints that need body inspection, read the body into
+//     memory subject to MaxBodyBytes, parse the policy fields, and
+//     either reject (synthesised 4xx) or restore the body and forward.
+//  4. For endpoints that need query inspection (PUT archive), check
+//     the `path` query, then forward.
+//  5. For streaming endpoints, forward without touching the body.
+//  6. For plain allow endpoints, forward as-is.
+//  7. For deny endpoints, synthesise a 403 with a friendly envelope
+//     that names the rejected (method, path).
+//
+// Every branch emits exactly one audit line before returning.
+func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	normPath := normalisePath(r.URL.Path)
+	kind := classifyRequest(r.Method, normPath)
+
+	switch kind {
+	case endpointAllow:
+		p.emitAudit(r, auditAllow, "policy:endpoint_allow:"+normPath)
+		p.upstream.ServeHTTP(w, r)
+
+	case endpointAllowStreaming:
+		p.emitAudit(r, auditAllow, "policy:endpoint_streaming:"+normPath)
+		p.upstream.ServeHTTP(w, r)
+
+	case endpointPolicyCreate:
+		p.handlePolicyCreate(w, r)
+
+	case endpointPolicyArchive:
+		p.handlePolicyArchive(w, r)
+
+	case endpointDeny:
+		fallthrough
+	default:
+		reason := "endpoint_not_allowed"
+		msg := fmt.Sprintf("endpoint %s %s is not permitted by the prism podman proxy", r.Method, r.URL.Path)
+		p.emitAudit(r, auditDeny, reason+":"+r.Method+" "+truncateForReason(normPath))
+		writeJSONError(w, http.StatusForbidden, msg)
+	}
+}
+
+// handlePolicyCreate is the body-inspecting branch for POST
+// /containers/create. The body is read in full into memory (bounded by
+// MaxBodyBytes), parsed, evaluated, and — if allowed — restored on the
+// request before forwarding upstream.
+//
+// The body restore step is the subtle bit: httputil.ReverseProxy reads
+// r.Body when copying the request to the upstream Transport. After
+// io.ReadAll the original ReadCloser is drained, so we substitute an
+// io.NopCloser-wrapped bytes.Reader and set ContentLength explicitly so
+// the upstream sees a valid Content-Length header.
+func (p *Proxy) handlePolicyCreate(w http.ResponseWriter, r *http.Request) {
+	body, readDec := p.readBoundedBody(w, r)
+	if !readDec.allow {
+		p.emitAudit(r, auditDeny, readDec.reason)
+		writeJSONError(w, readDec.status, readDec.message)
+		return
+	}
+
+	dec := p.inspectCreate(body)
+	if !dec.allow {
+		p.emitAudit(r, auditDeny, dec.reason)
+		writeJSONError(w, dec.status, dec.message)
+		return
+	}
+
+	// Restore the body for the reverse proxy. Use a fresh Reader so
+	// the proxy can re-read from offset 0; the ContentLength is set
+	// explicitly because http.MaxBytesReader leaves it as it was.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+
+	p.emitAudit(r, auditAllow, dec.reason)
+	p.upstream.ServeHTTP(w, r)
+}
+
+// handlePolicyArchive is the query-inspecting branch for PUT
+// /containers/{id}/archive. The body is a tar stream and is forwarded
+// without being touched.
+func (p *Proxy) handlePolicyArchive(w http.ResponseWriter, r *http.Request) {
+	dec := p.inspectArchive(r)
+	if !dec.allow {
+		p.emitAudit(r, auditDeny, dec.reason)
+		writeJSONError(w, dec.status, dec.message)
+		return
+	}
+	p.emitAudit(r, auditAllow, dec.reason)
+	p.upstream.ServeHTTP(w, r)
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/handler.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/handler.go
@@ -51,6 +51,9 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case endpointPolicyVolumeCreate:
 		p.handlePolicyVolumeCreate(w, r)
 
+	case endpointPolicyNetworkCreate:
+		p.handlePolicyNetworkCreate(w, r)
+
 	case endpointDeny:
 		fallthrough
 	default:
@@ -123,6 +126,28 @@ func (p *Proxy) handlePolicyUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	dec := p.inspectUpdate(body)
+	if !dec.allow {
+		p.emitAudit(r, auditDeny, dec.reason)
+		writeJSONError(w, dec.status, dec.message)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	p.emitAudit(r, auditAllow, dec.reason)
+	p.upstream.ServeHTTP(w, r)
+}
+
+// handlePolicyNetworkCreate is the body-inspecting branch for POST
+// /networks/create. Same shape as the other policy handlers; the
+// inspection itself just runs the schema-inversion pass.
+func (p *Proxy) handlePolicyNetworkCreate(w http.ResponseWriter, r *http.Request) {
+	body, readDec := p.readBoundedBody(w, r)
+	if !readDec.allow {
+		p.emitAudit(r, auditDeny, readDec.reason)
+		writeJSONError(w, readDec.status, readDec.message)
+		return
+	}
+	dec := p.inspectNetworkCreate(body)
 	if !dec.allow {
 		p.emitAudit(r, auditDeny, dec.reason)
 		writeJSONError(w, dec.status, dec.message)

--- a/modules/programs/prism/prism/internal/podmanproxy/handler.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/handler.go
@@ -42,6 +42,12 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case endpointPolicyArchive:
 		p.handlePolicyArchive(w, r)
 
+	case endpointPolicyUpdate:
+		p.handlePolicyUpdate(w, r)
+
+	case endpointPolicyExec:
+		p.handlePolicyExec(w, r)
+
 	case endpointDeny:
 		fallthrough
 	default:
@@ -97,6 +103,52 @@ func (p *Proxy) handlePolicyArchive(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, dec.status, dec.message)
 		return
 	}
+	p.emitAudit(r, auditAllow, dec.reason)
+	p.upstream.ServeHTTP(w, r)
+}
+
+// handlePolicyUpdate is the body-inspecting branch for POST
+// /containers/{id}/update. Mirrors handlePolicyCreate in shape: read
+// body bounded by MaxBodyBytes, parse JSON, apply resource-cap
+// policy in update-context mode, then either reject or restore the
+// body and forward.
+func (p *Proxy) handlePolicyUpdate(w http.ResponseWriter, r *http.Request) {
+	body, readDec := p.readBoundedBody(w, r)
+	if !readDec.allow {
+		p.emitAudit(r, auditDeny, readDec.reason)
+		writeJSONError(w, readDec.status, readDec.message)
+		return
+	}
+	dec := p.inspectUpdate(body)
+	if !dec.allow {
+		p.emitAudit(r, auditDeny, dec.reason)
+		writeJSONError(w, dec.status, dec.message)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	p.emitAudit(r, auditAllow, dec.reason)
+	p.upstream.ServeHTTP(w, r)
+}
+
+// handlePolicyExec is the body-inspecting branch for POST
+// /containers/{id}/exec. Same shape as handlePolicyUpdate, but the
+// policy is the exec-Privileged check rather than resource caps.
+func (p *Proxy) handlePolicyExec(w http.ResponseWriter, r *http.Request) {
+	body, readDec := p.readBoundedBody(w, r)
+	if !readDec.allow {
+		p.emitAudit(r, auditDeny, readDec.reason)
+		writeJSONError(w, readDec.status, readDec.message)
+		return
+	}
+	dec := p.inspectExec(body)
+	if !dec.allow {
+		p.emitAudit(r, auditDeny, dec.reason)
+		writeJSONError(w, dec.status, dec.message)
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
 	p.emitAudit(r, auditAllow, dec.reason)
 	p.upstream.ServeHTTP(w, r)
 }

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -57,27 +57,48 @@ func denyDecision(status int, reason, message string) policyDecision {
 // field (review-security PR #2326 round 2: 0 was previously a
 // drive-through bypass of the configured cap).
 type hostConfig struct {
-	Binds       []string          `json:"Binds"`
-	Mounts      []hostConfigMount `json:"Mounts"`
-	Privileged  bool              `json:"Privileged"`
-	CapAdd      []string          `json:"CapAdd"`
-	NetworkMode string            `json:"NetworkMode"`
-	PidMode     string            `json:"PidMode"`
-	IpcMode     string            `json:"IpcMode"`
-	UTSMode     string            `json:"UTSMode"`
-	UsernsMode  string            `json:"UsernsMode"`
-	Devices     []json.RawMessage `json:"Devices"`
-	SecurityOpt []string          `json:"SecurityOpt"`
-	Memory      *int64            `json:"Memory"`
-	CpuQuota    *int64            `json:"CpuQuota"`
-	NanoCpus    *int64            `json:"NanoCpus"`
+	Binds             []string          `json:"Binds"`
+	Mounts            []hostConfigMount `json:"Mounts"`
+	Privileged        bool              `json:"Privileged"`
+	CapAdd            []string          `json:"CapAdd"`
+	NetworkMode       string            `json:"NetworkMode"`
+	PidMode           string            `json:"PidMode"`
+	IpcMode           string            `json:"IpcMode"`
+	UTSMode           string            `json:"UTSMode"`
+	UsernsMode        string            `json:"UsernsMode"`
+	CgroupnsMode      string            `json:"CgroupnsMode"`
+	Devices           []json.RawMessage `json:"Devices"`
+	DeviceCgroupRules []string          `json:"DeviceCgroupRules"`
+	DeviceRequests    []json.RawMessage `json:"DeviceRequests"`
+	VolumesFrom       []string          `json:"VolumesFrom"`
+	MaskedPaths       *[]string         `json:"MaskedPaths"`
+	ReadonlyPaths     *[]string         `json:"ReadonlyPaths"`
+	SecurityOpt       []string          `json:"SecurityOpt"`
+	Sysctls           map[string]string `json:"Sysctls"`
+	Memory            *int64            `json:"Memory"`
+	CpuQuota          *int64            `json:"CpuQuota"`
+	NanoCpus          *int64            `json:"NanoCpus"`
 }
 
-// hostConfigMount mirrors a docker HostConfig.Mounts entry. Only the
-// fields needed for the bind-source check are extracted.
+// hostConfigMount mirrors a docker HostConfig.Mounts entry. The
+// VolumeOptions sub-struct is parsed so we can deny the local-driver
+// bind-volume escape (#2326 round 4 review-security CRITICAL #1):
+// Type=volume with VolumeOptions.DriverConfig.Name="local" plus
+// DriverConfig.Options.device=/host/path is functionally a bind mount
+// dressed up as a volume.
 type hostConfigMount struct {
-	Type   string `json:"Type"`
-	Source string `json:"Source"`
+	Type          string                   `json:"Type"`
+	Source        string                   `json:"Source"`
+	VolumeOptions *hostConfigVolumeOptions `json:"VolumeOptions"`
+}
+
+type hostConfigVolumeOptions struct {
+	DriverConfig *hostConfigDriverConfig `json:"DriverConfig"`
+}
+
+type hostConfigDriverConfig struct {
+	Name    string            `json:"Name"`
+	Options map[string]string `json:"Options"`
 }
 
 // containerCreateBody is the top-level shape of POST containers/create.
@@ -151,17 +172,34 @@ func (p *Proxy) checkHostConfig(hc *hostConfig) policyDecision {
 
 	// Host bind sources (newer Mounts slice).
 	for _, m := range hc.Mounts {
-		if !strings.EqualFold(m.Type, "bind") {
-			// "volume", "tmpfs", "npipe", "image" do not read host
-			// files. (npipe is Windows-only; we let the upstream
-			// reject it on Linux/Darwin.)
+		if strings.EqualFold(m.Type, "bind") {
+			if !p.isAllowedBindSource(m.Source) {
+				return denyDecision(http.StatusForbidden,
+					"mount_bind:"+truncateForReason(m.Source),
+					fmt.Sprintf("mount source %q is not in the allowlist", m.Source))
+			}
 			continue
 		}
-		if !p.isAllowedBindSource(m.Source) {
-			return denyDecision(http.StatusForbidden,
-				"mount_bind:"+truncateForReason(m.Source),
-				fmt.Sprintf("mount source %q is not in the allowlist", m.Source))
+		if strings.EqualFold(m.Type, "volume") {
+			// Type=volume with an inline DriverConfig is the
+			// local-driver bind-volume escape: VolumeOptions.
+			// DriverConfig.{Name,Options} can specify a host path
+			// to bind-mount via the volume mechanism, bypassing the
+			// Type=bind allowlist check above. The conservative fix
+			// per the cycle-5 coordinator directive is to deny any
+			// VolumeOptions.DriverConfig at all — the legitimate
+			// "named volume managed by podman" case has no
+			// DriverConfig (uses the default driver settings).
+			if m.VolumeOptions != nil && m.VolumeOptions.DriverConfig != nil {
+				return denyDecision(http.StatusForbidden,
+					"mount_volume_driver_config",
+					"Mounts entry of Type=volume with VolumeOptions.DriverConfig is not permitted (local-driver bind-volume escape; use a Type=bind Mount with an allowlisted Source instead)")
+			}
+			continue
 		}
+		// "tmpfs" (in-memory, container-internal), "npipe"
+		// (Windows), "image" (image-volume): no host-file access
+		// path, forward unmodified.
 	}
 
 	// Privileged is a single bit. Any "true" is a hard reject.
@@ -181,40 +219,87 @@ func (p *Proxy) checkHostConfig(hc *hostConfig) policyDecision {
 		}
 	}
 
-	// Host namespaces — any *Mode = "host" is a hard reject.
-	if mode := strings.ToLower(hc.NetworkMode); mode == "host" {
-		return denyDecision(http.StatusForbidden,
-			"network_mode_host",
-			"HostConfig.NetworkMode=host is not permitted")
+	// Host namespaces — any *Mode = "host" is a hard reject. The
+	// CgroupnsMode entry is the cycle-4 round-4 review-security
+	// finding (sibling of the other five that I had already blocked).
+	nsModes := []struct {
+		name, value, reason, msg string
+	}{
+		{"NetworkMode", hc.NetworkMode, "network_mode_host", "HostConfig.NetworkMode=host is not permitted"},
+		{"PidMode", hc.PidMode, "pid_mode_host", "HostConfig.PidMode=host is not permitted"},
+		{"IpcMode", hc.IpcMode, "ipc_mode_host", "HostConfig.IpcMode=host is not permitted"},
+		{"UTSMode", hc.UTSMode, "uts_mode_host", "HostConfig.UTSMode=host is not permitted"},
+		{"UsernsMode", hc.UsernsMode, "userns_mode_host", "HostConfig.UsernsMode=host is not permitted"},
+		{"CgroupnsMode", hc.CgroupnsMode, "cgroupns_mode_host", "HostConfig.CgroupnsMode=host is not permitted"},
 	}
-	if mode := strings.ToLower(hc.PidMode); mode == "host" {
-		return denyDecision(http.StatusForbidden,
-			"pid_mode_host",
-			"HostConfig.PidMode=host is not permitted")
-	}
-	if mode := strings.ToLower(hc.IpcMode); mode == "host" {
-		return denyDecision(http.StatusForbidden,
-			"ipc_mode_host",
-			"HostConfig.IpcMode=host is not permitted")
-	}
-	if mode := strings.ToLower(hc.UTSMode); mode == "host" {
-		return denyDecision(http.StatusForbidden,
-			"uts_mode_host",
-			"HostConfig.UTSMode=host is not permitted")
-	}
-	if mode := strings.ToLower(hc.UsernsMode); mode == "host" {
-		return denyDecision(http.StatusForbidden,
-			"userns_mode_host",
-			"HostConfig.UsernsMode=host is not permitted")
+	for _, m := range nsModes {
+		if strings.ToLower(m.value) == "host" {
+			return denyDecision(http.StatusForbidden, m.reason, m.msg)
+		}
 	}
 
 	// Device passthrough — any non-empty Devices is a hard reject.
-	// A future enhancement could allowlist e.g. /dev/null; for now
-	// we are strictly default-deny.
 	if len(hc.Devices) > 0 {
 		return denyDecision(http.StatusForbidden,
 			"devices_nonempty",
 			"HostConfig.Devices is not permitted")
+	}
+
+	// DeviceCgroupRules: parallel cgroup-rule mechanism to Devices.
+	// `"a *:* rwm"` grants unrestricted device-cgroup access; combined
+	// with CAP_MKNOD (in the default capset; my CapAdd policy only
+	// blocks ADDs, not what defaults grant) the agent can mknod and
+	// read the host's raw disks. Cycle-4 finding #2 (CRITICAL).
+	if len(hc.DeviceCgroupRules) > 0 {
+		return denyDecision(http.StatusForbidden,
+			"device_cgroup_rules_nonempty",
+			"HostConfig.DeviceCgroupRules is not permitted (mirrors the Devices denial; the rule mechanism is equivalent")
+	}
+
+	// DeviceRequests: GPU / nvidia-container-runtime style device
+	// passthrough. Cycle-4 finding #5.
+	if len(hc.DeviceRequests) > 0 {
+		return denyDecision(http.StatusForbidden,
+			"device_requests_nonempty",
+			"HostConfig.DeviceRequests is not permitted")
+	}
+
+	// VolumesFrom: inherit mounts from another container. The other
+	// container's mount set is impossible to audit transitively; the
+	// agent could inherit any host bind that any other container the
+	// user has on the host carries. Cycle-4 finding #5.
+	if len(hc.VolumesFrom) > 0 {
+		return denyDecision(http.StatusForbidden,
+			"volumes_from_nonempty",
+			"HostConfig.VolumesFrom is not permitted (mounts cannot be audited transitively)")
+	}
+
+	// MaskedPaths / ReadonlyPaths: setting these (even as empty
+	// arrays) overrides runc's safe defaults, re-exposing /proc/keys,
+	// /proc/sysrq-trigger, /sys/firmware, etc. inside the container.
+	// No legitimate workflow overrides these for security. Cycle-4
+	// finding #3. (Pointer types distinguish field-absent from
+	// field-present-with-empty-array.)
+	if hc.MaskedPaths != nil {
+		return denyDecision(http.StatusForbidden,
+			"masked_paths_present",
+			"HostConfig.MaskedPaths is not permitted (overrides runc's safe default; legitimate workflows should rely on the default)")
+	}
+	if hc.ReadonlyPaths != nil {
+		return denyDecision(http.StatusForbidden,
+			"readonly_paths_present",
+			"HostConfig.ReadonlyPaths is not permitted (overrides runc's safe default)")
+	}
+
+	// Sysctls: kernel parameters set in the container. Some sysctls
+	// are namespaced (safe), some are not. Defence-in-depth (cycle-5
+	// opportunistic sweep): deny any Sysctls entirely; legitimate
+	// workflows can request specific entries through the allowlist
+	// admission process.
+	if len(hc.Sysctls) > 0 {
+		return denyDecision(http.StatusForbidden,
+			"sysctls_nonempty",
+			"HostConfig.Sysctls is not permitted (defence-in-depth; some sysctls are not namespaced)")
 	}
 
 	// SecurityOpt entries are default-deny: any entry not present in
@@ -334,6 +419,46 @@ func (p *Proxy) inspectUpdate(body []byte) policyDecision {
 			"containers/update body is not valid JSON")
 	}
 	return p.checkResourceCaps(&hc, capContextUpdate)
+}
+
+// volumeCreateBody is the partial shape of POST volumes/create. We
+// inspect Driver and DriverOpts to close the cycle-4 round-4
+// review-security CRITICAL #1: the `local` driver with DriverOpts
+// {type=none, device=/host/path, o=bind} creates a named volume that
+// is functionally a host bind, then a follow-up containers/create
+// references the volume by name and bindSource() skips the
+// host-bind check (no leading slash).
+type volumeCreateBody struct {
+	Name       string            `json:"Name"`
+	Driver     string            `json:"Driver"`
+	DriverOpts map[string]string `json:"DriverOpts"`
+}
+
+// inspectVolumeCreate parses body as a volumes/create request and
+// rejects any DriverOpts on the local driver (the only mechanism we
+// have seen this used as a bind-mount-in-disguise). Coordinator
+// directive cycle 5: "lean deny entirely — local-driver bind-volumes
+// are an obscure workflow and not worth admitting."
+func (p *Proxy) inspectVolumeCreate(body []byte) policyDecision {
+	if len(bytes.TrimSpace(body)) == 0 {
+		// Empty body — podman will produce an anonymous volume with
+		// default driver. Safe; forward.
+		return allowDecision("policy:volumes/create:empty")
+	}
+	var req volumeCreateBody
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&req); err != nil {
+		return denyDecision(http.StatusBadRequest,
+			"malformed_body:"+truncateForReason(err.Error()),
+			"volumes/create body is not valid JSON")
+	}
+	driver := strings.ToLower(req.Driver)
+	if driver == "local" && len(req.DriverOpts) > 0 {
+		return denyDecision(http.StatusForbidden,
+			"volume_local_driver_opts",
+			"volumes/create with Driver=local and DriverOpts is not permitted (local-driver bind-volume escape; use a containers/create Bind/Mount with an allowlisted Source instead)")
+	}
+	return allowDecision("policy:volumes/create:ok")
 }
 
 // inspectExec parses body as a containers/{id}/exec request and

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -95,58 +96,58 @@ type hostConfig struct {
 	// FORWARDED — admitted as safe; bytes forwarded unmodified.
 	// Each entry below MUST have a rationale comment confirming it
 	// has no escape vector against the parent issue's threat table.
-	CapDrop              json.RawMessage `json:"CapDrop"`              // dropping caps is always safer
-	AutoRemove           json.RawMessage `json:"AutoRemove"`           // container lifecycle
-	RestartPolicy        json.RawMessage `json:"RestartPolicy"`        // container lifecycle
-	LogConfig            json.RawMessage `json:"LogConfig"`            // log driver settings
-	Tmpfs                json.RawMessage `json:"Tmpfs"`                // in-memory, container-internal
-	PortBindings         json.RawMessage `json:"PortBindings"`         // network port map
-	PublishAllPorts      json.RawMessage `json:"PublishAllPorts"`      // network port flag
-	ReadonlyRootfs       json.RawMessage `json:"ReadonlyRootfs"`       // safer-default; not escape
-	ExtraHosts           json.RawMessage `json:"ExtraHosts"`           // /etc/hosts entries
-	GroupAdd             json.RawMessage `json:"GroupAdd"`             // additional gids inside ct
-	Dns                  json.RawMessage `json:"Dns"`                  // DNS servers
-	DnsOptions           json.RawMessage `json:"DnsOptions"`           // DNS resolver options
-	DnsSearch            json.RawMessage `json:"DnsSearch"`            // DNS search domains
-	Links                json.RawMessage `json:"Links"`                // deprecated container-to-container
-	Cgroup               json.RawMessage `json:"Cgroup"`               // cgroup name (not host control)
-	CgroupParent         json.RawMessage `json:"CgroupParent"`         // parent cgroup placement
-	BlkioWeight          json.RawMessage `json:"BlkioWeight"`          // I/O QoS
-	BlkioWeightDevice    json.RawMessage `json:"BlkioWeightDevice"`    // I/O QoS per-device
-	BlkioDeviceReadBps   json.RawMessage `json:"BlkioDeviceReadBps"`   // I/O QoS
-	BlkioDeviceWriteBps  json.RawMessage `json:"BlkioDeviceWriteBps"`  // I/O QoS
-	BlkioDeviceReadIOps  json.RawMessage `json:"BlkioDeviceReadIOps"`  // I/O QoS
-	BlkioDeviceWriteIOps json.RawMessage `json:"BlkioDeviceWriteIOps"` // I/O QoS
-	CpuShares            json.RawMessage `json:"CpuShares"`            // CPU QoS (relative weighting)
-	CpuPeriod            json.RawMessage `json:"CpuPeriod"`            // CFS period (paired with CpuQuota)
-	CpuRealtimePeriod    json.RawMessage `json:"CpuRealtimePeriod"`    // RT QoS
-	CpuRealtimeRuntime   json.RawMessage `json:"CpuRealtimeRuntime"`   // RT QoS
-	CpusetCpus           json.RawMessage `json:"CpusetCpus"`           // CPU pinning
-	CpusetMems           json.RawMessage `json:"CpusetMems"`           // NUMA pinning
-	CpuPercent           json.RawMessage `json:"CpuPercent"`           // windows CPU %
-	CpuCount             json.RawMessage `json:"CpuCount"`             // windows CPU count
-	IOMaximumIOps        json.RawMessage `json:"IOMaximumIOps"`        // windows I/O cap
-	IOMaximumBandwidth   json.RawMessage `json:"IOMaximumBandwidth"`   // windows I/O cap
-	MemoryReservation    json.RawMessage `json:"MemoryReservation"`    // soft memory limit
-	MemorySwap           json.RawMessage `json:"MemorySwap"`           // swap size cap
-	MemorySwappiness     json.RawMessage `json:"MemorySwappiness"`     // swap tendency
-	KernelMemory         json.RawMessage `json:"KernelMemory"`         // deprecated kernel mem
-	KernelMemoryTCP      json.RawMessage `json:"KernelMemoryTCP"`      // kernel TCP buffer cap
-	OomKillDisable       json.RawMessage `json:"OomKillDisable"`       // OOM behaviour
-	OomScoreAdj          json.RawMessage `json:"OomScoreAdj"`          // OOM score bias
-	PidsLimit            json.RawMessage `json:"PidsLimit"`            // ct process count cap
-	Ulimits              json.RawMessage `json:"Ulimits"`              // per-ct rlimits
-	StorageOpt           json.RawMessage `json:"StorageOpt"`           // storage driver opts
-	ContainerIDFile      json.RawMessage `json:"ContainerIDFile"`      // path to write ct id
-	Init                 json.RawMessage `json:"Init"`                 // pid 1 init wrapper
-	VolumeDriver         json.RawMessage `json:"VolumeDriver"`         // default volume driver name
-	ConsoleSize          json.RawMessage `json:"ConsoleSize"`          // tty size
-	Annotations          json.RawMessage `json:"Annotations"`          // OCI annotations
-	DiskQuota            json.RawMessage `json:"DiskQuota"`            // disk quota
-	Isolation            json.RawMessage `json:"Isolation"`            // windows isolation
-	NetworkID            json.RawMessage `json:"NetworkID"`            // podman network id
-	ShmSize              json.RawMessage `json:"ShmSize"`              // /dev/shm size
-	Runtime              json.RawMessage `json:"Runtime"`              // runtime name (runc/crun)
+	CapDrop              json.RawMessage      `json:"CapDrop"`              // dropping caps is always safer
+	AutoRemove           json.RawMessage      `json:"AutoRemove"`           // container lifecycle
+	RestartPolicy        json.RawMessage      `json:"RestartPolicy"`        // container lifecycle
+	LogConfig            *hostConfigLogConfig `json:"LogConfig"`            // INSPECTED — Type allowlist (cycle 6)
+	Tmpfs                json.RawMessage      `json:"Tmpfs"`                // in-memory, container-internal
+	PortBindings         json.RawMessage      `json:"PortBindings"`         // network port map
+	PublishAllPorts      json.RawMessage      `json:"PublishAllPorts"`      // network port flag
+	ReadonlyRootfs       json.RawMessage      `json:"ReadonlyRootfs"`       // safer-default; not escape
+	ExtraHosts           json.RawMessage      `json:"ExtraHosts"`           // /etc/hosts entries
+	GroupAdd             json.RawMessage      `json:"GroupAdd"`             // additional gids inside ct
+	Dns                  json.RawMessage      `json:"Dns"`                  // DNS servers
+	DnsOptions           json.RawMessage      `json:"DnsOptions"`           // DNS resolver options
+	DnsSearch            json.RawMessage      `json:"DnsSearch"`            // DNS search domains
+	Links                json.RawMessage      `json:"Links"`                // deprecated container-to-container
+	Cgroup               json.RawMessage      `json:"Cgroup"`               // cgroup name (not host control)
+	CgroupParent         json.RawMessage      `json:"CgroupParent"`         // parent cgroup placement
+	BlkioWeight          json.RawMessage      `json:"BlkioWeight"`          // I/O QoS
+	BlkioWeightDevice    json.RawMessage      `json:"BlkioWeightDevice"`    // I/O QoS per-device
+	BlkioDeviceReadBps   json.RawMessage      `json:"BlkioDeviceReadBps"`   // I/O QoS
+	BlkioDeviceWriteBps  json.RawMessage      `json:"BlkioDeviceWriteBps"`  // I/O QoS
+	BlkioDeviceReadIOps  json.RawMessage      `json:"BlkioDeviceReadIOps"`  // I/O QoS
+	BlkioDeviceWriteIOps json.RawMessage      `json:"BlkioDeviceWriteIOps"` // I/O QoS
+	CpuShares            json.RawMessage      `json:"CpuShares"`            // CPU QoS (relative weighting)
+	CpuPeriod            json.RawMessage      `json:"CpuPeriod"`            // CFS period (paired with CpuQuota)
+	CpuRealtimePeriod    json.RawMessage      `json:"CpuRealtimePeriod"`    // RT QoS
+	CpuRealtimeRuntime   json.RawMessage      `json:"CpuRealtimeRuntime"`   // RT QoS
+	CpusetCpus           json.RawMessage      `json:"CpusetCpus"`           // CPU pinning
+	CpusetMems           json.RawMessage      `json:"CpusetMems"`           // NUMA pinning
+	CpuPercent           json.RawMessage      `json:"CpuPercent"`           // windows CPU %
+	CpuCount             json.RawMessage      `json:"CpuCount"`             // windows CPU count
+	IOMaximumIOps        json.RawMessage      `json:"IOMaximumIOps"`        // windows I/O cap
+	IOMaximumBandwidth   json.RawMessage      `json:"IOMaximumBandwidth"`   // windows I/O cap
+	MemoryReservation    json.RawMessage      `json:"MemoryReservation"`    // soft memory limit
+	MemorySwap           json.RawMessage      `json:"MemorySwap"`           // swap size cap
+	MemorySwappiness     json.RawMessage      `json:"MemorySwappiness"`     // swap tendency
+	KernelMemory         json.RawMessage      `json:"KernelMemory"`         // deprecated kernel mem
+	KernelMemoryTCP      json.RawMessage      `json:"KernelMemoryTCP"`      // kernel TCP buffer cap
+	OomKillDisable       json.RawMessage      `json:"OomKillDisable"`       // OOM behaviour
+	OomScoreAdj          json.RawMessage      `json:"OomScoreAdj"`          // OOM score bias
+	PidsLimit            json.RawMessage      `json:"PidsLimit"`            // ct process count cap
+	Ulimits              json.RawMessage      `json:"Ulimits"`              // per-ct rlimits
+	StorageOpt           json.RawMessage      `json:"StorageOpt"`           // storage driver opts
+	ContainerIDFile      json.RawMessage      `json:"ContainerIDFile"`      // path to write ct id
+	Init                 json.RawMessage      `json:"Init"`                 // pid 1 init wrapper
+	VolumeDriver         json.RawMessage      `json:"VolumeDriver"`         // default volume driver name
+	ConsoleSize          json.RawMessage      `json:"ConsoleSize"`          // tty size
+	Annotations          json.RawMessage      `json:"Annotations"`          // OCI annotations
+	DiskQuota            json.RawMessage      `json:"DiskQuota"`            // disk quota
+	Isolation            json.RawMessage      `json:"Isolation"`            // windows isolation
+	NetworkID            json.RawMessage      `json:"NetworkID"`            // podman network id
+	ShmSize              json.RawMessage      `json:"ShmSize"`              // /dev/shm size
+	Runtime              json.RawMessage      `json:"Runtime"`              // runtime name (runc/crun)
 }
 
 // hostConfigMount mirrors a docker HostConfig.Mounts entry. The
@@ -181,6 +182,15 @@ type hostConfigVolumeOptions struct {
 type hostConfigDriverConfig struct {
 	Name    string            `json:"Name"`
 	Options map[string]string `json:"Options"`
+}
+
+// hostConfigLogConfig is the cycle-6 typed parse of
+// HostConfig.LogConfig. Type is INSPECTED against the
+// logConfigTypeAllowlist; Config is FORWARDED as opaque map (driver-
+// specific options like max-size for json-file).
+type hostConfigLogConfig struct {
+	Type   string            `json:"Type"`
+	Config map[string]string `json:"Config"`
 }
 
 // containerCreateBody is the top-level shape of POST containers/create.
@@ -397,22 +407,37 @@ func (p *Proxy) checkHostConfig(hc *hostConfig) policyDecision {
 		}
 	}
 
-	// Host namespaces — any *Mode = "host" is a hard reject. The
-	// CgroupnsMode entry is the cycle-4 round-4 review-security
-	// finding (sibling of the other five that I had already blocked).
-	nsModes := []struct {
-		name, value, reason, msg string
-	}{
-		{"NetworkMode", hc.NetworkMode, "network_mode_host", "HostConfig.NetworkMode=host is not permitted"},
-		{"PidMode", hc.PidMode, "pid_mode_host", "HostConfig.PidMode=host is not permitted"},
-		{"IpcMode", hc.IpcMode, "ipc_mode_host", "HostConfig.IpcMode=host is not permitted"},
-		{"UTSMode", hc.UTSMode, "uts_mode_host", "HostConfig.UTSMode=host is not permitted"},
-		{"UsernsMode", hc.UsernsMode, "userns_mode_host", "HostConfig.UsernsMode=host is not permitted"},
-		{"CgroupnsMode", hc.CgroupnsMode, "cgroupns_mode_host", "HostConfig.CgroupnsMode=host is not permitted"},
+	// Host-namespace mode fields. Cycle 6: switched from deny-list
+	// (only "host" rejected) to allowlist (only known-safe literals
+	// + for NetworkMode a user-defined-name regex). Closes the
+	// container:<id> / ns:<path> / path-injection class of value-
+	// level bypasses that the deny-list pattern left open.
+	if dec := checkNetworkMode(hc.NetworkMode); !dec.allow {
+		return dec
 	}
-	for _, m := range nsModes {
-		if strings.ToLower(m.value) == "host" {
-			return denyDecision(http.StatusForbidden, m.reason, m.msg)
+	if dec := checkSimpleNamespaceMode("PidMode", hc.PidMode); !dec.allow {
+		return dec
+	}
+	if dec := checkSimpleNamespaceMode("IpcMode", hc.IpcMode); !dec.allow {
+		return dec
+	}
+	if dec := checkSimpleNamespaceMode("UTSMode", hc.UTSMode); !dec.allow {
+		return dec
+	}
+	if dec := checkSimpleNamespaceMode("UsernsMode", hc.UsernsMode); !dec.allow {
+		return dec
+	}
+	if dec := checkSimpleNamespaceMode("CgroupnsMode", hc.CgroupnsMode); !dec.allow {
+		return dec
+	}
+
+	// LogConfig.Type allowlist (cycle 6). Local-only drivers admit;
+	// network-shipping drivers (syslog/splunk/fluentd/gelf/awslogs/
+	// etwlogs/logentries) deny because they accept a network address
+	// the agent could point at host services we have not audited.
+	if hc.LogConfig != nil {
+		if dec := checkLogConfigType(hc.LogConfig.Type); !dec.allow {
+			return dec
 		}
 	}
 
@@ -915,6 +940,124 @@ func (p *Proxy) capIsAllowed(c string) bool {
 		}
 	}
 	return false
+}
+
+// networkModeFixedLiterals is the small allowlist of literal
+// NetworkMode values the proxy admits. Anything not in this set must
+// either match networkNameRegex (for user-defined networks) or deny.
+// "host" is INTENTIONALLY ABSENT — the previous denylist's only
+// rejection; preserved by the absence in this allowlist.
+var networkModeFixedLiterals = map[string]struct{}{
+	"":            {}, // default
+	"bridge":      {}, // docker / podman default bridge
+	"none":        {}, // no network
+	"default":     {}, // explicit default
+	"slirp4netns": {}, // podman rootless default
+	"pasta":       {}, // podman v5+ rootless default
+}
+
+// networkNameRegex matches a docker / podman user-defined network
+// name. The character class is intentionally narrow: alphanumerics,
+// dot, dash, underscore. No ":" (rules out container:<id>, ns:...).
+// No "/" (rules out path-like values). No whitespace. Length cap of
+// 63 mirrors docker's documented limit.
+var networkNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$`)
+
+// simpleNamespaceLiterals is the allowlist for PidMode / IpcMode /
+// UTSMode / UsernsMode / CgroupnsMode. These five do NOT accept
+// user-defined names the way NetworkMode does — only fixed literals.
+// "host" is intentionally absent.
+var simpleNamespaceLiterals = map[string]struct{}{
+	"":        {}, // default
+	"private": {}, // private namespace (the safe default in spirit)
+}
+
+// checkNetworkMode applies the NetworkMode value-level allowlist.
+func checkNetworkMode(value string) policyDecision {
+	if _, ok := networkModeFixedLiterals[value]; ok {
+		return allowDecision("policy:network_mode_literal_ok")
+	}
+	// The fixed denials below produce per-class audit reasons so
+	// the log distinguishes container-ref from path-injection from
+	// the literal "host" case.
+	if dec := denyIfUnsafeModeValue("NetworkMode", value); !dec.allow {
+		return dec
+	}
+	if networkNameRegex.MatchString(value) {
+		return allowDecision("policy:network_mode_user_name_ok")
+	}
+	return denyDecision(http.StatusForbidden,
+		"network_mode_invalid:"+truncateForReason(value),
+		fmt.Sprintf("HostConfig.NetworkMode=%q does not match any allowed literal or the user-defined-name pattern", value))
+}
+
+// checkSimpleNamespaceMode applies the allowlist for the five non-
+// NetworkMode namespace modes (Pid, Ipc, UTS, Userns, Cgroupns).
+func checkSimpleNamespaceMode(fieldName, value string) policyDecision {
+	if _, ok := simpleNamespaceLiterals[value]; ok {
+		return allowDecision("policy:" + fieldName + "_literal_ok")
+	}
+	if dec := denyIfUnsafeModeValue(fieldName, value); !dec.allow {
+		return dec
+	}
+	return denyDecision(http.StatusForbidden,
+		strings.ToLower(fieldName)+"_invalid:"+truncateForReason(value),
+		fmt.Sprintf("HostConfig.%s=%q does not match any allowed literal {\"\", \"private\"}", fieldName, value))
+}
+
+// denyIfUnsafeModeValue checks the universal dangerous-pattern set
+// shared by every namespace-mode field. Returns an allow decision
+// when nothing matches; the caller continues with allowlist matching.
+func denyIfUnsafeModeValue(fieldName, value string) policyDecision {
+	lower := strings.ToLower(value)
+	if lower == "host" {
+		return denyDecision(http.StatusForbidden,
+			strings.ToLower(fieldName)+"_host",
+			fmt.Sprintf("HostConfig.%s=host is not permitted", fieldName))
+	}
+	if strings.ContainsAny(value, " \t\n\r") {
+		return denyDecision(http.StatusForbidden,
+			strings.ToLower(fieldName)+"_whitespace",
+			fmt.Sprintf("HostConfig.%s=%q contains whitespace and is not permitted", fieldName, value))
+	}
+	if strings.Contains(value, ":") {
+		return denyDecision(http.StatusForbidden,
+			strings.ToLower(fieldName)+"_colon",
+			fmt.Sprintf("HostConfig.%s=%q contains ':' (container:<id> / ns:<path> form) and is not permitted", fieldName, value))
+	}
+	if strings.Contains(value, "/") {
+		return denyDecision(http.StatusForbidden,
+			strings.ToLower(fieldName)+"_slash",
+			fmt.Sprintf("HostConfig.%s=%q contains '/' (path-like form) and is not permitted", fieldName, value))
+	}
+	return allowDecision("")
+}
+
+// logConfigTypeAllowlist is the cycle-6 enum admission set for
+// HostConfig.LogConfig.Type. The drivers listed here all write
+// container logs to LOCAL destinations (file / stdio / local
+// journald / Kubernetes node-local CRI files). Drivers that ship
+// logs to network destinations (syslog, splunk, fluentd, gelf,
+// awslogs, etwlogs, logentries) are NOT in this set and therefore
+// deny — the agent has no legitimate need to direct container logs
+// at off-host services we have not audited.
+var logConfigTypeAllowlist = map[string]struct{}{
+	"":                {}, // default driver
+	"json-file":       {}, // local file
+	"none":            {}, // discard
+	"journald":        {}, // local systemd journal
+	"k8s-file":        {}, // CRI node-local
+	"passthrough":     {}, // podman passthrough
+	"passthrough-tty": {},
+}
+
+func checkLogConfigType(value string) policyDecision {
+	if _, ok := logConfigTypeAllowlist[value]; ok {
+		return allowDecision("policy:log_config_type_ok")
+	}
+	return denyDecision(http.StatusForbidden,
+		"log_config_type:"+truncateForReason(value),
+		fmt.Sprintf("HostConfig.LogConfig.Type=%q is not in the allowlist (network-shipping log drivers like syslog/splunk/fluentd/gelf/awslogs/etwlogs/logentries are denied; use json-file / journald / k8s-file / passthrough / none)", value))
 }
 
 // truncateForReason bounds a free-form string before splicing it into

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -56,28 +56,97 @@ func denyDecision(status int, reason, message string) policyDecision {
 // "unbounded", so the policy must treat 0 differently from a missing
 // field (review-security PR #2326 round 2: 0 was previously a
 // drive-through bypass of the configured cap).
+// Cycle 5: this struct is the AUDIT SPEC for HostConfig. After this
+// commit the parser runs with json.Decoder.DisallowUnknownFields(),
+// so any HostConfig field not declared here is rejected as
+// unknown-field. Adding a new field requires the same audit as
+// existing ones: classify it as INSPECTED (typed; checkHostConfig
+// runs a policy check) / DENIED (typed; non-empty rejects) /
+// FORWARDED (json.RawMessage; admitted as safe, forwarded
+// unmodified). The single most important reviewer task on a future
+// change to this file is checking the rationale comment on each
+// admission.
 type hostConfig struct {
-	Binds             []string          `json:"Binds"`
-	Mounts            []hostConfigMount `json:"Mounts"`
-	Privileged        bool              `json:"Privileged"`
-	CapAdd            []string          `json:"CapAdd"`
-	NetworkMode       string            `json:"NetworkMode"`
-	PidMode           string            `json:"PidMode"`
-	IpcMode           string            `json:"IpcMode"`
-	UTSMode           string            `json:"UTSMode"`
-	UsernsMode        string            `json:"UsernsMode"`
-	CgroupnsMode      string            `json:"CgroupnsMode"`
-	Devices           []json.RawMessage `json:"Devices"`
-	DeviceCgroupRules []string          `json:"DeviceCgroupRules"`
-	DeviceRequests    []json.RawMessage `json:"DeviceRequests"`
-	VolumesFrom       []string          `json:"VolumesFrom"`
-	MaskedPaths       *[]string         `json:"MaskedPaths"`
-	ReadonlyPaths     *[]string         `json:"ReadonlyPaths"`
-	SecurityOpt       []string          `json:"SecurityOpt"`
-	Sysctls           map[string]string `json:"Sysctls"`
-	Memory            *int64            `json:"Memory"`
-	CpuQuota          *int64            `json:"CpuQuota"`
-	NanoCpus          *int64            `json:"NanoCpus"`
+	// INSPECTED — policy check in checkHostConfig.
+	Binds        []string          `json:"Binds"`        // bind allowlist + symlink resolution
+	Mounts       []hostConfigMount `json:"Mounts"`       // bind allowlist + volume-driver escape
+	Privileged   bool              `json:"Privileged"`   // deny when true
+	CapAdd       []string          `json:"CapAdd"`       // allowlist (AllowedCaps)
+	NetworkMode  string            `json:"NetworkMode"`  // deny "host"
+	PidMode      string            `json:"PidMode"`      // deny "host"
+	IpcMode      string            `json:"IpcMode"`      // deny "host"
+	UTSMode      string            `json:"UTSMode"`      // deny "host"
+	UsernsMode   string            `json:"UsernsMode"`   // deny "host"
+	CgroupnsMode string            `json:"CgroupnsMode"` // deny "host"
+	SecurityOpt  []string          `json:"SecurityOpt"`  // allowlist (AllowedSecurityOpts)
+	Memory       *int64            `json:"Memory"`       // cap; strict when MaxMemoryBytes>0
+	CpuQuota     *int64            `json:"CpuQuota"`     // cap; strict when MaxCPUQuota>0
+	NanoCpus     *int64            `json:"NanoCpus"`     // cap; strict when MaxNanoCpus>0
+
+	// DENIED — typed; non-empty / non-default value rejects.
+	Devices           []json.RawMessage `json:"Devices"`           // deny non-empty
+	DeviceCgroupRules []string          `json:"DeviceCgroupRules"` // deny non-empty
+	DeviceRequests    []json.RawMessage `json:"DeviceRequests"`    // deny non-empty
+	VolumesFrom       []string          `json:"VolumesFrom"`       // deny non-empty
+	MaskedPaths       *[]string         `json:"MaskedPaths"`       // deny when present
+	ReadonlyPaths     *[]string         `json:"ReadonlyPaths"`     // deny when present
+	Sysctls           map[string]string `json:"Sysctls"`           // deny non-empty
+
+	// FORWARDED — admitted as safe; bytes forwarded unmodified.
+	// Each entry below MUST have a rationale comment confirming it
+	// has no escape vector against the parent issue's threat table.
+	CapDrop              json.RawMessage `json:"CapDrop"`              // dropping caps is always safer
+	AutoRemove           json.RawMessage `json:"AutoRemove"`           // container lifecycle
+	RestartPolicy        json.RawMessage `json:"RestartPolicy"`        // container lifecycle
+	LogConfig            json.RawMessage `json:"LogConfig"`            // log driver settings
+	Tmpfs                json.RawMessage `json:"Tmpfs"`                // in-memory, container-internal
+	PortBindings         json.RawMessage `json:"PortBindings"`         // network port map
+	PublishAllPorts      json.RawMessage `json:"PublishAllPorts"`      // network port flag
+	ReadonlyRootfs       json.RawMessage `json:"ReadonlyRootfs"`       // safer-default; not escape
+	ExtraHosts           json.RawMessage `json:"ExtraHosts"`           // /etc/hosts entries
+	GroupAdd             json.RawMessage `json:"GroupAdd"`             // additional gids inside ct
+	Dns                  json.RawMessage `json:"Dns"`                  // DNS servers
+	DnsOptions           json.RawMessage `json:"DnsOptions"`           // DNS resolver options
+	DnsSearch            json.RawMessage `json:"DnsSearch"`            // DNS search domains
+	Links                json.RawMessage `json:"Links"`                // deprecated container-to-container
+	Cgroup               json.RawMessage `json:"Cgroup"`               // cgroup name (not host control)
+	CgroupParent         json.RawMessage `json:"CgroupParent"`         // parent cgroup placement
+	BlkioWeight          json.RawMessage `json:"BlkioWeight"`          // I/O QoS
+	BlkioWeightDevice    json.RawMessage `json:"BlkioWeightDevice"`    // I/O QoS per-device
+	BlkioDeviceReadBps   json.RawMessage `json:"BlkioDeviceReadBps"`   // I/O QoS
+	BlkioDeviceWriteBps  json.RawMessage `json:"BlkioDeviceWriteBps"`  // I/O QoS
+	BlkioDeviceReadIOps  json.RawMessage `json:"BlkioDeviceReadIOps"`  // I/O QoS
+	BlkioDeviceWriteIOps json.RawMessage `json:"BlkioDeviceWriteIOps"` // I/O QoS
+	CpuShares            json.RawMessage `json:"CpuShares"`            // CPU QoS (relative weighting)
+	CpuPeriod            json.RawMessage `json:"CpuPeriod"`            // CFS period (paired with CpuQuota)
+	CpuRealtimePeriod    json.RawMessage `json:"CpuRealtimePeriod"`    // RT QoS
+	CpuRealtimeRuntime   json.RawMessage `json:"CpuRealtimeRuntime"`   // RT QoS
+	CpusetCpus           json.RawMessage `json:"CpusetCpus"`           // CPU pinning
+	CpusetMems           json.RawMessage `json:"CpusetMems"`           // NUMA pinning
+	CpuPercent           json.RawMessage `json:"CpuPercent"`           // windows CPU %
+	CpuCount             json.RawMessage `json:"CpuCount"`             // windows CPU count
+	IOMaximumIOps        json.RawMessage `json:"IOMaximumIOps"`        // windows I/O cap
+	IOMaximumBandwidth   json.RawMessage `json:"IOMaximumBandwidth"`   // windows I/O cap
+	MemoryReservation    json.RawMessage `json:"MemoryReservation"`    // soft memory limit
+	MemorySwap           json.RawMessage `json:"MemorySwap"`           // swap size cap
+	MemorySwappiness     json.RawMessage `json:"MemorySwappiness"`     // swap tendency
+	KernelMemory         json.RawMessage `json:"KernelMemory"`         // deprecated kernel mem
+	KernelMemoryTCP      json.RawMessage `json:"KernelMemoryTCP"`      // kernel TCP buffer cap
+	OomKillDisable       json.RawMessage `json:"OomKillDisable"`       // OOM behaviour
+	OomScoreAdj          json.RawMessage `json:"OomScoreAdj"`          // OOM score bias
+	PidsLimit            json.RawMessage `json:"PidsLimit"`            // ct process count cap
+	Ulimits              json.RawMessage `json:"Ulimits"`              // per-ct rlimits
+	StorageOpt           json.RawMessage `json:"StorageOpt"`           // storage driver opts
+	ContainerIDFile      json.RawMessage `json:"ContainerIDFile"`      // path to write ct id
+	Init                 json.RawMessage `json:"Init"`                 // pid 1 init wrapper
+	VolumeDriver         json.RawMessage `json:"VolumeDriver"`         // default volume driver name
+	ConsoleSize          json.RawMessage `json:"ConsoleSize"`          // tty size
+	Annotations          json.RawMessage `json:"Annotations"`          // OCI annotations
+	DiskQuota            json.RawMessage `json:"DiskQuota"`            // disk quota
+	Isolation            json.RawMessage `json:"Isolation"`            // windows isolation
+	NetworkID            json.RawMessage `json:"NetworkID"`            // podman network id
+	ShmSize              json.RawMessage `json:"ShmSize"`              // /dev/shm size
+	Runtime              json.RawMessage `json:"Runtime"`              // runtime name (runc/crun)
 }
 
 // hostConfigMount mirrors a docker HostConfig.Mounts entry. The
@@ -87,13 +156,26 @@ type hostConfig struct {
 // DriverConfig.Options.device=/host/path is functionally a bind mount
 // dressed up as a volume.
 type hostConfigMount struct {
-	Type          string                   `json:"Type"`
-	Source        string                   `json:"Source"`
-	VolumeOptions *hostConfigVolumeOptions `json:"VolumeOptions"`
+	Type          string                   `json:"Type"`          // INSPECTED (bind vs volume)
+	Source        string                   `json:"Source"`        // INSPECTED (host bind path)
+	VolumeOptions *hostConfigVolumeOptions `json:"VolumeOptions"` // INSPECTED (deny .DriverConfig)
+
+	// FORWARDED — mount fields admitted as safe.
+	Target         json.RawMessage `json:"Target"`         // in-container path
+	ReadOnly       json.RawMessage `json:"ReadOnly"`       // safer-default
+	Consistency    json.RawMessage `json:"Consistency"`    // macOS perf flag
+	BindOptions    json.RawMessage `json:"BindOptions"`    // propagation flags
+	TmpfsOptions   json.RawMessage `json:"TmpfsOptions"`   // size/mode for tmpfs Type
+	ClusterOptions json.RawMessage `json:"ClusterOptions"` // swarm cluster volumes
 }
 
 type hostConfigVolumeOptions struct {
-	DriverConfig *hostConfigDriverConfig `json:"DriverConfig"`
+	DriverConfig *hostConfigDriverConfig `json:"DriverConfig"` // INSPECTED — presence denies
+
+	// FORWARDED.
+	NoCopy  json.RawMessage `json:"NoCopy"`
+	Labels  json.RawMessage `json:"Labels"`
+	Subpath json.RawMessage `json:"Subpath"`
 }
 
 type hostConfigDriverConfig struct {
@@ -102,53 +184,132 @@ type hostConfigDriverConfig struct {
 }
 
 // containerCreateBody is the top-level shape of POST containers/create.
-// We extract only HostConfig — the other fields (Image, Cmd, Env, Labels,
-// WorkingDir, NetworkingConfig, etc.) carry no policy concerns and are
-// forwarded unmodified.
+// Same allow-list discipline as hostConfig: every field admitted here
+// is either INSPECTED, DENIED, or FORWARDED with a rationale.
+//
+// Top-level fields are largely container-internal (Image, Cmd, Env,
+// WorkingDir, Labels, etc.) and have no documented escape vector.
+// HostConfig and NetworkingConfig are nested structures — only
+// HostConfig has a parser; NetworkingConfig is admitted as opaque
+// for now and revisited if it surfaces escapes.
 type containerCreateBody struct {
-	HostConfig *hostConfig `json:"HostConfig"`
+	// INSPECTED.
+	HostConfig *json.RawMessage `json:"HostConfig"` // parsed strictly in a second pass
+
+	// FORWARDED — container-internal config; no host-impact.
+	Hostname         json.RawMessage `json:"Hostname"`
+	Domainname       json.RawMessage `json:"Domainname"`
+	User             json.RawMessage `json:"User"`
+	AttachStdin      json.RawMessage `json:"AttachStdin"`
+	AttachStdout     json.RawMessage `json:"AttachStdout"`
+	AttachStderr     json.RawMessage `json:"AttachStderr"`
+	ExposedPorts     json.RawMessage `json:"ExposedPorts"`
+	Tty              json.RawMessage `json:"Tty"`
+	OpenStdin        json.RawMessage `json:"OpenStdin"`
+	StdinOnce        json.RawMessage `json:"StdinOnce"`
+	Env              json.RawMessage `json:"Env"`
+	Cmd              json.RawMessage `json:"Cmd"`
+	Healthcheck      json.RawMessage `json:"Healthcheck"`
+	ArgsEscaped      json.RawMessage `json:"ArgsEscaped"` // windows
+	Image            json.RawMessage `json:"Image"`
+	Volumes          json.RawMessage `json:"Volumes"` // anonymous-volume placeholders
+	WorkingDir       json.RawMessage `json:"WorkingDir"`
+	Entrypoint       json.RawMessage `json:"Entrypoint"`
+	NetworkDisabled  json.RawMessage `json:"NetworkDisabled"`
+	MacAddress       json.RawMessage `json:"MacAddress"`
+	OnBuild          json.RawMessage `json:"OnBuild"`
+	Labels           json.RawMessage `json:"Labels"`
+	StopSignal       json.RawMessage `json:"StopSignal"`
+	StopTimeout      json.RawMessage `json:"StopTimeout"`
+	Shell            json.RawMessage `json:"Shell"`
+	NetworkingConfig json.RawMessage `json:"NetworkingConfig"`
+	// podman libpod additions
+	Name json.RawMessage `json:"Name"` // libpod allows Name in body (in addition to ?name=)
 }
 
-// containerExecBody is the partial shape of POST containers/{id}/exec.
-// The only field we inspect is Privileged: docker exec grants the
-// supplied capability set to the exec process independent of the
-// parent container's HostConfig.Privileged, so an agent that creates
-// a non-privileged container can otherwise exec into it with
-// Privileged: true and bypass the create-time deny. Cmd, Env, User,
-// WorkingDir, etc. are forwarded unmodified — they affect what runs
-// inside the (already-isolated) container, not the host.
+// containerExecBody is the explicit allowlist for POST
+// containers/{id}/exec. Privileged is INSPECTED (cycle-2 bypass
+// fix); everything else is admitted as opaque — the exec body
+// describes what to run INSIDE the (already-isolated) container.
 type containerExecBody struct {
+	// INSPECTED.
 	Privileged bool `json:"Privileged"`
+
+	// FORWARDED.
+	AttachStdin  json.RawMessage `json:"AttachStdin"`
+	AttachStdout json.RawMessage `json:"AttachStdout"`
+	AttachStderr json.RawMessage `json:"AttachStderr"`
+	DetachKeys   json.RawMessage `json:"DetachKeys"`
+	Tty          json.RawMessage `json:"Tty"`
+	Env          json.RawMessage `json:"Env"`
+	Cmd          json.RawMessage `json:"Cmd"`
+	User         json.RawMessage `json:"User"`
+	WorkingDir   json.RawMessage `json:"WorkingDir"`
+	ConsoleSize  json.RawMessage `json:"ConsoleSize"`
 }
 
-// inspectCreate parses body as a containers/create request and applies
-// the HostConfig policy. body must be the entire request body; on
-// success the caller restores r.Body before forwarding.
+// inspectCreate parses body as a containers/create request and
+// applies the HostConfig policy. Two-stage parse: first the
+// top-level body with DisallowUnknownFields (rejects unknown
+// top-level fields), then — if HostConfig is present — the
+// HostConfig with DisallowUnknownFields too.
+//
+// The two-stage parse exists because the JSON for HostConfig is
+// nested. A flat single-pass parser would accept ANY shape inside
+// HostConfig if the top-level admits HostConfig as RawMessage. The
+// second pass is where the per-field allowlist actually fires.
 func (p *Proxy) inspectCreate(body []byte) policyDecision {
 	if len(bytes.TrimSpace(body)) == 0 {
-		// An empty body is malformed for containers/create — even a
-		// minimal request needs at least {"Image":"..."}. Per the
-		// "malformed JSON returns 400" AC, deny.
 		return denyDecision(http.StatusBadRequest,
 			"malformed_body:empty",
 			"containers/create request body is empty")
 	}
 
 	var req containerCreateBody
-	dec := json.NewDecoder(bytes.NewReader(body))
-	if err := dec.Decode(&req); err != nil {
-		return denyDecision(http.StatusBadRequest,
-			"malformed_body:"+truncateForReason(err.Error()),
-			"containers/create body is not valid JSON")
+	if dec := decodeStrict(body, &req); !dec.allow {
+		dec.reason = "create_top:" + dec.reason
+		dec.message = "containers/create top-level body: " + dec.message
+		return dec
 	}
 
-	if req.HostConfig == nil {
+	if req.HostConfig == nil || len(*req.HostConfig) == 0 {
 		// No HostConfig is harmless — a container without any host
 		// configuration cannot bind-mount or request privileges.
 		return allowDecision("policy:containers/create:no_host_config")
 	}
 
-	return p.checkHostConfig(req.HostConfig)
+	var hc hostConfig
+	if dec := decodeStrict(*req.HostConfig, &hc); !dec.allow {
+		dec.reason = "create_hostconfig:" + dec.reason
+		dec.message = "containers/create HostConfig: " + dec.message
+		return dec
+	}
+
+	return p.checkHostConfig(&hc)
+}
+
+// decodeStrict runs json.Decoder.DisallowUnknownFields against body
+// and returns a uniform policyDecision distinguishing
+// unknown-field (the schema-inversion deny we WANT to surface
+// loudly) from malformed-JSON (the original cycle-2 "400 on bad
+// body" path). The reason and message strings are general-purpose;
+// callers prefix them with an endpoint-specific tag so the audit
+// log makes the source endpoint clear.
+func decodeStrict(body []byte, dst any) policyDecision {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "unknown field") {
+			return denyDecision(http.StatusForbidden,
+				"unknown_field:"+truncateForReason(msg),
+				"body contains a field not in the proxy's allowlist ("+truncateForReason(msg)+")")
+		}
+		return denyDecision(http.StatusBadRequest,
+			"malformed_body:"+truncateForReason(msg),
+			"body is not valid JSON")
+	}
+	return allowDecision("decode_ok")
 }
 
 // checkHostConfig walks the parsed HostConfig and returns the first
@@ -402,55 +563,82 @@ func (p *Proxy) checkOneResourceCap(
 // the cap check runs in update-context mode (absent fields allowed,
 // present fields must be within bounds).
 //
-// This closes the bypass where an agent creates a container with
-// Memory=4G (within cap) and then POSTs an update with Memory=0 to
-// remove the cap (#2326 round 2 review-security).
+// Cycle 5: also runs with DisallowUnknownFields, so the same
+// hostConfig allowlist constrains which UpdateConfig fields the
+// agent may set. A previously-unknown HostConfig field cannot be
+// smuggled through an update.
 func (p *Proxy) inspectUpdate(body []byte) policyDecision {
 	if len(bytes.TrimSpace(body)) == 0 {
-		// An empty update body is a no-op upstream — forward it. The
-		// upstream will return 200 with no state change.
+		// An empty update body is a no-op upstream — forward it.
 		return allowDecision("policy:containers/update:empty")
 	}
 	var hc hostConfig
-	dec := json.NewDecoder(bytes.NewReader(body))
-	if err := dec.Decode(&hc); err != nil {
-		return denyDecision(http.StatusBadRequest,
-			"malformed_body:"+truncateForReason(err.Error()),
-			"containers/update body is not valid JSON")
+	if dec := decodeStrict(body, &hc); !dec.allow {
+		dec.reason = "update:" + dec.reason
+		dec.message = "containers/update: " + dec.message
+		return dec
 	}
 	return p.checkResourceCaps(&hc, capContextUpdate)
 }
 
-// volumeCreateBody is the partial shape of POST volumes/create. We
-// inspect Driver and DriverOpts to close the cycle-4 round-4
-// review-security CRITICAL #1: the `local` driver with DriverOpts
-// {type=none, device=/host/path, o=bind} creates a named volume that
-// is functionally a host bind, then a follow-up containers/create
-// references the volume by name and bindSource() skips the
-// host-bind check (no leading slash).
+// volumeCreateBody is the explicit allowlist for POST volumes/create.
+// Driver + DriverOpts are INSPECTED (cycle-4 finding #1 fix); Name
+// and Labels are FORWARDED. ClusterVolumeSpec is admitted opaque for
+// swarm-mode requests we are not policy-relevant for.
 type volumeCreateBody struct {
-	Name       string            `json:"Name"`
-	Driver     string            `json:"Driver"`
-	DriverOpts map[string]string `json:"DriverOpts"`
+	Name       string            `json:"Name"`       // INSPECTED (audit log only; no policy)
+	Driver     string            `json:"Driver"`     // INSPECTED — deny local + opts
+	DriverOpts map[string]string `json:"DriverOpts"` // INSPECTED with Driver
+
+	// FORWARDED.
+	Labels            json.RawMessage `json:"Labels"`
+	ClusterVolumeSpec json.RawMessage `json:"ClusterVolumeSpec"`
+}
+
+// networkCreateBody is the explicit allowlist for POST
+// networks/create. None of the fields are currently INSPECTED — the
+// network-mode escape lives on HostConfig.NetworkMode of a container
+// (already checked), not on the network definition itself. The
+// inversion exists purely so a future docker-API addition cannot
+// silently introduce an escape via networks/create.
+type networkCreateBody struct {
+	Name           json.RawMessage `json:"Name"`
+	CheckDuplicate json.RawMessage `json:"CheckDuplicate"`
+	Driver         json.RawMessage `json:"Driver"`
+	Scope          json.RawMessage `json:"Scope"`
+	EnableIPv6     json.RawMessage `json:"EnableIPv6"`
+	IPAM           json.RawMessage `json:"IPAM"`
+	Internal       json.RawMessage `json:"Internal"`
+	Attachable     json.RawMessage `json:"Attachable"`
+	Ingress        json.RawMessage `json:"Ingress"`
+	ConfigFrom     json.RawMessage `json:"ConfigFrom"`
+	ConfigOnly     json.RawMessage `json:"ConfigOnly"`
+	Options        json.RawMessage `json:"Options"`
+	Labels         json.RawMessage `json:"Labels"`
+	// podman libpod additions
+	ID                json.RawMessage `json:"id"`
+	Created           json.RawMessage `json:"created"`
+	NetworkInterface  json.RawMessage `json:"network_interface"`
+	Subnets           json.RawMessage `json:"subnets"`
+	IPv6Enabled       json.RawMessage `json:"ipv6_enabled"`
+	DNSEnabled        json.RawMessage `json:"dns_enabled"`
+	Routes            json.RawMessage `json:"routes"`
+	NetworkDNSServers json.RawMessage `json:"network_dns_servers"`
 }
 
 // inspectVolumeCreate parses body as a volumes/create request and
-// rejects any DriverOpts on the local driver (the only mechanism we
-// have seen this used as a bind-mount-in-disguise). Coordinator
-// directive cycle 5: "lean deny entirely — local-driver bind-volumes
-// are an obscure workflow and not worth admitting."
+// rejects any DriverOpts on the local driver. Cycle 5: also runs
+// with DisallowUnknownFields so unknown volumes/create fields
+// reject.
 func (p *Proxy) inspectVolumeCreate(body []byte) policyDecision {
 	if len(bytes.TrimSpace(body)) == 0 {
-		// Empty body — podman will produce an anonymous volume with
-		// default driver. Safe; forward.
 		return allowDecision("policy:volumes/create:empty")
 	}
 	var req volumeCreateBody
-	dec := json.NewDecoder(bytes.NewReader(body))
-	if err := dec.Decode(&req); err != nil {
-		return denyDecision(http.StatusBadRequest,
-			"malformed_body:"+truncateForReason(err.Error()),
-			"volumes/create body is not valid JSON")
+	if dec := decodeStrict(body, &req); !dec.allow {
+		dec.reason = "volumes_create:" + dec.reason
+		dec.message = "volumes/create: " + dec.message
+		return dec
 	}
 	driver := strings.ToLower(req.Driver)
 	if driver == "local" && len(req.DriverOpts) > 0 {
@@ -461,6 +649,25 @@ func (p *Proxy) inspectVolumeCreate(body []byte) policyDecision {
 	return allowDecision("policy:volumes/create:ok")
 }
 
+// inspectNetworkCreate parses body as a networks/create request and
+// rejects unknown fields. No fields are currently INSPECTED — the
+// network-mode escape lives on HostConfig.NetworkMode of a
+// container, not on the network definition. The schema-inversion
+// exists purely to lock networks/create down so a future docker-API
+// field cannot silently introduce an escape via this endpoint.
+func (p *Proxy) inspectNetworkCreate(body []byte) policyDecision {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return allowDecision("policy:networks/create:empty")
+	}
+	var req networkCreateBody
+	if dec := decodeStrict(body, &req); !dec.allow {
+		dec.reason = "networks_create:" + dec.reason
+		dec.message = "networks/create: " + dec.message
+		return dec
+	}
+	return allowDecision("policy:networks/create:ok")
+}
+
 // inspectExec parses body as a containers/{id}/exec request and
 // rejects Privileged: true. The exec body has its own Privileged
 // field that grants additional capabilities to the exec process
@@ -468,16 +675,13 @@ func (p *Proxy) inspectVolumeCreate(body []byte) policyDecision {
 // create-time deny does not cover it.
 func (p *Proxy) inspectExec(body []byte) policyDecision {
 	if len(bytes.TrimSpace(body)) == 0 {
-		// An exec body of {} is valid (defaults). An empty body is
-		// arguable but harmless — forward and let the upstream decide.
 		return allowDecision("policy:containers/exec:empty")
 	}
 	var req containerExecBody
-	dec := json.NewDecoder(bytes.NewReader(body))
-	if err := dec.Decode(&req); err != nil {
-		return denyDecision(http.StatusBadRequest,
-			"malformed_body:"+truncateForReason(err.Error()),
-			"containers/exec body is not valid JSON")
+	if dec := decodeStrict(body, &req); !dec.allow {
+		dec.reason = "exec:" + dec.reason
+		dec.message = "containers/exec: " + dec.message
+		return dec
 	}
 	if req.Privileged {
 		return denyDecision(http.StatusForbidden,

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -409,37 +409,118 @@ func bindSource(bind string) string {
 
 // isAllowedBindSource reports whether src is permitted as a host bind
 // source given the configured prefix allowlist. A path is allowed iff,
-// after filepath.Clean, it equals an entry exactly or starts with
-// entry + "/". The substring trap — "/srv" allowing "/srv-other" — is
-// closed by requiring the separator.
+// after BOTH lexical cleanup (filepath.Clean, which collapses ".."
+// and double slashes) AND symlink resolution (filepath.EvalSymlinks,
+// which follows every symlink in the chain to its canonical target),
+// the resolved source equals an allowlist entry exactly or starts
+// with entry + "/". The substring trap — "/srv" allowing
+// "/srv-other" — is closed by requiring the separator.
 //
 // The special entry "/" allows every absolute path; it exists so the
 // security test suite can run a negative-control case proving the
 // positive tests are not no-ops.
+//
+// # Symlink resolution
+//
+// Pre-cycle-4 (#2326 round 3), the check was purely lexical: an
+// agent with write access to its worktree could create a symlink at
+// (allowed-prefix)/key → /etc/passwd, bind it, and the kernel's
+// mount(2) would follow the symlink and expose the host file. The
+// fix is to resolve symlinks on BOTH the source and the allowlist
+// entries so the prefix comparison is between canonical paths.
+//
+// EvalSymlinks errors on paths that do not exist, on broken symlink
+// chains, and on EACCES. In every case the source is not a usable
+// bind target and the proxy denies. This is intentionally stricter
+// than docker, which forwards an unresolved source to runc and lets
+// runc error — the proxy prefers to give the agent an actionable 4xx
+// over surfacing a runc internal error, and a non-existent source on
+// a bind request is suspect anyway.
+//
+// # Residual TOCTOU
+//
+// EvalSymlinks runs at policy time, mount(2) runs in podman/runc
+// later. Between those two moments the agent COULD swap a resolved-
+// safe path for a symlink pointing somewhere dangerous. The window
+// is small and the bind point inside the container is fixed at
+// create time, but the residual risk is real. Acceptable for v1 on
+// the basis that:
+//
+//   - Closing the TOCTOU window requires either kernel-level fs
+//     freezing primitives (not portable) or filesystem snapshots
+//     (heavyweight, out of scope for a Step-1 library PR).
+//   - The agent process is otherwise sandboxed; arming the race in
+//     the first place still requires write access to a path inside
+//     an allowed prefix, which the worktree-only bind allowlist
+//     already restricts.
+//   - Defence-in-depth at the sandbox layer (bwrap / sandbox-exec)
+//     remains in front — the proxy is one link in a chain, not the
+//     sole boundary.
+//
+// Step 3 and onwards should consider whether the per-session
+// scratch dir (which is the agent's only realistic vector for
+// creating a malicious symlink) should be mounted with `nosymfollow`
+// or similar where the kernel/platform supports it. Out of scope
+// for this PR but worth a comment in #2317 when Step 3 lands.
 func (p *Proxy) isAllowedBindSource(src string) bool {
 	if src == "" {
 		return false
 	}
 	if !strings.HasPrefix(src, "/") {
+		// Relative paths are never allowed — they cannot be validated
+		// against an absolute-path allowlist, and docker's Binds spec
+		// requires absolute sources anyway. Defence-in-depth: reject
+		// rather than relying on docker to reject downstream.
 		return false
 	}
-	clean := filepath.Clean(src)
+	canonicalSrc, ok := canonicalisePath(src)
+	if !ok {
+		return false
+	}
 	for _, raw := range p.cfg.AllowedBindSources {
 		if raw == "" {
 			continue
 		}
+		// Resolve the allowlist entry too — if the host's TMPDIR (or
+		// any other path in the allowlist) goes through a symlink
+		// like /tmp→/private/tmp on macOS, the source's canonical
+		// form will only prefix-match the allowlist's canonical form.
+		// Fall back to lexical when the entry does not currently
+		// exist so a yet-to-be-created scratch dir does not silently
+		// deny-all.
 		allowed := filepath.Clean(raw)
+		if resolved, ok := canonicalisePath(raw); ok {
+			allowed = resolved
+		}
 		if allowed == "/" {
 			return true
 		}
-		if clean == allowed {
+		if canonicalSrc == allowed {
 			return true
 		}
-		if strings.HasPrefix(clean, allowed+"/") {
+		if strings.HasPrefix(canonicalSrc, allowed+"/") {
 			return true
 		}
 	}
 	return false
+}
+
+// canonicalisePath returns the canonical (lexically cleaned + symlink-
+// resolved) form of p, or ("", false) if p is not a usable path on
+// the current host — does not exist, is a broken symlink chain, or
+// is otherwise unreachable. Defensive about every error mode of
+// filepath.EvalSymlinks because the call sites depend on a strict
+// canonical form for the prefix-match security check.
+func canonicalisePath(p string) (string, bool) {
+	if p == "" {
+		return "", false
+	}
+	cleaned := filepath.Clean(p)
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", false
+	}
+	return resolved, true
 }
 
 // firstDisallowedCap returns the first CapAdd entry that is not in the

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -44,14 +44,18 @@ func denyDecision(status int, reason, message string) policyDecision {
 }
 
 // hostConfig is the subset of HostConfig the proxy parses out of
-// containers/create. Every field listed in #2317 §4 (the threat table)
-// must appear here; fields not present in this struct are silently
-// ignored by the parser (json.Decoder skips unknown keys by default).
+// containers/create (and the partial-HostConfig shape that
+// containers/{id}/update also accepts). Every field listed in #2317 §4
+// (the threat table) must appear here. Fields not present in this
+// struct are silently ignored by the parser (json.Decoder skips
+// unknown keys by default) and forwarded unmodified.
 //
 // Pointer types are used where the difference between "field absent"
-// and "field explicitly set to zero/false" matters — Memory and
-// CpuQuota in particular, where an explicit 0 means "unbounded" in
-// docker's semantics and should NOT be capped.
+// and "field explicitly set to zero" matters — Memory, CpuQuota, and
+// NanoCpus in particular. In docker semantics an explicit 0 means
+// "unbounded", so the policy must treat 0 differently from a missing
+// field (review-security PR #2326 round 2: 0 was previously a
+// drive-through bypass of the configured cap).
 type hostConfig struct {
 	Binds       []string          `json:"Binds"`
 	Mounts      []hostConfigMount `json:"Mounts"`
@@ -63,8 +67,10 @@ type hostConfig struct {
 	UTSMode     string            `json:"UTSMode"`
 	UsernsMode  string            `json:"UsernsMode"`
 	Devices     []json.RawMessage `json:"Devices"`
+	SecurityOpt []string          `json:"SecurityOpt"`
 	Memory      *int64            `json:"Memory"`
 	CpuQuota    *int64            `json:"CpuQuota"`
+	NanoCpus    *int64            `json:"NanoCpus"`
 }
 
 // hostConfigMount mirrors a docker HostConfig.Mounts entry. Only the
@@ -80,6 +86,18 @@ type hostConfigMount struct {
 // forwarded unmodified.
 type containerCreateBody struct {
 	HostConfig *hostConfig `json:"HostConfig"`
+}
+
+// containerExecBody is the partial shape of POST containers/{id}/exec.
+// The only field we inspect is Privileged: docker exec grants the
+// supplied capability set to the exec process independent of the
+// parent container's HostConfig.Privileged, so an agent that creates
+// a non-privileged container can otherwise exec into it with
+// Privileged: true and bypass the create-time deny. Cmd, Env, User,
+// WorkingDir, etc. are forwarded unmodified — they affect what runs
+// inside the (already-isolated) container, not the host.
+type containerExecBody struct {
+	Privileged bool `json:"Privileged"`
 }
 
 // inspectCreate parses body as a containers/create request and applies
@@ -199,22 +217,149 @@ func (p *Proxy) checkHostConfig(hc *hostConfig) policyDecision {
 			"HostConfig.Devices is not permitted")
 	}
 
-	// Resource caps. Memory=0 in docker means "unlimited" — but our
-	// policy treats it as "no value set" and lets it through. The
-	// upper bound only fires when the agent explicitly requested a
-	// value above the cap.
-	if p.cfg.MaxMemoryBytes > 0 && hc.Memory != nil && *hc.Memory > p.cfg.MaxMemoryBytes {
+	// SecurityOpt entries are default-deny: any entry not present in
+	// AllowedSecurityOpts is rejected. This closes the
+	// seccomp=unconfined / apparmor=unconfined / no-new-privileges=false /
+	// label=disable class of escapes; allowlist entries one by one when
+	// a workflow genuinely needs them.
+	if bad, ok := p.firstDisallowedSecurityOpt(hc.SecurityOpt); !ok {
 		return denyDecision(http.StatusForbidden,
-			"memory_over_cap",
-			fmt.Sprintf("HostConfig.Memory=%d exceeds cap %d", *hc.Memory, p.cfg.MaxMemoryBytes))
+			"security_opt:"+truncateForReason(bad),
+			fmt.Sprintf("HostConfig.SecurityOpt entry %q is not in the allowlist", bad))
 	}
-	if p.cfg.MaxCPUQuota > 0 && hc.CpuQuota != nil && *hc.CpuQuota > p.cfg.MaxCPUQuota {
-		return denyDecision(http.StatusForbidden,
-			"cpu_quota_over_cap",
-			fmt.Sprintf("HostConfig.CpuQuota=%d exceeds cap %d", *hc.CpuQuota, p.cfg.MaxCPUQuota))
+
+	// Resource caps. Strict mode: when a cap is configured the
+	// corresponding field MUST be set to a positive value within the
+	// cap. Absent / zero / negative all deny so that docker's "0 means
+	// unlimited" semantic cannot be used to bypass the cap.
+	if dec := p.checkResourceCaps(hc, capContextCreate); !dec.allow {
+		return dec
 	}
 
 	return allowDecision("policy:containers/create:ok")
+}
+
+// capContext distinguishes the two body shapes that resource-cap
+// checks apply to. The semantics differ in one place: on create, an
+// absent field is a deny (the agent must declare an explicit value
+// within the cap); on update, an absent field is allowed (the field
+// is simply not being updated).
+type capContext int
+
+const (
+	capContextCreate capContext = iota
+	capContextUpdate
+)
+
+// checkResourceCaps validates Memory, CpuQuota, and NanoCpus against
+// the configured caps. Called from both the containers/create body
+// inspector and the containers/{id}/update body inspector; the ctx
+// flag toggles the absent-field policy between the two.
+func (p *Proxy) checkResourceCaps(hc *hostConfig, ctx capContext) policyDecision {
+	if dec := p.checkOneResourceCap(
+		"Memory", hc.Memory, p.cfg.MaxMemoryBytes, ctx,
+		"memory_required", "memory_nonpositive", "memory_over_cap",
+	); !dec.allow {
+		return dec
+	}
+	if dec := p.checkOneResourceCap(
+		"CpuQuota", hc.CpuQuota, p.cfg.MaxCPUQuota, ctx,
+		"cpu_quota_required", "cpu_quota_nonpositive", "cpu_quota_over_cap",
+	); !dec.allow {
+		return dec
+	}
+	if dec := p.checkOneResourceCap(
+		"NanoCpus", hc.NanoCpus, p.cfg.MaxNanoCpus, ctx,
+		"nano_cpus_required", "nano_cpus_nonpositive", "nano_cpus_over_cap",
+	); !dec.allow {
+		return dec
+	}
+	return allowDecision("policy:resource_caps:ok")
+}
+
+// checkOneResourceCap is the per-field cap checker. The three reason
+// strings are passed in so the audit log distinguishes which cap
+// fired and why — "memory_required" vs "memory_nonpositive" vs
+// "memory_over_cap".
+func (p *Proxy) checkOneResourceCap(
+	fieldName string, value *int64, cap int64, ctx capContext,
+	reasonRequired, reasonNonpositive, reasonOverCap string,
+) policyDecision {
+	if cap <= 0 {
+		// Cap not configured — no enforcement.
+		return allowDecision("policy:resource_cap_disabled")
+	}
+	if value == nil {
+		if ctx == capContextCreate {
+			return denyDecision(http.StatusForbidden,
+				reasonRequired,
+				fmt.Sprintf("HostConfig.%s is required when a cap is configured (set a positive value <= %d)", fieldName, cap))
+		}
+		// Update: absent field means "not changing this". Allow.
+		return allowDecision("policy:resource_cap_absent_in_update")
+	}
+	if *value <= 0 {
+		return denyDecision(http.StatusForbidden,
+			reasonNonpositive,
+			fmt.Sprintf("HostConfig.%s=%d is invalid (must be > 0; 0 means unlimited and would bypass the cap)", fieldName, *value))
+	}
+	if *value > cap {
+		return denyDecision(http.StatusForbidden,
+			reasonOverCap,
+			fmt.Sprintf("HostConfig.%s=%d exceeds cap %d", fieldName, *value, cap))
+	}
+	return allowDecision("policy:resource_cap_ok")
+}
+
+// inspectUpdate parses body as a containers/{id}/update request and
+// applies the resource-cap policy. Update bodies are a partial
+// HostConfig shape — only the fields being changed are present — so
+// the cap check runs in update-context mode (absent fields allowed,
+// present fields must be within bounds).
+//
+// This closes the bypass where an agent creates a container with
+// Memory=4G (within cap) and then POSTs an update with Memory=0 to
+// remove the cap (#2326 round 2 review-security).
+func (p *Proxy) inspectUpdate(body []byte) policyDecision {
+	if len(bytes.TrimSpace(body)) == 0 {
+		// An empty update body is a no-op upstream — forward it. The
+		// upstream will return 200 with no state change.
+		return allowDecision("policy:containers/update:empty")
+	}
+	var hc hostConfig
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&hc); err != nil {
+		return denyDecision(http.StatusBadRequest,
+			"malformed_body:"+truncateForReason(err.Error()),
+			"containers/update body is not valid JSON")
+	}
+	return p.checkResourceCaps(&hc, capContextUpdate)
+}
+
+// inspectExec parses body as a containers/{id}/exec request and
+// rejects Privileged: true. The exec body has its own Privileged
+// field that grants additional capabilities to the exec process
+// independent of the parent container's HostConfig.Privileged — the
+// create-time deny does not cover it.
+func (p *Proxy) inspectExec(body []byte) policyDecision {
+	if len(bytes.TrimSpace(body)) == 0 {
+		// An exec body of {} is valid (defaults). An empty body is
+		// arguable but harmless — forward and let the upstream decide.
+		return allowDecision("policy:containers/exec:empty")
+	}
+	var req containerExecBody
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&req); err != nil {
+		return denyDecision(http.StatusBadRequest,
+			"malformed_body:"+truncateForReason(err.Error()),
+			"containers/exec body is not valid JSON")
+	}
+	if req.Privileged {
+		return denyDecision(http.StatusForbidden,
+			"exec_privileged",
+			"containers/exec body has Privileged=true, which is not permitted (would bypass the create-time HostConfig.Privileged deny)")
+	}
+	return allowDecision("policy:containers/exec:ok")
 }
 
 // inspectArchive applies the path-prefix policy to PUT
@@ -308,6 +453,30 @@ func (p *Proxy) firstDisallowedCap(caps []string) (string, bool) {
 		}
 	}
 	return "", true
+}
+
+// firstDisallowedSecurityOpt returns the first SecurityOpt entry that
+// is not in AllowedSecurityOpts. Comparison is exact (case-sensitive,
+// no normalisation) because SecurityOpt values are docker-defined
+// strings whose exact form matters — "no-new-privileges:true" and
+// "no-new-privileges=true" are both valid but distinct, and an
+// allowlist entry should match exactly what the caller permits.
+func (p *Proxy) firstDisallowedSecurityOpt(opts []string) (string, bool) {
+	for _, o := range opts {
+		if !p.securityOptIsAllowed(o) {
+			return o, false
+		}
+	}
+	return "", true
+}
+
+func (p *Proxy) securityOptIsAllowed(opt string) bool {
+	for _, allowed := range p.cfg.AllowedSecurityOpts {
+		if opt == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Proxy) capIsAllowed(c string) bool {

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -1,0 +1,359 @@
+package podmanproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// policyDecision is the outcome of inspecting a request body or query.
+// allow is the only field that gates forwarding; status and reason are
+// only consumed when allow is false.
+type policyDecision struct {
+	allow  bool
+	status int    // HTTP status code to return when allow is false
+	reason string // structured reason string written to the audit log
+	// message is the human-readable text embedded in the JSON envelope
+	// returned to the client. When empty, reason is reused.
+	message string
+}
+
+// allowDecision returns a "forward upstream" decision with the supplied
+// audit reason. Helper to keep policy callers readable.
+func allowDecision(reason string) policyDecision {
+	return policyDecision{allow: true, reason: reason}
+}
+
+// denyDecision returns a deny decision. The message is the friendly
+// text shown to the client; the reason is the structured audit token.
+func denyDecision(status int, reason, message string) policyDecision {
+	if message == "" {
+		message = reason
+	}
+	return policyDecision{
+		allow:   false,
+		status:  status,
+		reason:  reason,
+		message: message,
+	}
+}
+
+// hostConfig is the subset of HostConfig the proxy parses out of
+// containers/create. Every field listed in #2317 §4 (the threat table)
+// must appear here; fields not present in this struct are silently
+// ignored by the parser (json.Decoder skips unknown keys by default).
+//
+// Pointer types are used where the difference between "field absent"
+// and "field explicitly set to zero/false" matters — Memory and
+// CpuQuota in particular, where an explicit 0 means "unbounded" in
+// docker's semantics and should NOT be capped.
+type hostConfig struct {
+	Binds       []string          `json:"Binds"`
+	Mounts      []hostConfigMount `json:"Mounts"`
+	Privileged  bool              `json:"Privileged"`
+	CapAdd      []string          `json:"CapAdd"`
+	NetworkMode string            `json:"NetworkMode"`
+	PidMode     string            `json:"PidMode"`
+	IpcMode     string            `json:"IpcMode"`
+	UTSMode     string            `json:"UTSMode"`
+	UsernsMode  string            `json:"UsernsMode"`
+	Devices     []json.RawMessage `json:"Devices"`
+	Memory      *int64            `json:"Memory"`
+	CpuQuota    *int64            `json:"CpuQuota"`
+}
+
+// hostConfigMount mirrors a docker HostConfig.Mounts entry. Only the
+// fields needed for the bind-source check are extracted.
+type hostConfigMount struct {
+	Type   string `json:"Type"`
+	Source string `json:"Source"`
+}
+
+// containerCreateBody is the top-level shape of POST containers/create.
+// We extract only HostConfig — the other fields (Image, Cmd, Env, Labels,
+// WorkingDir, NetworkingConfig, etc.) carry no policy concerns and are
+// forwarded unmodified.
+type containerCreateBody struct {
+	HostConfig *hostConfig `json:"HostConfig"`
+}
+
+// inspectCreate parses body as a containers/create request and applies
+// the HostConfig policy. body must be the entire request body; on
+// success the caller restores r.Body before forwarding.
+func (p *Proxy) inspectCreate(body []byte) policyDecision {
+	if len(bytes.TrimSpace(body)) == 0 {
+		// An empty body is malformed for containers/create — even a
+		// minimal request needs at least {"Image":"..."}. Per the
+		// "malformed JSON returns 400" AC, deny.
+		return denyDecision(http.StatusBadRequest,
+			"malformed_body:empty",
+			"containers/create request body is empty")
+	}
+
+	var req containerCreateBody
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&req); err != nil {
+		return denyDecision(http.StatusBadRequest,
+			"malformed_body:"+truncateForReason(err.Error()),
+			"containers/create body is not valid JSON")
+	}
+
+	if req.HostConfig == nil {
+		// No HostConfig is harmless — a container without any host
+		// configuration cannot bind-mount or request privileges.
+		return allowDecision("policy:containers/create:no_host_config")
+	}
+
+	return p.checkHostConfig(req.HostConfig)
+}
+
+// checkHostConfig walks the parsed HostConfig and returns the first
+// policy violation. Field order in this function is significant: the
+// most dangerous fields (host binds, privileged) are checked first so
+// the audit reason names the worst violation when multiple are present.
+func (p *Proxy) checkHostConfig(hc *hostConfig) policyDecision {
+	// Host bind sources (legacy Binds slice).
+	for _, b := range hc.Binds {
+		src := bindSource(b)
+		if src == "" {
+			// A volume name (no leading '/') is not a host bind.
+			continue
+		}
+		if !p.isAllowedBindSource(src) {
+			return denyDecision(http.StatusForbidden,
+				"host_bind:"+truncateForReason(src),
+				fmt.Sprintf("host bind source %q is not in the allowlist", src))
+		}
+	}
+
+	// Host bind sources (newer Mounts slice).
+	for _, m := range hc.Mounts {
+		if !strings.EqualFold(m.Type, "bind") {
+			// "volume", "tmpfs", "npipe", "image" do not read host
+			// files. (npipe is Windows-only; we let the upstream
+			// reject it on Linux/Darwin.)
+			continue
+		}
+		if !p.isAllowedBindSource(m.Source) {
+			return denyDecision(http.StatusForbidden,
+				"mount_bind:"+truncateForReason(m.Source),
+				fmt.Sprintf("mount source %q is not in the allowlist", m.Source))
+		}
+	}
+
+	// Privileged is a single bit. Any "true" is a hard reject.
+	if hc.Privileged {
+		return denyDecision(http.StatusForbidden,
+			"privileged",
+			"HostConfig.Privileged is not permitted")
+	}
+
+	// CapAdd — every entry must be in the allowlist. CapDrop is
+	// unrestricted (dropping capabilities is always safer).
+	if len(hc.CapAdd) > 0 {
+		if cap, ok := p.firstDisallowedCap(hc.CapAdd); !ok {
+			return denyDecision(http.StatusForbidden,
+				"cap_add:"+truncateForReason(cap),
+				fmt.Sprintf("HostConfig.CapAdd entry %q is not in the allowlist", cap))
+		}
+	}
+
+	// Host namespaces — any *Mode = "host" is a hard reject.
+	if mode := strings.ToLower(hc.NetworkMode); mode == "host" {
+		return denyDecision(http.StatusForbidden,
+			"network_mode_host",
+			"HostConfig.NetworkMode=host is not permitted")
+	}
+	if mode := strings.ToLower(hc.PidMode); mode == "host" {
+		return denyDecision(http.StatusForbidden,
+			"pid_mode_host",
+			"HostConfig.PidMode=host is not permitted")
+	}
+	if mode := strings.ToLower(hc.IpcMode); mode == "host" {
+		return denyDecision(http.StatusForbidden,
+			"ipc_mode_host",
+			"HostConfig.IpcMode=host is not permitted")
+	}
+	if mode := strings.ToLower(hc.UTSMode); mode == "host" {
+		return denyDecision(http.StatusForbidden,
+			"uts_mode_host",
+			"HostConfig.UTSMode=host is not permitted")
+	}
+	if mode := strings.ToLower(hc.UsernsMode); mode == "host" {
+		return denyDecision(http.StatusForbidden,
+			"userns_mode_host",
+			"HostConfig.UsernsMode=host is not permitted")
+	}
+
+	// Device passthrough — any non-empty Devices is a hard reject.
+	// A future enhancement could allowlist e.g. /dev/null; for now
+	// we are strictly default-deny.
+	if len(hc.Devices) > 0 {
+		return denyDecision(http.StatusForbidden,
+			"devices_nonempty",
+			"HostConfig.Devices is not permitted")
+	}
+
+	// Resource caps. Memory=0 in docker means "unlimited" — but our
+	// policy treats it as "no value set" and lets it through. The
+	// upper bound only fires when the agent explicitly requested a
+	// value above the cap.
+	if p.cfg.MaxMemoryBytes > 0 && hc.Memory != nil && *hc.Memory > p.cfg.MaxMemoryBytes {
+		return denyDecision(http.StatusForbidden,
+			"memory_over_cap",
+			fmt.Sprintf("HostConfig.Memory=%d exceeds cap %d", *hc.Memory, p.cfg.MaxMemoryBytes))
+	}
+	if p.cfg.MaxCPUQuota > 0 && hc.CpuQuota != nil && *hc.CpuQuota > p.cfg.MaxCPUQuota {
+		return denyDecision(http.StatusForbidden,
+			"cpu_quota_over_cap",
+			fmt.Sprintf("HostConfig.CpuQuota=%d exceeds cap %d", *hc.CpuQuota, p.cfg.MaxCPUQuota))
+	}
+
+	return allowDecision("policy:containers/create:ok")
+}
+
+// inspectArchive applies the path-prefix policy to PUT
+// containers/{id}/archive. The dangerous field is the `path` query
+// parameter — the in-container destination. Defence-in-depth: even
+// though Binds policy already filters mount sources, restricting the
+// archive write path stops an agent that finds a container with a
+// system mount from using `podman cp` to clobber host files.
+func (p *Proxy) inspectArchive(r *http.Request) policyDecision {
+	path := r.URL.Query().Get("path")
+	if path == "" {
+		return denyDecision(http.StatusBadRequest,
+			"archive_missing_path",
+			"PUT /containers/{id}/archive requires a non-empty `path` query parameter")
+	}
+	if !p.isAllowedBindSource(path) {
+		return denyDecision(http.StatusForbidden,
+			"archive_path:"+truncateForReason(path),
+			fmt.Sprintf("archive path %q is not in the allowlist", path))
+	}
+	return allowDecision("policy:containers/archive:ok")
+}
+
+// bindSource extracts the host source from a HostConfig.Binds entry of
+// the form "src:dst[:options]". If the source has no leading '/' it is
+// treated as a named volume and bindSource returns "" so the caller
+// skips the host-path check.
+//
+// Edge cases:
+//   - "src::ro" (empty dst) — still extract src; the upstream will
+//     reject; we err on the side of inspecting the source anyway.
+//   - "src" alone (no colon) — invalid bind syntax; return "" so the
+//     upstream returns its own malformed-bind error and we don't
+//     fabricate a security decision for something podman will reject.
+func bindSource(bind string) string {
+	idx := strings.Index(bind, ":")
+	if idx < 0 {
+		return ""
+	}
+	src := bind[:idx]
+	if !strings.HasPrefix(src, "/") {
+		// Named volume, not a host path.
+		return ""
+	}
+	return src
+}
+
+// isAllowedBindSource reports whether src is permitted as a host bind
+// source given the configured prefix allowlist. A path is allowed iff,
+// after filepath.Clean, it equals an entry exactly or starts with
+// entry + "/". The substring trap — "/srv" allowing "/srv-other" — is
+// closed by requiring the separator.
+//
+// The special entry "/" allows every absolute path; it exists so the
+// security test suite can run a negative-control case proving the
+// positive tests are not no-ops.
+func (p *Proxy) isAllowedBindSource(src string) bool {
+	if src == "" {
+		return false
+	}
+	if !strings.HasPrefix(src, "/") {
+		return false
+	}
+	clean := filepath.Clean(src)
+	for _, raw := range p.cfg.AllowedBindSources {
+		if raw == "" {
+			continue
+		}
+		allowed := filepath.Clean(raw)
+		if allowed == "/" {
+			return true
+		}
+		if clean == allowed {
+			return true
+		}
+		if strings.HasPrefix(clean, allowed+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// firstDisallowedCap returns the first CapAdd entry that is not in the
+// allowlist, or ("", true) if every entry is permitted. The comparison
+// is case-insensitive and tolerant of the leading "CAP_" prefix on
+// either side so callers can pass either form.
+func (p *Proxy) firstDisallowedCap(caps []string) (string, bool) {
+	for _, c := range caps {
+		if !p.capIsAllowed(c) {
+			return c, false
+		}
+	}
+	return "", true
+}
+
+func (p *Proxy) capIsAllowed(c string) bool {
+	want := strings.ToUpper(strings.TrimPrefix(strings.ToUpper(c), "CAP_"))
+	for _, allowed := range p.cfg.AllowedCaps {
+		got := strings.ToUpper(strings.TrimPrefix(strings.ToUpper(allowed), "CAP_"))
+		if want == got {
+			return true
+		}
+	}
+	return false
+}
+
+// truncateForReason bounds a free-form string before splicing it into
+// the audit reason field. Bind sources and error messages can be
+// arbitrarily long; the audit log should not blow up to MiBs per line
+// because the attacker padded a path.
+func truncateForReason(s string) string {
+	const max = 200
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// readBoundedBody reads the request body into memory subject to
+// p.cfg.MaxBodyBytes. It returns a decision when the body exceeds the
+// cap or another read error occurs; on success it returns the body
+// bytes and an allow decision so the caller can proceed.
+//
+// The error wrapping here uses *http.MaxBytesError so the caller can
+// distinguish "too large" (413) from other I/O failures (400).
+func (p *Proxy) readBoundedBody(w http.ResponseWriter, r *http.Request) ([]byte, policyDecision) {
+	reader := http.MaxBytesReader(w, r.Body, p.cfg.MaxBodyBytes)
+	defer r.Body.Close()
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			return nil, denyDecision(http.StatusRequestEntityTooLarge,
+				"body_too_large",
+				fmt.Sprintf("request body exceeds %d bytes", p.cfg.MaxBodyBytes))
+		}
+		return nil, denyDecision(http.StatusBadRequest,
+			"body_read_error",
+			"could not read request body")
+	}
+	return body, allowDecision("body_read_ok")
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -331,36 +331,53 @@ func (p *Proxy) checkHostConfig(hc *hostConfig) policyDecision {
 		}
 	}
 
-	// Host bind sources (newer Mounts slice).
+	// Host bind sources (newer Mounts slice). Cycle 6 closes the
+	// Type=glob bypass found by review-security: this loop now uses
+	// an explicit allowlist of Type values (case-SENSITIVE), not a
+	// deny-list. Anything outside the allowlist denies, including
+	// case variants ("BIND"), whitespace-padded values (" bind "),
+	// and the podman-specific Type="glob" that calls filepath.Glob
+	// on the host and creates a bind mount for every match.
+	//
+	// The allowlist is intentionally small. New Mount types added
+	// to docker/podman in the future are denied by default until
+	// they have been audited against the threat table and added
+	// here with a rationale comment.
 	for _, m := range hc.Mounts {
-		if strings.EqualFold(m.Type, "bind") {
+		switch m.Type {
+		case "bind":
+			// INSPECTED: Source must pass the bind-source allowlist
+			// + EvalSymlinks check.
 			if !p.isAllowedBindSource(m.Source) {
 				return denyDecision(http.StatusForbidden,
 					"mount_bind:"+truncateForReason(m.Source),
 					fmt.Sprintf("mount source %q is not in the allowlist", m.Source))
 			}
-			continue
-		}
-		if strings.EqualFold(m.Type, "volume") {
-			// Type=volume with an inline DriverConfig is the
-			// local-driver bind-volume escape: VolumeOptions.
-			// DriverConfig.{Name,Options} can specify a host path
-			// to bind-mount via the volume mechanism, bypassing the
-			// Type=bind allowlist check above. The conservative fix
-			// per the cycle-5 coordinator directive is to deny any
-			// VolumeOptions.DriverConfig at all — the legitimate
-			// "named volume managed by podman" case has no
-			// DriverConfig (uses the default driver settings).
+		case "volume":
+			// INSPECTED: presence of VolumeOptions.DriverConfig
+			// indicates the local-driver bind-volume escape; deny.
+			// Plain Type=volume with no DriverConfig is a podman-
+			// managed named volume — safe.
 			if m.VolumeOptions != nil && m.VolumeOptions.DriverConfig != nil {
 				return denyDecision(http.StatusForbidden,
 					"mount_volume_driver_config",
 					"Mounts entry of Type=volume with VolumeOptions.DriverConfig is not permitted (local-driver bind-volume escape; use a Type=bind Mount with an allowlisted Source instead)")
 			}
-			continue
+		case "tmpfs":
+			// In-memory, container-internal. No host-file access
+			// path. Safe; forward.
+		default:
+			// Cycle-6 review-security CRITICAL: Type="glob" calls
+			// filepath.Glob(Source) on the host and creates a bind
+			// mount for every matched path — bypassing the bind
+			// allowlist entirely. "image" / "npipe" / "" / case
+			// variants like "BIND" / whitespace-padded values — all
+			// fall here and deny. Allowing a new Type requires an
+			// audit and an explicit case branch above.
+			return denyDecision(http.StatusForbidden,
+				"mount_type_not_allowed:"+truncateForReason(m.Type),
+				fmt.Sprintf("Mounts entry Type=%q is not in the allowlist {bind, volume, tmpfs} (case-sensitive)", m.Type))
 		}
-		// "tmpfs" (in-memory, container-internal), "npipe"
-		// (Windows), "image" (image-volume): no host-file access
-		// path, forward unmodified.
 	}
 
 	// Privileged is a single bit. Any "true" is a hard reject.

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy.go
@@ -48,13 +48,42 @@ type Config struct {
 	// proxy normalises both ends of the comparison.
 	AllowedCaps []string
 
-	// MaxMemoryBytes is the inclusive upper bound for HostConfig.Memory.
-	// Zero disables the cap (any memory value passes).
+	// MaxMemoryBytes is the inclusive upper bound for HostConfig.Memory
+	// (and for the Memory field of a containers/{id}/update body). When
+	// non-zero the cap is enforced strictly: a containers/create body
+	// MUST specify a positive Memory <= cap, and any container update
+	// that sets Memory must keep it in the same range. Zero disables
+	// the cap entirely.
+	//
+	// The strict interpretation closes the docker-semantic bypass where
+	// Memory=0 means "unlimited" — if we only checked the > cap branch,
+	// the agent could exhaust host RAM by sending Memory: 0.
 	MaxMemoryBytes int64
 
 	// MaxCPUQuota is the inclusive upper bound for HostConfig.CpuQuota
-	// (CFS quota in microseconds). Zero disables the cap.
+	// (CFS quota in microseconds). Same strict semantics as
+	// MaxMemoryBytes: when non-zero, create requests must specify a
+	// positive CpuQuota within the cap and update requests must keep
+	// any CpuQuota change inside the cap. Zero disables the cap.
 	MaxCPUQuota int64
+
+	// MaxNanoCpus is the inclusive upper bound for HostConfig.NanoCpus
+	// (cores * 1e9). NanoCpus is the docker --cpus expression and is a
+	// fully orthogonal way to set a CPU cap from CpuQuota — capping
+	// CpuQuota alone leaves a bypass where the agent expresses the cap
+	// as NanoCpus instead. Same strict semantics as MaxCPUQuota. Zero
+	// disables the cap.
+	MaxNanoCpus int64
+
+	// AllowedSecurityOpts is the set of HostConfig.SecurityOpt entries
+	// that may appear on a containers/create body. Comparison is
+	// case-sensitive and matches the full entry string (e.g.
+	// "no-new-privileges=true" or "seccomp=/etc/foo.json"). Empty by
+	// default — any SecurityOpt entry is rejected unless explicitly
+	// allowlisted. The empty-default closes the seccomp=unconfined /
+	// apparmor=unconfined / no-new-privileges=false / label=disable
+	// class of escapes documented in #2317 §4.
+	AllowedSecurityOpts []string
 
 	// AuditWriter receives exactly one JSON line per accepted or
 	// rejected request. Nil silently drops audit events.

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy.go
@@ -1,0 +1,268 @@
+package podmanproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Config holds the proxy's runtime configuration. All public fields are
+// inputs; the proxy never mutates Config after NewProxy returns.
+type Config struct {
+	// ListenerPath is the absolute path of the Unix socket the proxy
+	// listens on. Required. The file is created by Serve and removed
+	// when Serve returns.
+	ListenerPath string
+
+	// UpstreamPath is the absolute path of the docker/podman Unix socket
+	// the proxy forwards to. Required. The file does not need to exist
+	// at NewProxy time — when it is missing, every request returns the
+	// friendly upstream-unavailable 503 envelope.
+	UpstreamPath string
+
+	// AllowedBindSources is the set of host path prefixes that may appear
+	// as the source side of a HostConfig.Bind, the Source side of a
+	// HostConfig.Mounts entry of Type "bind", or the `path` query on
+	// PUT /containers/{id}/archive. A path is allowed iff, after
+	// filepath.Clean, it equals an entry exactly or is a strict child of
+	// one (i.e., starts with entry + "/"). Substring matches are NOT
+	// permitted: "/srv" does NOT allow "/srv-other".
+	//
+	// The set MAY contain "/" — this is intentional so the security
+	// test suite can use a negative-control profile that opens every
+	// path, proving the positive tests are not no-ops because of an
+	// unrelated denial code path.
+	AllowedBindSources []string
+
+	// AllowedCaps is the set of Linux capabilities that may appear in
+	// HostConfig.CapAdd. Comparison is case-insensitive; callers may
+	// pass either "CAP_NET_BIND_SERVICE" or "NET_BIND_SERVICE" and the
+	// proxy normalises both ends of the comparison.
+	AllowedCaps []string
+
+	// MaxMemoryBytes is the inclusive upper bound for HostConfig.Memory.
+	// Zero disables the cap (any memory value passes).
+	MaxMemoryBytes int64
+
+	// MaxCPUQuota is the inclusive upper bound for HostConfig.CpuQuota
+	// (CFS quota in microseconds). Zero disables the cap.
+	MaxCPUQuota int64
+
+	// AuditWriter receives exactly one JSON line per accepted or
+	// rejected request. Nil silently drops audit events.
+	AuditWriter io.Writer
+
+	// MaxBodyBytes caps the size of a body-bearing request that the
+	// proxy will buffer in memory for inspection. Zero uses
+	// DefaultMaxBodyBytes. Bodies exceeding the cap are denied with
+	// 413 Request Entity Too Large and never forwarded.
+	MaxBodyBytes int64
+
+	// DialTimeout caps how long the upstream Unix-socket dial may take
+	// before the proxy synthesises a 503 upstream-unavailable. Zero
+	// uses DefaultDialTimeout.
+	DialTimeout time.Duration
+
+	// Clock is the time source used to stamp audit events. nil uses
+	// time.Now. Tests override this to assert exact timestamps.
+	Clock func() time.Time
+}
+
+// Default values used by Config when zero-valued.
+const (
+	// DefaultMaxBodyBytes is the request-body cap used when Config.MaxBodyBytes
+	// is zero. 16 MiB is generous enough for containers/create bodies that
+	// carry a moderately-sized Env or Labels map without forcing callers
+	// to override the default.
+	DefaultMaxBodyBytes int64 = 16 << 20
+
+	// DefaultDialTimeout is the upstream dial timeout used when
+	// Config.DialTimeout is zero.
+	DefaultDialTimeout = 5 * time.Second
+
+	// shutdownTimeout is how long Serve gives the http.Server to drain
+	// in-flight requests on context cancellation before returning.
+	shutdownTimeout = 2 * time.Second
+)
+
+// Proxy is a default-deny HTTP filter proxy in front of a docker/podman
+// REST API Unix socket. Construct with NewProxy and run with Serve.
+type Proxy struct {
+	cfg      Config
+	upstream *httputil.ReverseProxy
+
+	// mu guards listener and server while Serve is initialising; once
+	// Serve enters its select loop, listener and server are read-only.
+	mu       sync.Mutex
+	listener net.Listener
+	server   *http.Server
+
+	// auditMu serialises writes to AuditWriter. The AC requires exactly
+	// one JSON line per request, so interleaved writes from concurrent
+	// requests must not corrupt each other.
+	auditMu sync.Mutex
+}
+
+// NewProxy validates cfg and returns a Proxy ready to be Served. The
+// proxy does not bind its listener until Serve is called — the only
+// failure modes of NewProxy are missing required Config fields.
+func NewProxy(cfg Config) (*Proxy, error) {
+	if cfg.ListenerPath == "" {
+		return nil, errors.New("podmanproxy: Config.ListenerPath is required")
+	}
+	if cfg.UpstreamPath == "" {
+		return nil, errors.New("podmanproxy: Config.UpstreamPath is required")
+	}
+	if cfg.MaxBodyBytes == 0 {
+		cfg.MaxBodyBytes = DefaultMaxBodyBytes
+	}
+	if cfg.MaxBodyBytes < 0 {
+		return nil, fmt.Errorf("podmanproxy: Config.MaxBodyBytes must be >= 0, got %d", cfg.MaxBodyBytes)
+	}
+	if cfg.DialTimeout == 0 {
+		cfg.DialTimeout = DefaultDialTimeout
+	}
+	if cfg.DialTimeout < 0 {
+		return nil, fmt.Errorf("podmanproxy: Config.DialTimeout must be >= 0, got %v", cfg.DialTimeout)
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = time.Now
+	}
+
+	p := &Proxy{cfg: cfg}
+
+	dialer := &net.Dialer{Timeout: cfg.DialTimeout}
+	transport := &http.Transport{
+		// All connections route through the upstream Unix socket
+		// regardless of the request URL — we set Director below to
+		// rewrite the scheme/host so net/http does not try DNS.
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "unix", cfg.UpstreamPath)
+		},
+		// Compression is irrelevant for a local Unix socket and would
+		// only obscure body inspection during debugging.
+		DisableCompression: true,
+		// Allow long-lived streaming connections (attach, exec, logs
+		// follow=1) without a forced idle close.
+		IdleConnTimeout: 0,
+	}
+
+	p.upstream = &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			r.URL.Scheme = "http"
+			// The host is irrelevant for a Unix-socket dial but the
+			// Go HTTP client still requires a non-empty URL.Host and
+			// Host header for HTTP/1.1 request-line composition.
+			r.URL.Host = "podman.sock"
+			r.Host = "podman.sock"
+		},
+		Transport:    transport,
+		ErrorHandler: p.upstreamErrorHandler,
+		// FlushInterval -1 flushes immediately on every Write, which
+		// matters for streaming endpoints (attach / exec start / logs
+		// follow). Buffering would stall the agent's interactive
+		// session.
+		FlushInterval: -1,
+	}
+
+	return p, nil
+}
+
+// Serve binds the listener at ListenerPath, serves HTTP, and blocks
+// until ctx is cancelled. On cancellation it shuts the http.Server down
+// (giving in-flight requests up to shutdownTimeout to drain) and removes
+// the listener socket file before returning.
+//
+// The error returned by Serve is nil on clean ctx-cancellation shutdown,
+// or a wrapped non-nil error if the initial bind failed or the server
+// returned an unexpected error during accept.
+func (p *Proxy) Serve(ctx context.Context) error {
+	// Remove any leftover socket file from a previous run before bind.
+	// On a fresh boot ListenerPath does not exist; on a crashed-and-
+	// restarted process it may exist as a dead socket file and bind
+	// would fail with EADDRINUSE. Best-effort: ignore the result.
+	_ = os.Remove(p.cfg.ListenerPath)
+
+	l, err := net.Listen("unix", p.cfg.ListenerPath)
+	if err != nil {
+		return fmt.Errorf("podmanproxy: listen %q: %w", p.cfg.ListenerPath, err)
+	}
+	// Restrict the socket to the owning user. The umask of the calling
+	// process is the floor here; chmod 0600 hardens against an over-
+	// permissive umask.
+	_ = os.Chmod(p.cfg.ListenerPath, 0o600)
+
+	srv := &http.Server{
+		Handler:           http.HandlerFunc(p.serveHTTP),
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	p.mu.Lock()
+	p.listener = l
+	p.server = srv
+	p.mu.Unlock()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		err := srv.Serve(l)
+		if errors.Is(err, http.ErrServerClosed) {
+			serveErr <- nil
+			return
+		}
+		serveErr <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+		<-serveErr
+		_ = os.Remove(p.cfg.ListenerPath)
+		return nil
+
+	case err := <-serveErr:
+		_ = os.Remove(p.cfg.ListenerPath)
+		if err != nil {
+			return fmt.Errorf("podmanproxy: serve: %w", err)
+		}
+		return nil
+	}
+}
+
+// upstreamErrorHandler runs when the reverse proxy fails to dial or
+// receive a usable response from the upstream socket. It synthesises
+// the friendly 503 envelope.
+//
+// No audit line is emitted here: by the time the upstream is contacted,
+// the policy decision (allow) was already audited at serveHTTP time.
+// The AC requires exactly one audit line per request.
+func (p *Proxy) upstreamErrorHandler(w http.ResponseWriter, _ *http.Request, err error) {
+	writeUnavailable(w, classifyUpstreamErr(err))
+}
+
+// classifyUpstreamErr maps a net/http upstream error to a short reason
+// string embedded in the friendly 503 envelope. The reason is used
+// verbatim in the message body, so it MUST be safe to render to an
+// untrusted client (no host paths or internal IDs).
+func classifyUpstreamErr(err error) string {
+	switch {
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return "connection refused"
+	case errors.Is(err, syscall.ENOENT), errors.Is(err, os.ErrNotExist):
+		return "socket missing"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "dial timeout"
+	case errors.Is(err, syscall.EACCES), errors.Is(err, os.ErrPermission):
+		return "permission denied"
+	default:
+		return "dial failed"
+	}
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1863,6 +1864,101 @@ func TestSecurity_SysctlsNonEmpty_Denied(t *testing.T) {
 		t.Fatalf("Sysctls non-empty should be denied; got %d", resp.StatusCode)
 	}
 	assertNoForward(t, fu)
+}
+
+// ──────────────────────── cycle 6 ───────────────────────────────
+//
+// Coordinator-authorised cycle 6. Closes review-security's CRITICAL
+// Mount.Type=glob bypass + extends the cycle-5 schema-inversion
+// discipline from FIELD names to enumerable VALUES inside admitted
+// fields. Tests below pair with commit 1 (Mount.Type allowlist);
+// the NetworkMode-family + LogConfig.Type tests live with commit 2.
+
+// review-security's exact PoC: Type="glob" with Source set to a
+// host path that filepath.Glob will resolve to the literal path.
+// Deny.
+func TestSecurity_MountTypeGlob_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "glob",
+				"Source": "/etc/hosts",
+				"Target": "/key",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Mount Type=glob should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Mount Types outside the {bind, volume, tmpfs} allowlist must all
+// deny. Includes case variants (case-SENSITIVE matching), whitespace-
+// padded values, and unicode-lookalike tricks.
+func TestSecurity_MountType_AllowlistEnforced(t *testing.T) {
+	cases := []string{
+		"glob",       // the CRITICAL PoC
+		"image",      // image-as-volume; not audited
+		"npipe",      // windows named pipe
+		"artifact",   // podman artifact mount
+		"ramfs",      // ramfs
+		"devpts",     // pty fs
+		"",           // empty Type
+		"BIND",       // case variant
+		"Bind",       // case variant
+		"VOLUME",     // case variant
+		" bind",      // leading whitespace
+		"bind ",      // trailing whitespace
+		"bind\t",     // tab
+		"bind\n",     // newline
+		"bind\u200b", // zero-width space
+	}
+	for _, tp := range cases {
+		tp := tp
+		t.Run(strconv.Quote(tp), func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			sock := h.sock
+			resp := postCreate(t, sock, map[string]any{
+				"Mounts": []map[string]any{
+					{
+						"Type":   tp,
+						"Source": h.allowedDir,
+						"Target": "/x",
+					},
+				},
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("Mount Type=%q should be denied; got %d", tp, resp.StatusCode)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+// Positive control: Mount.Type=tmpfs is admitted (no host-file
+// access path). Proves the allowlist is real and not a blanket deny.
+func TestSecurity_MountTypeTmpfs_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "tmpfs",
+				"Target": "/in-memory",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Mount Type=tmpfs should be allowed; got %d", resp.StatusCode)
+	}
 }
 
 // ──────── schema-inversion: unknown-field rejection per endpoint ────────

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -1941,6 +1941,195 @@ func TestSecurity_MountType_AllowlistEnforced(t *testing.T) {
 	}
 }
 
+// ──────── cycle 6 commit 2: NetworkMode-family value allowlist ───────
+//
+// Closes the class "admitted enum-field value with a deny-list".
+// NetworkMode + 5 siblings (PidMode, IpcMode, UTSMode, UsernsMode,
+// CgroupnsMode) previously denied only literal "host"; now allow
+// only an explicit set of literals (plus a user-defined-name regex
+// for NetworkMode).
+
+func TestSecurity_NetworkMode_AllowedLiterals(t *testing.T) {
+	cases := []string{"", "bridge", "none", "default", "slirp4netns", "pasta"}
+	for _, mode := range cases {
+		mode := mode
+		t.Run(strconv.Quote(mode), func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			resp := postCreate(t, h.sock, map[string]any{
+				"NetworkMode": mode,
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("NetworkMode=%q should be allowed; got %d", mode, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestSecurity_NetworkMode_UserDefinedName_Allowed(t *testing.T) {
+	cases := []string{"my-net", "user_net1", "a.b.c", "X", "net.with.dots"}
+	for _, name := range cases {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			resp := postCreate(t, h.sock, map[string]any{
+				"NetworkMode": name,
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("NetworkMode=%q (user-defined name) should be allowed; got %d", name, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestSecurity_NetworkMode_DangerousValues_Denied(t *testing.T) {
+	cases := []string{
+		"host",              // literal host
+		"HOST",              // case (denyIfUnsafeModeValue lowercases)
+		"container:abc123",  // container reference
+		"ns:/proc/1/ns/net", // namespace path
+		"/proc/1/ns/net",    // path injection
+		"my net",            // whitespace
+		"-leading-dash",     // regex requires leading alphanumeric
+		".leading-dot",      // regex requires leading alphanumeric
+		"name with space",   // whitespace
+		"name\twith\ttab",   // tab
+		"a:b",               // generic colon
+		"network/path",      // slash
+	}
+	for _, mode := range cases {
+		mode := mode
+		t.Run(strconv.Quote(mode), func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			resp := postCreate(t, h.sock, map[string]any{
+				"NetworkMode": mode,
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("NetworkMode=%q should be denied; got %d", mode, resp.StatusCode)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+// Simple namespace modes (PidMode/IpcMode/UTSMode/UsernsMode/
+// CgroupnsMode) admit only {"", "private"} and deny everything else,
+// including "container:<id>".
+func TestSecurity_SimpleNamespaceModes_AllowedLiterals(t *testing.T) {
+	fields := []string{"PidMode", "IpcMode", "UTSMode", "UsernsMode", "CgroupnsMode"}
+	literals := []string{"", "private"}
+	for _, field := range fields {
+		for _, lit := range literals {
+			field, lit := field, lit
+			t.Run(field+"="+strconv.Quote(lit), func(t *testing.T) {
+				fu := newFakeUpstream(t)
+				h := startProxy(t, fu)
+				resp := postCreate(t, h.sock, map[string]any{
+					field: lit,
+				})
+				if resp.StatusCode != http.StatusOK {
+					t.Fatalf("%s=%q should be allowed; got %d", field, lit, resp.StatusCode)
+				}
+			})
+		}
+	}
+}
+
+func TestSecurity_SimpleNamespaceModes_DangerousValues_Denied(t *testing.T) {
+	fields := []string{"PidMode", "IpcMode", "UTSMode", "UsernsMode", "CgroupnsMode"}
+	dangerous := []string{
+		"host",              // already covered by cycle 4 but now via allowlist
+		"container:abc",     // container reference
+		"ns:/proc/1/ns/pid", // namespace path
+		"shareable",         // outside the {"", "private"} allowlist
+		"private ",          // whitespace
+		"my-network",        // user-defined names NOT allowed for non-NetworkMode modes
+	}
+	for _, field := range fields {
+		for _, value := range dangerous {
+			field, value := field, value
+			t.Run(field+"="+strconv.Quote(value), func(t *testing.T) {
+				fu := newFakeUpstream(t)
+				h := startProxy(t, fu)
+				resp := postCreate(t, h.sock, map[string]any{
+					field: value,
+				})
+				if resp.StatusCode != http.StatusForbidden {
+					t.Fatalf("%s=%q should be denied; got %d", field, value, resp.StatusCode)
+				}
+				assertNoForward(t, fu)
+			})
+		}
+	}
+}
+
+// ─────────────── LogConfig.Type allowlist (cycle 6) ─────────────────────
+func TestSecurity_LogConfigType_LocalDrivers_Allowed(t *testing.T) {
+	cases := []string{"", "json-file", "none", "journald", "k8s-file", "passthrough", "passthrough-tty"}
+	for _, typ := range cases {
+		typ := typ
+		t.Run(strconv.Quote(typ), func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			resp := postCreate(t, h.sock, map[string]any{
+				"LogConfig": map[string]any{"Type": typ},
+			})
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("LogConfig.Type=%q should be allowed; got %d", typ, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestSecurity_LogConfigType_NetworkDrivers_Denied(t *testing.T) {
+	cases := []string{"syslog", "splunk", "fluentd", "gelf", "awslogs", "etwlogs", "logentries"}
+	for _, typ := range cases {
+		typ := typ
+		t.Run(strconv.Quote(typ), func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			resp := postCreate(t, h.sock, map[string]any{
+				"LogConfig": map[string]any{"Type": typ},
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("LogConfig.Type=%q (network driver) should be denied; got %d", typ, resp.StatusCode)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+func TestSecurity_LogConfigType_UnknownDriver_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	resp := postCreate(t, h.sock, map[string]any{
+		"LogConfig": map[string]any{"Type": "bogus-future-driver"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("LogConfig.Type=bogus-future-driver should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// LogConfig.Config (driver-specific options like max-size) is
+// FORWARDED; verify the typed parse admits a Config payload
+// alongside a known-safe Type.
+func TestSecurity_LogConfigWithLocalDriverAndOptions_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	resp := postCreate(t, h.sock, map[string]any{
+		"LogConfig": map[string]any{
+			"Type":   "json-file",
+			"Config": map[string]string{"max-size": "10m"},
+		},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("LogConfig with json-file + Config should be allowed; got %d", resp.StatusCode)
+	}
+}
+
 // Positive control: Mount.Type=tmpfs is admitted (no host-file
 // access path). Proves the allowlist is real and not a blanket deny.
 func TestSecurity_MountTypeTmpfs_Allowed(t *testing.T) {

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -1865,6 +1865,157 @@ func TestSecurity_SysctlsNonEmpty_Denied(t *testing.T) {
 	assertNoForward(t, fu)
 }
 
+// ──────── schema-inversion: unknown-field rejection per endpoint ────────
+//
+// Cycle-5 commit 2: every body-bearing endpoint now parses with
+// DisallowUnknownFields. Any HostConfig (or top-level / exec /
+// update / volume / network) field that is not in the explicit
+// allowlist struct is rejected as an unknown-field error. This
+// closes the "future docker-API field silently bypasses the proxy"
+// class of escape (cycles 2/3/4 all surfaced one or more instances).
+
+func TestSecurity_SchemaInversion_UnknownHostConfigField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	// A made-up HostConfig field. If the proxy ever silently
+	// admitted unknown fields, this would be forwarded — the test
+	// proves the schema inversion fires.
+	resp := postCreate(t, sock, map[string]any{
+		"BogusFutureSandboxEscape": "value",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown HostConfig field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+	env := readEnvelope(t, resp)
+	if !strings.Contains(env.Message, "unknown") &&
+		!strings.Contains(env.Message, "BogusFutureSandboxEscape") {
+		t.Errorf("envelope should name the unknown field, got %q", env.Message)
+	}
+}
+
+func TestSecurity_SchemaInversion_UnknownTopLevelField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	// Same idea, but at the top level of containers/create.
+	body, _ := json.Marshal(map[string]any{
+		"Image":                    "alpine",
+		"BogusTopLevelEscapeField": "x",
+	})
+	req, _ := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/create",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown top-level field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_SchemaInversion_UnknownMountField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	// Unknown field inside a HostConfig.Mounts entry. Tests the
+	// second nested allowlist (hostConfigMount).
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":                  "bind",
+				"Source":                h.allowedDir,
+				"Target":                "/x",
+				"BogusNestedMountField": true,
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown Mount field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_SchemaInversion_UnknownUpdateField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/update",
+		map[string]any{"BogusUpdateField": 1})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown update field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_SchemaInversion_UnknownExecField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/exec",
+		map[string]any{"BogusExecField": true})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown exec field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_SchemaInversion_UnknownVolumeCreateField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/volumes/create",
+		map[string]any{"Name": "v", "BogusVolField": 1})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown volumes/create field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_SchemaInversion_UnknownNetworkCreateField_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/networks/create",
+		map[string]any{"Name": "n", "BogusNetField": 1})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unknown networks/create field should be rejected; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Positive control: networks/create with only admitted fields is
+// forwarded. Proves the schema inversion is not a blanket deny.
+func TestSecurity_NetworkCreate_AdmittedFields_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/networks/create",
+		map[string]any{"Name": "netname", "Driver": "bridge"})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("networks/create with admitted fields should be allowed; got %d", resp.StatusCode)
+	}
+}
+
 func TestSecurity_NegativeControl_RootAllowlistPasses(t *testing.T) {
 	fu := newFakeUpstream(t)
 	dir := shortSocketDir(t)

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -28,6 +28,35 @@ import (
 
 // ───────────────────────────── test scaffold ─────────────────────────────
 
+// shortSocketDir creates a temp directory with a short path suitable
+// for a Unix socket bind. The Linux sockaddr_un.sun_path field is
+// limited to 108 bytes; Darwin caps at 104. t.TempDir() embeds the
+// test name and parallel-subtest counter, which can push the path
+// past the limit when TMPDIR is the Nix sandbox
+// (/dev/shm/prism-go-test.<token>/...) and the subtest name is long
+// — review-context found this exact overflow on CI's
+// nix-build-prism-checked job: a 117-byte path failed bind with
+// EINVAL on TestSecurity_StreamingEndpoints_ForwardWithoutBodyParse/*.
+//
+// Pattern matches cmd/merge_proxy_test.go's startFakeHostAPIServer —
+// MkdirTemp("/tmp", "p") deterministically yields a short path
+// regardless of how long TMPDIR happens to be on the host. /tmp is
+// writable in the Nix build sandbox (verified by the existing tests
+// in cmd/ that use this pattern under the homeless-shelter gate).
+//
+// Use this helper for any test that creates a socket file. The
+// directory is registered for cleanup via t.Cleanup so it does not
+// outlive the test.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "p")
+	if err != nil {
+		t.Fatalf("mkdir socket tempdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 // fakeUpstream is a minimal docker-API mock that records every request
 // it sees and returns 200 OK to every well-formed request. The proxy's
 // reverse-proxy path forwards to this; the proxy's deny path never
@@ -49,7 +78,11 @@ type fakeUpstream struct {
 
 func newFakeUpstream(t *testing.T) *fakeUpstream {
 	t.Helper()
-	dir := t.TempDir()
+	// shortSocketDir, not t.TempDir() — Unix socket path length is
+	// kernel-bounded (108 bytes on Linux, 104 on Darwin) and
+	// t.TempDir() embeds the full test/subtest name which can blow
+	// the limit under the Nix sandbox.
+	dir := shortSocketDir(t)
 	sockPath := filepath.Join(dir, "podman.sock")
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -88,7 +121,8 @@ func (fu *fakeUpstream) captured() int64 {
 // startProxyWithConfig.
 func startProxy(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) {
 	t.Helper()
-	dir := t.TempDir()
+	// shortSocketDir, not t.TempDir() — see newFakeUpstream for rationale.
+	dir := shortSocketDir(t)
 	listenPath := filepath.Join(dir, "proxy.sock")
 	auditBuf := &bytes.Buffer{}
 	cfg := Config{
@@ -309,7 +343,7 @@ func TestSecurity_CapAddDisallowed_Denied(t *testing.T) {
 // cap-add allowlist: explicit allow-list entry passes (sanity check).
 func TestSecurity_CapAddInAllowlist_Allowed(t *testing.T) {
 	fu := newFakeUpstream(t)
-	dir := t.TempDir()
+	dir := shortSocketDir(t)
 	cfg := Config{
 		ListenerPath:       filepath.Join(dir, "proxy.sock"),
 		UpstreamPath:       fu.sockPath,
@@ -518,7 +552,7 @@ func TestSecurity_EmptyCreateBody_Denied(t *testing.T) {
 // and then closing the listener while leaving the socket file behind.
 func TestSecurity_UpstreamMissing_Returns503Envelope(t *testing.T) {
 	// Construct a proxy whose UpstreamPath does not exist.
-	dir := t.TempDir()
+	dir := shortSocketDir(t)
 	cfg := Config{
 		ListenerPath:       filepath.Join(dir, "proxy.sock"),
 		UpstreamPath:       filepath.Join(dir, "does-not-exist.sock"),
@@ -556,7 +590,7 @@ func TestSecurity_UpstreamMissing_Returns503Envelope(t *testing.T) {
 // This pairs with TestSecurity_UpstreamMissing_Returns503Envelope to
 // cover both halves of the upstream-unavailable AC.
 func TestSecurity_UpstreamECONNREFUSED_Returns503Envelope(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortSocketDir(t)
 	deadSocket := filepath.Join(dir, "dead.sock")
 
 	// Bind a real unix listener and close it. Go's UnixListener.Close
@@ -827,7 +861,7 @@ func TestSecurity_AllowedBinds_ForwardsUnmodified(t *testing.T) {
 // positive tests are not no-ops because of unrelated policy code paths.
 func TestSecurity_NegativeControl_RootAllowlistPasses(t *testing.T) {
 	fu := newFakeUpstream(t)
-	dir := t.TempDir()
+	dir := shortSocketDir(t)
 	cfg := Config{
 		ListenerPath: filepath.Join(dir, "proxy.sock"),
 		UpstreamPath: fu.sockPath,

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -1598,6 +1598,273 @@ func TestSecurity_BindSymlinkedAllowlistEntry_Matched(t *testing.T) {
 // AC: A negative-control test that mutates Config.AllowedBindSources
 // to include "/" causes a host-bind request to PASS — proving the
 // positive tests are not no-ops because of unrelated policy code paths.
+// ──────────────────────── cycle 5 ───────────────────────────────
+//
+// Coordinator-authorised cycle 5. Closes the 5 round-4 review-
+// security findings (commit 1) and inverts the HostConfig parser to
+// default-deny unknown fields (commit 2). Tests here pair with each
+// closure; the schema-inversion tests live below in the
+// "unknown-field rejection" section.
+
+// Cycle-4 finding #1 (CRITICAL): local-volume bind-mount bypass via
+// volumes/create. The agent calls POST volumes/create with Driver=
+// local and DriverOpts that bind a host path through the local
+// driver's option language; then references the volume by name from
+// a containers/create body. bindSource() returns "" for named-volume
+// references (no leading slash) so the host-bind allowlist is
+// skipped. Closure: deny volumes/create with Driver=local + non-empty
+// DriverOpts.
+func TestSecurity_VolumeCreate_LocalDriverBindMount_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/volumes/create",
+		map[string]any{
+			"Name":   "evil",
+			"Driver": "local",
+			"DriverOpts": map[string]string{
+				"type":   "none",
+				"device": "/etc/hosts",
+				"o":      "bind",
+			},
+		})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("volumes/create local-driver+DriverOpts should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Default-driver volumes/create (no DriverOpts) is the legitimate
+// case and must still pass — proves the volumes/create policy is not
+// a blanket deny.
+func TestSecurity_VolumeCreate_DefaultDriver_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/volumes/create",
+		map[string]any{
+			"Name":   "normal-volume",
+			"Driver": "local",
+		})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("volumes/create default driver no opts should be allowed; got %d", resp.StatusCode)
+	}
+}
+
+func TestSecurity_VolumeCreate_MalformedJSON_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	req, _ := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/volumes/create",
+		bytes.NewReader([]byte(`{garbage`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("malformed volumes/create body should be 400; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Cycle-4 finding #1 (second path): the same exploit via inline
+// Mounts of Type=volume with VolumeOptions.DriverConfig in the
+// containers/create body. Closure: deny any Type=volume Mount with
+// VolumeOptions.DriverConfig set.
+func TestSecurity_MountVolumeWithDriverConfig_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "volume",
+				"Source": "anon",
+				"Target": "/x",
+				"VolumeOptions": map[string]any{
+					"DriverConfig": map[string]any{
+						"Name": "local",
+						"Options": map[string]string{
+							"type":   "none",
+							"device": "/etc/hosts",
+							"o":      "bind",
+						},
+					},
+				},
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Mounts Type=volume with VolumeOptions.DriverConfig should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// A plain Type=volume Mount with no VolumeOptions is the legitimate
+// case (anonymous or named volume managed by podman's default driver
+// settings). Forward unmodified.
+func TestSecurity_MountVolumeWithoutDriverConfig_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "volume",
+				"Source": "namedvol",
+				"Target": "/x",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Mounts Type=volume without DriverConfig should be allowed; got %d", resp.StatusCode)
+	}
+}
+
+// Cycle-4 finding #2 (CRITICAL): DeviceCgroupRules unfiltered.
+func TestSecurity_DeviceCgroupRulesNonEmpty_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"DeviceCgroupRules": []string{"a *:* rwm"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("DeviceCgroupRules non-empty should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Cycle-4 finding #5 (MAJOR): DeviceRequests unfiltered.
+func TestSecurity_DeviceRequestsNonEmpty_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"DeviceRequests": []map[string]any{
+			{
+				"Driver":       "nvidia",
+				"Count":        -1,
+				"Capabilities": [][]string{{"gpu"}},
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("DeviceRequests non-empty should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Cycle-4 finding #5 (MAJOR): VolumesFrom unfiltered.
+func TestSecurity_VolumesFromNonEmpty_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"VolumesFrom": []string{"other-container:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("VolumesFrom non-empty should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Cycle-4 finding #3 (MAJOR): MaskedPaths present.
+func TestSecurity_MaskedPathsPresent_Denied(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"empty-array-overrides-default", []string{}},
+		{"explicit-allowlist-with-keys", []string{"/safe1", "/safe2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			sock := h.sock
+			resp := postCreate(t, sock, map[string]any{
+				"MaskedPaths": tc.value,
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("MaskedPaths present (%s) should be denied; got %d", tc.name, resp.StatusCode)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+func TestSecurity_ReadonlyPathsPresent_Denied(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"empty-array-overrides-default", []string{}},
+		{"explicit-allowlist-with-keys", []string{"/safe1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			h := startProxy(t, fu)
+			sock := h.sock
+			resp := postCreate(t, sock, map[string]any{
+				"ReadonlyPaths": tc.value,
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("ReadonlyPaths present (%s) should be denied; got %d", tc.name, resp.StatusCode)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+// Cycle-4 finding #4 (MAJOR): CgroupnsMode: "host" — sibling of the
+// other five host-namespace modes I already blocked.
+func TestSecurity_CgroupnsModeHost_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"CgroupnsMode": "host",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("CgroupnsMode=host should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Cycle-5 opportunistic sweep: Sysctls. Some sysctls are not
+// namespaced (writable from a container affects the host). Default-
+// deny entirely; legitimate workflows can request specific entries
+// through the field-admission process.
+func TestSecurity_SysctlsNonEmpty_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"Sysctls": map[string]string{
+			"net.ipv4.ip_forward": "1",
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Sysctls non-empty should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
 func TestSecurity_NegativeControl_RootAllowlistPasses(t *testing.T) {
 	fu := newFakeUpstream(t)
 	dir := shortSocketDir(t)

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -116,8 +116,12 @@ func (fu *fakeUpstream) captured() int64 {
 
 // startProxy stands a podmanproxy.Proxy on a fresh listener socket in
 // front of the supplied upstream, with sensible defaults that cover
-// the threat table. Tests can override AllowedBindSources / AllowedCaps
-// /etc. by mutating the returned Config and rebuilding via
+// the threat-table tests. Resource caps are intentionally LEFT
+// DISABLED here: when a cap is configured the strict mode requires
+// every create body to set the corresponding field, which would force
+// every unrelated test (bind escapes, privileged, etc.) to also
+// include placeholder Memory/CpuQuota values. Tests that specifically
+// exercise the resource caps configure them in their own Config via
 // startProxyWithConfig.
 func startProxy(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) {
 	t.Helper()
@@ -130,11 +134,44 @@ func startProxy(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) 
 		UpstreamPath:       fu.sockPath,
 		AllowedBindSources: []string{"/workspace", "/scratch"},
 		AllowedCaps:        []string{}, // empty by default
+		AuditWriter:        auditBuf,
+		// No MaxMemoryBytes / MaxCPUQuota / MaxNanoCpus — see comment above.
+		// No AllowedSecurityOpts — default-deny on SecurityOpt is exercised
+		// by the SecurityOpt-specific tests.
+	}
+	return startProxyWithConfig(t, cfg, auditBuf, listenPath), auditBuf, listenPath
+}
+
+// startProxyWithCaps mirrors startProxy but enables the resource
+// caps. Tests that exercise the cap policy (over-cap, zero, negative,
+// absent) use this so the cap is actually active.
+func startProxyWithCaps(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) {
+	t.Helper()
+	dir := shortSocketDir(t)
+	listenPath := filepath.Join(dir, "proxy.sock")
+	auditBuf := &bytes.Buffer{}
+	cfg := Config{
+		ListenerPath:       listenPath,
+		UpstreamPath:       fu.sockPath,
+		AllowedBindSources: []string{"/workspace", "/scratch"},
 		MaxMemoryBytes:     4 * 1024 * 1024 * 1024,
 		MaxCPUQuota:        200_000,
+		MaxNanoCpus:        2_000_000_000, // 2 cores
 		AuditWriter:        auditBuf,
 	}
 	return startProxyWithConfig(t, cfg, auditBuf, listenPath), auditBuf, listenPath
+}
+
+// validCapsBody returns a hostConfig fragment that satisfies all the
+// active resource caps configured by startProxyWithCaps. Tests that
+// want to exercise a single cap (e.g. memory-over-cap) start with
+// this baseline and override the one field under test.
+func validCapsBody() map[string]any {
+	return map[string]any{
+		"Memory":   int64(1 * 1024 * 1024 * 1024), // 1 GiB
+		"CpuQuota": int64(50_000),                 // 0.5 cores
+		"NanoCpus": int64(500_000_000),            // 0.5 cores
+	}
 }
 
 // startProxyWithConfig is the low-level scaffold helper used by tests
@@ -216,6 +253,24 @@ func postCreate(t *testing.T, sock string, hostConfig map[string]any) *http.Resp
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return doRequest(t, sock, req)
+}
+
+// mustNewRequest is the equivalent of postCreate for non-create
+// endpoints: it marshals body as JSON and constructs the request.
+// Used by the update / exec / SecurityOpt-allowlist tests where the
+// URL is something other than /containers/create.
+func mustNewRequest(t *testing.T, method, url string, body any) *http.Request {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req
 }
 
 func doRequest(t *testing.T, sock string, req *http.Request) *http.Response {
@@ -408,18 +463,24 @@ func TestSecurity_DevicesNonEmpty_Denied(t *testing.T) {
 	assertNoForward(t, fu)
 }
 
-// memory cap exceeded.
+// ───────────────── resource caps (strict mode) ─────────────────────
 //
-// (Auxiliary AC: resource caps enforced server-side; out-of-bounds
-// returns 403.)
+// AC (auxiliary): resource caps enforced server-side; out-of-bounds
+// returns 403. The strict interpretation (review-security PR #2326
+// round 2) is that the cap must actually be enforceable — docker's
+// Memory=0 "unlimited" semantic and an absent Memory field both have
+// to be denied when the cap is configured, otherwise the cap can be
+// trivially bypassed.
+
 func TestSecurity_MemoryOverCap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	_, _, sock := startProxyWithCaps(t, fu)
 
-	// Configured cap is 4 GiB; request 10 TiB.
-	resp := postCreate(t, sock, map[string]any{
-		"Memory": int64(10) * 1024 * 1024 * 1024 * 1024,
-	})
+	// Configured cap is 4 GiB; request 10 TiB. CpuQuota / NanoCpus
+	// supplied so the request only trips the memory check.
+	body := validCapsBody()
+	body["Memory"] = int64(10) * 1024 * 1024 * 1024 * 1024
+	resp := postCreate(t, sock, body)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
@@ -428,16 +489,349 @@ func TestSecurity_MemoryOverCap_Denied(t *testing.T) {
 
 func TestSecurity_CPUQuotaOverCap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	_, _, sock := startProxyWithCaps(t, fu)
 
-	// Configured cap is 200_000; request 2_000_000.
-	resp := postCreate(t, sock, map[string]any{
-		"CpuQuota": 2_000_000,
-	})
+	body := validCapsBody()
+	body["CpuQuota"] = int64(2_000_000)
+	resp := postCreate(t, sock, body)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
 	assertNoForward(t, fu)
+}
+
+// MemoryZero: docker treats Memory=0 as "unlimited". When a cap is
+// configured, 0 must be denied so the cap cannot be bypassed by
+// stating "I want unlimited memory".
+func TestSecurity_MemoryZero_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	body["Memory"] = int64(0)
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Memory=0 should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_MemoryNegative_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	body["Memory"] = int64(-1)
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Memory<0 should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// MemoryAbsent_DeniedWhenCapActive: an agent that simply omits the
+// Memory field also gets the host default (unlimited) on docker /
+// podman, which is the same bypass class as Memory=0. The strict
+// policy denies this too so the cap is actually enforceable.
+func TestSecurity_MemoryAbsent_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	delete(body, "Memory")
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("absent Memory should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// MemoryAbsent_AllowedWhenNoCap: when MaxMemoryBytes==0 (cap disabled)
+// an absent Memory field must NOT be denied — the cap is opt-in and
+// the default-no-cap mode preserves docker's default behaviour.
+func TestSecurity_MemoryAbsent_AllowedWhenNoCap(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+	// No Memory field, no other resource fields. With no cap active,
+	// this should pass.
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{"/workspace/proj:/app:ro"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("absent Memory with no cap should be allowed; got %d", resp.StatusCode)
+	}
+}
+
+// CpuQuotaZero / CpuQuotaAbsent: identical class to Memory.
+func TestSecurity_CpuQuotaZero_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	body["CpuQuota"] = int64(0)
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("CpuQuota=0 should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_CpuQuotaAbsent_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	delete(body, "CpuQuota")
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("absent CpuQuota should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// NanoCpus is a fully orthogonal way to express CPU caps from
+// CpuQuota. If only CpuQuota was capped, an agent that wanted to
+// burst above the cap could simply state the request as NanoCpus.
+func TestSecurity_NanoCpusOverCap_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	body["NanoCpus"] = int64(8_000_000_000) // 8 cores; cap is 2 cores
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("NanoCpus over cap should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_NanoCpusZero_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	body["NanoCpus"] = int64(0)
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("NanoCpus=0 should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_NanoCpusAbsent_DeniedWhenCapActive(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	body := validCapsBody()
+	delete(body, "NanoCpus")
+	resp := postCreate(t, sock, body)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("absent NanoCpus should be denied when cap is active; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Sanity: when every cap is set to a value within bounds, the
+// request is forwarded. Proves the strict cap suite is not just a
+// blanket deny.
+func TestSecurity_ResourceCapsWithinBounds_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	resp := postCreate(t, sock, validCapsBody())
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("valid resource caps should be allowed; got %d", resp.StatusCode)
+	}
+	if fu.captured() != 1 {
+		t.Errorf("expected 1 upstream call, got %d", fu.captured())
+	}
+}
+
+// ─────────── containers/update: cap fields cannot be reset ───────────
+//
+// AC class: an agent that creates with valid caps could otherwise
+// POST update with Memory=0 to remove the cap. Update body must run
+// the same per-field nonpositive / over-cap denials, but with the
+// absent-field policy relaxed (an update body is partial — missing
+// fields just are not being changed).
+
+func TestSecurity_UpdateEndpoint_MemoryZero_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/update",
+		map[string]any{"Memory": int64(0)})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("update Memory=0 should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_UpdateEndpoint_MemoryOverCap_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/update",
+		map[string]any{"Memory": int64(10) * 1024 * 1024 * 1024 * 1024})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("update Memory over cap should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_UpdateEndpoint_PartialBodyAllowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	// Only setting CpuShares (not in our cap list). Absent Memory and
+	// CpuQuota are allowed in update context.
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/update",
+		map[string]any{"CpuShares": 512})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update with only non-capped fields should be allowed; got %d", resp.StatusCode)
+	}
+}
+
+func TestSecurity_UpdateEndpoint_MalformedJSON_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxyWithCaps(t, fu)
+	req, _ := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/update",
+		bytes.NewReader([]byte(`{garbage`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("malformed update body should be 400; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// ─────────── containers/exec: Privileged cannot be re-introduced ──────
+//
+// AC class: an agent that creates a non-privileged container could
+// otherwise exec into it with Privileged=true — docker exec grants
+// extra capabilities independent of the parent container's
+// HostConfig.Privileged.
+
+func TestSecurity_ExecPrivileged_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/exec",
+		map[string]any{
+			"Cmd":        []string{"id"},
+			"Privileged": true,
+		})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("exec with Privileged=true should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_ExecWithoutPrivileged_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+	req := mustNewRequest(t, http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/exec",
+		map[string]any{
+			"Cmd":        []string{"id"},
+			"Privileged": false,
+		})
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("exec without Privileged should be allowed; got %d", resp.StatusCode)
+	}
+	if fu.captured() != 1 {
+		t.Errorf("expected 1 upstream call, got %d", fu.captured())
+	}
+}
+
+func TestSecurity_ExecMalformedJSON_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+	req, _ := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/abc/exec",
+		bytes.NewReader([]byte(`{garbage`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("malformed exec body should be 400; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// ─────────── SecurityOpt default-deny ─────────────────────────────────
+//
+// AC class: SecurityOpt entries like "seccomp=unconfined",
+// "apparmor=unconfined", "no-new-privileges=false", and
+// "label=disable" disable the container's security primitives. The
+// strict default-deny policy rejects every SecurityOpt entry not in
+// the configured allowlist (which is empty by default).
+
+func TestSecurity_SecurityOpt_DefaultDenyAll(t *testing.T) {
+	cases := []string{
+		"seccomp=unconfined",
+		"apparmor=unconfined",
+		"no-new-privileges=false",
+		"no-new-privileges:false",
+		"label=disable",
+		"label:disable",
+		"systempaths=unconfined",
+		// A custom seccomp profile path is also denied under default-deny.
+		"seccomp=/etc/custom.json",
+	}
+	for _, opt := range cases {
+		t.Run(opt, func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			_, _, sock := startProxy(t, fu)
+			resp := postCreate(t, sock, map[string]any{
+				"SecurityOpt": []string{opt},
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("SecurityOpt %q should be denied by default; got %d", opt, resp.StatusCode)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+// When an entry IS in AllowedSecurityOpts, it passes (sanity check
+// that the deny is allowlist-driven, not a blanket reject).
+func TestSecurity_SecurityOpt_InAllowlist_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	dir := shortSocketDir(t)
+	cfg := Config{
+		ListenerPath:        filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:        fu.sockPath,
+		AllowedBindSources:  []string{"/workspace"},
+		AllowedSecurityOpts: []string{"no-new-privileges:true"},
+		AuditWriter:         &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	resp := postCreate(t, cfg.ListenerPath, map[string]any{
+		"SecurityOpt": []string{"no-new-privileges:true"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("SecurityOpt in allowlist should be allowed; got %d", resp.StatusCode)
+	}
+}
+
+// Allowlist match is exact; the deny still fires for a sibling entry
+// not in the allowlist.
+func TestSecurity_SecurityOpt_PartialAllowlist_ExactMatch(t *testing.T) {
+	fu := newFakeUpstream(t)
+	dir := shortSocketDir(t)
+	cfg := Config{
+		ListenerPath:        filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:        fu.sockPath,
+		AllowedBindSources:  []string{"/workspace"},
+		AllowedSecurityOpts: []string{"no-new-privileges:true"},
+		AuditWriter:         &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	resp := postCreate(t, cfg.ListenerPath, map[string]any{
+		"SecurityOpt": []string{"no-new-privileges:true", "seccomp=unconfined"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("sibling unconfined entry should be denied; got %d", resp.StatusCode)
+	}
 }
 
 // archive exfil: PUT /containers/{id}/archive?path=/etc — host path.
@@ -869,9 +1263,11 @@ func TestSecurity_NegativeControl_RootAllowlistPasses(t *testing.T) {
 		// is in the allowlist.
 		AllowedBindSources: []string{"/"},
 		AllowedCaps:        []string{},
-		MaxMemoryBytes:     4 * 1024 * 1024 * 1024,
-		MaxCPUQuota:        200_000,
-		AuditWriter:        &bytes.Buffer{},
+		// Resource caps intentionally LEFT DISABLED so the negative
+		// control isolates the bind-source policy: if caps were
+		// active, the body would also need to satisfy them and a
+		// failure could mislead about which policy fired.
+		AuditWriter: &bytes.Buffer{},
 	}
 	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
 

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -1,0 +1,881 @@
+package podmanproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Tests for #2318: every escape vector in the parent threat table
+// (#2317 §4) gets an explicit security test. The tests share a small
+// scaffold that stands up a real podmanproxy in front of a fake
+// upstream so we can assert both the synthesised 4xx (no upstream
+// forward) AND the upstream-forwarded path.
+//
+// The negative-control test (TestSecurity_NegativeControl_RootAllowlistPasses)
+// at the bottom of this file is the load-bearing meta-test that proves
+// the positive denials are not no-ops resulting from an unrelated
+// failure mode somewhere else in the policy code path.
+
+// ───────────────────────────── test scaffold ─────────────────────────────
+
+// fakeUpstream is a minimal docker-API mock that records every request
+// it sees and returns 200 OK to every well-formed request. The proxy's
+// reverse-proxy path forwards to this; the proxy's deny path never
+// reaches it.
+type fakeUpstream struct {
+	server   *http.Server
+	sockPath string
+	listener net.Listener
+
+	// requests counts every request that reached the upstream. The
+	// security tests assert that denied requests do NOT increment this.
+	requests atomic.Int64
+
+	// lastBody captures the body of the most recent request. Used by
+	// the "forward unmodified" tests to assert the proxy didn't mangle
+	// a legitimate body en route.
+	lastBody atomic.Value // []byte
+}
+
+func newFakeUpstream(t *testing.T) *fakeUpstream {
+	t.Helper()
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "podman.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen upstream sock: %v", err)
+	}
+	fu := &fakeUpstream{sockPath: sockPath, listener: ln}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fu.requests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		fu.lastBody.Store(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"Id":"deadbeef"}`))
+	})
+	fu.server = &http.Server{Handler: mux}
+	go func() { _ = fu.server.Serve(ln) }()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = fu.server.Shutdown(shutdownCtx)
+	})
+	return fu
+}
+
+// captured returns the recorded request count. Helper so tests read
+// fluently as "want zero upstream calls".
+func (fu *fakeUpstream) captured() int64 {
+	return fu.requests.Load()
+}
+
+// startProxy stands a podmanproxy.Proxy on a fresh listener socket in
+// front of the supplied upstream, with sensible defaults that cover
+// the threat table. Tests can override AllowedBindSources / AllowedCaps
+// /etc. by mutating the returned Config and rebuilding via
+// startProxyWithConfig.
+func startProxy(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) {
+	t.Helper()
+	dir := t.TempDir()
+	listenPath := filepath.Join(dir, "proxy.sock")
+	auditBuf := &bytes.Buffer{}
+	cfg := Config{
+		ListenerPath:       listenPath,
+		UpstreamPath:       fu.sockPath,
+		AllowedBindSources: []string{"/workspace", "/scratch"},
+		AllowedCaps:        []string{}, // empty by default
+		MaxMemoryBytes:     4 * 1024 * 1024 * 1024,
+		MaxCPUQuota:        200_000,
+		AuditWriter:        auditBuf,
+	}
+	return startProxyWithConfig(t, cfg, auditBuf, listenPath), auditBuf, listenPath
+}
+
+// startProxyWithConfig is the low-level scaffold helper used by tests
+// that need to mutate the policy config (e.g. the negative-control).
+func startProxyWithConfig(t *testing.T, cfg Config, _ *bytes.Buffer, listenPath string) *Proxy {
+	t.Helper()
+	p, err := NewProxy(cfg)
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- p.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-serveErr:
+			if err != nil {
+				t.Logf("Serve returned: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Log("Serve did not return within 3s of cancellation")
+		}
+	})
+	waitForSocket(t, listenPath)
+	return p
+}
+
+// waitForSocket polls until the proxy's listener accepts connections
+// or the timeout elapses. Tests use this to avoid a race between
+// Serve's listener bind and the first client request.
+func waitForSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.Dial("unix", path)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("proxy socket %s did not become ready: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// proxyClient returns an http.Client wired to dial the proxy's Unix
+// socket. Every test request goes through this client.
+func proxyClient(socket string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socket)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+}
+
+// postCreate is a tiny helper for the most-used test shape: POST
+// /v1.41/containers/create with the supplied HostConfig.
+func postCreate(t *testing.T, sock string, hostConfig map[string]any) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"Image":      "alpine",
+		"HostConfig": hostConfig,
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/create",
+		bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return doRequest(t, sock, req)
+}
+
+func doRequest(t *testing.T, sock string, req *http.Request) *http.Response {
+	t.Helper()
+	client := proxyClient(sock)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return resp
+}
+
+// readEnvelope reads resp.Body and unmarshals the {"message": "..."}
+// envelope. Tests assert the message text contains a guidance keyword
+// rather than the full string, so the wording can evolve without
+// breaking the tests.
+func readEnvelope(t *testing.T, resp *http.Response) errorEnvelope {
+	t.Helper()
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var env errorEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v (body=%q)", err, body)
+	}
+	return env
+}
+
+// assertNoForward fails the test when the upstream's request count is
+// non-zero. Used after every deny-path test.
+func assertNoForward(t *testing.T, fu *fakeUpstream) {
+	t.Helper()
+	if got := fu.captured(); got != 0 {
+		t.Fatalf("expected zero upstream requests, got %d (a deny path forwarded to upstream)", got)
+	}
+}
+
+// ───────────────────────── threat-table tests ─────────────────────────
+
+// host-bind escape: Binds source outside the allowlist.
+//
+// AC: A containers/create request with any HostConfig.Binds source
+// outside the allowlist returns 403 with a docker-compatible
+// {"message": "..."} body and is NOT forwarded upstream.
+func TestSecurity_HostBindOutsideAllowlist_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{"/etc/passwd:/host_passwd:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	env := readEnvelope(t, resp)
+	if env.Message == "" {
+		t.Fatal("expected non-empty error message")
+	}
+	if !strings.Contains(env.Message, "/etc/passwd") {
+		t.Errorf("error message should name the rejected source, got: %q", env.Message)
+	}
+	assertNoForward(t, fu)
+}
+
+// host-bind escape: Mounts source outside the allowlist (newer API).
+func TestSecurity_HostMountOutsideAllowlist_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "bind",
+				"Source": "/Users/bensherman",
+				"Target": "/host",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// privileged escape.
+//
+// AC: A containers/create request with HostConfig.Privileged: true
+// returns 403 and is not forwarded.
+func TestSecurity_Privileged_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"Privileged": true,
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	env := readEnvelope(t, resp)
+	if !strings.Contains(strings.ToLower(env.Message), "privileged") {
+		t.Errorf("envelope should mention 'privileged', got %q", env.Message)
+	}
+	assertNoForward(t, fu)
+}
+
+// cap-add escape: CapAdd entry outside the allowlist.
+//
+// AC: A containers/create request with HostConfig.CapAdd containing a
+// value outside the allowlist returns 403.
+func TestSecurity_CapAddDisallowed_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"CapAdd": []string{"SYS_ADMIN"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// cap-add allowlist: explicit allow-list entry passes (sanity check).
+func TestSecurity_CapAddInAllowlist_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	dir := t.TempDir()
+	cfg := Config{
+		ListenerPath:       filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:       fu.sockPath,
+		AllowedBindSources: []string{"/workspace"},
+		AllowedCaps:        []string{"NET_BIND_SERVICE"},
+		AuditWriter:        &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	resp := postCreate(t, cfg.ListenerPath, map[string]any{
+		"CapAdd": []string{"CAP_NET_BIND_SERVICE"}, // both forms
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if fu.captured() != 1 {
+		t.Errorf("expected 1 upstream request, got %d", fu.captured())
+	}
+}
+
+// host-network escape and the four sibling host-* modes.
+//
+// AC: A containers/create request with HostConfig.NetworkMode: "host"
+// returns 403. Same for PidMode, IpcMode, UTSMode, UsernsMode.
+func TestSecurity_HostNamespaceModes_Denied(t *testing.T) {
+	modes := []string{"NetworkMode", "PidMode", "IpcMode", "UTSMode", "UsernsMode"}
+	for _, field := range modes {
+		t.Run(field, func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			_, _, sock := startProxy(t, fu)
+			resp := postCreate(t, sock, map[string]any{
+				field: "host",
+			})
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("%s: status got %d want %d", field, resp.StatusCode, http.StatusForbidden)
+			}
+			assertNoForward(t, fu)
+		})
+	}
+}
+
+// devices escape: non-empty Devices.
+//
+// AC: A containers/create request with non-empty HostConfig.Devices
+// returns 403.
+func TestSecurity_DevicesNonEmpty_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"Devices": []map[string]any{
+			{
+				"PathOnHost":        "/dev/sda1",
+				"PathInContainer":   "/dev/sda1",
+				"CgroupPermissions": "rwm",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// memory cap exceeded.
+//
+// (Auxiliary AC: resource caps enforced server-side; out-of-bounds
+// returns 403.)
+func TestSecurity_MemoryOverCap_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	// Configured cap is 4 GiB; request 10 TiB.
+	resp := postCreate(t, sock, map[string]any{
+		"Memory": int64(10) * 1024 * 1024 * 1024 * 1024,
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+func TestSecurity_CPUQuotaOverCap_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	// Configured cap is 200_000; request 2_000_000.
+	resp := postCreate(t, sock, map[string]any{
+		"CpuQuota": 2_000_000,
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// archive exfil: PUT /containers/{id}/archive?path=/etc — host path.
+//
+// AC: A PUT /containers/{id}/archive request with a `path` query
+// parameter outside the allowlist returns 403.
+func TestSecurity_ArchivePathOutsideAllowlist_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	req, err := http.NewRequest(http.MethodPut,
+		"http://podman.sock/v1.41/containers/abc123/archive?path=%2Fetc",
+		bytes.NewReader([]byte("tar body would go here")))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// endpoint allowlist: any endpoint not in the allowlist returns 403.
+//
+// AC: A request to an endpoint outside the allowlist returns 403 with
+// an actionable error message identifying the rejected endpoint.
+func TestSecurity_UnknownEndpoint_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	for _, tc := range []struct {
+		name, method, path string
+	}{
+		{"unknown-top-level", http.MethodGet, "/v1.41/server/info"},
+		{"unknown-libpod", http.MethodPost, "/libpod/secrets/create"},
+		{"undeclared-method", http.MethodPatch, "/v1.41/containers/abc/json"},
+		{"swarm-mode", http.MethodGet, "/v1.41/swarm"},
+		{"unversioned-bogus", http.MethodPost, "/swarm/init"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, "http://podman.sock"+tc.path, nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp := doRequest(t, sock, req)
+			if resp.StatusCode != http.StatusForbidden {
+				t.Fatalf("%s %s: status got %d want %d", tc.method, tc.path, resp.StatusCode, http.StatusForbidden)
+			}
+			env := readEnvelope(t, resp)
+			if !strings.Contains(env.Message, tc.path) {
+				t.Errorf("envelope should name rejected path %q, got %q", tc.path, env.Message)
+			}
+			if !strings.Contains(strings.ToLower(env.Message), "not permitted") {
+				t.Errorf("envelope should explain rejection, got %q", env.Message)
+			}
+		})
+	}
+	assertNoForward(t, fu)
+}
+
+// malformed JSON body returns 400 and is not forwarded.
+//
+// AC: A malformed JSON body on a body-bearing endpoint returns 400 and
+// is not forwarded.
+func TestSecurity_MalformedJSONBody_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	req, err := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/create",
+		bytes.NewReader([]byte(`{this is not valid JSON`)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	assertNoForward(t, fu)
+}
+
+// empty body on containers/create is treated as malformed.
+func TestSecurity_EmptyCreateBody_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	req, err := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/create",
+		bytes.NewReader(nil))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	assertNoForward(t, fu)
+}
+
+// upstream unavailable: synthesise the friendly 503 envelope.
+//
+// AC: When the upstream socket is unreachable (file does not exist,
+// OR dial fails with ECONNREFUSED), the proxy returns 503 with the
+// actionable {"message": "..."} body.
+//
+// This test covers the "file does not exist" branch (ENOENT). The
+// ECONNREFUSED branch is covered by TestSecurity_UpstreamECONNREFUSED_Returns503Envelope
+// below, which engineers a real ECONNREFUSED by binding a unix socket
+// and then closing the listener while leaving the socket file behind.
+func TestSecurity_UpstreamMissing_Returns503Envelope(t *testing.T) {
+	// Construct a proxy whose UpstreamPath does not exist.
+	dir := t.TempDir()
+	cfg := Config{
+		ListenerPath:       filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:       filepath.Join(dir, "does-not-exist.sock"),
+		AllowedBindSources: []string{"/workspace"},
+		AuditWriter:        &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	req, err := http.NewRequest(http.MethodGet,
+		"http://podman.sock/v1.41/_ping", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp := doRequest(t, cfg.ListenerPath, req)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	env := readEnvelope(t, resp)
+	if !strings.HasPrefix(env.Message, "podman socket unavailable: ") {
+		t.Errorf("envelope prefix: got %q, want 'podman socket unavailable: …'", env.Message)
+	}
+	if !strings.Contains(env.Message, "podman machine start") {
+		t.Errorf("envelope should mention macOS recovery, got %q", env.Message)
+	}
+	if !strings.Contains(env.Message, "systemctl --user status podman.socket") {
+		t.Errorf("envelope should mention Linux recovery, got %q", env.Message)
+	}
+}
+
+// upstream connection-refused: bind a listener and close it, leaving
+// a dead socket file behind. A dial against that file yields
+// ECONNREFUSED on every platform where unix sockets are implemented
+// (Linux, Darwin, *BSD).
+//
+// This pairs with TestSecurity_UpstreamMissing_Returns503Envelope to
+// cover both halves of the upstream-unavailable AC.
+func TestSecurity_UpstreamECONNREFUSED_Returns503Envelope(t *testing.T) {
+	dir := t.TempDir()
+	deadSocket := filepath.Join(dir, "dead.sock")
+
+	// Bind a real unix listener and close it. Go's UnixListener.Close
+	// unlinks by default for Listen-created listeners, so we recreate
+	// the file as a regular file afterwards — connecting to a non-socket
+	// file path produces ECONNREFUSED on Linux and ENOTSOCK on Darwin,
+	// both of which our classifier maps to a 503 envelope (the Darwin
+	// case falls into the "dial failed" default branch, which still
+	// returns 503).
+	ln, err := net.Listen("unix", deadSocket)
+	if err != nil {
+		t.Fatalf("bind dead listener: %v", err)
+	}
+	_ = ln.Close()
+	// Recreate the file as a regular file so the proxy's Transport
+	// gets a definite dial failure rather than ENOENT.
+	if err := os.WriteFile(deadSocket, []byte{}, 0o600); err != nil {
+		t.Fatalf("recreate dead file: %v", err)
+	}
+
+	cfg := Config{
+		ListenerPath:       filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:       deadSocket,
+		AllowedBindSources: []string{"/workspace"},
+		AuditWriter:        &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	req, err := http.NewRequest(http.MethodGet,
+		"http://podman.sock/v1.41/_ping", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp := doRequest(t, cfg.ListenerPath, req)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	env := readEnvelope(t, resp)
+	if !strings.HasPrefix(env.Message, "podman socket unavailable: ") {
+		t.Errorf("envelope prefix: got %q, want 'podman socket unavailable: …'", env.Message)
+	}
+}
+
+// streaming endpoints forward without parsing a body.
+//
+// AC: Streaming endpoints (containers/{id}/attach, exec/{id}/start,
+// containers/{id}/logs?follow=1) forward without attempting to parse
+// a body.
+func TestSecurity_StreamingEndpoints_ForwardWithoutBodyParse(t *testing.T) {
+	cases := []struct {
+		name, method, path string
+		// supplyBody true means we send a non-JSON body that would
+		// otherwise trip the JSON parser. The upstream is forgiving;
+		// any non-403 response from the proxy proves the body did
+		// not go through the inspector.
+		supplyBody bool
+	}{
+		{"attach", http.MethodPost, "/v1.41/containers/abc/attach?stream=1", false},
+		{"exec-start", http.MethodPost, "/v1.41/exec/exec123/start", true},
+		{"logs-follow", http.MethodGet, "/v1.41/containers/abc/logs?follow=1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fu := newFakeUpstream(t)
+			_, _, sock := startProxy(t, fu)
+			var body io.Reader
+			if tc.supplyBody {
+				// A body that is NOT valid JSON. If the proxy
+				// were body-parsing this endpoint it would return
+				// 400; instead we expect the upstream to be hit.
+				body = bytes.NewReader([]byte("not-json-and-shouldnt-be-parsed"))
+			}
+			req, err := http.NewRequest(tc.method, "http://podman.sock"+tc.path, body)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			resp := doRequest(t, sock, req)
+			if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusBadRequest {
+				t.Fatalf("streaming endpoint should not be policy-rejected, got %d", resp.StatusCode)
+			}
+			if fu.captured() == 0 {
+				t.Errorf("streaming endpoint should have forwarded to upstream")
+			}
+		})
+	}
+}
+
+// audit log: one JSON line per request with the required fields.
+//
+// AC: Every accepted and rejected request emits exactly one line to
+// the configured audit io.Writer with fields timestamp, method,
+// endpoint, decision, reason as JSON.
+func TestSecurity_AuditLog_OneLinePerRequest(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, audit, sock := startProxy(t, fu)
+
+	// Reject: privileged container.
+	r1 := postCreate(t, sock, map[string]any{"Privileged": true})
+	_ = r1.Body.Close()
+
+	// Accept: harmless containers/create.
+	r2 := postCreate(t, sock, map[string]any{"Binds": []string{"/workspace/sub:/x:ro"}})
+	_ = r2.Body.Close()
+
+	// Reject: unknown endpoint.
+	req, _ := http.NewRequest(http.MethodGet, "http://podman.sock/v1.41/swarm", nil)
+	r3 := doRequest(t, sock, req)
+	_ = r3.Body.Close()
+
+	lines := splitNonEmptyLines(audit.String())
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 audit lines, got %d:\n%s", len(lines), audit.String())
+	}
+
+	wantDecisions := []string{auditDeny, auditAllow, auditDeny}
+	for i, line := range lines {
+		var entry auditLine
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("line %d not valid JSON: %v\n%s", i, err, line)
+		}
+		if entry.Timestamp == "" {
+			t.Errorf("line %d missing timestamp", i)
+		}
+		if entry.Method == "" {
+			t.Errorf("line %d missing method", i)
+		}
+		if entry.Endpoint == "" {
+			t.Errorf("line %d missing endpoint", i)
+		}
+		if entry.Decision != wantDecisions[i] {
+			t.Errorf("line %d decision: got %q want %q", i, entry.Decision, wantDecisions[i])
+		}
+		if entry.Reason == "" {
+			t.Errorf("line %d missing reason", i)
+		}
+	}
+}
+
+// Each audit line must end with a newline so log aggregators that
+// expect line-delimited JSON can parse the stream without grammar
+// hacks.
+func TestSecurity_AuditLog_NewlineTerminated(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, audit, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{})
+	_ = resp.Body.Close()
+	out := audit.String()
+	if out == "" {
+		t.Fatal("audit log is empty")
+	}
+	if out[len(out)-1] != '\n' {
+		t.Errorf("audit line is not newline-terminated, last byte = %x", out[len(out)-1])
+	}
+}
+
+// raw-socket-curl bypass attempt — verify there is no path from the
+// agent to the underlying upstream socket directly. The proxy package
+// itself cannot prove this (the bind/SBPL rules are owned by later
+// steps), but it CAN prove the proxy never exposes a path query that
+// returns the real socket location, and it CAN prove a request that
+// claims to want to talk directly to /var/run/docker.sock just sees
+// the same allowlist denial.
+//
+// This is a smoke test for the "the proxy is the only API surface"
+// invariant.
+func TestSecurity_RawSocketCurlBypass_NoPath(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	// Try the docker convention of an Engine API path that would not
+	// exist on podman in any case, and a podman-machine-specific
+	// shim path that would expose the underlying connection.
+	for _, path := range []string{
+		"/var/run/docker.sock",
+		"/run/podman/podman.sock",
+		"/_raw/passthrough",
+	} {
+		req, _ := http.NewRequest(http.MethodGet, "http://podman.sock"+path, nil)
+		resp := doRequest(t, sock, req)
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("path %q: status got %d want %d", path, resp.StatusCode, http.StatusForbidden)
+		}
+		_ = resp.Body.Close()
+	}
+	assertNoForward(t, fu)
+}
+
+// path-traversal in bind source: filepath.Clean must collapse "..".
+//
+// "Allowlist = /workspace; source = /workspace/../etc/passwd" must
+// resolve to "/etc/passwd" and be denied.
+func TestSecurity_BindSourceTraversal_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{"/workspace/../etc/passwd:/host_passwd:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// substring trap: "/workspace" must NOT allow "/workspace-other".
+func TestSecurity_BindSourceSubstringTrap_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{"/workspace-other:/x:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("substring trap: status got %d want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	assertNoForward(t, fu)
+}
+
+// Happy path: a containers/create with allowed binds forwards the
+// body to the upstream unmodified.
+//
+// AC: A containers/create request whose HostConfig.Binds entries all
+// have sources under the configured allowlist forwards to the upstream
+// socket unmodified.
+func TestSecurity_AllowedBinds_ForwardsUnmodified(t *testing.T) {
+	fu := newFakeUpstream(t)
+	_, _, sock := startProxy(t, fu)
+
+	hostConfig := map[string]any{
+		"Binds": []string{"/workspace/proj:/app:rw", "/scratch:/tmp:ro"},
+	}
+	resp := postCreate(t, sock, hostConfig)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if fu.captured() != 1 {
+		t.Errorf("expected exactly 1 upstream call, got %d", fu.captured())
+	}
+	// The upstream's lastBody should match what we sent — the proxy
+	// must NOT have mangled the legitimate body.
+	got := fu.lastBody.Load().([]byte)
+	var roundtrip struct {
+		Image      string         `json:"Image"`
+		HostConfig map[string]any `json:"HostConfig"`
+	}
+	if err := json.Unmarshal(got, &roundtrip); err != nil {
+		t.Fatalf("upstream body not valid JSON: %v\n%s", err, got)
+	}
+	if roundtrip.Image != "alpine" {
+		t.Errorf("upstream Image: got %q, want alpine", roundtrip.Image)
+	}
+}
+
+// ────────────────────────── negative control ──────────────────────────
+
+// TestSecurity_NegativeControl_RootAllowlistPasses is the load-bearing
+// meta-test: if I mutate Config.AllowedBindSources to contain "/" (the
+// universal-allow value), the SAME host-bind request that was rejected
+// by TestSecurity_HostBindOutsideAllowlist_Denied above must NOW PASS.
+//
+// This proves the positive tests are not no-ops due to an unrelated
+// policy code path always rejecting requests for some other reason. If
+// this test fails, every other security test in this file is suspect.
+//
+// AC: A negative-control test that mutates Config.AllowedBindSources
+// to include "/" causes a host-bind request to PASS — proving the
+// positive tests are not no-ops because of unrelated policy code paths.
+func TestSecurity_NegativeControl_RootAllowlistPasses(t *testing.T) {
+	fu := newFakeUpstream(t)
+	dir := t.TempDir()
+	cfg := Config{
+		ListenerPath: filepath.Join(dir, "proxy.sock"),
+		UpstreamPath: fu.sockPath,
+		// The only difference from the rejection test above: "/"
+		// is in the allowlist.
+		AllowedBindSources: []string{"/"},
+		AllowedCaps:        []string{},
+		MaxMemoryBytes:     4 * 1024 * 1024 * 1024,
+		MaxCPUQuota:        200_000,
+		AuditWriter:        &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	// EXACTLY the same body as TestSecurity_HostBindOutsideAllowlist_Denied —
+	// /etc/passwd on the host. With AllowedBindSources=["/"] this MUST
+	// be allowed.
+	body, _ := json.Marshal(map[string]any{
+		"Image": "alpine",
+		"HostConfig": map[string]any{
+			"Binds": []string{"/etc/passwd:/host_passwd:ro"},
+		},
+	})
+	req, err := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/create",
+		bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, cfg.ListenerPath, req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("NEGATIVE CONTROL FAILED: the same body that is rejected with a normal allowlist must pass with allowlist=['/']; got status %d — review the entire security suite", resp.StatusCode)
+	}
+	if fu.captured() != 1 {
+		t.Fatalf("NEGATIVE CONTROL FAILED: upstream call count = %d, want 1; the request did not reach the upstream", fu.captured())
+	}
+}
+
+// splitNonEmptyLines is a defensive split that drops the trailing
+// empty entry that strings.Split produces when the buffer ends with a
+// newline. Used by audit-log assertions that count "real" lines.
+func splitNonEmptyLines(s string) []string {
+	out := []string{}
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,6 +115,25 @@ func (fu *fakeUpstream) captured() int64 {
 	return fu.requests.Load()
 }
 
+// proxyHarness is the per-test return value of startProxy /
+// startProxyWithCaps. It packages the listener socket path, the
+// audit buffer, and the REAL allowed directories the test should
+// bind to in positive-path tests.
+//
+// allowedDir and scratchDir are real, existing directories in the
+// configured AllowedBindSources list. After the cycle-4 symlink-
+// resolution change, isAllowedBindSource calls filepath.EvalSymlinks,
+// which errors on paths that do not exist — so a test that wants to
+// exercise the positive path of the bind allowlist must use a path
+// that actually exists on disk. Tests can also create subdirectories
+// inside allowedDir / scratchDir for finer-grained scenarios.
+type proxyHarness struct {
+	sock       string
+	audit      *bytes.Buffer
+	allowedDir string
+	scratchDir string
+}
+
 // startProxy stands a podmanproxy.Proxy on a fresh listener socket in
 // front of the supplied upstream, with sensible defaults that cover
 // the threat-table tests. Resource caps are intentionally LEFT
@@ -123,43 +143,78 @@ func (fu *fakeUpstream) captured() int64 {
 // include placeholder Memory/CpuQuota values. Tests that specifically
 // exercise the resource caps configure them in their own Config via
 // startProxyWithConfig.
-func startProxy(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) {
+func startProxy(t *testing.T, fu *fakeUpstream) *proxyHarness {
 	t.Helper()
 	// shortSocketDir, not t.TempDir() — see newFakeUpstream for rationale.
 	dir := shortSocketDir(t)
 	listenPath := filepath.Join(dir, "proxy.sock")
 	auditBuf := &bytes.Buffer{}
+
+	allowedDir := mkRealDir(t, "allow")
+	scratchDir := mkRealDir(t, "scratch")
+
 	cfg := Config{
 		ListenerPath:       listenPath,
 		UpstreamPath:       fu.sockPath,
-		AllowedBindSources: []string{"/workspace", "/scratch"},
+		AllowedBindSources: []string{allowedDir, scratchDir},
 		AllowedCaps:        []string{}, // empty by default
 		AuditWriter:        auditBuf,
 		// No MaxMemoryBytes / MaxCPUQuota / MaxNanoCpus — see comment above.
 		// No AllowedSecurityOpts — default-deny on SecurityOpt is exercised
 		// by the SecurityOpt-specific tests.
 	}
-	return startProxyWithConfig(t, cfg, auditBuf, listenPath), auditBuf, listenPath
+	startProxyWithConfig(t, cfg, auditBuf, listenPath)
+	return &proxyHarness{
+		sock:       listenPath,
+		audit:      auditBuf,
+		allowedDir: allowedDir,
+		scratchDir: scratchDir,
+	}
 }
 
 // startProxyWithCaps mirrors startProxy but enables the resource
 // caps. Tests that exercise the cap policy (over-cap, zero, negative,
 // absent) use this so the cap is actually active.
-func startProxyWithCaps(t *testing.T, fu *fakeUpstream) (*Proxy, *bytes.Buffer, string) {
+func startProxyWithCaps(t *testing.T, fu *fakeUpstream) *proxyHarness {
 	t.Helper()
 	dir := shortSocketDir(t)
 	listenPath := filepath.Join(dir, "proxy.sock")
 	auditBuf := &bytes.Buffer{}
+
+	allowedDir := mkRealDir(t, "allow")
+	scratchDir := mkRealDir(t, "scratch")
+
 	cfg := Config{
 		ListenerPath:       listenPath,
 		UpstreamPath:       fu.sockPath,
-		AllowedBindSources: []string{"/workspace", "/scratch"},
+		AllowedBindSources: []string{allowedDir, scratchDir},
 		MaxMemoryBytes:     4 * 1024 * 1024 * 1024,
 		MaxCPUQuota:        200_000,
 		MaxNanoCpus:        2_000_000_000, // 2 cores
 		AuditWriter:        auditBuf,
 	}
-	return startProxyWithConfig(t, cfg, auditBuf, listenPath), auditBuf, listenPath
+	startProxyWithConfig(t, cfg, auditBuf, listenPath)
+	return &proxyHarness{
+		sock:       listenPath,
+		audit:      auditBuf,
+		allowedDir: allowedDir,
+		scratchDir: scratchDir,
+	}
+}
+
+// mkRealDir creates a real, existing tempdir under /tmp with the
+// given prefix. Cleanup is registered with t.Cleanup. Used as
+// allowlist entries (the cycle-4 symlink-resolution check requires
+// allowlist entries to actually exist) and as bind sources in
+// positive-path tests.
+func mkRealDir(t *testing.T, prefix string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", prefix)
+	if err != nil {
+		t.Fatalf("mkdir real dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 // validCapsBody returns a hostConfig fragment that satisfies all the
@@ -319,7 +374,8 @@ func assertNoForward(t *testing.T, fu *fakeUpstream) {
 // {"message": "..."} body and is NOT forwarded upstream.
 func TestSecurity_HostBindOutsideAllowlist_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	resp := postCreate(t, sock, map[string]any{
 		"Binds": []string{"/etc/passwd:/host_passwd:ro"},
@@ -340,7 +396,8 @@ func TestSecurity_HostBindOutsideAllowlist_Denied(t *testing.T) {
 // host-bind escape: Mounts source outside the allowlist (newer API).
 func TestSecurity_HostMountOutsideAllowlist_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	resp := postCreate(t, sock, map[string]any{
 		"Mounts": []map[string]any{
@@ -363,7 +420,8 @@ func TestSecurity_HostMountOutsideAllowlist_Denied(t *testing.T) {
 // returns 403 and is not forwarded.
 func TestSecurity_Privileged_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	resp := postCreate(t, sock, map[string]any{
 		"Privileged": true,
@@ -384,7 +442,8 @@ func TestSecurity_Privileged_Denied(t *testing.T) {
 // value outside the allowlist returns 403.
 func TestSecurity_CapAddDisallowed_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	resp := postCreate(t, sock, map[string]any{
 		"CapAdd": []string{"SYS_ADMIN"},
@@ -399,10 +458,11 @@ func TestSecurity_CapAddDisallowed_Denied(t *testing.T) {
 func TestSecurity_CapAddInAllowlist_Allowed(t *testing.T) {
 	fu := newFakeUpstream(t)
 	dir := shortSocketDir(t)
+	allowedDir := mkRealDir(t, "allow")
 	cfg := Config{
 		ListenerPath:       filepath.Join(dir, "proxy.sock"),
 		UpstreamPath:       fu.sockPath,
-		AllowedBindSources: []string{"/workspace"},
+		AllowedBindSources: []string{allowedDir},
 		AllowedCaps:        []string{"NET_BIND_SERVICE"},
 		AuditWriter:        &bytes.Buffer{},
 	}
@@ -428,7 +488,8 @@ func TestSecurity_HostNamespaceModes_Denied(t *testing.T) {
 	for _, field := range modes {
 		t.Run(field, func(t *testing.T) {
 			fu := newFakeUpstream(t)
-			_, _, sock := startProxy(t, fu)
+			h := startProxy(t, fu)
+			sock := h.sock
 			resp := postCreate(t, sock, map[string]any{
 				field: "host",
 			})
@@ -446,7 +507,8 @@ func TestSecurity_HostNamespaceModes_Denied(t *testing.T) {
 // returns 403.
 func TestSecurity_DevicesNonEmpty_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	resp := postCreate(t, sock, map[string]any{
 		"Devices": []map[string]any{
@@ -474,7 +536,8 @@ func TestSecurity_DevicesNonEmpty_Denied(t *testing.T) {
 
 func TestSecurity_MemoryOverCap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 
 	// Configured cap is 4 GiB; request 10 TiB. CpuQuota / NanoCpus
 	// supplied so the request only trips the memory check.
@@ -489,7 +552,8 @@ func TestSecurity_MemoryOverCap_Denied(t *testing.T) {
 
 func TestSecurity_CPUQuotaOverCap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 
 	body := validCapsBody()
 	body["CpuQuota"] = int64(2_000_000)
@@ -505,7 +569,8 @@ func TestSecurity_CPUQuotaOverCap_Denied(t *testing.T) {
 // stating "I want unlimited memory".
 func TestSecurity_MemoryZero_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	body["Memory"] = int64(0)
 	resp := postCreate(t, sock, body)
@@ -517,7 +582,8 @@ func TestSecurity_MemoryZero_DeniedWhenCapActive(t *testing.T) {
 
 func TestSecurity_MemoryNegative_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	body["Memory"] = int64(-1)
 	resp := postCreate(t, sock, body)
@@ -533,7 +599,8 @@ func TestSecurity_MemoryNegative_DeniedWhenCapActive(t *testing.T) {
 // policy denies this too so the cap is actually enforceable.
 func TestSecurity_MemoryAbsent_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	delete(body, "Memory")
 	resp := postCreate(t, sock, body)
@@ -548,11 +615,13 @@ func TestSecurity_MemoryAbsent_DeniedWhenCapActive(t *testing.T) {
 // the default-no-cap mode preserves docker's default behaviour.
 func TestSecurity_MemoryAbsent_AllowedWhenNoCap(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 	// No Memory field, no other resource fields. With no cap active,
-	// this should pass.
+	// this should pass. Use the harness's real allowedDir so the
+	// bind source resolves via EvalSymlinks.
 	resp := postCreate(t, sock, map[string]any{
-		"Binds": []string{"/workspace/proj:/app:ro"},
+		"Binds": []string{h.allowedDir + ":/app:ro"},
 	})
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("absent Memory with no cap should be allowed; got %d", resp.StatusCode)
@@ -562,7 +631,8 @@ func TestSecurity_MemoryAbsent_AllowedWhenNoCap(t *testing.T) {
 // CpuQuotaZero / CpuQuotaAbsent: identical class to Memory.
 func TestSecurity_CpuQuotaZero_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	body["CpuQuota"] = int64(0)
 	resp := postCreate(t, sock, body)
@@ -574,7 +644,8 @@ func TestSecurity_CpuQuotaZero_DeniedWhenCapActive(t *testing.T) {
 
 func TestSecurity_CpuQuotaAbsent_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	delete(body, "CpuQuota")
 	resp := postCreate(t, sock, body)
@@ -589,7 +660,8 @@ func TestSecurity_CpuQuotaAbsent_DeniedWhenCapActive(t *testing.T) {
 // burst above the cap could simply state the request as NanoCpus.
 func TestSecurity_NanoCpusOverCap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	body["NanoCpus"] = int64(8_000_000_000) // 8 cores; cap is 2 cores
 	resp := postCreate(t, sock, body)
@@ -601,7 +673,8 @@ func TestSecurity_NanoCpusOverCap_Denied(t *testing.T) {
 
 func TestSecurity_NanoCpusZero_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	body["NanoCpus"] = int64(0)
 	resp := postCreate(t, sock, body)
@@ -613,7 +686,8 @@ func TestSecurity_NanoCpusZero_DeniedWhenCapActive(t *testing.T) {
 
 func TestSecurity_NanoCpusAbsent_DeniedWhenCapActive(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	body := validCapsBody()
 	delete(body, "NanoCpus")
 	resp := postCreate(t, sock, body)
@@ -628,7 +702,8 @@ func TestSecurity_NanoCpusAbsent_DeniedWhenCapActive(t *testing.T) {
 // blanket deny.
 func TestSecurity_ResourceCapsWithinBounds_Allowed(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	resp := postCreate(t, sock, validCapsBody())
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("valid resource caps should be allowed; got %d", resp.StatusCode)
@@ -648,7 +723,8 @@ func TestSecurity_ResourceCapsWithinBounds_Allowed(t *testing.T) {
 
 func TestSecurity_UpdateEndpoint_MemoryZero_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	req := mustNewRequest(t, http.MethodPost,
 		"http://podman.sock/v1.41/containers/abc/update",
 		map[string]any{"Memory": int64(0)})
@@ -661,7 +737,8 @@ func TestSecurity_UpdateEndpoint_MemoryZero_Denied(t *testing.T) {
 
 func TestSecurity_UpdateEndpoint_MemoryOverCap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	req := mustNewRequest(t, http.MethodPost,
 		"http://podman.sock/v1.41/containers/abc/update",
 		map[string]any{"Memory": int64(10) * 1024 * 1024 * 1024 * 1024})
@@ -674,7 +751,8 @@ func TestSecurity_UpdateEndpoint_MemoryOverCap_Denied(t *testing.T) {
 
 func TestSecurity_UpdateEndpoint_PartialBodyAllowed(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	// Only setting CpuShares (not in our cap list). Absent Memory and
 	// CpuQuota are allowed in update context.
 	req := mustNewRequest(t, http.MethodPost,
@@ -688,7 +766,8 @@ func TestSecurity_UpdateEndpoint_PartialBodyAllowed(t *testing.T) {
 
 func TestSecurity_UpdateEndpoint_MalformedJSON_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxyWithCaps(t, fu)
+	h := startProxyWithCaps(t, fu)
+	sock := h.sock
 	req, _ := http.NewRequest(http.MethodPost,
 		"http://podman.sock/v1.41/containers/abc/update",
 		bytes.NewReader([]byte(`{garbage`)))
@@ -709,7 +788,8 @@ func TestSecurity_UpdateEndpoint_MalformedJSON_Denied(t *testing.T) {
 
 func TestSecurity_ExecPrivileged_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 	req := mustNewRequest(t, http.MethodPost,
 		"http://podman.sock/v1.41/containers/abc/exec",
 		map[string]any{
@@ -725,7 +805,8 @@ func TestSecurity_ExecPrivileged_Denied(t *testing.T) {
 
 func TestSecurity_ExecWithoutPrivileged_Allowed(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 	req := mustNewRequest(t, http.MethodPost,
 		"http://podman.sock/v1.41/containers/abc/exec",
 		map[string]any{
@@ -743,7 +824,8 @@ func TestSecurity_ExecWithoutPrivileged_Allowed(t *testing.T) {
 
 func TestSecurity_ExecMalformedJSON_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 	req, _ := http.NewRequest(http.MethodPost,
 		"http://podman.sock/v1.41/containers/abc/exec",
 		bytes.NewReader([]byte(`{garbage`)))
@@ -778,7 +860,8 @@ func TestSecurity_SecurityOpt_DefaultDenyAll(t *testing.T) {
 	for _, opt := range cases {
 		t.Run(opt, func(t *testing.T) {
 			fu := newFakeUpstream(t)
-			_, _, sock := startProxy(t, fu)
+			h := startProxy(t, fu)
+			sock := h.sock
 			resp := postCreate(t, sock, map[string]any{
 				"SecurityOpt": []string{opt},
 			})
@@ -795,10 +878,11 @@ func TestSecurity_SecurityOpt_DefaultDenyAll(t *testing.T) {
 func TestSecurity_SecurityOpt_InAllowlist_Allowed(t *testing.T) {
 	fu := newFakeUpstream(t)
 	dir := shortSocketDir(t)
+	allowedDir := mkRealDir(t, "allow")
 	cfg := Config{
 		ListenerPath:        filepath.Join(dir, "proxy.sock"),
 		UpstreamPath:        fu.sockPath,
-		AllowedBindSources:  []string{"/workspace"},
+		AllowedBindSources:  []string{allowedDir},
 		AllowedSecurityOpts: []string{"no-new-privileges:true"},
 		AuditWriter:         &bytes.Buffer{},
 	}
@@ -817,10 +901,11 @@ func TestSecurity_SecurityOpt_InAllowlist_Allowed(t *testing.T) {
 func TestSecurity_SecurityOpt_PartialAllowlist_ExactMatch(t *testing.T) {
 	fu := newFakeUpstream(t)
 	dir := shortSocketDir(t)
+	allowedDir := mkRealDir(t, "allow")
 	cfg := Config{
 		ListenerPath:        filepath.Join(dir, "proxy.sock"),
 		UpstreamPath:        fu.sockPath,
-		AllowedBindSources:  []string{"/workspace"},
+		AllowedBindSources:  []string{allowedDir},
 		AllowedSecurityOpts: []string{"no-new-privileges:true"},
 		AuditWriter:         &bytes.Buffer{},
 	}
@@ -840,7 +925,8 @@ func TestSecurity_SecurityOpt_PartialAllowlist_ExactMatch(t *testing.T) {
 // parameter outside the allowlist returns 403.
 func TestSecurity_ArchivePathOutsideAllowlist_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	req, err := http.NewRequest(http.MethodPut,
 		"http://podman.sock/v1.41/containers/abc123/archive?path=%2Fetc",
@@ -861,7 +947,8 @@ func TestSecurity_ArchivePathOutsideAllowlist_Denied(t *testing.T) {
 // an actionable error message identifying the rejected endpoint.
 func TestSecurity_UnknownEndpoint_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	for _, tc := range []struct {
 		name, method, path string
@@ -899,7 +986,8 @@ func TestSecurity_UnknownEndpoint_Denied(t *testing.T) {
 // is not forwarded.
 func TestSecurity_MalformedJSONBody_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	req, err := http.NewRequest(http.MethodPost,
 		"http://podman.sock/v1.41/containers/create",
@@ -918,7 +1006,8 @@ func TestSecurity_MalformedJSONBody_Denied(t *testing.T) {
 // empty body on containers/create is treated as malformed.
 func TestSecurity_EmptyCreateBody_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	req, err := http.NewRequest(http.MethodPost,
 		"http://podman.sock/v1.41/containers/create",
@@ -1049,7 +1138,8 @@ func TestSecurity_StreamingEndpoints_ForwardWithoutBodyParse(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fu := newFakeUpstream(t)
-			_, _, sock := startProxy(t, fu)
+			h := startProxy(t, fu)
+			sock := h.sock
 			var body io.Reader
 			if tc.supplyBody {
 				// A body that is NOT valid JSON. If the proxy
@@ -1079,14 +1169,16 @@ func TestSecurity_StreamingEndpoints_ForwardWithoutBodyParse(t *testing.T) {
 // endpoint, decision, reason as JSON.
 func TestSecurity_AuditLog_OneLinePerRequest(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, audit, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
+	audit := h.audit
 
 	// Reject: privileged container.
 	r1 := postCreate(t, sock, map[string]any{"Privileged": true})
 	_ = r1.Body.Close()
 
-	// Accept: harmless containers/create.
-	r2 := postCreate(t, sock, map[string]any{"Binds": []string{"/workspace/sub:/x:ro"}})
+	// Accept: harmless containers/create with a real allowed path.
+	r2 := postCreate(t, sock, map[string]any{"Binds": []string{h.allowedDir + ":/x:ro"}})
 	_ = r2.Body.Close()
 
 	// Reject: unknown endpoint.
@@ -1128,7 +1220,9 @@ func TestSecurity_AuditLog_OneLinePerRequest(t *testing.T) {
 // hacks.
 func TestSecurity_AuditLog_NewlineTerminated(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, audit, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
+	audit := h.audit
 
 	resp := postCreate(t, sock, map[string]any{})
 	_ = resp.Body.Close()
@@ -1153,7 +1247,8 @@ func TestSecurity_AuditLog_NewlineTerminated(t *testing.T) {
 // invariant.
 func TestSecurity_RawSocketCurlBypass_NoPath(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
 	// Try the docker convention of an Engine API path that would not
 	// exist on podman in any case, and a podman-machine-specific
@@ -1173,16 +1268,25 @@ func TestSecurity_RawSocketCurlBypass_NoPath(t *testing.T) {
 	assertNoForward(t, fu)
 }
 
-// path-traversal in bind source: filepath.Clean must collapse "..".
+// path-traversal in bind source: filepath.Clean (and now
+// filepath.EvalSymlinks) must collapse ".." to a canonical path,
+// after which the prefix check against the allowlist runs.
 //
-// "Allowlist = /workspace; source = /workspace/../etc/passwd" must
-// resolve to "/etc/passwd" and be denied.
+// Concrete scenario: allowlist = h.allowedDir; source = h.allowedDir
+// + "/../../etc/passwd". After lexical Clean the source becomes
+// "/etc/passwd"; after EvalSymlinks it stays "/etc/passwd" (exists
+// on every Unix host). The prefix check against h.allowedDir fails.
+// DENY.
 func TestSecurity_BindSourceTraversal_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
+	// Build a traversal source that, after Clean, escapes the allowed
+	// prefix and lands on a real host file outside the allowlist.
+	traversal := h.allowedDir + "/../../../../etc/hosts"
 	resp := postCreate(t, sock, map[string]any{
-		"Binds": []string{"/workspace/../etc/passwd:/host_passwd:ro"},
+		"Binds": []string{traversal + ":/x:ro"},
 	})
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
@@ -1190,13 +1294,34 @@ func TestSecurity_BindSourceTraversal_Denied(t *testing.T) {
 	assertNoForward(t, fu)
 }
 
-// substring trap: "/workspace" must NOT allow "/workspace-other".
+// substring trap: an allowlist entry must NOT match a sibling path
+// whose name shares the prefix but adds extra characters before the
+// next separator. "/foo" must NOT allow "/foo-other".
+//
+// We create two real sibling directories under a common parent so
+// EvalSymlinks resolves both, isolating the prefix-check logic.
 func TestSecurity_BindSourceSubstringTrap_Denied(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	parent := mkRealDir(t, "trap")
+	allowed := filepath.Join(parent, "allow")
+	sibling := filepath.Join(parent, "allow-other")
+	if err := os.Mkdir(allowed, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	if err := os.Mkdir(sibling, 0o755); err != nil {
+		t.Fatalf("mkdir sibling: %v", err)
+	}
+	dir := shortSocketDir(t)
+	cfg := Config{
+		ListenerPath:       filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:       fu.sockPath,
+		AllowedBindSources: []string{allowed},
+		AuditWriter:        &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
 
-	resp := postCreate(t, sock, map[string]any{
-		"Binds": []string{"/workspace-other:/x:ro"},
+	resp := postCreate(t, cfg.ListenerPath, map[string]any{
+		"Binds": []string{sibling + ":/x:ro"},
 	})
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("substring trap: status got %d want %d", resp.StatusCode, http.StatusForbidden)
@@ -1212,10 +1337,17 @@ func TestSecurity_BindSourceSubstringTrap_Denied(t *testing.T) {
 // socket unmodified.
 func TestSecurity_AllowedBinds_ForwardsUnmodified(t *testing.T) {
 	fu := newFakeUpstream(t)
-	_, _, sock := startProxy(t, fu)
+	h := startProxy(t, fu)
+	sock := h.sock
 
+	// Create a real subdirectory inside allowedDir so the bind source
+	// is both inside the allowlist AND resolvable by EvalSymlinks.
+	projDir := filepath.Join(h.allowedDir, "proj")
+	if err := os.Mkdir(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir proj: %v", err)
+	}
 	hostConfig := map[string]any{
-		"Binds": []string{"/workspace/proj:/app:rw", "/scratch:/tmp:ro"},
+		"Binds": []string{projDir + ":/app:rw", h.scratchDir + ":/tmp:ro"},
 	}
 	resp := postCreate(t, sock, hostConfig)
 	if resp.StatusCode != http.StatusOK {
@@ -1240,6 +1372,219 @@ func TestSecurity_AllowedBinds_ForwardsUnmodified(t *testing.T) {
 }
 
 // ────────────────────────── negative control ──────────────────────────
+
+// ─────────── cycle-4: symlink bypass of bind-source allowlist ────────────
+//
+// Reviewer's exact exploit (PR #2326 round 3, CRITICAL): the agent
+// has write access to a path INSIDE an allowed prefix, so it plants
+// a symlink at <allowed>/key → <forbidden host file>. The proxy's
+// lexical prefix check sees /<allowed>/key starting with /<allowed>/
+// → ALLOW. The proxy forwards to podman, runc's mount(2) follows
+// the symlink at the kernel level, and the container ends up with
+// the forbidden host file bind-mounted in.
+//
+// Fix: filepath.EvalSymlinks on the source before the prefix check.
+// This test pins the fix down to the reviewer's verbatim scenario.
+
+func TestSecurity_BindSymlinkToForbiddenPath_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	// Plant a symlink inside the allowed prefix pointing at /etc/hosts
+	// (the canonical "forbidden host file" stand-in that exists on
+	// every Unix host).
+	symlinkPath := filepath.Join(h.allowedDir, "key")
+	if err := os.Symlink("/etc/hosts", symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{symlinkPath + ":/k:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("symlink-to-forbidden bind should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Same exploit shape via HostConfig.Mounts of Type=bind — the
+// reviewer specifically noted this second call site at policy.go:160.
+func TestSecurity_MountSymlinkToForbiddenPath_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	symlinkPath := filepath.Join(h.allowedDir, "keymount")
+	if err := os.Symlink("/etc/hosts", symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "bind",
+				"Source": symlinkPath,
+				"Target": "/k",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("symlink-to-forbidden mount should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Same exploit shape via the PUT /containers/{id}/archive path
+// query — the reviewer's third call site at policy.go:378.
+func TestSecurity_ArchiveSymlinkToForbiddenPath_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	symlinkPath := filepath.Join(h.allowedDir, "keyarchive")
+	if err := os.Symlink("/etc/hosts", symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodPut,
+		"http://podman.sock/v1.41/containers/abc/archive?path="+url.QueryEscape(symlinkPath),
+		bytes.NewReader([]byte("tar")))
+	resp := doRequest(t, sock, req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("symlink-to-forbidden archive path should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Symlink that points to a location ALSO inside the allowed prefix
+// must still resolve and pass. Proves the symlink-resolution code
+// is not a blanket "any symlink → deny".
+func TestSecurity_BindSymlinkToAllowedPath_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	targetDir := filepath.Join(h.allowedDir, "target")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	symlinkPath := filepath.Join(h.allowedDir, "link")
+	if err := os.Symlink(targetDir, symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{symlinkPath + ":/x:ro"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("symlink to within-allowlist target should be allowed; got %d", resp.StatusCode)
+	}
+}
+
+// Non-existent source: EvalSymlinks errors → DENY. The coordinator's
+// directive explicitly said "lean reject" for non-existent paths.
+func TestSecurity_BindNonExistentSource_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	// Path under the allowed prefix but the file does not exist —
+	// without EvalSymlinks the lexical check would ALLOW this; with
+	// EvalSymlinks it errors and we DENY.
+	nonexistent := filepath.Join(h.allowedDir, "does-not-exist")
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{nonexistent + ":/x:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("non-existent source should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Broken symlink chain (link → missing target): EvalSymlinks errors
+// on the missing target, so DENY even though the symlink itself
+// exists at an allowed path. Defence-in-depth against an agent that
+// plants a broken symlink as a stepping stone.
+func TestSecurity_BindBrokenSymlink_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	linkPath := filepath.Join(h.allowedDir, "broken")
+	if err := os.Symlink(filepath.Join(h.allowedDir, "missing-target"), linkPath); err != nil {
+		t.Fatalf("create broken symlink: %v", err)
+	}
+	resp := postCreate(t, sock, map[string]any{
+		"Binds": []string{linkPath + ":/x:ro"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("broken symlink source should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// Relative path source via HostConfig.Mounts.Source. The Docker API
+// spec requires absolute source paths for Type=bind mounts; the
+// proxy rejects relative sources defensively.
+func TestSecurity_MountRelativeSource_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxy(t, fu)
+	sock := h.sock
+
+	resp := postCreate(t, sock, map[string]any{
+		"Mounts": []map[string]any{
+			{
+				"Type":   "bind",
+				"Source": "relative/path",
+				"Target": "/x",
+			},
+		},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("relative Mounts source should be denied; got %d", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+}
+
+// macOS-on-symlinked-TMPDIR sanity: when /tmp is a symlink to
+// /private/tmp (macOS default), an allowlist entry under /tmp must
+// still match a source under /private/tmp (and vice versa). The
+// canonicalisePath helper resolves the allowlist entry so the
+// prefix comparison is done in canonical form. This is most
+// relevant on Darwin, but the helper exercises the same
+// canonicalisation path on Linux too.
+func TestSecurity_BindSymlinkedAllowlistEntry_Matched(t *testing.T) {
+	fu := newFakeUpstream(t)
+	dir := shortSocketDir(t)
+
+	real := mkRealDir(t, "real")
+	sub := filepath.Join(real, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+	// Symlink alias to that directory — used as the allowlist entry.
+	aliasParent := mkRealDir(t, "alias")
+	alias := filepath.Join(aliasParent, "link")
+	if err := os.Symlink(real, alias); err != nil {
+		t.Fatalf("create alias symlink: %v", err)
+	}
+
+	cfg := Config{
+		ListenerPath:       filepath.Join(dir, "proxy.sock"),
+		UpstreamPath:       fu.sockPath,
+		AllowedBindSources: []string{alias},
+		AuditWriter:        &bytes.Buffer{},
+	}
+	startProxyWithConfig(t, cfg, nil, cfg.ListenerPath)
+
+	// Bind the CANONICAL path. Without canonical-form allowlist
+	// resolution this would not match (alias != real lexically);
+	// with canonical resolution both sides resolve to the same
+	// target and the bind is allowed.
+	resp := postCreate(t, cfg.ListenerPath, map[string]any{
+		"Binds": []string{sub + ":/x:ro"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("canonical source under symlinked allowlist entry should be allowed; got %d", resp.StatusCode)
+	}
+}
 
 // TestSecurity_NegativeControl_RootAllowlistPasses is the load-bearing
 // meta-test: if I mutate Config.AllowedBindSources to contain "/" (the

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
@@ -86,7 +86,9 @@ func TestNewProxy_DefaultsAreApplied(t *testing.T) {
 // ───────────────────────────── Serve lifecycle ─────────────────────────
 
 func TestServe_BlocksUntilContextCancelled(t *testing.T) {
-	dir := t.TempDir()
+	// shortSocketDir, not t.TempDir() — see proxy_security_test.go
+	// for rationale (sockaddr_un.sun_path overflow under Nix sandbox).
+	dir := shortSocketDir(t)
 	listenPath := filepath.Join(dir, "proxy.sock")
 	upstreamPath := filepath.Join(dir, "upstream.sock") // does not need to exist
 	p, err := NewProxy(Config{
@@ -140,7 +142,7 @@ func TestServe_BlocksUntilContextCancelled(t *testing.T) {
 
 func TestServe_BindFailureReturnsError(t *testing.T) {
 	// Use a path that cannot exist (parent dir is a regular file).
-	dir := t.TempDir()
+	dir := shortSocketDir(t)
 	regularFile := filepath.Join(dir, "not-a-dir")
 	if err := os.WriteFile(regularFile, []byte("x"), 0o600); err != nil {
 		t.Fatalf("write regular file: %v", err)
@@ -163,7 +165,7 @@ func TestServe_BindFailureReturnsError(t *testing.T) {
 }
 
 func TestServe_RemovesStaleSocketBeforeBind(t *testing.T) {
-	dir := t.TempDir()
+	dir := shortSocketDir(t)
 	listenPath := filepath.Join(dir, "proxy.sock")
 	// Pre-create a stale socket file.
 	if err := os.WriteFile(listenPath, []byte("stale"), 0o600); err != nil {

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
@@ -447,6 +447,7 @@ func TestClassifyRequest_AllowsCoreEndpoints(t *testing.T) {
 		{http.MethodPost, "containers/abc/attach", endpointAllowStreaming},
 		{http.MethodPost, "containers/abc/exec", endpointPolicyExec},
 		{http.MethodPost, "containers/abc/update", endpointPolicyUpdate},
+		{http.MethodPost, "volumes/create", endpointPolicyVolumeCreate},
 		{http.MethodPost, "exec/abc/start", endpointAllowStreaming},
 		{http.MethodGet, "containers/abc/logs", endpointAllowStreaming},
 		{http.MethodPut, "containers/abc/archive", endpointPolicyArchive},

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
@@ -409,6 +409,8 @@ func TestClassifyRequest_AllowsCoreEndpoints(t *testing.T) {
 		{http.MethodPost, "containers/create", endpointPolicyCreate},
 		{http.MethodPost, "containers/abc/start", endpointAllow},
 		{http.MethodPost, "containers/abc/attach", endpointAllowStreaming},
+		{http.MethodPost, "containers/abc/exec", endpointPolicyExec},
+		{http.MethodPost, "containers/abc/update", endpointPolicyUpdate},
 		{http.MethodPost, "exec/abc/start", endpointAllowStreaming},
 		{http.MethodGet, "containers/abc/logs", endpointAllowStreaming},
 		{http.MethodPut, "containers/abc/archive", endpointPolicyArchive},

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
@@ -280,41 +280,68 @@ func TestIsVersionSegment(t *testing.T) {
 
 // ─────────────────────── isAllowedBindSource ───────────────────────────
 
+// As of cycle 4, these tests use REAL paths because isAllowedBindSource
+// now calls filepath.EvalSymlinks (which errors on paths that do not
+// exist). The scaffold creates a /tmp/<rand>/ tree with sibling
+// directories so each behavioural case maps to a real on-disk layout.
 func TestIsAllowedBindSource(t *testing.T) {
+	base, err := os.MkdirTemp("/tmp", "iabs")
+	if err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+
+	mkdir := func(p string) string {
+		t.Helper()
+		full := filepath.Join(base, p)
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", full, err)
+		}
+		return full
+	}
+	workspace := mkdir("workspace")
+	sub := mkdir("workspace/sub")
+	deeper := mkdir("workspace/sub/deeper")
+	scratch := mkdir("scratch")
+	wsOther := mkdir("workspace-other")
+	ws2 := mkdir("workspace2")
+	elseFile := filepath.Join(mkdir("elsewhere"), "file")
+	if err := os.WriteFile(elseFile, []byte{}, 0o600); err != nil {
+		t.Fatalf("touch %s: %v", elseFile, err)
+	}
+
 	p := &Proxy{cfg: Config{
-		AllowedBindSources: []string{"/workspace", "/scratch", "/var/lib/data/"},
+		AllowedBindSources: []string{workspace, scratch},
 	}}
 
 	cases := []struct {
+		name string
 		src  string
 		want bool
 	}{
-		// Direct match.
-		{"/workspace", true},
-		// Child path.
-		{"/workspace/sub", true},
-		{"/workspace/sub/deeper", true},
-		// Trailing-slash on allowlist entry must work.
-		{"/var/lib/data", true},
-		{"/var/lib/data/file", true},
-		// Substring trap: must NOT pass.
-		{"/workspace-other", false},
-		{"/workspace2", false},
-		// Disallowed paths.
-		{"/etc/passwd", false},
-		{"/Users/bensherman", false},
-		{"/", false},
-		{"", false},
-		// Relative path — never allowed.
-		{"relative/path", false},
-		// Traversal — filepath.Clean collapses ".."
-		{"/workspace/../etc", false},
-		// Edge: source IS an ancestor of allow entry — not allowed
-		// (allowing /workspace ≠ allowing /).
-		{"/work", false},
+		{"direct-match-workspace", workspace, true},
+		{"child-of-workspace", sub, true},
+		{"grandchild-of-workspace", deeper, true},
+		{"direct-match-scratch", scratch, true},
+		{"substring-trap-other", wsOther, false},
+		{"substring-trap-2", ws2, false},
+		{"file-outside-allowlist", elseFile, false},
+		{"existing-host-path", "/etc/hosts", false},
+		{"slash", "/", false},
+		{"empty", "", false},
+		{"relative-path", "relative/path", false},
+		// Traversal escaping the allowlist: after lexical Clean the
+		// source lands one level above base, which is not under the
+		// workspace allowlist entry.
+		{"traversal-out", workspace + "/../..", false},
+		// Traversal that lands back inside the allowlist is allowed
+		// (Clean collapses sub/.. to workspace itself).
+		{"traversal-back-in", workspace + "/sub/..", true},
+		// Non-existent paths fail EvalSymlinks and are denied.
+		{"nonexistent", "/this/does/not/exist/anywhere/12345", false},
 	}
 	for _, tc := range cases {
-		t.Run(tc.src, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			got := p.isAllowedBindSource(tc.src)
 			if got != tc.want {
 				t.Errorf("isAllowedBindSource(%q) = %v, want %v", tc.src, got, tc.want)
@@ -325,7 +352,10 @@ func TestIsAllowedBindSource(t *testing.T) {
 
 func TestIsAllowedBindSource_RootEntry(t *testing.T) {
 	p := &Proxy{cfg: Config{AllowedBindSources: []string{"/"}}}
-	cases := []string{"/etc/passwd", "/Users/bensherman", "/var/log/syslog", "/"}
+	// Paths used here MUST exist on every Unix host the test suite
+	// runs on (Linux Nix sandbox + Darwin dev). /etc/hosts, /tmp, /
+	// are the safe trio.
+	cases := []string{"/etc/hosts", "/tmp", "/"}
 	for _, src := range cases {
 		if !p.isAllowedBindSource(src) {
 			t.Errorf("with root allowlist, %q should be allowed", src)
@@ -334,6 +364,12 @@ func TestIsAllowedBindSource_RootEntry(t *testing.T) {
 	// Empty source still not allowed (defensive).
 	if p.isAllowedBindSource("") {
 		t.Error("empty source should never be allowed, even with root allowlist")
+	}
+	// Non-existent paths fail EvalSymlinks and are denied even when
+	// the allowlist is the universal "/". This is intentional: a
+	// non-existent bind source is suspect.
+	if p.isAllowedBindSource("/this/does/not/exist/anywhere/67890") {
+		t.Error("non-existent path must be denied even with root allowlist (EvalSymlinks contract)")
 	}
 }
 

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
@@ -1,0 +1,428 @@
+package podmanproxy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Tests for the non-security ACs in #2318:
+//
+//   - NewProxy returns nil + non-nil error on missing required Config.
+//   - NewProxy returns *Proxy + nil error on a valid Config.
+//   - Serve(ctx) blocks until ctx is cancelled, then returns nil after
+//     the listener socket file is removed.
+//   - classifyUpstreamErr maps each known syscall error to the right
+//     short-form reason.
+//   - normalisePath strips version and libpod prefixes as documented.
+//   - isAllowedBindSource closes the substring trap and respects /.
+//   - capIsAllowed normalises CAP_ prefixes and is case-insensitive.
+
+// ─────────────────────── NewProxy / Config validation ──────────────────
+
+func TestNewProxy_RejectsMissingListenerPath(t *testing.T) {
+	_, err := NewProxy(Config{UpstreamPath: "/x"})
+	if err == nil {
+		t.Fatal("expected error for missing ListenerPath, got nil")
+	}
+}
+
+func TestNewProxy_RejectsMissingUpstreamPath(t *testing.T) {
+	_, err := NewProxy(Config{ListenerPath: "/x"})
+	if err == nil {
+		t.Fatal("expected error for missing UpstreamPath, got nil")
+	}
+}
+
+func TestNewProxy_AcceptsValidConfig(t *testing.T) {
+	p, err := NewProxy(Config{
+		ListenerPath: "/tmp/proxy.sock",
+		UpstreamPath: "/tmp/upstream.sock",
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+	if p == nil {
+		t.Fatal("NewProxy returned a nil *Proxy with no error")
+	}
+}
+
+func TestNewProxy_RejectsNegativeBodyCap(t *testing.T) {
+	_, err := NewProxy(Config{
+		ListenerPath: "/x",
+		UpstreamPath: "/y",
+		MaxBodyBytes: -1,
+	})
+	if err == nil {
+		t.Fatal("expected error for negative MaxBodyBytes")
+	}
+}
+
+func TestNewProxy_DefaultsAreApplied(t *testing.T) {
+	p, err := NewProxy(Config{
+		ListenerPath: "/x",
+		UpstreamPath: "/y",
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+	if p.cfg.MaxBodyBytes != DefaultMaxBodyBytes {
+		t.Errorf("MaxBodyBytes default: got %d, want %d", p.cfg.MaxBodyBytes, DefaultMaxBodyBytes)
+	}
+	if p.cfg.DialTimeout != DefaultDialTimeout {
+		t.Errorf("DialTimeout default: got %v, want %v", p.cfg.DialTimeout, DefaultDialTimeout)
+	}
+	if p.cfg.Clock == nil {
+		t.Error("Clock should default to time.Now")
+	}
+}
+
+// ───────────────────────────── Serve lifecycle ─────────────────────────
+
+func TestServe_BlocksUntilContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	listenPath := filepath.Join(dir, "proxy.sock")
+	upstreamPath := filepath.Join(dir, "upstream.sock") // does not need to exist
+	p, err := NewProxy(Config{
+		ListenerPath: listenPath,
+		UpstreamPath: upstreamPath,
+		AuditWriter:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- p.Serve(ctx) }()
+
+	// Poll until the socket exists, then assert Serve has NOT returned.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(listenPath); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, err := os.Stat(listenPath); err != nil {
+		t.Fatalf("listener socket %s never created: %v", listenPath, err)
+	}
+
+	select {
+	case err := <-serveDone:
+		t.Fatalf("Serve returned before context cancellation: %v", err)
+	case <-time.After(100 * time.Millisecond):
+		// Good — Serve is still blocking.
+	}
+
+	cancel()
+
+	select {
+	case err := <-serveDone:
+		if err != nil {
+			t.Fatalf("Serve returned non-nil after cancel: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Serve did not return within 3s of cancel")
+	}
+
+	// AC: the listener socket file is removed.
+	if _, err := os.Stat(listenPath); !os.IsNotExist(err) {
+		t.Fatalf("listener socket %s still exists after Serve returned: stat err=%v", listenPath, err)
+	}
+}
+
+func TestServe_BindFailureReturnsError(t *testing.T) {
+	// Use a path that cannot exist (parent dir is a regular file).
+	dir := t.TempDir()
+	regularFile := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(regularFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+	listenPath := filepath.Join(regularFile, "proxy.sock") // bind under a non-dir
+	p, err := NewProxy(Config{
+		ListenerPath: listenPath,
+		UpstreamPath: "/tmp/upstream.sock",
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err = p.Serve(ctx)
+	if err == nil {
+		t.Fatal("expected bind error from Serve, got nil")
+	}
+}
+
+func TestServe_RemovesStaleSocketBeforeBind(t *testing.T) {
+	dir := t.TempDir()
+	listenPath := filepath.Join(dir, "proxy.sock")
+	// Pre-create a stale socket file.
+	if err := os.WriteFile(listenPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+
+	p, err := NewProxy(Config{
+		ListenerPath: listenPath,
+		UpstreamPath: "/tmp/upstream.sock",
+		AuditWriter:  io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("NewProxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- p.Serve(ctx) }()
+
+	// Wait for the socket to be bound.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		fi, err := os.Stat(listenPath)
+		if err == nil && fi.Mode()&os.ModeSocket != 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	fi, err := os.Stat(listenPath)
+	if err != nil {
+		t.Fatalf("post-bind stat: %v", err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		t.Errorf("expected socket file, got mode %v", fi.Mode())
+	}
+
+	cancel()
+	<-serveDone
+}
+
+// ───────────────────────── classifyUpstreamErr ─────────────────────────
+
+func TestClassifyUpstreamErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"ECONNREFUSED", syscall.ECONNREFUSED, "connection refused"},
+		{"ENOENT", syscall.ENOENT, "socket missing"},
+		{"os.ErrNotExist", os.ErrNotExist, "socket missing"},
+		{"DeadlineExceeded", context.DeadlineExceeded, "dial timeout"},
+		{"EACCES", syscall.EACCES, "permission denied"},
+		{"unknown", errors.New("something else"), "dial failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyUpstreamErr(tc.err)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ─────────────────────────── normalisePath ─────────────────────────────
+
+func TestNormalisePath(t *testing.T) {
+	cases := []struct {
+		in, out string
+	}{
+		{"/v1.41/containers/json", "containers/json"},
+		{"/v5.0.0/libpod/containers/create", "containers/create"},
+		{"/libpod/containers/json", "containers/json"},
+		{"/containers/create", "containers/create"},
+		{"/", ""},
+		{"", ""},
+		{"//etc/passwd", ""},
+		{"//", ""},
+		{"/v1/_ping", "_ping"},
+		{"/version", "version"},
+		{"/v1a/containers/json", "v1a/containers/json"}, // not a version
+		{"no-leading-slash", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := normalisePath(tc.in)
+			if got != tc.out {
+				t.Errorf("normalisePath(%q) = %q, want %q", tc.in, got, tc.out)
+			}
+		})
+	}
+}
+
+func TestIsVersionSegment(t *testing.T) {
+	cases := map[string]bool{
+		"v1":     true,
+		"v1.41":  true,
+		"v5.0.0": true,
+		"v":      false,
+		"v1a":    false,
+		"":       false,
+		"foo":    false,
+	}
+	for in, want := range cases {
+		got := isVersionSegment(in)
+		if got != want {
+			t.Errorf("isVersionSegment(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// ─────────────────────── isAllowedBindSource ───────────────────────────
+
+func TestIsAllowedBindSource(t *testing.T) {
+	p := &Proxy{cfg: Config{
+		AllowedBindSources: []string{"/workspace", "/scratch", "/var/lib/data/"},
+	}}
+
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		// Direct match.
+		{"/workspace", true},
+		// Child path.
+		{"/workspace/sub", true},
+		{"/workspace/sub/deeper", true},
+		// Trailing-slash on allowlist entry must work.
+		{"/var/lib/data", true},
+		{"/var/lib/data/file", true},
+		// Substring trap: must NOT pass.
+		{"/workspace-other", false},
+		{"/workspace2", false},
+		// Disallowed paths.
+		{"/etc/passwd", false},
+		{"/Users/bensherman", false},
+		{"/", false},
+		{"", false},
+		// Relative path — never allowed.
+		{"relative/path", false},
+		// Traversal — filepath.Clean collapses ".."
+		{"/workspace/../etc", false},
+		// Edge: source IS an ancestor of allow entry — not allowed
+		// (allowing /workspace ≠ allowing /).
+		{"/work", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			got := p.isAllowedBindSource(tc.src)
+			if got != tc.want {
+				t.Errorf("isAllowedBindSource(%q) = %v, want %v", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAllowedBindSource_RootEntry(t *testing.T) {
+	p := &Proxy{cfg: Config{AllowedBindSources: []string{"/"}}}
+	cases := []string{"/etc/passwd", "/Users/bensherman", "/var/log/syslog", "/"}
+	for _, src := range cases {
+		if !p.isAllowedBindSource(src) {
+			t.Errorf("with root allowlist, %q should be allowed", src)
+		}
+	}
+	// Empty source still not allowed (defensive).
+	if p.isAllowedBindSource("") {
+		t.Error("empty source should never be allowed, even with root allowlist")
+	}
+}
+
+// ─────────────────────────── capIsAllowed ──────────────────────────────
+
+func TestCapIsAllowed_NormalisesCAPPrefix(t *testing.T) {
+	p := &Proxy{cfg: Config{AllowedCaps: []string{"NET_BIND_SERVICE"}}}
+
+	cases := map[string]bool{
+		"NET_BIND_SERVICE":     true,
+		"CAP_NET_BIND_SERVICE": true,
+		"net_bind_service":     true,
+		"cap_net_bind_service": true,
+		"SYS_ADMIN":            false,
+		"CAP_SYS_ADMIN":        false,
+		"":                     false,
+	}
+	for in, want := range cases {
+		got := p.capIsAllowed(in)
+		if got != want {
+			t.Errorf("capIsAllowed(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestCapIsAllowed_EmptyAllowlistDeniesAll(t *testing.T) {
+	p := &Proxy{cfg: Config{AllowedCaps: nil}}
+	if p.capIsAllowed("NET_BIND_SERVICE") {
+		t.Error("with empty allowlist, no capability should be allowed")
+	}
+}
+
+// ─────────────────────────── bindSource ────────────────────────────────
+
+func TestBindSource(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/host/src:/in_container", "/host/src"},
+		{"/host/src:/in_container:ro", "/host/src"},
+		{"volume_name:/in_container", ""}, // named volume
+		{"volume_name:/in:ro", ""},        // named volume w/ opts
+		{"/", ""},                         // no colon = invalid bind syntax
+		{"no-colon", ""},                  // invalid bind syntax
+		{"", ""},                          // empty
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := bindSource(tc.in)
+			if got != tc.want {
+				t.Errorf("bindSource(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ───────────────────── handler dispatch sanity ─────────────────────────
+
+// The classifyRequest table is tested implicitly by the security suite,
+// but a small subset is worth pinning here so a refactor that breaks
+// allowlist coverage shows up as a unit-test failure rather than a
+// security-test failure (cheaper to debug).
+func TestClassifyRequest_AllowsCoreEndpoints(t *testing.T) {
+	cases := []struct {
+		method, path string
+		want         endpointKind
+	}{
+		{http.MethodGet, "_ping", endpointAllow},
+		{http.MethodGet, "info", endpointAllow},
+		{http.MethodGet, "version", endpointAllow},
+		{http.MethodGet, "containers/json", endpointAllow},
+		{http.MethodGet, "containers/abc/json", endpointAllow},
+		{http.MethodPost, "containers/create", endpointPolicyCreate},
+		{http.MethodPost, "containers/abc/start", endpointAllow},
+		{http.MethodPost, "containers/abc/attach", endpointAllowStreaming},
+		{http.MethodPost, "exec/abc/start", endpointAllowStreaming},
+		{http.MethodGet, "containers/abc/logs", endpointAllowStreaming},
+		{http.MethodPut, "containers/abc/archive", endpointPolicyArchive},
+		{http.MethodDelete, "containers/abc", endpointAllow},
+		{http.MethodHead, "_ping", endpointAllow},
+		// deny cases
+		{http.MethodGet, "swarm", endpointDeny},
+		{http.MethodPatch, "containers/abc", endpointDeny},
+		{http.MethodPut, "containers/abc/start", endpointDeny},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+"_"+tc.path, func(t *testing.T) {
+			got := classifyRequest(tc.method, tc.path)
+			if got != tc.want {
+				t.Errorf("classifyRequest(%s, %s) = %v, want %v", tc.method, tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_test.go
@@ -448,6 +448,7 @@ func TestClassifyRequest_AllowsCoreEndpoints(t *testing.T) {
 		{http.MethodPost, "containers/abc/exec", endpointPolicyExec},
 		{http.MethodPost, "containers/abc/update", endpointPolicyUpdate},
 		{http.MethodPost, "volumes/create", endpointPolicyVolumeCreate},
+		{http.MethodPost, "networks/create", endpointPolicyNetworkCreate},
 		{http.MethodPost, "exec/abc/start", endpointAllowStreaming},
 		{http.MethodGet, "containers/abc/logs", endpointAllowStreaming},
 		{http.MethodPut, "containers/abc/archive", endpointPolicyArchive},

--- a/modules/programs/prism/prism/internal/podmanproxy/responses.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/responses.go
@@ -1,0 +1,39 @@
+package podmanproxy
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// errorEnvelope is the docker-compatible JSON response body used for
+// every synthesised response. The single "message" field is the lowest
+// common denominator across docker CLI, podman, fsouza/go-dockerclient,
+// containers/buildah, etc.
+type errorEnvelope struct {
+	Message string `json:"message"`
+}
+
+// writeJSONError writes status and a JSON {"message": msg} body. The
+// content-type is set to application/json. Any error returned by
+// http.ResponseWriter.Write is intentionally ignored — there is no
+// useful recovery path at the top of an HTTP handler.
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	body, err := json.Marshal(errorEnvelope{Message: msg})
+	if err != nil {
+		// json.Marshal of a struct with a string field cannot fail
+		// in practice, but fall back to a safe minimal envelope.
+		body = []byte(`{"message":"internal error"}`)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+// writeUnavailable writes the friendly upstream-unavailable envelope.
+// The body shape is locked by the parent issue's AC; do not reword it
+// without updating both #2317 and #2318.
+func writeUnavailable(w http.ResponseWriter, reason string) {
+	msg := "podman socket unavailable: " + reason +
+		"; on macOS run 'podman machine start', on Linux check 'systemctl --user status podman.socket'"
+	writeJSONError(w, http.StatusServiceUnavailable, msg)
+}


### PR DESCRIPTION
Step 1 of the train tracked by #2317. Implements the standalone podman socket filter proxy as a self-contained Go package at `modules/programs/prism/prism/internal/podmanproxy/`. No prism integration in this PR — sidecar wiring (Step 3 / #2320), DB migration (Step 2 / #2327, already merged on main), bwrap profile (Step 4), sandbox-exec profile (Step 5), CLI flag (Step 6), cleanup (Step 7), and final docs (Step 8 / #2325) all land in later steps.

Refs #2317
Refs #2318

## Cycle history — six rounds of structural hardening

Across six review cycles, review-security found a different structural class of permissiveness each round. Each cycle closed its findings AND inverted one layer of the default-deny model so the next layer down became the next surface to audit. The canonical security spec is now the typed structs and the value allowlists in `policy.go`, not the deny-list comments scattered through old commit messages.

| Cycle | Class of finding | Layer inverted |
|---|---|---|
| 1 | Initial implementation + AC coverage | Endpoint allowlist (positive `classifyRequest` table) |
| 2 | 5 missing-field denials (`Memory=0` bypass, `NanoCpus` unparsed, `/update` resets caps, exec-`Privileged` bypass, `SecurityOpt` unfiltered) | Body-content policy expanded |
| 3 | 1 CRITICAL — bind-source check was purely lexical; symlinks bypassed it | Path resolution: `filepath.EvalSymlinks` on bind sources |
| 4 | 5 missing-field denials (`DeviceCgroupRules`, `MaskedPaths`/`ReadonlyPaths`, `CgroupnsMode`, `VolumesFrom`/`DeviceRequests`, local-driver volume bind) | Body-content policy hardened further |
| 5 | Pattern recognised: the body parser was permissive at the FIELD-NAME layer | **Field-name layer:** `json.Decoder.DisallowUnknownFields()` + typed allowlist structs at every body-bearing endpoint |
| 6 | One level down: admitted fields had VALUE-LEVEL deny-lists (`Mount.Type` forwarded everything that wasn't `bind`/`volume`, including the podman-specific `glob` Type → CRITICAL) | **Field-value layer:** per-field value allowlists for enumerable fields |

After cycle 6 the body-inspection model is default-deny at both the field-NAME and the field-VALUE layers. A future docker-API field or value that introduces an escape vector is rejected by default until it is explicitly admitted via the field-admission process (documented in `doc.go`).

## What's in this PR

### Core proxy machinery (cycle 1)

- `Proxy` struct + `Config` carrying `ListenerPath`, `UpstreamPath`, `AllowedBindSources`, `AllowedCaps`, `AllowedSecurityOpts`, `MaxMemoryBytes`, `MaxCPUQuota`, `MaxNanoCpus`, `AuditWriter`, `MaxBodyBytes`, `DialTimeout`, `Clock`.
- `NewProxy(cfg) (*Proxy, error)` constructor with explicit Config validation.
- `(*Proxy).Serve(ctx) error` lifecycle: binds the Unix listener, serves HTTP, blocks until ctx is cancelled, removes the listener socket file on return.
- HTTP reverse proxy on `net/http` + `httputil.ReverseProxy` with a custom `Director` (rewrites scheme/host) and `Transport` (dials the upstream Unix socket). `FlushInterval = -1` so streaming endpoints (attach / exec start / logs follow) don't stall in interactive sessions.
- Body-inspecting policy enforcers + query-inspecting enforcer for `PUT /containers/{id}/archive`.
- Endpoint allowlist (paths + methods) for everything else.
- Friendly 503 envelope on upstream-unavailable, body shape locked by the AC: `{"message": "podman socket unavailable: <reason>; on macOS run 'podman machine start', on Linux check 'systemctl --user status podman.socket'"}`.
- Audit log emitter: one JSON line per request with fields `timestamp`, `method`, `endpoint`, `decision`, `reason`. Serialised by a mutex so concurrent writes never interleave.

### Cycle-2 closures: resource-cap strict mode + new body inspectors

- Strict-mode caps: when `MaxMemoryBytes` / `MaxCPUQuota` / `MaxNanoCpus` is configured, the field MUST be present and a positive value within the cap. Closed the docker-semantic `Memory: 0` ("unlimited") bypass; same for `CpuQuota`.
- Added `NanoCpus` parsing + `MaxNanoCpus` Config field (cap could otherwise be bypassed by expressing the request as NanoCpus).
- New `endpointPolicyUpdate` + `inspectUpdate` for `POST /containers/{id}/update` (an agent could create with valid caps then `update` Memory to 0).
- New `endpointPolicyExec` + `inspectExec` for `POST /containers/{id}/exec` (exec body has its own `Privileged` field that bypassed the create-time deny).
- New `SecurityOpt []string` admission + `AllowedSecurityOpts` Config field (default empty = deny-all). Closed `seccomp=unconfined` / `apparmor=unconfined` / `no-new-privileges=false` / `label=disable` class.

### Cycle-3 closure: symlink resolution in bind paths

- `isAllowedBindSource` now resolves symlinks via `filepath.EvalSymlinks` on both the source AND the allowlist entries before the prefix comparison. The exploit it closes: agent plants `<allowed>/key → /etc/passwd`, lexical prefix-match allows, runc's `mount(2)` follows the symlink and exposes the host file.
- New `canonicalisePath` helper used at all three call sites: `HostConfig.Binds`, `HostConfig.Mounts` of `Type=bind`, and `PUT /containers/{id}/archive ?path=`.
- Proactive same-class defences in the same change: relative-path source rejected, non-existent source → deny (EvalSymlinks errors), broken symlink chain → deny, macOS `/tmp → /private/tmp` allowlist-entry canonicalisation handled.
- Documented residual TOCTOU between proxy `EvalSymlinks` and runc's `mount(2)`. Acceptable for v1; Step 3+ should consider mounting the per-session scratch with `nosymfollow` (Linux) or the equivalent SBPL restriction (Darwin).

### Cycle-4 closures: missing dangerous-field denials

All paired with non-vacuous tests:

- `DeviceCgroupRules` non-empty → deny (CRITICAL: parallel cgroup-rule mechanism to `Devices`; with `CAP_MKNOD` in the default capset, agent could mknod host disks).
- `MaskedPaths` / `ReadonlyPaths` present → deny (overrides runc safe-list; re-exposes `/proc/keys`, `/proc/sysrq-trigger`, etc.).
- `CgroupnsMode: "host"` → deny (sixth host-namespace mode added alongside the existing five).
- `VolumesFrom` non-empty → deny (inherits any other container's mounts; impossible to audit transitively).
- `DeviceRequests` non-empty → deny (GPU / nvidia-container-runtime passthrough).
- New `endpointPolicyVolumeCreate` + `inspectVolumeCreate` for `POST /volumes/create`: `Driver=local` with non-empty `DriverOpts` denied (functionally-a-bind named-volume escape).
- Same exploit inline via `Mounts` of `Type=volume` with `VolumeOptions.DriverConfig` set: denied in `checkHostConfig`'s Mounts loop.
- Opportunistic sweep: `Sysctls` non-empty → deny (some sysctls are not namespaced).

### Cycle-5 closure: field-name layer schema inversion

- `json.Decoder.DisallowUnknownFields()` applied to typed structs at every body-parsing endpoint: `containers/create` (top-level + nested `HostConfig` via two-stage parse), `containers/{id}/update`, `containers/{id}/exec`, `volumes/create`, and the new `networks/create` (`endpointPolicyNetworkCreate`). The build and prune endpoints remain `endpointAllow` because they take query-only or opaque-body inputs.
- The typed structs (`hostConfig`, `containerCreateBody`, `containerExecBody`, `volumeCreateBody`, `networkCreateBody`) are the canonical security spec. Every admitted field is annotated `INSPECTED` (policy-checked), `DENIED` (rejected when non-empty), or `FORWARDED` (admitted as opaque `json.RawMessage`, bytes pass to the upstream unmodified).
- `hostConfig` enumerates ~55 fields covering the full docker HostConfig surface plus podman libpod additions, each with a one-line rationale comment. Adding a new field requires the same audit as existing ones.
- New `decodeStrict()` helper distinguishes unknown-field error (403, audit reason `unknown_field:<json error>`) from malformed-JSON (400).

### Cycle-6 closure: field-value layer allowlists

- `Mount.Type` switched from deny-list (`if EqualFold "bind" elif EqualFold "volume" else forward`) to case-sensitive `switch` with explicit allowlist `{bind, volume, tmpfs}`. Closed the CRITICAL podman-specific `Type="glob"` bypass (calls `filepath.Glob(Source)` on the host) plus `image`, `npipe`, `artifact`, `ramfs`, `devpts`, empty string, case variants (`BIND`/`Bind`/`VOLUME`), whitespace variants, and unicode zero-width space.
- `NetworkMode`: literal allowlist `{"", bridge, none, default, slirp4netns, pasta}` + user-defined regex `^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$`. Denies anything containing `:` (container:<id>, ns:<path>), `/` (path injection), whitespace, or literal `host`. Diagnostic reasons categorised per class (`_host` / `_whitespace` / `_colon` / `_slash`).
- `PidMode` / `IpcMode` / `UTSMode` / `UsernsMode` / `CgroupnsMode` (five siblings): literal allowlist `{"", "private"}`. No user-defined regex — these don't have user-defined namespaces the way networks do.
- `LogConfig.Type`: parsed (was opaque `RawMessage`) into typed `hostConfigLogConfig`; local-only drivers `{json-file, none, journald, k8s-file, passthrough, passthrough-tty}` allowed; network-shipping drivers (`syslog`, `splunk`, `fluentd`, `gelf`, `awslogs`, `etwlogs`, `logentries`) denied.
- Streaming-endpoint body audit documented inline in `endpointAllowStreaming`'s doc comment: `/containers/{id}/attach` (empty body / hijacked stream), `/exec/{id}/start` (audited `{Detach, Tty}`), `/containers/{id}/logs` (empty body, safe query params).

## Default-deny is enforced at six layers

| # | Layer | Mechanism | Cycle |
|---|---|---|---|
| 1 | **Endpoint** | Positive allowlist via `classifyRequest`; the last branch of every method helper is `endpointDeny` | 1 |
| 2 | **Field-name** | `json.Decoder.DisallowUnknownFields()` + typed struct per body-bearing endpoint; structs are the canonical spec | 5 |
| 3 | **Field-value** | Per-field literal allowlists (+ NetworkMode user-defined regex) for enumerable values: `Mount.Type`, the six `*Mode` fields, `LogConfig.Type` | 6 |
| 4 | **Body-content** | `checkHostConfig` walks the parsed HostConfig and rejects dangerous values (`Privileged: true`, host-namespace modes, non-empty `Devices`/`DeviceCgroupRules`/`DeviceRequests`/`VolumesFrom`, present `MaskedPaths`/`ReadonlyPaths`, non-empty `Sysctls`, `Mounts` of `Type=volume` with `VolumeOptions.DriverConfig`, cap-add outside allowlist, SecurityOpt outside allowlist, resource caps in strict mode) | 1 + 2 + 4 |
| 5 | **Path-resolution** | `filepath.EvalSymlinks` + lexical `filepath.Clean` on both sources and allowlist entries; relative paths, broken symlink chains, and non-existent sources all deny | 3 |
| 6 | **Query** | `PUT /containers/{id}/archive` `path` query checked against `AllowedBindSources` with the same canonicalised-prefix logic as `Binds` | 1 |

## Negative-control test

`TestSecurity_NegativeControl_RootAllowlistPasses` is the load-bearing meta-test required by the AC: it mutates `Config.AllowedBindSources` to `["/"]` and asserts that the same `/etc/passwd` bind request that returns 403 in `TestSecurity_HostBindOutsideAllowlist_Denied` now PASSES to the upstream. This proves the positive denial tests are not no-ops from an unrelated policy code path. Verified non-vacuous across the PR's lifetime by reverting the `"/"` special case in `isAllowedBindSource` and observing the test fail with the documented diagnostic.

In addition, every cycle-2-through-6 closure was paired with its own revert-and-watch-fail discipline verification — commit messages list the matrix per cycle.

## Package boundary

`internal/podmanproxy/` imports only the standard library. No `internal/sidecar`, `internal/container`, `internal/db`, or any other prism package. `grep -rn "prismatic-koi/prism" internal/podmanproxy/` returns empty.

## Verification

From `modules/programs/prism/prism/`:

```
gofmt -l ./internal/podmanproxy/        # clean
go vet ./internal/podmanproxy/...       # clean
go test ./internal/podmanproxy/ -race   # 100 test functions, 276 RUN entries, all PASS
go test ./...                           # full suite green (32 packages)
```

From the repo root:

```
nix build .#prism --no-link             # OK
nix build --impure --no-link \
  --expr '(builtins.getFlake (toString ./.)).packages.aarch64-darwin.prism.override { runChecks = true; }'
# OK — homeless-shelter parity build (the gate CI runs as nix-build-prism-checked)
```

CI on head commit `3707ed0a`: all green (pr-gate, go-tests, nix-build-prism-checked, validate-flakes).

## AC coverage (#2318)

| AC | Test |
|---|---|
| [functional] NewProxy success / missing-listener / missing-upstream | `TestNewProxy_AcceptsValidConfig`, `TestNewProxy_RejectsMissingListenerPath`, `TestNewProxy_RejectsMissingUpstreamPath`, `TestNewProxy_RejectsNegativeBodyCap`, `TestNewProxy_DefaultsAreApplied` |
| [functional] Serve blocks until ctx cancelled, removes listener socket file | `TestServe_BlocksUntilContextCancelled`, `TestServe_BindFailureReturnsError`, `TestServe_RemovesStaleSocketBeforeBind` |
| [functional] Allowed Binds forwards unmodified | `TestSecurity_AllowedBinds_ForwardsUnmodified` |
| [security] Bind source outside allowlist → 403 | `TestSecurity_HostBindOutsideAllowlist_Denied`, `TestSecurity_HostMountOutsideAllowlist_Denied` |
| [security] Privileged: true → 403 | `TestSecurity_Privileged_Denied` |
| [security] CapAdd outside allowlist → 403 | `TestSecurity_CapAddDisallowed_Denied`, `TestSecurity_CapAddInAllowlist_Allowed` |
| [security] {Network,Pid,Ipc,UTS,Userns}Mode=host → 403 | `TestSecurity_HostNamespaceModes_Denied` (5 subtests) |
| [security] Non-empty Devices → 403 | `TestSecurity_DevicesNonEmpty_Denied` |
| [security] Archive path outside allowlist → 403 | `TestSecurity_ArchivePathOutsideAllowlist_Denied`, `TestSecurity_ArchiveSymlinkToForbiddenPath_Denied` |
| [security] Unknown endpoint → 403 with actionable message | `TestSecurity_UnknownEndpoint_Denied` (5 subtests), `TestSecurity_RawSocketCurlBypass_NoPath` |
| [edge] Malformed JSON → 400, not forwarded | `TestSecurity_MalformedJSONBody_Denied`, `TestSecurity_EmptyCreateBody_Denied`, `TestSecurity_UpdateEndpoint_MalformedJSON_Denied`, `TestSecurity_ExecMalformedJSON_Denied`, `TestSecurity_VolumeCreate_MalformedJSON_Denied` |
| [edge] Upstream unavailable → 503 envelope | `TestSecurity_UpstreamMissing_Returns503Envelope` (ENOENT), `TestSecurity_UpstreamECONNREFUSED_Returns503Envelope` (dead socket), `TestClassifyUpstreamErr` (unit-tests every error class) |
| [edge] Streaming endpoints forward without body parse | `TestSecurity_StreamingEndpoints_ForwardWithoutBodyParse` (3 subtests: attach, exec-start, logs-follow) |
| [functional] One audit line per request with required fields | `TestSecurity_AuditLog_OneLinePerRequest`, `TestSecurity_AuditLog_NewlineTerminated` |
| [security] Negative-control: `/` allowlist passes host bind | `TestSecurity_NegativeControl_RootAllowlistPasses` |
| [functional] Package has no imports outside std lib | grep audit (verified manually + by `go vet`); no test |

Extra coverage from cycles 2-6 hardening:

| Class | Tests |
|---|---|
| [security] Resource caps strict-mode | `TestSecurity_MemoryOverCap_Denied`, `TestSecurity_MemoryZero_DeniedWhenCapActive`, `TestSecurity_MemoryNegative_DeniedWhenCapActive`, `TestSecurity_MemoryAbsent_DeniedWhenCapActive`, `TestSecurity_MemoryAbsent_AllowedWhenNoCap`, `TestSecurity_CPUQuotaOverCap_Denied`, `TestSecurity_CpuQuotaZero_DeniedWhenCapActive`, `TestSecurity_CpuQuotaAbsent_DeniedWhenCapActive`, `TestSecurity_NanoCpusOverCap_Denied`, `TestSecurity_NanoCpusZero_DeniedWhenCapActive`, `TestSecurity_NanoCpusAbsent_DeniedWhenCapActive`, `TestSecurity_ResourceCapsWithinBounds_Allowed` |
| [security] containers/{id}/update body inspection | `TestSecurity_UpdateEndpoint_MemoryZero_Denied`, `TestSecurity_UpdateEndpoint_MemoryOverCap_Denied`, `TestSecurity_UpdateEndpoint_PartialBodyAllowed` |
| [security] containers/{id}/exec Privileged bypass closed | `TestSecurity_ExecPrivileged_Denied`, `TestSecurity_ExecWithoutPrivileged_Allowed` |
| [security] SecurityOpt allowlist | `TestSecurity_SecurityOpt_DefaultDenyAll` (8 subtests including `seccomp=unconfined`, `apparmor=unconfined`, `no-new-privileges=false`/`:false`, `label=disable`/`:disable`, `systempaths=unconfined`), `TestSecurity_SecurityOpt_InAllowlist_Allowed`, `TestSecurity_SecurityOpt_PartialAllowlist_ExactMatch` |
| [security] Symlink resolution on bind sources | `TestSecurity_BindSymlinkToForbiddenPath_Denied`, `TestSecurity_MountSymlinkToForbiddenPath_Denied`, `TestSecurity_ArchiveSymlinkToForbiddenPath_Denied`, `TestSecurity_BindSymlinkToAllowedPath_Allowed`, `TestSecurity_BindNonExistentSource_Denied`, `TestSecurity_BindBrokenSymlink_Denied`, `TestSecurity_MountRelativeSource_Denied`, `TestSecurity_BindSymlinkedAllowlistEntry_Matched`, `TestSecurity_BindSourceTraversal_Denied`, `TestSecurity_BindSourceSubstringTrap_Denied` |
| [security] DeviceCgroupRules / MaskedPaths / ReadonlyPaths / CgroupnsMode / VolumesFrom / DeviceRequests / Sysctls | `TestSecurity_DeviceCgroupRulesNonEmpty_Denied`, `TestSecurity_DeviceRequestsNonEmpty_Denied`, `TestSecurity_VolumesFromNonEmpty_Denied`, `TestSecurity_MaskedPathsPresent_Denied` (2 subtests), `TestSecurity_ReadonlyPathsPresent_Denied` (2 subtests), `TestSecurity_CgroupnsModeHost_Denied`, `TestSecurity_SysctlsNonEmpty_Denied` |
| [security] volumes/create local-driver bind-volume escape | `TestSecurity_VolumeCreate_LocalDriverBindMount_Denied`, `TestSecurity_VolumeCreate_DefaultDriver_Allowed`, `TestSecurity_MountVolumeWithDriverConfig_Denied`, `TestSecurity_MountVolumeWithoutDriverConfig_Allowed` |
| [security] Field-name schema inversion (cycle 5) | `TestSecurity_SchemaInversion_UnknownHostConfigField_Denied`, `TestSecurity_SchemaInversion_UnknownTopLevelField_Denied`, `TestSecurity_SchemaInversion_UnknownMountField_Denied`, `TestSecurity_SchemaInversion_UnknownUpdateField_Denied`, `TestSecurity_SchemaInversion_UnknownExecField_Denied`, `TestSecurity_SchemaInversion_UnknownVolumeCreateField_Denied`, `TestSecurity_SchemaInversion_UnknownNetworkCreateField_Denied`, `TestSecurity_NetworkCreate_AdmittedFields_Allowed` |
| [security] Mount.Type value allowlist (cycle 6 CRITICAL closure) | `TestSecurity_MountTypeGlob_Denied`, `TestSecurity_MountType_AllowlistEnforced` (15 subtests: image, npipe, artifact, ramfs, devpts, empty, case variants, whitespace, unicode zero-width space), `TestSecurity_MountTypeTmpfs_Allowed` |
| [security] NetworkMode-family value allowlist (cycle 6) | `TestSecurity_NetworkMode_AllowedLiterals` (6 subtests), `TestSecurity_NetworkMode_UserDefinedName_Allowed` (5 subtests), `TestSecurity_NetworkMode_DangerousValues_Denied` (12 subtests covering host, container:<id>, ns:<path>, paths, whitespace, regex-failing names, colons, slashes), `TestSecurity_SimpleNamespaceModes_AllowedLiterals` (10 subtests: 5 fields × 2 literals), `TestSecurity_SimpleNamespaceModes_DangerousValues_Denied` (30 subtests: 5 fields × 6 dangerous values) |
| [security] LogConfig.Type allowlist (cycle 6) | `TestSecurity_LogConfigType_LocalDrivers_Allowed` (7 subtests), `TestSecurity_LogConfigType_NetworkDrivers_Denied` (7 subtests), `TestSecurity_LogConfigType_UnknownDriver_Denied`, `TestSecurity_LogConfigWithLocalDriverAndOptions_Allowed` |

100 top-level test functions, 276 RUN entries including subtests. All PASS with `-race`.

## TOCTOU residual and limitations for Step 3+

Step 3+ will need to inherit these documented limitations:

1. **EvalSymlinks → mount(2) TOCTOU window.** Symlink resolution runs at proxy policy time; runc's `mount(2)` runs some milliseconds later. The agent can race the gap by swapping a resolved-safe symlink for a dangerous one between the two moments. Acceptable for v1 because the bind target inside the container is fixed at create time (a changed symlink cannot retarget the agent's reach), the agent is otherwise sandboxed, and the bwrap / sandbox-exec layer sits in front of the proxy. The correct architectural home for the proper mitigation is the surrounding sandbox profile — `nosymfollow` (Linux) or the equivalent SBPL restriction (Darwin) on the per-session scratch directory. Step 3 should evaluate.

2. **Field admission process.** The schema inversion means any new docker-API field (or new value of an enumerable field) introduced upstream is rejected by default until it has been audited and admitted to the relevant typed struct or allowlist in `policy.go`. Workflows in Step 3+ that surface a needed field will see a 403 with `"unknown field <Name>"` in the message; the response is to file an issue, audit the field against #2317 §4, and open a PR adding it with a rationale comment. Process documented in `doc.go`.

## Out of scope (later steps in the train)

- Sidecar wiring (Step 3 / #2320)
- bwrap profile changes (Step 4)
- sandbox-exec profile changes (Step 5)
- `--containers` spawn flag (Step 6)
- Cleanup integration (Step 7)
- Final wiring + docs (Step 8 / #2325 — that PR is the one that says `Closes #2317`)
- Container name auto-prefixing (#2317 §8 open question 1)
- Resource cap defaults (#2317 §8 open question 3 — this PR's Config accepts whatever the caller passes)
