### PR TITLE
prism: DB migration v36→v37 adding containers_enabled / containers_flag columns

### DIFF
--- a/modules/programs/prism/prism/internal/db/db.go
+++ b/modules/programs/prism/prism/internal/db/db.go
@@ -29,7 +29,7 @@ const (
 	// It must be bumped whenever a new migrateVNtoVN+1 function is added.
 	// A meta-test in db_test.go asserts that this constant equals the count of
 	// migration functions, so forgetting to bump it will fail CI.
-	currentSchemaVersion = 36
+	currentSchemaVersion = 37
 )
 
 // DB wraps a SQLite connection.
@@ -119,7 +119,13 @@ CREATE TABLE IF NOT EXISTS agent_status (
   harness_session_id TEXT,
   harness_port      INTEGER,
   group_id          TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
-  muted             INTEGER NOT NULL DEFAULT 0
+  muted             INTEGER NOT NULL DEFAULT 0,
+  -- containers_enabled is the runtime gate read by the sidecar to decide
+  -- whether to start the per-session filtering podman API socket proxy
+  -- (#2317 / #2319). 0 = proxy not started (default); 1 = proxy is
+  -- started and the agent CONTAINER_HOST / DOCKER_HOST env vars point at
+  -- the filtered socket. Flipped by prism spawn --containers (Step 6).
+  containers_enabled INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS bus_messages (
@@ -218,6 +224,15 @@ CREATE TABLE IF NOT EXISTS spawn_inputs (
     pr_number              INTEGER,
     branch_flag            TEXT,
     ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+
+    -- containers_flag mirrors the --containers CLI flag (audit symmetry
+    -- with host_mode_flag / isolation_flag, #2317 / #2319). 0 = flag
+    -- omitted (default); 1 = prism spawn --containers was passed.
+    -- Written by InsertSpawnInputs and rendered by prism stats compare
+    -- in the Spawn Inputs block. Distinct from
+    -- agent_status.containers_enabled, which is the live runtime gate;
+    -- containers_flag is immutable per-spawn audit trail.
+    containers_flag        INTEGER NOT NULL DEFAULT 0,
 
     -- Resolved effective isolation mode the session actually ran under
     -- (bwrap/sandbox-exec/host), captured at spawn time post profile/
@@ -556,7 +571,7 @@ func seedSchemaVersionIfEmpty(conn *sql.DB) error {
 }
 
 // runMigrations reads the current schema_version and applies all pending
-// migrations in order from v1 to v33.
+// migrations in order from v1 to v37.
 func runMigrations(conn *sql.DB) error {
 	var version int
 	if err := conn.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
@@ -667,6 +682,9 @@ func runMigrations(conn *sql.DB) error {
 	if err := migrateV35ToV36(conn, &version); err != nil {
 		return err
 	}
+	if err := migrateV36ToV37(conn, &version); err != nil {
+		return err
+	}
 	if version > currentSchemaVersion {
 		return fmt.Errorf(
 			"db schema version %d is newer than this prism binary (max %d); "+
@@ -740,6 +758,65 @@ func runMigrations(conn *sql.DB) error {
 // The ALTER TABLE is guarded by a pragma_table_info check so the migration
 // is idempotent on fresh databases where the declarative schema block above
 // already includes the column.
+// migrateV36ToV37 adds two new columns in a single migration
+// (#2317 §3f / #2319):
+//
+//   - agent_status.containers_enabled INTEGER NOT NULL DEFAULT 0 — the
+//     runtime gate read by the sidecar to decide whether to start the
+//     per-session filtering podman API socket proxy. Default 0 means no
+//     proxy; the column is flipped to 1 by Step 3 (sidecar wiring) and
+//     Step 6 (`prism spawn --containers`).
+//   - spawn_inputs.containers_flag INTEGER NOT NULL DEFAULT 0 — audit
+//     symmetry with host_mode_flag / isolation_flag. Captures whether
+//     the user passed `--containers` at spawn time, independent of the
+//     runtime gate. Read by `prism stats compare` in the Spawn Inputs
+//     block.
+//
+// Both columns are added in one migration because they share a single
+// rationale (the containers feature train of #2317) and the migration
+// runner is sequential anyway — splitting would only inflate the
+// schema-version counter without any operational benefit.
+//
+// Each ALTER TABLE is guarded by a pragma_table_info check so the
+// migration is idempotent on fresh databases where the declarative
+// schema block above already includes both columns. Existing rows take
+// the column DEFAULT of 0 (both columns are NOT NULL).
+func migrateV36ToV37(conn *sql.DB, version *int) error {
+	if *version >= 37 {
+		return nil
+	}
+	var exists int
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('agent_status') WHERE name = 'containers_enabled'`,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("db: migration v36\u2192v37: check containers_enabled column: %w", err)
+	}
+	if exists == 0 {
+		if _, err := conn.Exec(
+			`ALTER TABLE agent_status ADD COLUMN containers_enabled INTEGER NOT NULL DEFAULT 0`,
+		); err != nil {
+			return fmt.Errorf("db: migration v36\u2192v37: add containers_enabled: %w", err)
+		}
+	}
+	if err := conn.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info('spawn_inputs') WHERE name = 'containers_flag'`,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf("db: migration v36\u2192v37: check containers_flag column: %w", err)
+	}
+	if exists == 0 {
+		if _, err := conn.Exec(
+			`ALTER TABLE spawn_inputs ADD COLUMN containers_flag INTEGER NOT NULL DEFAULT 0`,
+		); err != nil {
+			return fmt.Errorf("db: migration v36\u2192v37: add containers_flag: %w", err)
+		}
+	}
+	if _, err := conn.Exec(`UPDATE schema_version SET version = 37`); err != nil {
+		return fmt.Errorf("db: migration v36\u2192v37: %w", err)
+	}
+	*version = 37
+	return nil
+}
+
 func migrateV35ToV36(conn *sql.DB, version *int) error {
 	if *version >= 36 {
 		return nil
@@ -2190,6 +2267,12 @@ type SpawnInputs struct {
 
 	IgnoreConcurrencyCap bool
 
+	// ContainersFlag mirrors --containers (#2317 §3f / #2319). Audit-only
+	// symmetry with HostModeFlag / IsolationFlag; the live runtime gate is
+	// agent_status.containers_enabled (Status.ContainersEnabled). Defaults
+	// to false when the caller does not set it.
+	ContainersFlag bool
+
 	// C.2 hook: per-role model-variant overrides (JSON).
 	ModelVariantOverrides *string
 
@@ -2228,7 +2311,7 @@ func (d *DB) InsertSpawnInputs(si SpawnInputs) error {
 INSERT OR IGNORE INTO spawn_inputs (
     instance_id,
     profile_name, model_flag, variant_flag, agent_flag, harness_flag,
-    isolation_flag, host_mode_flag,
+    isolation_flag, host_mode_flag, containers_flag,
     pr_number, branch_flag, ignore_concurrency_cap,
     isolation_mode,
     model_variant_overrides,
@@ -2238,7 +2321,7 @@ INSERT OR IGNORE INTO spawn_inputs (
 ) VALUES (
     ?,
     ?, ?, ?, ?, ?,
-    ?, ?,
+    ?, ?, ?,
     ?, ?, ?,
     ?,
     ?,
@@ -2248,7 +2331,7 @@ INSERT OR IGNORE INTO spawn_inputs (
 )`,
 		si.InstanceID,
 		si.ProfileName, si.ModelFlag, si.VariantFlag, si.AgentFlag, si.HarnessFlag,
-		si.IsolationFlag, boolToInt(si.HostModeFlag),
+		si.IsolationFlag, boolToInt(si.HostModeFlag), boolToInt(si.ContainersFlag),
 		si.PRNumber, si.BranchFlag, boolToInt(si.IgnoreConcurrencyCap),
 		si.IsolationMode,
 		si.ModelVariantOverrides,
@@ -2269,7 +2352,7 @@ func (d *DB) SpawnInputsByInstanceID(instanceID string) (*SpawnInputs, error) {
 SELECT
     instance_id,
     profile_name, model_flag, variant_flag, agent_flag, harness_flag,
-    isolation_flag, host_mode_flag,
+    isolation_flag, host_mode_flag, containers_flag,
     pr_number, branch_flag, ignore_concurrency_cap,
     isolation_mode,
     model_variant_overrides,
@@ -2285,11 +2368,11 @@ WHERE instance_id = ?`
 	var prNumber sql.NullInt64
 	var branchFlag, modelVariantOverrides, skillsManifestHash, promptTemplateHash, agentPromptHash sql.NullString
 	var promptText, promptSource, abtestPairID, extras sql.NullString
-	var hostModeFlag, ignoreConcurrencyCap int
+	var hostModeFlag, containersFlag, ignoreConcurrencyCap int
 	err := row.Scan(
 		&si.InstanceID,
 		&profileName, &modelFlag, &variantFlag, &agentFlag, &harnessFlag,
-		&isolationFlag, &hostModeFlag,
+		&isolationFlag, &hostModeFlag, &containersFlag,
 		&prNumber, &branchFlag, &ignoreConcurrencyCap,
 		&isolationMode,
 		&modelVariantOverrides,
@@ -2325,6 +2408,7 @@ WHERE instance_id = ?`
 		si.IsolationMode = &isolationMode.String
 	}
 	si.HostModeFlag = hostModeFlag != 0
+	si.ContainersFlag = containersFlag != 0
 	if prNumber.Valid {
 		n := int(prNumber.Int64)
 		si.PRNumber = &n

--- a/modules/programs/prism/prism/internal/db/db_migration_v34_v35_test.go
+++ b/modules/programs/prism/prism/internal/db/db_migration_v34_v35_test.go
@@ -162,8 +162,8 @@ func TestMigration_V34ToV35_BodyRuns_AddsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var n int
@@ -197,8 +197,8 @@ func TestMigration_V34ToV35_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var n int
@@ -234,8 +234,8 @@ func TestMigration_V34ToV35_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version after second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	var n int

--- a/modules/programs/prism/prism/internal/db/db_migration_v35_v36_test.go
+++ b/modules/programs/prism/prism/internal/db/db_migration_v35_v36_test.go
@@ -155,8 +155,8 @@ func TestMigration_V35ToV36_BodyRuns_AddsDeliveredAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var n int
@@ -204,8 +204,8 @@ func TestMigration_V35ToV36_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var n int
@@ -241,8 +241,8 @@ func TestMigration_V35ToV36_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version after second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	var n int

--- a/modules/programs/prism/prism/internal/db/db_migration_v36_v37_test.go
+++ b/modules/programs/prism/prism/internal/db/db_migration_v36_v37_test.go
@@ -1,0 +1,577 @@
+package db_test
+
+// Tests for the v36→v37 migration that adds two columns in a single
+// migration (#2317 / #2319):
+//
+//   - agent_status.containers_enabled — runtime gate read by the sidecar
+//     to decide whether to start the per-session filtering podman API
+//     socket proxy.
+//   - spawn_inputs.containers_flag — audit symmetry with host_mode_flag
+//     and isolation_flag, capturing whether the user passed --containers
+//     at spawn time.
+//
+// The migration follows the muted-column template (v33→v34): two
+// idempotent ALTER TABLE statements, each guarded by a pragma_table_info
+// check, with INTEGER NOT NULL DEFAULT 0 shape.
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// seedV36DB creates a v36 DB. The flags allow simulating "the declarative
+// schema block already added the column" — in which case the migration's
+// pragma_table_info guard must detect the column and skip the ALTER TABLE.
+func seedV36DB(t *testing.T, dbPath string, withContainersEnabled, withContainersFlag bool) {
+	t.Helper()
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open v36 db: %v", err)
+	}
+	defer rawConn.Close()
+
+	containersEnabledCol := ""
+	if withContainersEnabled {
+		containersEnabledCol = ",\n\t\t  containers_enabled INTEGER NOT NULL DEFAULT 0"
+	}
+	containersFlagCol := ""
+	if withContainersFlag {
+		containersFlagCol = "containers_flag INTEGER NOT NULL DEFAULT 0,"
+	}
+
+	_, err = rawConn.Exec(`
+		CREATE TABLE IF NOT EXISTS agent_events (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, repo TEXT NOT NULL,
+		  worktree TEXT NOT NULL, harness_session_id TEXT, type TEXT NOT NULL,
+		  payload TEXT NOT NULL, created_at INTEGER NOT NULL,
+		  instance_id TEXT
+		);
+		CREATE TABLE IF NOT EXISTS session_groups (
+		  group_id TEXT PRIMARY KEY,
+		  parent_session TEXT NOT NULL,
+		  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		  pr_number TEXT,
+		  round INTEGER,
+		  delivered_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS agent_status (
+		  session_name TEXT PRIMARY KEY, repo TEXT NOT NULL, worktree TEXT NOT NULL,
+		  state TEXT NOT NULL, title TEXT,
+		  agent_name TEXT, model_id TEXT, root_agent_name TEXT, root_model_id TEXT,
+		  isolation_mode TEXT,
+		  instance_id TEXT, last_seen INTEGER NOT NULL, ended_at INTEGER,
+		  harness TEXT NOT NULL DEFAULT 'pi',
+		  harness_session_id TEXT, harness_port INTEGER,
+		  group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  muted INTEGER NOT NULL DEFAULT 0` + containersEnabledCol + `
+		);
+		CREATE TABLE IF NOT EXISTS bus_messages (
+		  id TEXT PRIMARY KEY, from_session TEXT NOT NULL, to_session TEXT NOT NULL,
+		  to_instance_id TEXT,
+		  repo TEXT NOT NULL, text TEXT NOT NULL, urgency TEXT NOT NULL DEFAULT 'normal',
+		  sent_at INTEGER NOT NULL, delivered_at INTEGER, failed_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS sessions (
+		  instance_id        TEXT PRIMARY KEY,
+		  session_name       TEXT NOT NULL,
+		  agent_role         TEXT,
+		  root_agent_name    TEXT,
+		  repo               TEXT NOT NULL,
+		  worktree           TEXT NOT NULL,
+		  harness            TEXT NOT NULL,
+		  harness_session_id TEXT,
+		  group_id           TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		  started_at         INTEGER NOT NULL,
+		  ended_at           INTEGER,
+		  end_state          TEXT,
+		  archive_path       TEXT,
+		  prism_version      TEXT,
+		  parent_session     TEXT
+		);
+		CREATE TABLE IF NOT EXISTS pending_merges (
+		  pr INTEGER PRIMARY KEY, session_name TEXT NOT NULL, instance_id TEXT NOT NULL,
+		  queue_position INTEGER NOT NULL, status TEXT NOT NULL, title TEXT, error TEXT,
+		  queued_at INTEGER NOT NULL, last_checked_at INTEGER, merged_at INTEGER, ended_at INTEGER
+		);
+		CREATE TABLE IF NOT EXISTS spawn_inputs (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    profile_name TEXT, model_flag TEXT, variant_flag TEXT, agent_flag TEXT,
+		    harness_flag TEXT, isolation_flag TEXT, host_mode_flag INTEGER NOT NULL DEFAULT 0,
+		    pr_number INTEGER, branch_flag TEXT, ignore_concurrency_cap INTEGER NOT NULL DEFAULT 0,
+		    isolation_mode TEXT,
+		    ` + containersFlagCol + `
+		    model_variant_overrides TEXT, skills_manifest_hash TEXT, prompt_template_hash TEXT,
+		    agent_prompt_hash TEXT, prompt_text TEXT, prompt_source TEXT,
+		    abtest_pair_id TEXT,
+		    extras TEXT,
+		    created_at INTEGER NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS spawn_outcome (
+		    instance_id TEXT PRIMARY KEY REFERENCES sessions(instance_id) ON DELETE CASCADE,
+		    end_state TEXT, exit_code INTEGER, duration_ms INTEGER,
+		    interrupted_count INTEGER NOT NULL DEFAULT 0,
+		    compaction_count INTEGER NOT NULL DEFAULT 0,
+		    error_event_count INTEGER NOT NULL DEFAULT 0,
+		    permission_ask_count INTEGER NOT NULL DEFAULT 0,
+		    permission_denied_count INTEGER NOT NULL DEFAULT 0,
+		    doom_loop_count INTEGER NOT NULL DEFAULT 0,
+		    pr_number INTEGER, pr_merged_at INTEGER,
+		    review_group_id TEXT REFERENCES session_groups(group_id) ON DELETE SET NULL,
+		    review_verdict TEXT, review_pass_count INTEGER,
+		    review_fail_count INTEGER, review_none_count INTEGER,
+		    rubric_verdict TEXT, rubric_score REAL,
+		    rubric_breakdown TEXT, rubric_grader TEXT,
+		    tokens_input_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_output_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_cache_read_total INTEGER NOT NULL DEFAULT 0,
+		    tokens_cache_write_total INTEGER NOT NULL DEFAULT 0,
+		    cost_usd_total REAL NOT NULL DEFAULT 0,
+		    tool_call_count INTEGER NOT NULL DEFAULT 0,
+		    tool_error_count INTEGER NOT NULL DEFAULT 0,
+		    msg_assistant_count INTEGER NOT NULL DEFAULT 0,
+		    time_to_first_event_ms INTEGER, time_to_finished_ms INTEGER,
+		    computed_at INTEGER NOT NULL,
+		    schema_version INTEGER NOT NULL DEFAULT 1
+		);
+		CREATE TABLE IF NOT EXISTS harness_frames (
+		  id TEXT PRIMARY KEY, session_name TEXT NOT NULL, instance_id TEXT,
+		  direction TEXT NOT NULL, type TEXT, payload TEXT NOT NULL, created_at INTEGER NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_active_coordinator_per_repo
+		   ON agent_status (repo)
+		   WHERE root_agent_name = 'coordinator' AND ended_at IS NULL;
+		CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+		INSERT INTO schema_version (version) VALUES (36);
+	`)
+	if err != nil {
+		t.Fatalf("seed v36 db: %v", err)
+	}
+}
+
+// columnShape pulls the pragma_table_info row that the ACs assert on:
+// type, notnull, dflt_value. Returns ok=false when the column does not
+// exist on the named table.
+type columnShape struct {
+	cType     string
+	notNull   int
+	dfltValue string
+}
+
+func readColumnShape(t *testing.T, d *db.DB, table, column string) (columnShape, bool) {
+	t.Helper()
+	var info columnShape
+	var dflt sql.NullString
+	err := d.QueryRow(
+		`SELECT type, "notnull", dflt_value FROM pragma_table_info(?) WHERE name = ?`,
+		table, column,
+	).Scan(&info.cType, &info.notNull, &dflt)
+	if err == sql.ErrNoRows {
+		return columnShape{}, false
+	}
+	if err != nil {
+		t.Fatalf("pragma_table_info(%s).%s: %v", table, column, err)
+	}
+	if dflt.Valid {
+		info.dfltValue = dflt.String
+	}
+	return info, true
+}
+
+// assertColumnShape verifies the column has type INTEGER, notnull=1, and
+// default 0 — the shape required by the issue ACs (#1, #2).
+func assertColumnShape(t *testing.T, d *db.DB, table, column string) {
+	t.Helper()
+	info, ok := readColumnShape(t, d, table, column)
+	if !ok {
+		t.Fatalf("%s.%s: column missing after migration", table, column)
+	}
+	if info.cType != "INTEGER" {
+		t.Errorf("%s.%s.type: got %q, want INTEGER", table, column, info.cType)
+	}
+	if info.notNull != 1 {
+		t.Errorf("%s.%s.notnull: got %d, want 1", table, column, info.notNull)
+	}
+	if info.dfltValue != "0" {
+		t.Errorf("%s.%s.dflt_value: got %q, want %q", table, column, info.dfltValue, "0")
+	}
+}
+
+// countColumn returns the number of pragma_table_info rows for a column,
+// which is 0 (missing) or 1 (present). Used to assert ALTER TABLE was not
+// double-applied (a duplicate-ADD would error before reaching this assert,
+// but the count check is the natural shape of the AC).
+func countColumn(t *testing.T, d *db.DB, table, column string) int {
+	t.Helper()
+	var n int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`, table, column,
+	).Scan(&n); err != nil {
+		t.Fatalf("pragma_table_info COUNT(%s.%s): %v", table, column, err)
+	}
+	return n
+}
+
+// readVersion reads the schema_version row.
+func readVersion(t *testing.T, d *db.DB) int {
+	t.Helper()
+	var v int
+	if err := d.QueryRow(`SELECT version FROM schema_version`).Scan(&v); err != nil {
+		t.Fatalf("read schema_version: %v", err)
+	}
+	return v
+}
+
+// TestMigration_V36ToV37_BodyRuns_AddsBothColumns exercises the body-runs
+// branch (#2319 ACs #1, #2, #3): a v36 DB without either new column.
+// Both ALTER TABLE statements execute, both columns end up at INTEGER
+// NOT NULL DEFAULT 0, and schema_version is bumped to 37.
+func TestMigration_V36ToV37_BodyRuns_AddsBothColumns(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v36_body_runs.db")
+	seedV36DB(t, dbPath, false /*withContainersEnabled*/, false /*withContainersFlag*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	if v := readVersion(t, d); v != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", v)
+	}
+	assertColumnShape(t, d, "agent_status", "containers_enabled")
+	assertColumnShape(t, d, "spawn_inputs", "containers_flag")
+}
+
+// TestMigration_V36ToV37_BodySkips_BothColumnsPreExist exercises the
+// body-skips branch: both new columns already exist (declarative schema
+// already added them). The migration's pragma_table_info guards detect
+// both and skip both ALTER TABLE statements. Each column must appear
+// exactly once — no duplicate-add and no error.
+func TestMigration_V36ToV37_BodySkips_BothColumnsPreExist(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v36_body_skips_both.db")
+	seedV36DB(t, dbPath, true /*withContainersEnabled*/, true /*withContainersFlag*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	if v := readVersion(t, d); v != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", v)
+	}
+	if n := countColumn(t, d, "agent_status", "containers_enabled"); n != 1 {
+		t.Errorf("agent_status.containers_enabled count after body-skips: got %d, want 1", n)
+	}
+	if n := countColumn(t, d, "spawn_inputs", "containers_flag"); n != 1 {
+		t.Errorf("spawn_inputs.containers_flag count after body-skips: got %d, want 1", n)
+	}
+}
+
+// TestMigration_V36ToV37_BodyMixed_OnlyContainersEnabledPreExists exercises
+// the mixed branch: agent_status.containers_enabled is pre-existing but
+// spawn_inputs.containers_flag is not. The migration must skip the first
+// ALTER TABLE and execute the second — both columns end up present.
+//
+// This guards against the failure mode where one pragma check accidentally
+// short-circuits the entire migration body.
+func TestMigration_V36ToV37_BodyMixed_OnlyContainersEnabledPreExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v36_body_mixed_a.db")
+	seedV36DB(t, dbPath, true /*withContainersEnabled*/, false /*withContainersFlag*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	if v := readVersion(t, d); v != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", v)
+	}
+	if n := countColumn(t, d, "agent_status", "containers_enabled"); n != 1 {
+		t.Errorf("agent_status.containers_enabled count: got %d, want 1", n)
+	}
+	assertColumnShape(t, d, "spawn_inputs", "containers_flag")
+}
+
+// TestMigration_V36ToV37_BodyMixed_OnlyContainersFlagPreExists is the
+// mirror case: spawn_inputs.containers_flag pre-exists but
+// agent_status.containers_enabled does not.
+func TestMigration_V36ToV37_BodyMixed_OnlyContainersFlagPreExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v36_body_mixed_b.db")
+	seedV36DB(t, dbPath, false /*withContainersEnabled*/, true /*withContainersFlag*/)
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	if v := readVersion(t, d); v != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", v)
+	}
+	assertColumnShape(t, d, "agent_status", "containers_enabled")
+	if n := countColumn(t, d, "spawn_inputs", "containers_flag"); n != 1 {
+		t.Errorf("spawn_inputs.containers_flag count: got %d, want 1", n)
+	}
+}
+
+// TestMigration_V36ToV37_Idempotent verifies the AC: running the migration
+// twice in a row (via a second Open) is a no-op. Both columns remain
+// present exactly once and schema_version stays at 37.
+func TestMigration_V36ToV37_Idempotent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v36_idem.db")
+	seedV36DB(t, dbPath, false, false)
+
+	d1, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("first db.Open: %v", err)
+	}
+	d1.Close()
+
+	d2, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("second db.Open: %v", err)
+	}
+	defer d2.Close()
+
+	if v := readVersion(t, d2); v != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", v)
+	}
+	if n := countColumn(t, d2, "agent_status", "containers_enabled"); n != 1 {
+		t.Errorf("agent_status.containers_enabled count after idempotent open: got %d, want 1", n)
+	}
+	if n := countColumn(t, d2, "spawn_inputs", "containers_flag"); n != 1 {
+		t.Errorf("spawn_inputs.containers_flag count after idempotent open: got %d, want 1", n)
+	}
+}
+
+// TestMigration_V36ToV37_FreshDB verifies the AC: opening a fresh empty
+// database ends at v37 with both columns present (declarative schema
+// covers both columns; the migration's pragma guards detect the
+// pre-existing columns and do not double-add).
+func TestMigration_V36ToV37_FreshDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "fresh.db")
+
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open (fresh): %v", err)
+	}
+	defer d.Close()
+
+	if v := readVersion(t, d); v != 37 {
+		t.Errorf("schema_version on fresh DB: got %d, want 37", v)
+	}
+	assertColumnShape(t, d, "agent_status", "containers_enabled")
+	assertColumnShape(t, d, "spawn_inputs", "containers_flag")
+}
+
+// TestMigration_V36ToV37_PopulatedV36RowsDefaultToZero verifies the AC:
+// migrating from a v36 DB with existing populated rows leaves every
+// existing row with containers_enabled=0 and containers_flag=0. The
+// columns are NOT NULL DEFAULT 0 so existing rows must take the default
+// (no row is left NULL and no row is mistakenly backfilled to 1).
+func TestMigration_V36ToV37_PopulatedV36RowsDefaultToZero(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "v36_populated.db")
+	seedV36DB(t, dbPath, false, false)
+
+	// Seed live rows on the pre-migration shape via a raw connection.
+	rawConn, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	// Two agent_status rows.
+	if _, err := rawConn.Exec(
+		`INSERT INTO agent_status (session_name, repo, worktree, state, last_seen, instance_id)
+		 VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)`,
+		"nixos-config@main", "nixos-config", "/repo", "active", 1234, "inst-a",
+		"nixos-config@feat", "nixos-config", "/repo-feat", "active", 1234, "inst-b",
+	); err != nil {
+		t.Fatalf("seed agent_status rows: %v", err)
+	}
+	// Matching sessions rows are required by spawn_inputs's FK.
+	if _, err := rawConn.Exec(
+		`INSERT INTO sessions (instance_id, session_name, repo, worktree, harness, started_at)
+		 VALUES (?, ?, ?, ?, 'pi', 0), (?, ?, ?, ?, 'pi', 0)`,
+		"inst-a", "nixos-config@main", "nixos-config", "/repo",
+		"inst-b", "nixos-config@feat", "nixos-config", "/repo-feat",
+	); err != nil {
+		t.Fatalf("seed sessions rows: %v", err)
+	}
+	// Two spawn_inputs rows on the pre-v37 shape (no containers_flag).
+	if _, err := rawConn.Exec(
+		`INSERT INTO spawn_inputs (instance_id, created_at) VALUES (?, ?), (?, ?)`,
+		"inst-a", 1234, "inst-b", 5678,
+	); err != nil {
+		t.Fatalf("seed spawn_inputs rows: %v", err)
+	}
+	rawConn.Close()
+
+	// Run the migration.
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	// Verify every existing agent_status row has containers_enabled = 0.
+	var nonZeroAgentStatus int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM agent_status WHERE containers_enabled != 0`,
+	).Scan(&nonZeroAgentStatus); err != nil {
+		t.Fatalf("count agent_status rows with containers_enabled != 0: %v", err)
+	}
+	if nonZeroAgentStatus != 0 {
+		t.Errorf("post-migration: %d agent_status rows have containers_enabled != 0; want 0", nonZeroAgentStatus)
+	}
+
+	// Verify every existing spawn_inputs row has containers_flag = 0.
+	var nonZeroSpawnInputs int
+	if err := d.QueryRow(
+		`SELECT COUNT(*) FROM spawn_inputs WHERE containers_flag != 0`,
+	).Scan(&nonZeroSpawnInputs); err != nil {
+		t.Fatalf("count spawn_inputs rows with containers_flag != 0: %v", err)
+	}
+	if nonZeroSpawnInputs != 0 {
+		t.Errorf("post-migration: %d spawn_inputs rows have containers_flag != 0; want 0", nonZeroSpawnInputs)
+	}
+
+	// And confirm the rows are still readable through the Go API with the
+	// new fields defaulting to false.
+	st, err := d.CurrentStatus("nixos-config@main")
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: row missing")
+	}
+	if st.ContainersEnabled {
+		t.Error("CurrentStatus.ContainersEnabled = true on pre-migration row; want false")
+	}
+
+	si, err := d.SpawnInputsByInstanceID("inst-a")
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si == nil {
+		t.Fatal("SpawnInputsByInstanceID: row missing")
+	}
+	if si.ContainersFlag {
+		t.Error("SpawnInputsByInstanceID.ContainersFlag = true on pre-migration row; want false")
+	}
+}
+
+// TestStatus_ContainersEnabledDefaultsFalse verifies that the Status
+// roundtrip through CurrentStatus returns ContainersEnabled = false for
+// a fresh row created via the existing UpsertStatus writer (which does
+// not set containers_enabled — the column takes its DEFAULT of 0).
+//
+// AC: db.Status has a ContainersEnabled bool field; CurrentStatus
+// populates it from the column (defaulting to false).
+func TestStatus_ContainersEnabledDefaultsFalse(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "status_default.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	const session = "prism-test@main"
+	if err := d.UpsertStatus(session, "prism-test", "/tmp/w", "active", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus: %v", err)
+	}
+
+	st, err := d.CurrentStatus(session)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: nil status for freshly inserted row")
+	}
+	if st.ContainersEnabled {
+		t.Errorf("fresh status default ContainersEnabled = true, want false")
+	}
+}
+
+// seedSessionForFK inserts a sessions row so a subsequent spawn_inputs
+// INSERT can satisfy the FK. Returns the instance_id used.
+func seedSessionForFK(t *testing.T, d *db.DB, instanceID, sessionName string) {
+	t.Helper()
+	sess := db.Session{
+		InstanceID:  instanceID,
+		SessionName: sessionName,
+		Repo:        "nixos-config",
+		Worktree:    "/repo",
+		Harness:     "pi",
+	}
+	if err := d.InsertSession(sess); err != nil {
+		t.Fatalf("InsertSession: %v", err)
+	}
+}
+
+// TestSpawnInputs_ContainersFlagRoundtripDefaultsFalse verifies the AC:
+// InsertSpawnInputs writes containers_flag, defaulting to false when the
+// caller does not set it. We insert a SpawnInputs value with the field
+// unset (zero-value bool == false) and verify the round-trip returns
+// false.
+func TestSpawnInputs_ContainersFlagRoundtripDefaultsFalse(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "roundtrip_default.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	seedSessionForFK(t, d, "inst-default", "nixos-config@main")
+	// Insert spawn_inputs with ContainersFlag unset (zero-value false).
+	si := db.SpawnInputs{InstanceID: "inst-default", CreatedAt: 1234}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID("inst-default")
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: row missing")
+	}
+	if got.ContainersFlag {
+		t.Errorf("ContainersFlag roundtrip default: got true, want false")
+	}
+}
+
+// TestSpawnInputs_ContainersFlagRoundtripTrue verifies that setting
+// ContainersFlag = true on the input persists and round-trips back as
+// true. This is the positive-case bookend to
+// TestSpawnInputs_ContainersFlagRoundtripDefaultsFalse: proves the
+// boolean is actually wired through both directions of InsertSpawnInputs
+// / SpawnInputsByInstanceID, not just defaulting in lockstep.
+func TestSpawnInputs_ContainersFlagRoundtripTrue(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "roundtrip_true.db")
+	d, err := db.Open(dbPath)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	seedSessionForFK(t, d, "inst-true", "nixos-config@main")
+	si := db.SpawnInputs{InstanceID: "inst-true", CreatedAt: 1234, ContainersFlag: true}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID("inst-true")
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: row missing")
+	}
+	if !got.ContainersFlag {
+		t.Errorf("ContainersFlag roundtrip true: got false, want true")
+	}
+}

--- a/modules/programs/prism/prism/internal/db/db_test.go
+++ b/modules/programs/prism/prism/internal/db/db_test.go
@@ -51,8 +51,8 @@ func TestOpen_CreatesSchema(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version: got %d, want 37", version)
 	}
 
 	// Verify the partial unique index for coordinator-per-repo was created (v12).
@@ -1233,8 +1233,8 @@ func TestMigration_V1ToV2(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// Verify the new columns exist and the existing row is preserved.
@@ -1308,8 +1308,8 @@ func TestMigration_V2ToV3(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1860,8 +1860,8 @@ func TestMigration_V3ToV4(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1926,8 +1926,8 @@ func TestMigration_V4ToV5(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -1996,8 +1996,8 @@ func TestMigration_V5ToV6(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	s, err := d.CurrentStatus("repo@main")
@@ -2091,8 +2091,8 @@ func TestMigration_V6ToV7(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// Existing row must be preserved with failed_at = NULL.
@@ -2184,8 +2184,8 @@ func TestMigration_V7ToV11(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// All existing rows must be preserved unmodified (additive migration guarantee).
@@ -2728,8 +2728,8 @@ func TestMigration_V8ToV9(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// session_groups table must exist after migration.
@@ -2817,8 +2817,8 @@ func TestMigration_V9ToV10(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// isolation_mode column must exist and be backfilled by v22→v23.
@@ -4651,8 +4651,8 @@ func TestMigration_V12ToV13_LegacyRowsEnded(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// Check each row.
@@ -5079,8 +5079,8 @@ func TestMigration_V13ToV14_BackfillsLastSeen(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// repo@stale: last_seen must be MAX(created_at) = 5000.
@@ -5354,8 +5354,8 @@ func TestMigration_V14ToV15_RenamesColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// harness_session_id column must now exist in agent_events.
@@ -5575,8 +5575,8 @@ func TestMigration_V15ToV16_CreatesSessionsTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// sessions table must exist.
@@ -5729,8 +5729,8 @@ func TestMigration_V15ToV16_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 }
 
@@ -6283,8 +6283,8 @@ func TestMigration_V17ToV18_BackfillsStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// iid-has-events: started_at must be updated to 1600000000000 (min event ts).
@@ -6341,8 +6341,8 @@ func TestMigration_V17ToV18_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	// iid-has-events should still have the corrected timestamp.
@@ -6643,8 +6643,8 @@ func TestMigration_V20ToV21_BackfillsHarnessSessionID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// iid-with-sid: harness_session_id must have been backfilled.
@@ -6705,8 +6705,8 @@ func TestMigration_V20ToV21_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	// iid-with-sid must still have the backfilled value.
@@ -6864,8 +6864,8 @@ func TestMigration_V21ToV22_BackfillsZeroStartedAt(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// iid-zero-has-events: started_at must be updated to the minimum event ts.
@@ -6918,8 +6918,8 @@ func TestMigration_V21ToV22_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	var startedAt int64
@@ -7072,8 +7072,8 @@ func TestMigration_V22ToV23_BackfillsIsolationMode(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// host-null: host_mode=1, was NULL → must now be 'host'.
@@ -7145,8 +7145,8 @@ func TestMigration_V22ToV23_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	// Values must be stable after a second open.
@@ -7281,8 +7281,8 @@ func TestMigration_V23ToV24_DropsOutcomeSummaryAndCreatesSpawnOutcome(t *testing
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// outcome_summary column must no longer exist on sessions.
@@ -7335,8 +7335,8 @@ func TestMigration_V23ToV24_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	// spawn_outcome must still exist.
@@ -7450,8 +7450,8 @@ func TestMigration_V23ToV24_CrashRecovery(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&finalVer); err != nil {
 		t.Fatalf("read schema_version after recovery: %v", err)
 	}
-	if finalVer != 36 {
-		t.Errorf("schema_version after recovery: got %d, want 36", finalVer)
+	if finalVer != 37 {
+		t.Errorf("schema_version after recovery: got %d, want 37", finalVer)
 	}
 
 	// Sessions data must be preserved (the two rows seeded by seedV23DB).
@@ -8336,8 +8336,8 @@ func TestMigration_V10ToV11_DropsLegacyOpencodeColumns(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// opencode_sid and opencode_port must be gone from agent_status.
@@ -8420,8 +8420,8 @@ func TestMigration_V10ToV11_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	// Columns must remain dropped.
@@ -8590,8 +8590,8 @@ func TestMigration_V11ToV12_CreatesIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// Index must exist after migration.
@@ -8663,8 +8663,8 @@ func TestMigration_V11ToV12_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	var idxName string
@@ -8764,8 +8764,8 @@ func TestMigration_V16ToV17_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// The pre-existing sessions row must be unchanged.
@@ -8800,8 +8800,8 @@ func TestMigration_V16ToV17_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 }
 
@@ -8892,8 +8892,8 @@ func TestMigration_V18ToV19_CreatesPendingMerges(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var tname string
@@ -9039,8 +9039,8 @@ func TestMigration_V19ToV20_AddsStatusSessionIndex(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var iname string
@@ -9208,8 +9208,8 @@ func TestMigration_V24ToV25_CreatesSpawnInputs(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var tname string
@@ -9410,8 +9410,8 @@ func TestMigration_V25ToV26_DropsHostModeAndBackfillsPodman(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// host_mode column must be gone.
@@ -9509,8 +9509,8 @@ func TestMigration_V25ToV26_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 
 	var hmCount int
@@ -9630,8 +9630,8 @@ func TestMigration_V26ToV27_CreatesHarnessFrames(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var tname string
@@ -9800,8 +9800,8 @@ func TestMigration_V27ToV28_BodyRuns_AddsAbtestPairID(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// abtest_pair_id must exist on spawn_inputs.
@@ -9844,8 +9844,8 @@ func TestMigration_V27ToV28_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// The column must still be present — exactly one (not duplicated by a
@@ -9973,8 +9973,8 @@ func TestMigration_V28ToV29_BumpsVersion(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var startedAt int64
@@ -10007,8 +10007,8 @@ func TestMigration_V28ToV29_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version on second open: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 }
 
@@ -10105,8 +10105,8 @@ func TestMigration_V29ToV30_BodyRuns_AddsParentSession(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	var n int
@@ -10145,8 +10145,8 @@ func TestMigration_V29ToV30_BodySkips_PreExistingColumn(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	// Exactly one parent_session column — not duplicated by re-ADD.
@@ -10276,8 +10276,8 @@ func TestMigration_V30ToV31_AddsPRNumberAndRound(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after migration: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after migration: got %d, want 37", version)
 	}
 
 	for _, col := range []string{"pr_number", "round"} {

--- a/modules/programs/prism/prism/internal/db/groups.go
+++ b/modules/programs/prism/prism/internal/db/groups.go
@@ -536,7 +536,7 @@ WHERE a.session_name = ?`
 // to a session_groups row with parent_session = parentSession.
 func (d *DB) GroupMembersForParent(parentSession string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)`
 	return d.queryStatuses(q, parentSession)
@@ -548,7 +548,7 @@ WHERE group_id IN (SELECT group_id FROM session_groups WHERE parent_session = ?)
 // cleaned up.
 func (d *DB) GroupMembersForGroup(groupID string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE group_id = ?
 ORDER BY session_name ASC`
@@ -646,7 +646,7 @@ func (d *DB) ReviewGroupsList(limit int) ([]ReviewGroupSummary, error) {
 	placeholders := strings.Repeat("?,", len(groupIDs))
 	placeholders = placeholders[:len(placeholders)-1] // trim trailing comma
 	memberQ := `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE group_id IN (` + placeholders + `)
 ORDER BY group_id ASC, session_name ASC`

--- a/modules/programs/prism/prism/internal/db/harness_frames_test.go
+++ b/modules/programs/prism/prism/internal/db/harness_frames_test.go
@@ -264,8 +264,8 @@ func TestHarnessFrame_MigrationCreatesTable(t *testing.T) {
 	if err := d.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 36 {
-		t.Errorf("schema_version after fresh open = %d, want 36", ver)
+	if ver != 37 {
+		t.Errorf("schema_version after fresh open = %d, want 37", ver)
 	}
 
 	// The expected indexes must exist (look them up by name).
@@ -299,8 +299,8 @@ func TestHarnessFrame_MigrationIdempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&ver); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if ver != 36 {
-		t.Errorf("schema_version after second open = %d, want 36", ver)
+	if ver != 37 {
+		t.Errorf("schema_version after second open = %d, want 37", ver)
 	}
 
 	// The table must still accept rows.

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -989,7 +989,7 @@ func (d *DB) HarnessSessionIDForInstance(instanceID string) (string, error) {
 // CurrentStatus returns the agent_status row for sessionName, or nil if not found.
 func (d *DB) CurrentStatus(sessionName string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE session_name = ?`
 	row := d.conn.QueryRow(q, sessionName)
@@ -1006,7 +1006,7 @@ WHERE session_name = ?`
 // AllActiveStatus returns all agent_status rows where ended_at IS NULL.
 func (d *DB) AllActiveStatus() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL`
 	return d.queryStatuses(q)
@@ -1037,7 +1037,7 @@ func (d *DB) ActiveSessionCountForMode(mode string) (int, error) {
 // helpers; callable for any IsolationMode value.
 func (d *DB) ActiveSessionsForMode(mode string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL AND isolation_mode = ?`
 	return d.queryStatuses(q, mode)
@@ -1046,7 +1046,7 @@ WHERE ended_at IS NULL AND isolation_mode = ?`
 // AllActiveStatusForRepo returns all active agent_status rows for repo.
 func (d *DB) AllActiveStatusForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ?`
 	return d.queryStatuses(q, repo)
@@ -1069,7 +1069,7 @@ WHERE ended_at IS NULL AND repo = ?`
 // coordinators. Other-repo workers are hidden as noise.
 func (d *DB) AllActiveStatusForRepoAndOtherCoordinators(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL
   AND (
@@ -1090,7 +1090,7 @@ WHERE ended_at IS NULL
 // exists. This is the natural-key dedupe check used by prism spawn --reuse.
 func (d *DB) ActiveStatusForRepoBranch(repo, branch string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL AND repo = ? AND worktree = ?
 LIMIT 1`
@@ -1116,7 +1116,7 @@ func (d *DB) AllStatusesWithPrefix(prefix string) ([]Status, error) {
 	// percent signs in session names are matched exactly, not as wildcards.
 	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE session_name LIKE ? ESCAPE '\'`
 	return d.queryStatuses(q, escaped+"%")
@@ -1150,7 +1150,7 @@ func (d *DB) WaitingCount() (int, error) {
 // strict per-coordinator targeting is required.
 func (d *DB) ActivePISessionsForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL AND harness = 'pi' AND repo = ? AND state IN ('active', 'idle', 'waiting')`
 	return d.queryStatuses(q, repo)
@@ -1161,7 +1161,7 @@ WHERE ended_at IS NULL AND harness = 'pi' AND repo = ? AND state IN ('active', '
 // by the /apply-profile and /register-provider host-API endpoints (P3.LIVE, #1214).
 func (d *DB) AllActivePISessions() ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE ended_at IS NULL AND harness = 'pi' AND state IN ('active', 'idle', 'waiting')`
 	return d.queryStatuses(q)
@@ -1179,7 +1179,7 @@ WHERE ended_at IS NULL AND harness = 'pi' AND state IN ('active', 'idle', 'waiti
 // or more means the worker must specify --to explicitly.
 func (d *DB) CoordinatorCandidatesForRepo(repo string) ([]Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE repo = ? AND ended_at IS NULL
   AND (root_agent_name = 'coordinator' OR (root_agent_name IS NULL AND session_name = ? || '@main'))
@@ -1194,7 +1194,7 @@ ORDER BY last_seen DESC`
 // returned and a duplicate is silently tolerated.
 func (d *DB) CoordinatorForRepo(repo string) (*Status, error) {
 	const q = `
-SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted
+SELECT session_name, repo, worktree, state, title, agent_name, model_id, root_agent_name, root_model_id, isolation_mode, instance_id, last_seen, ended_at, harness, harness_session_id, harness_port, group_id, muted, containers_enabled
 FROM agent_status
 WHERE repo = ? AND root_agent_name = 'coordinator' AND ended_at IS NULL
 ORDER BY last_seen DESC
@@ -1269,11 +1269,12 @@ func scanStatus(s scanner) (*Status, error) {
 	var isolationMode sql.NullString
 	var groupID sql.NullString
 	var muted int64
+	var containersEnabled int64
 	err := s.Scan(
 		&st.SessionName, &st.Repo, &st.Worktree, &st.State,
 		&st.Title, &st.AgentName, &st.ModelID,
 		&st.RootAgentName, &st.RootModelID, &isolationMode, &instanceID, &lastSeen, &endedAt,
-		&harness, &harnessSessionID, &harnessPort, &groupID, &muted,
+		&harness, &harnessSessionID, &harnessPort, &groupID, &muted, &containersEnabled,
 	)
 	if err != nil {
 		return nil, err
@@ -1308,6 +1309,7 @@ func scanStatus(s scanner) (*Status, error) {
 		st.HarnessPort = &hp
 	}
 	st.Muted = muted != 0
+	st.ContainersEnabled = containersEnabled != 0
 	return &st, nil
 }
 

--- a/modules/programs/prism/prism/internal/db/types.go
+++ b/modules/programs/prism/prism/internal/db/types.go
@@ -48,6 +48,12 @@ type Status struct {
 	// (a muted session that hits finished stays muted, and the missed
 	// notification is dropped, not queued).
 	Muted bool `json:"muted"`
+	// ContainersEnabled is the runtime gate for the per-session filtering
+	// podman API socket proxy (#2317 §3f / #2319). When true, the sidecar
+	// starts the proxy and the agent's CONTAINER_HOST / DOCKER_HOST env
+	// vars point at the filtered socket. Defaults to false; flipped by
+	// Step 3 (sidecar wiring) and Step 6 (`prism spawn --containers`).
+	ContainersEnabled bool `json:"containers_enabled"`
 }
 
 // BusMessage represents a row in the bus_messages table.

--- a/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
+++ b/modules/programs/prism/prism/internal/mergequeue/watcher_test.go
@@ -1424,8 +1424,8 @@ func TestMigration_V18ToV19_Idempotent(t *testing.T) {
 	if err := d2.QueryRow("SELECT version FROM schema_version").Scan(&version); err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if version != 36 {
-		t.Errorf("schema_version after second open: got %d, want 36", version)
+	if version != 37 {
+		t.Errorf("schema_version after second open: got %d, want 37", version)
 	}
 }
 


### PR DESCRIPTION
Step 2 of the train tracked by #2317. Implements the DB migration v36→v37 adding `agent_status.containers_enabled` and `spawn_inputs.containers_flag` columns. No production code reads or writes these to anything other than false in this PR — that lands in Steps 3 and 6.

Refs #2317
Refs #2319

## What's in this PR

All changes are in `modules/programs/prism/prism/internal/db/` plus one mechanical edit under `internal/mergequeue/`.

### Schema and migration (`db.go`)

- New `migrateV36ToV37` modelled on `migrateV33ToV34` (the muted column). Two `pragma_table_info`-guarded `ALTER TABLE ADD COLUMN` statements, each idempotent. Migration runner chain in `runMigrations` gains the new call between `migrateV35ToV36` and the schema-version-too-new guard.
- Declarative `schema` block updated in both table definitions:
  - `agent_status` (lines 104-127) gains `containers_enabled INTEGER NOT NULL DEFAULT 0`.
  - `spawn_inputs` (lines 204-262) gains `containers_flag INTEGER NOT NULL DEFAULT 0`.
- `currentSchemaVersion` bumped from 36 → 37.
- Doc-comment on `runMigrations` retargeted from "v1 to v33" → "v1 to v37".

### Go type plumbing

- `db.Status` (`types.go`) gains `ContainersEnabled bool` with a doc-comment pointing forward at Steps 3 and 6.
- `db.SpawnInputs` (`db.go`) gains `ContainersFlag bool` defaulting to false; doc-comment notes the audit-symmetry role alongside `HostModeFlag` / `IsolationFlag`.

### Reader wiring

- `scanStatus` in `status.go` adds the trailing column scan into `ContainersEnabled`.
- All 14 `SELECT … FROM agent_status` sites that flow through `scanStatus` — 11 in `status.go` (`CurrentStatus`, `AllActiveStatus`, `ActiveSessionsForMode`, `AllActiveStatusForRepo`, `AllActiveStatusForRepoAndOtherCoordinators`, `ActiveStatusForRepoBranch`, `AllStatusesWithPrefix`, `ActivePISessionsForRepo`, `AllActivePISessions`, `CoordinatorCandidatesForRepo`, `CoordinatorForRepo`) and 3 in `groups.go` (`GroupMembersForParent`, `GroupMembersForGroup`, `ReviewGroupsList`'s batched member fetch) — gain `containers_enabled` in the trailing position so the new field is populated on every Status load.
- `SpawnInputsByInstanceID` adds `containers_flag` to its `SELECT`, declares a `containersFlag int` scan target, and assigns `si.ContainersFlag = containersFlag != 0` alongside the existing `HostModeFlag` assignment.

### Writer wiring

- `InsertSpawnInputs` adds `containers_flag` to the column list, an extra `?` placeholder, and `boolToInt(si.ContainersFlag)` to the value bindings. Existing callers (`internal/session/spawn.go::spawnInputsFromOpts`, `cmd/pr.go::buildPRSpawnInputs`) leave the field at its zero value, so the column is written 0 in every production path until Step 6.

### Tests

- **New** `db_migration_v36_v37_test.go` (8 migration-branch tests + 2 roundtrip tests):
  - `TestMigration_V36ToV37_BodyRuns_AddsBothColumns` — pre-migration v36 DB, both ALTER TABLEs execute, columns end up `INTEGER NOT NULL DEFAULT 0`.
  - `TestMigration_V36ToV37_BodySkips_BothColumnsPreExist` — pre-migration v36 DB with both columns already added, both pragma guards detect them, no duplicate-add.
  - `TestMigration_V36ToV37_BodyMixed_OnlyContainersEnabledPreExists` and `…_OnlyContainersFlagPreExists` — guard against the failure mode where one pragma check accidentally short-circuits the entire body.
  - `TestMigration_V36ToV37_Idempotent` — second `db.Open` is a no-op.
  - `TestMigration_V36ToV37_FreshDB` — declarative schema covers both columns; ends at v37 with both present.
  - `TestMigration_V36ToV37_PopulatedV36RowsDefaultToZero` — seeds two `agent_status` rows + two `spawn_inputs` rows on the pre-v37 shape, runs the migration, asserts every existing row has both columns at 0.
  - `TestStatus_ContainersEnabledDefaultsFalse` — `UpsertStatus` then `CurrentStatus` returns `ContainersEnabled: false`.
  - `TestSpawnInputs_ContainersFlagRoundtripDefaultsFalse` and `…RoundtripTrue` — `InsertSpawnInputs` + `SpawnInputsByInstanceID` roundtrip for both bool values, proving the field is actually wired through and not just defaulting in lockstep.
- **Mechanical updates** to existing test files: `db_test.go`, `harness_frames_test.go`, `db_migration_v34_v35_test.go`, `db_migration_v35_v36_test.go`, and `internal/mergequeue/watcher_test.go` all had hardcoded `if version != 36` / `want 36` assertions that needed bumping to 37 to track the new `currentSchemaVersion`. No literal `db.Status{…}` or `db.SpawnInputs{…}` constructions exist in tests — the new fields are populated via scan paths and zero-valued via struct literals, so no test had to gain the new fields in its literal. The `schema-version-guard_test.go` meta-test `TestCurrentSchemaVersion_MatchesMigrationCount` is dynamic against the constant; it still reconciles (36 migration functions, `currentSchemaVersion=37`).

### Test-validity check

Per the worker discipline: gutted the migration body + reverted the declarative schema additions, re-ran the new test suite, confirmed every new assertion fails (column missing / no such column errors). Restored, re-ran, confirmed every new assertion passes.

## AC coverage (#2319)

| # | AC | Coverage |
|---|---|---|
| 1 | `pragma_table_info('agent_status')` includes `containers_enabled` INTEGER notnull=1 dflt=0 | `TestMigration_V36ToV37_BodyRuns_AddsBothColumns` via `assertColumnShape(d, "agent_status", "containers_enabled")` (asserts type, notnull, dflt_value) |
| 2 | `pragma_table_info('spawn_inputs')` includes `containers_flag` INTEGER notnull=1 dflt=0 | Same test, `assertColumnShape(d, "spawn_inputs", "containers_flag")` |
| 3 | `currentSchemaVersion == 37` and runner invokes `migrateV36ToV37` | Same test asserts `readVersion(d) == 37`; `TestCurrentSchemaVersion_MatchesMigrationCount` independently asserts the chain has the right number of migration functions |
| 4 | `db.Status.ContainersEnabled` populated by `CurrentStatus` and other readers | `TestStatus_ContainersEnabledDefaultsFalse` (CurrentStatus path); `TestMigration_V36ToV37_PopulatedV36RowsDefaultToZero` also reads via `CurrentStatus`. Compile-time coverage of the other 13 reader sites is forced by the scan column order in `scanStatus` |
| 5 | `db.SpawnInputs.ContainersFlag` written by `InsertSpawnInputs` (defaults false) | `TestSpawnInputs_ContainersFlagRoundtripDefaultsFalse` (default path) and `TestSpawnInputs_ContainersFlagRoundtripTrue` (positive bookend) |
| 6 | Running the migration twice in a row is a no-op | `TestMigration_V36ToV37_Idempotent` — second `db.Open`, both columns still present exactly once, schema_version still 37 |
| 7 | Fresh empty DB ends at v37 with both columns; declarative + migration do not double-add | `TestMigration_V36ToV37_FreshDB`; `TestMigration_V36ToV37_BodySkips_BothColumnsPreExist` also exercises the no-double-add path |
| 8 | v36 DB with populated rows leaves every row at 0 for both columns | `TestMigration_V36ToV37_PopulatedV36RowsDefaultToZero` seeds two rows in each table on the pre-v37 shape, runs migration, asserts `COUNT(*) WHERE containers_enabled != 0` and `WHERE containers_flag != 0` are both 0, plus a Go-API roundtrip |
| 9 | All existing prism Go tests pass without modification (no behavioural change for non-opt-in callers) | Verified via full `go test ./...` and `go test ./... -race` (33 packages green). Test edits in other files are mechanical version-bump assertions only — no behavioural-test changes |

## Verification

From `modules/programs/prism/prism/`:

```
gofmt -l .                              # clean
go vet ./...                            # clean
go build ./...                          # OK
go test ./...                           # 33 packages green
go test ./... -race                     # 33 packages green
```

From the repo root:

```
nix build .#prism                       # OK
```

The homeless-shelter signal is exercised by CI's `nix-build-prism-checked` job; this PR touches `internal/db/` so the prism-touching gate triggers. All review-cycle-1 status checks (`pr-gate`, `go-tests`, `nix-build-prism-checked`, `validate-flakes`) are green.

## Out of scope (later steps in the train)

- Sidecar wiring to read `agent_status.containers_enabled` and start the per-session filtered podman proxy (Step 3).
- bwrap profile changes (Step 4).
- sandbox-exec profile changes (Step 5).
- `prism spawn --containers` flag flipping both columns (Step 6).
- Cleanup integration (Step 7).
- Train closer (Step 8 — the one that `Closes #2317`).
