### PR TITLE
prism: wire podman proxy into sidecar, gated on containers_enabled (Step 3 of #2317)

### DIFF
--- a/modules/programs/prism/prism/cmd/sidecar.go
+++ b/modules/programs/prism/prism/cmd/sidecar.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/prismatic-koi/prism/internal/config"
 	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/git"
 	"github.com/prismatic-koi/prism/internal/harness"
 	_ "github.com/prismatic-koi/prism/internal/harness/pi"
 	"github.com/prismatic-koi/prism/internal/proglog"
@@ -329,28 +330,48 @@ func runSidecar(cmd *cobra.Command, args []string) error {
 		ctrCfg.RuntimeEnv = h.RuntimeEnv()
 	}
 
+	// Resolve the per-session podman proxy listener path (#2317 / #2320).
+	// The path is set unconditionally so the sidecar wiring sees it; the
+	// gate on actually starting the proxy is the agent_status.containers_enabled
+	// column, read inside runPodmanProxyIfEnabled. Resolution failure is
+	// non-fatal — the sidecar still starts, just without the proxy surface.
+	podmanProxyListenerPath, podmanProxyErr := prismSession.SidecarPodmanProxyPath(sessionName)
+	if podmanProxyErr != nil {
+		proglog.Warnf("[prism sidecar] resolve podman proxy socket path: %v (containers_enabled sessions will have no proxy)\n", podmanProxyErr)
+		podmanProxyListenerPath = ""
+	}
+
+	// bareRoot is the worktree's bare repo root, used by the podman proxy's
+	// allowed bind sources so the agent can mount the bare repo into a
+	// container alongside the worktree. git.BareRoot returns "" when the
+	// path is not inside a bare+worktree layout; that is fine — the
+	// allowlist just gains one fewer entry in that case.
+	bareRoot := git.BareRoot(worktree)
+
 	cfg := sidecar.Config{
-		SessionName:         sessionName,
-		Repo:                repo,
-		Worktree:            worktree,
-		HarnessURL:          harnessURL,
-		DB:                  d,
-		Clock:               sidecar.RealClock(),
-		AgentRole:           agentRole,
-		AgentModel:          agentModel,
-		ModelsByRole:        modelsByRole,
-		HarnessName:         harnessName,
-		HarnessBinaryPath:   harnessBinaryPath,
-		BwrapPath:           bwrapPath,
-		InstanceID:          instanceID,
-		IsolationMode:       isolationMode,
-		Container:           ctrCfg,
-		HostAPISockPath:     hostAPISockPath,
-		HarnessPipeSockPath: harnessPipeSockPath,
-		HarnessPipeTCPPort:  harnessPipeTCPPort,
-		OnReady:             onReady,
-		InitialPrompt:       initialPrompt,
-		Harness:             h,
+		SessionName:             sessionName,
+		Repo:                    repo,
+		Worktree:                worktree,
+		BareRoot:                bareRoot,
+		HarnessURL:              harnessURL,
+		DB:                      d,
+		Clock:                   sidecar.RealClock(),
+		AgentRole:               agentRole,
+		AgentModel:              agentModel,
+		ModelsByRole:            modelsByRole,
+		HarnessName:             harnessName,
+		HarnessBinaryPath:       harnessBinaryPath,
+		BwrapPath:               bwrapPath,
+		InstanceID:              instanceID,
+		IsolationMode:           isolationMode,
+		Container:               ctrCfg,
+		HostAPISockPath:         hostAPISockPath,
+		HarnessPipeSockPath:     harnessPipeSockPath,
+		HarnessPipeTCPPort:      harnessPipeTCPPort,
+		PodmanProxyListenerPath: podmanProxyListenerPath,
+		OnReady:                 onReady,
+		InitialPrompt:           initialPrompt,
+		Harness:                 h,
 	}
 	sc := sidecar.New(cfg)
 

--- a/modules/programs/prism/prism/internal/session/sidecar.go
+++ b/modules/programs/prism/prism/internal/session/sidecar.go
@@ -127,6 +127,27 @@ func SidecarHostAPIPath(sessionName string) (string, error) {
 	return filepath.Join(base, "run", SessionDirName(sessionName), "hostapi.sock"), nil
 }
 
+// SidecarPodmanProxyPath returns the Unix socket path for the session's
+// filtering podman API socket proxy listener (#2317 §3b / #2320).
+//
+// The socket lives in the same per-session directory as the host-API socket
+// (hostapi.sock) and the harness-pipe socket (pipe.sock), so the existing
+// bind-mount entry in bwrap and the SBPL subpath rule in sandbox-exec both
+// cover this socket too — no additional mount or allow rule is required.
+//
+// The directory name is the same SessionDirName-derived 12-hex prefix used
+// by SidecarHostAPIPath, keeping the socket path well under sun_path limits
+// on both Linux (108 bytes) and Darwin (104 bytes) — see #1050.
+//
+// Socket path: $XDG_STATE_HOME/prism/run/<12-hex-of-sha256(session)>/podman.sock
+func SidecarPodmanProxyPath(sessionName string) (string, error) {
+	base, err := sidecarStateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "run", SessionDirName(sessionName), "podman.sock"), nil
+}
+
 // SidecarHarnessPipePath returns the Unix socket path for the session's
 // PI harness pipe socket. This socket is the sidecar-side end of the
 // bidirectional JSONL protocol defined in P2.WIRE (#1208).

--- a/modules/programs/prism/prism/internal/session/sidecar_test.go
+++ b/modules/programs/prism/prism/internal/session/sidecar_test.go
@@ -642,6 +642,93 @@ func TestSidecarHarnessPipePath_CoLocatesWithHostAPI(t *testing.T) {
 	}
 }
 
+// ── SidecarPodmanProxyPath tests (#2317 / #2320) ────────────────────────
+
+func TestSidecarPodmanProxyPath_DefaultXDG(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	const sess = "myrepo@feature"
+	got, err := SidecarPodmanProxyPath(sess)
+	if err != nil {
+		t.Fatalf("SidecarPodmanProxyPath: %v", err)
+	}
+
+	want := filepath.Join(home, ".local", "state", "prism", "run", SessionDirName(sess), "podman.sock")
+	if got != want {
+		t.Errorf("SidecarPodmanProxyPath = %q, want %q", got, want)
+	}
+}
+
+func TestSidecarPodmanProxyPath_CustomXDG(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sess = "myrepo@main"
+	got, err := SidecarPodmanProxyPath(sess)
+	if err != nil {
+		t.Fatalf("SidecarPodmanProxyPath: %v", err)
+	}
+
+	want := filepath.Join(tmp, "prism", "run", SessionDirName(sess), "podman.sock")
+	if got != want {
+		t.Errorf("SidecarPodmanProxyPath = %q, want %q", got, want)
+	}
+}
+
+// realisticPodmanProxyPath builds the proxy socket path a production system
+// with the given $HOME would produce, without depending on test-time
+// XDG_STATE_HOME.
+func realisticPodmanProxyPath(home, sessionName string) string {
+	return filepath.Join(home, ".local", "state", "prism", "run", SessionDirName(sessionName), "podman.sock")
+}
+
+// TestSidecarPodmanProxyPath_LengthInvariant_WorstCaseSession asserts that
+// the proxy socket path fits the cross-platform sun_path budget (104 bytes).
+// Same shape as the host-API / pipe equivalents — a third socket in the same
+// per-session run directory adds a small constant overhead over the basename
+// difference ("podman.sock" vs "hostapi.sock"), so the invariant holds on the
+// same worst-case input.
+func TestSidecarPodmanProxyPath_LengthInvariant_WorstCaseSession(t *testing.T) {
+	const home = "/home/prismatic-koi"
+	worstCase := "nixos-config@" + strings.Repeat("x", 80) + "~review-99-review-context"
+
+	got := realisticPodmanProxyPath(home, worstCase)
+	if len(got) > sunPathBudget {
+		t.Errorf("worst-case podman proxy socket path is %d bytes (limit %d): %q",
+			len(got), sunPathBudget, got)
+	}
+}
+
+// TestSidecarPodmanProxyPath_CoLocatesWithHostAPI asserts that the proxy
+// socket lives in the same directory as the host-API and harness-pipe
+// sockets, so the existing bind-mount (bwrap) and SBPL subpath (sandbox-exec)
+// already cover this socket too — no additional bind or allow rule required.
+// This is the central design assumption of #2317 sec.3b ("piggyback on the
+// existing run dir").
+func TestSidecarPodmanProxyPath_CoLocatesWithHostAPI(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	const sess = "nixos-config@main"
+	hostAPIPath, err := SidecarHostAPIPath(sess)
+	if err != nil {
+		t.Fatalf("SidecarHostAPIPath: %v", err)
+	}
+	proxyPath, err := SidecarPodmanProxyPath(sess)
+	if err != nil {
+		t.Fatalf("SidecarPodmanProxyPath: %v", err)
+	}
+
+	if filepath.Dir(hostAPIPath) != filepath.Dir(proxyPath) {
+		t.Errorf("host-API dir %q != podman proxy dir %q — bind-mount assumption violated",
+			filepath.Dir(hostAPIPath), filepath.Dir(proxyPath))
+	}
+}
+
 // ── KillSidecarAndWait tests ────────────────────────────────────────────────────────────────────
 
 // startLongRunningStub re-invokes the current test binary with

--- a/modules/programs/prism/prism/internal/sidecar/podman_proxy.go
+++ b/modules/programs/prism/prism/internal/sidecar/podman_proxy.go
@@ -1,0 +1,338 @@
+// Podman proxy lifecycle wiring (Step 3 of #2317 / issue #2320).
+//
+// This file plumbs the standalone internal/podmanproxy package (Step 1)
+// into the per-session sidecar, gated on the agent_status.containers_enabled
+// column (Step 2). Policy and request inspection live in the proxy package;
+// this file does NOT make policy decisions -- it only:
+//
+//   1. Discovers the upstream podman socket per platform.
+//   2. Opens the per-session audit log file.
+//   3. Builds podmanproxy.Config from sidecar.Config + the discovered upstream.
+//   4. Runs the proxy's Serve loop in a goroutine tracked by notifyWG.
+//
+// All the security guarantees come from the proxy package's default-deny
+// model. This wiring file MUST NOT relax any of those checks; if a request
+// is rejected unexpectedly, the correct response is to escalate via
+// `prism escalate` and either admit the new field upstream in the
+// podmanproxy package or revisit the integration design, NOT to weaken the
+// proxy here.
+//
+// Out-of-scope reminders for Step 3:
+//   - bwrap CONTAINER_HOST/DOCKER_HOST + container-scratch bind -- Step 4.
+//   - sandbox-exec SBPL allow + env injection -- Step 5.
+//   - prism spawn --containers CLI flag -- Step 6.
+//   - orphan-container cleanup sweep -- Step 7.
+
+package sidecar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/podmanproxy"
+)
+
+// defaultPodmanMachineName is the Darwin podman-machine name probed when
+// Config.PodmanMachineName is empty. This matches the default machine name
+// used by `podman machine init` when no --name flag is passed, and is the
+// only machine name we attempt to discover automatically. Step 6 will add a
+// per-spawn override via the same Config.PodmanMachineName field.
+const defaultPodmanMachineName = "podman-machine-default"
+
+// runPodmanProxyIfEnabled starts the per-session filtering podman API socket
+// proxy when the session's agent_status.containers_enabled gate is set. It
+// is called from (*Sidecar).Run after instance_id and the FK-guard row have
+// been settled -- the instance_id is needed to derive the audit-log path,
+// and the row must exist before any audit writes occur.
+//
+// When containers_enabled is false (the default), this function returns
+// without creating any listener, file, or goroutine -- the AC for "no proxy
+// listener when containers_enabled=0" is enforced by this early return.
+//
+// When containers_enabled is true:
+//
+//   - Upstream discovery is attempted per platform. Failure is NOT fatal:
+//     the proxy is still started with the resolved (possibly non-existent)
+//     upstream path, and the proxy package's friendly 503 envelope handles
+//     every request until the upstream becomes reachable. This matches
+//     #2317 sec.3e ("friendly failure mode") and the corresponding AC.
+//   - The audit log is opened in append-only mode under
+//     <XDG_STATE_HOME>/prism/sessions/<instanceID>/podman-proxy.log so log
+//     entries survive sidecar restarts within a single session incarnation.
+//   - The proxy's Serve goroutine is launched via goNotify so notifyWG tracks
+//     it; ctx cancellation -- triggered by Shutdown() -- drains the accept
+//     loop within the proxy's own shutdown budget.
+//   - The audit file handle is stored on the Sidecar so Shutdown can close
+//     it after the proxy goroutine exits.
+//
+// Errors during file/dir setup are logged but NOT propagated: a configured
+// proxy that cannot start should not prevent the rest of the sidecar from
+// coming up, because the agent's non-container surface (host-API, harness
+// pipe, SSE) is independent of container access.
+func (s *Sidecar) runPodmanProxyIfEnabled(ctx context.Context) {
+	// Resolve the listener path. Empty means the caller did not wire a path
+	// (back-compat for older spawns / tests that do not need the proxy);
+	// skip silently.
+	listenerPath := s.cfg.PodmanProxyListenerPath
+	if listenerPath == "" {
+		return
+	}
+
+	// Containers-enabled gate. The DB is the source of truth: spawn flags
+	// in spawn_inputs are an audit row only; agent_status.containers_enabled
+	// is the live runtime gate. A nil DB (some tests, ad-hoc bring-up) keeps
+	// the proxy off -- there is no row to read.
+	if s.cfg.DB == nil {
+		return
+	}
+	status, err := s.cfg.DB.CurrentStatus(s.cfg.SessionName)
+	if err != nil {
+		s.logger().Printf("sidecar: podman-proxy: CurrentStatus: %v (proxy not started)", err)
+		return
+	}
+	if status == nil || !status.ContainersEnabled {
+		// Default-off path: no listener, no audit file, no goroutine. This
+		// is the AC asserted by tests that grep for podman.sock absence.
+		return
+	}
+
+	// At this point containers_enabled=1. Build the proxy config.
+	upstream := s.resolvePodmanUpstreamPath()
+
+	// Open the audit log. The directory is the per-session work dir, which
+	// production code prepares via PrepareSessionWorkDir. We create it here
+	// defensively so tests -- and the rare case where the proxy starts
+	// before agent-run has prepared the directory -- do not lose audit
+	// lines.
+	auditFile, auditPath, auditErr := s.openPodmanProxyAuditFile()
+	if auditErr != nil {
+		// Audit-file open failure should not prevent the proxy from
+		// starting (the AC "audit log exists" only fires when the proxy
+		// itself is healthy). Log and run with a nil writer -- the proxy
+		// package silently drops audit events when AuditWriter is nil.
+		s.logger().Printf("sidecar: podman-proxy: audit log open: %v (proxy will run without audit)", auditErr)
+		auditFile = nil
+		auditPath = ""
+	}
+
+	allowed := s.allowedPodmanBindSources()
+	cfg := podmanproxy.Config{
+		ListenerPath:       listenerPath,
+		UpstreamPath:       upstream,
+		AllowedBindSources: allowed,
+		// Step 3 ships with the default-deny policy from Step 1. No
+		// AllowedCaps, no AllowedSecurityOpts, no MaxMemoryBytes etc.
+		// Step 6 / Step 7 may revisit cap defaults once real workloads
+		// surface. Until then, every escape vector documented in
+		// #2317 sec.4 is rejected by default.
+	}
+	if auditFile != nil {
+		cfg.AuditWriter = auditFile
+	}
+
+	proxy, err := podmanproxy.NewProxy(cfg)
+	if err != nil {
+		s.logger().Printf("sidecar: podman-proxy: NewProxy: %v (proxy not started)", err)
+		if auditFile != nil {
+			_ = auditFile.Close()
+		}
+		return
+	}
+
+	// Track the audit file on the Sidecar so Shutdown can close it once the
+	// proxy goroutine has exited. We deliberately do NOT log the upstream
+	// socket path verbatim -- the security AC says it must not appear in
+	// the sidecar log. The discovery-classification string ("env-derived",
+	// "fallback", "machine-inspect", "override", "missing") is the
+	// observability we expose instead.
+	s.mu.Lock()
+	s.podmanProxyAuditFile = auditFile
+	s.podmanProxyAuditPath = auditPath
+	s.mu.Unlock()
+	s.logger().Printf("sidecar: podman-proxy: listening on %s (audit=%s, allowed_bind_sources=%d)",
+		listenerPath, auditPath, len(allowed))
+
+	// Run the proxy's Serve loop in a tracked goroutine. goNotify increments
+	// notifyWG so test code can drain it, and Run() returns when ctx is
+	// cancelled (i.e. when Shutdown is invoked). On ctx cancellation Serve
+	// drains in-flight requests up to its own shutdownTimeout (2s) and
+	// removes the listener socket file before returning.
+	//
+	// The audit file is closed inside this goroutine, AFTER Serve returns,
+	// so the last audit line is guaranteed flushed before fclose. Shutdown
+	// also calls closePodmanProxyAuditFile defensively in case Serve never
+	// started (e.g. failure path before this branch was reached); both
+	// callers are guarded by an s.mu nil-check so a double close is safe.
+	s.goNotify(func() {
+		if err := proxy.Serve(ctx); err != nil {
+			s.logger().Printf("sidecar: podman-proxy: Serve: %v", err)
+		}
+		s.closePodmanProxyAuditFile()
+	})
+}
+
+// closePodmanProxyAuditFile closes the audit log file handle if one was
+// opened. Called from Shutdown after the proxy goroutine has exited so the
+// last audit line has already been written.
+func (s *Sidecar) closePodmanProxyAuditFile() {
+	s.mu.Lock()
+	f := s.podmanProxyAuditFile
+	s.podmanProxyAuditFile = nil
+	s.mu.Unlock()
+	if f != nil {
+		_ = f.Close()
+	}
+}
+
+// resolvePodmanUpstreamPath returns the absolute path of the upstream
+// docker/podman Unix socket the proxy should forward to. The path does not
+// have to exist -- if it doesn't, the proxy returns the friendly 503
+// envelope for every request, which is the documented behaviour from
+// #2317 sec.3e.
+//
+// Precedence:
+//  1. Config.PodmanUpstreamPath override (test seam; will also be the
+//     conduit for the Step-6 --podman-machine flag).
+//  2. Platform-specific discovery (NixOS env, Darwin `podman machine inspect`).
+//  3. A non-existent placeholder path as a final fallback -- the proxy
+//     handles ENOENT/ECONNREFUSED at dial time and returns the friendly 503.
+func (s *Sidecar) resolvePodmanUpstreamPath() string {
+	if s.cfg.PodmanUpstreamPath != "" {
+		return s.cfg.PodmanUpstreamPath
+	}
+	switch runtime.GOOS {
+	case "linux":
+		return s.resolvePodmanUpstreamLinux()
+	case "darwin":
+		return s.resolvePodmanUpstreamDarwin()
+	default:
+		// Unsupported platforms get a non-existent placeholder; the proxy
+		// handles dial failure as "podman socket unavailable".
+		return "/podman-unavailable.sock"
+	}
+}
+
+// resolvePodmanUpstreamLinux applies the NixOS / Linux discovery rules:
+//
+//   - $XDG_RUNTIME_DIR/podman/podman.sock when XDG_RUNTIME_DIR is set.
+//   - /run/user/<uid>/podman/podman.sock as the fallback when XDG_RUNTIME_DIR
+//     is unset.
+//
+// Discovery never inspects the path's existence -- the proxy itself
+// handles ENOENT at dial time.
+func (s *Sidecar) resolvePodmanUpstreamLinux() string {
+	if rt := os.Getenv("XDG_RUNTIME_DIR"); rt != "" {
+		return filepath.Join(rt, "podman", "podman.sock")
+	}
+	return fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid())
+}
+
+// resolvePodmanUpstreamDarwin shells out to `podman machine inspect <name>
+// --format '{{.ConnectionInfo.PodmanSocket.Path}}'` and returns the trimmed
+// stdout. When the command is missing, exits non-zero, or returns empty
+// output, a non-existent placeholder is returned so the proxy hits its
+// friendly 503 path. Discovery is best-effort by design -- #2317 sec.3e
+// documents that a stopped machine is a normal failure mode.
+func (s *Sidecar) resolvePodmanUpstreamDarwin() string {
+	machine := s.cfg.PodmanMachineName
+	if machine == "" {
+		machine = defaultPodmanMachineName
+	}
+	cmd := exec.Command("podman", "machine", "inspect", machine,
+		"--format", "{{.ConnectionInfo.PodmanSocket.Path}}")
+	out, err := cmd.Output()
+	if err != nil {
+		// Use a stable classification token instead of the raw err so we
+		// do not leak the upstream socket path if it appears in stderr.
+		s.logger().Printf("sidecar: podman-proxy: machine-inspect failed (%s); proxy will return 503 envelope", classifyDiscoveryError(err))
+		return "/podman-machine-unavailable.sock"
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		s.logger().Printf("sidecar: podman-proxy: machine-inspect returned empty path; proxy will return 503 envelope")
+		return "/podman-machine-unavailable.sock"
+	}
+	// IMPORTANT: do NOT log `path` here. The security AC requires the
+	// upstream socket path to NOT appear in the sidecar log.
+	return path
+}
+
+// classifyDiscoveryError produces a short, redaction-safe token describing
+// why upstream discovery failed. Never include err.Error() verbatim in the
+// sidecar log -- the upstream socket path may appear in stderr output and
+// the security AC forbids that leak.
+func classifyDiscoveryError(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return fmt.Sprintf("exit-status-%d", exitErr.ExitCode())
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return "binary-not-found"
+	}
+	return "io-error"
+}
+
+// allowedPodmanBindSources returns the set of host path prefixes that may
+// appear as the source side of HostConfig.Binds / Mounts entries on a
+// containers/create request. Step 4 (bwrap) and Step 5 (sandbox-exec) will
+// also bind / SBPL-allow these same paths inside the sandbox.
+//
+// The set always includes:
+//   - The session's worktree (cfg.Worktree).
+//   - The bare repo root (cfg.BareRoot) when non-empty.
+//   - <sessionDir>/container-scratch/ when the instance ID is known.
+//
+// Empty fields are skipped. The scratch directory may not exist yet at this
+// point -- that's fine, the proxy treats the AllowedBindSources entries as
+// path prefixes, not file references.
+func (s *Sidecar) allowedPodmanBindSources() []string {
+	var allowed []string
+	if s.cfg.Worktree != "" {
+		allowed = append(allowed, s.cfg.Worktree)
+	}
+	if s.cfg.BareRoot != "" {
+		allowed = append(allowed, s.cfg.BareRoot)
+	}
+	if s.cfg.InstanceID != "" {
+		if sessionDir, err := container.SessionWorkDirPath(s.cfg.InstanceID); err == nil {
+			allowed = append(allowed, filepath.Join(sessionDir, "container-scratch"))
+		}
+	}
+	return allowed
+}
+
+// openPodmanProxyAuditFile opens the per-session audit log file in
+// append-only mode and returns the file handle plus the absolute path. The
+// audit log lives under the per-session work dir so RemoveSessionWorkDir
+// wipes it on cleanup, alongside the rest of the session's transient state.
+//
+// The directory is created with 0o700 to match the rest of the per-session
+// state; the file is opened 0o600 so only the sidecar owner can read it.
+func (s *Sidecar) openPodmanProxyAuditFile() (*os.File, string, error) {
+	if s.cfg.InstanceID == "" {
+		return nil, "", fmt.Errorf("instance ID is empty")
+	}
+	sessionDir, err := container.SessionWorkDirPath(s.cfg.InstanceID)
+	if err != nil {
+		return nil, "", fmt.Errorf("session work dir: %w", err)
+	}
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return nil, "", fmt.Errorf("mkdir session dir: %w", err)
+	}
+	auditPath := filepath.Join(sessionDir, "podman-proxy.log")
+	f, err := os.OpenFile(auditPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return nil, "", fmt.Errorf("open audit log: %w", err)
+	}
+	return f, auditPath, nil
+}

--- a/modules/programs/prism/prism/internal/sidecar/podman_proxy_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/podman_proxy_test.go
@@ -1,0 +1,456 @@
+package sidecar
+
+// Tests for the per-session podman-proxy wiring (Step 3 of #2317 / #2320).
+//
+// These tests use sidecartest.NewIsolated per AGENTS.md
+// "Test-suite isolation (#1608)" so they never touch a real podman socket on
+// the host. The PodmanUpstreamPath override is the seam that lets us point
+// the proxy at:
+//
+//   - a non-existent path, exercising the friendly 503 envelope from the
+//     proxy package without a real podman dependency, OR
+//   - an httptest-style upstream stub (not exercised here yet -- Step 3 only
+//     needs to prove that the sidecar STARTS the proxy and forwards the
+//     dial-failure case correctly; deeper request-shape tests live in the
+//     podmanproxy package).
+//
+// Session names use the "prism-test@" prefix per the test isolation
+// convention.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/container"
+	"github.com/prismatic-koi/prism/internal/harness"
+	prismsession "github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// newPodmanProxyTestSidecar builds a Sidecar wired to start the podman proxy
+// when the agent_status.containers_enabled column is true. The caller must
+// flip the column before invoking Run -- toggling it after Run starts will
+// not retroactively start the proxy (the read happens once at startup).
+//
+// The supplied upstream path may be empty (no override; production
+// discovery applies on the host) or a path to a stub / non-existent file
+// (test seam for #2320 ACs).
+//
+// Returns the constructed Sidecar plus the resolved proxy listener path so
+// tests can probe / assert on the listener directly.
+func newPodmanProxyTestSidecar(t *testing.T, bus *sidecartest.Bus, session, upstream string) (*Sidecar, string) {
+	t.Helper()
+	listenerPath, err := prismsession.SidecarPodmanProxyPath(session)
+	if err != nil {
+		t.Fatalf("SidecarPodmanProxyPath: %v", err)
+	}
+	if len(listenerPath) > maxSunPath {
+		t.Fatalf("podman proxy socket path too long (%d > %d): %s", len(listenerPath), maxSunPath, listenerPath)
+	}
+	// Use the legacy HTTP-port path (empty HarnessName) with a fake SSE
+	// harness so Run() does not require a live podman socket OR a live PI
+	// extension. We override SubscribeFn to block on ctx.Done instead of
+	// returning an immediately-closed channel — otherwise Run() exits at
+	// the SSE loop before the test gets a chance to probe the proxy.
+	h := newSSEHarness()
+	h.SubscribeFn = func(ctx context.Context) (<-chan harness.HarnessEvent, error) {
+		ch := make(chan harness.HarnessEvent)
+		go func() {
+			<-ctx.Done()
+			close(ch)
+		}()
+		return ch, nil
+	}
+	cfg := Config{
+		SessionName:             session,
+		Repo:                    "prism-test",
+		Worktree:                t.TempDir(),
+		DB:                      bus.DB,
+		Clock:                   newTestClock(),
+		AgentRole:               "worker",
+		InstanceID:              "test-instance-" + t.Name(),
+		HarnessURL:              "http://127.0.0.1:1", // unreachable; not used with overridden SubscribeFn
+		Harness:                 h,
+		PodmanProxyListenerPath: listenerPath,
+		PodmanUpstreamPath:      upstream,
+	}
+	return New(cfg), listenerPath
+}
+
+// runSidecarBackground starts the sidecar's Run loop in a goroutine and
+// returns a channel that closes once Run exits. The channel is closed
+// (not just sent to) so multiple receivers can race on it: tests typically
+// wait on it explicitly, and the t.Cleanup wait is a backstop.
+func runSidecarBackground(t *testing.T, sc *Sidecar, ctx context.Context) <-chan struct{} {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := sc.Run(ctx); err != nil {
+			t.Logf("Run returned: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Log("Run() did not exit within 3s of context cancellation")
+		}
+	})
+	return done
+}
+
+// waitForPath polls until path exists or the timeout elapses. Returns true if
+// the path showed up in time.
+func waitForPath(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// waitForPathGone polls until path does NOT exist or the timeout elapses.
+// Returns true if the path was gone within timeout.
+func waitForPathGone(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// proxyClientFor returns an http.Client whose Transport dials the supplied
+// Unix socket. Identical in shape to the helper used inside the podmanproxy
+// package tests but kept local so we do not export the helper from there.
+func proxyClientFor(sock string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", sock)
+			},
+		},
+		Timeout: 3 * time.Second,
+	}
+}
+
+// setContainersEnabled flips the agent_status.containers_enabled column for
+// session via a direct DB update. NewIsolated has already seeded the row.
+func setContainersEnabled(t *testing.T, bus *sidecartest.Bus, session string, enabled bool) {
+	t.Helper()
+	v := 0
+	if enabled {
+		v = 1
+	}
+	// The DB type exposes QueryRow (used by tests for surgical updates);
+	// RETURNING + Scan is the idiomatic shape in this package -- see
+	// review_recovery_test.go and notify_test.go for the same pattern.
+	if err := bus.DB.QueryRow(
+		"UPDATE agent_status SET containers_enabled = ? WHERE session_name = ? RETURNING session_name",
+		v, session,
+	).Scan(new(string)); err != nil {
+		t.Fatalf("set containers_enabled=%d for %q: %v", v, session, err)
+	}
+}
+
+// ── AC: "no proxy listener when containers_enabled=0" ─────────────────────
+
+// TestPodmanProxy_DefaultOff_NoListener verifies that when
+// containers_enabled is false (the default for every existing session), the
+// sidecar does NOT create a podman.sock listener file in the per-session run
+// directory. This is the greppable AC from #2320.
+func TestPodmanProxy_DefaultOff_NoListener(t *testing.T) {
+	session := "prism-test@" + t.Name()
+	bus := sidecartest.NewIsolated(t, session)
+
+	sc, listenerPath := newPodmanProxyTestSidecar(t, bus, session, "")
+	// Explicitly leave containers_enabled false (the default seeded by
+	// NewIsolated -> UpsertStatusWithAgent).
+	setContainersEnabled(t, bus, session, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := runSidecarBackground(t, sc, ctx)
+
+	// Give the proxy goroutine plenty of time to NOT start. We deliberately
+	// poll for the absence of the socket rather than spin a single check, so
+	// scheduler latency does not give us a false negative.
+	deadline := time.Now().Add(750 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(listenerPath); err == nil {
+			t.Fatalf("podman.sock unexpectedly exists at %s while containers_enabled=0", listenerPath)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+}
+
+// ── AC: "containers_enabled=1 -> proxy listens, audit log exists, 503 on probe" ──
+
+// TestPodmanProxy_ContainersEnabled_ProxyListensAndReturns503 covers the
+// happy-but-no-upstream path: containers_enabled is true, the proxy starts,
+// the listener socket exists, the audit log exists, and a probe request
+// returns the friendly 503 envelope from the podmanproxy package. This is
+// the production failure mode on Darwin without `podman machine start` --
+// the AC explicitly calls it out.
+func TestPodmanProxy_ContainersEnabled_ProxyListensAndReturns503(t *testing.T) {
+	session := "prism-test@" + t.Name()
+	bus := sidecartest.NewIsolated(t, session)
+
+	// Point the proxy at a path that does not exist; the proxy's
+	// upstreamErrorHandler maps the resulting ENOENT/ECONNREFUSED to the
+	// friendly 503 envelope. We construct the path under the test's XDG
+	// tempdir so we never leak outside the isolation.
+	upstream := filepath.Join(bus.XDGStateHome, "fake-podman.sock")
+
+	sc, listenerPath := newPodmanProxyTestSidecar(t, bus, session, upstream)
+	setContainersEnabled(t, bus, session, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := runSidecarBackground(t, sc, ctx)
+
+	// The listener must appear within a couple of seconds. The proxy goroutine
+	// is launched via goNotify from inside Run() after the FK guard, so the
+	// socket binds asynchronously.
+	if !waitForPath(listenerPath, 3*time.Second) {
+		t.Fatalf("podman.sock listener did not appear at %s", listenerPath)
+	}
+
+	// The audit file path is deterministic: <sessionDir>/podman-proxy.log.
+	sessionDir, err := container.SessionWorkDirPath(sc.cfg.InstanceID)
+	if err != nil {
+		t.Fatalf("SessionWorkDirPath: %v", err)
+	}
+	auditPath := filepath.Join(sessionDir, "podman-proxy.log")
+
+	// Fire a probe request at the proxy's ListenerPath. Expect 503 + the
+	// friendly envelope shape locked by the parent issue's AC.
+	client := proxyClientFor(listenerPath)
+	resp, err := client.Get("http://podman.sock/v1.41/_ping")
+	if err != nil {
+		t.Fatalf("GET /_ping via proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "podman socket unavailable") {
+		t.Errorf("envelope: got %q, want substring 'podman socket unavailable'", body)
+	}
+
+	// The audit log must exist and contain at least one line after the probe.
+	// Audit writes are append-only and serialised under the proxy's auditMu,
+	// so a single Stat-after-probe is race-free.
+	st, err := os.Stat(auditPath)
+	if err != nil {
+		t.Fatalf("stat audit log %s: %v", auditPath, err)
+	}
+	if st.Size() == 0 {
+		t.Errorf("audit log %s is empty after probe; want at least one line", auditPath)
+	}
+	// Spot-check the audit line shape: it must parse as JSON with the
+	// expected fields. Use the first line only; trailing bytes (if any) may
+	// belong to an in-flight request.
+	auditBytes, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	firstLine := strings.SplitN(strings.TrimSpace(string(auditBytes)), "\n", 2)[0]
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(firstLine), &rec); err != nil {
+		t.Fatalf("audit line is not valid JSON: %v\nline=%q", err, firstLine)
+	}
+	for _, field := range []string{"timestamp", "method", "endpoint", "decision", "reason"} {
+		if _, ok := rec[field]; !ok {
+			t.Errorf("audit line missing field %q: %v", field, rec)
+		}
+	}
+
+	cancel()
+	<-done
+}
+
+// ── AC: "ctx cancellation drains the proxy and unlinks the socket" ─────────
+
+// TestPodmanProxy_CtxCancellationUnlinksSocket verifies that cancelling the
+// sidecar's run context exits the proxy goroutine within 5 seconds (per
+// #2320 AC) and unlinks the listener socket file as a side effect of the
+// proxy's Serve loop's deferred cleanup.
+func TestPodmanProxy_CtxCancellationUnlinksSocket(t *testing.T) {
+	session := "prism-test@" + t.Name()
+	bus := sidecartest.NewIsolated(t, session)
+
+	upstream := filepath.Join(bus.XDGStateHome, "fake-podman.sock")
+	sc, listenerPath := newPodmanProxyTestSidecar(t, bus, session, upstream)
+	setContainersEnabled(t, bus, session, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runSidecarBackground(t, sc, ctx)
+	if !waitForPath(listenerPath, 3*time.Second) {
+		t.Fatalf("podman.sock listener did not appear at %s", listenerPath)
+	}
+
+	cancel()
+
+	// The proxy's Serve loop removes the socket file on ctx cancellation.
+	if !waitForPathGone(listenerPath, 5*time.Second) {
+		t.Errorf("podman.sock still exists 5s after ctx cancellation: %s", listenerPath)
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Error("Run() did not exit within 5s of ctx cancellation")
+	}
+}
+
+// ── AC: "real upstream socket path not in sidecar log" ─────────────────────
+
+// TestPodmanProxy_UpstreamDiscovery_OverridePrecedence verifies the
+// override-precedence rule (test seam for #1608): when
+// Config.PodmanUpstreamPath is non-empty, platform-specific discovery is
+// short-circuited and the override value is returned verbatim. This is the
+// seam that lets tests run without a real podman socket and that Step 6
+// will reuse for a future --podman-upstream spawn flag.
+func TestPodmanProxy_UpstreamDiscovery_OverridePrecedence(t *testing.T) {
+	sc := New(Config{
+		SessionName:        "prism-test@override",
+		Harness:            newSSEHarness(),
+		PodmanUpstreamPath: "/tmp/explicit-override.sock",
+	})
+	if got := sc.resolvePodmanUpstreamPath(); got != "/tmp/explicit-override.sock" {
+		t.Errorf("resolvePodmanUpstreamPath with override = %q, want %q",
+			got, "/tmp/explicit-override.sock")
+	}
+}
+
+// TestPodmanProxy_UpstreamDiscovery_Linux_XDGRuntimeDir asserts the NixOS
+// happy path from #2317 sec.3e: when $XDG_RUNTIME_DIR is set, the upstream
+// socket is $XDG_RUNTIME_DIR/podman/podman.sock. The shape of the path is
+// stable across distros that use the systemd user-podman socket.
+func TestPodmanProxy_UpstreamDiscovery_Linux_XDGRuntimeDir(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/12345")
+	sc := New(Config{
+		SessionName: "prism-test@xdgrt",
+		Harness:     newSSEHarness(),
+	})
+	got := sc.resolvePodmanUpstreamLinux()
+	want := "/run/user/12345/podman/podman.sock"
+	if got != want {
+		t.Errorf("resolvePodmanUpstreamLinux with XDG_RUNTIME_DIR set = %q, want %q", got, want)
+	}
+}
+
+// TestPodmanProxy_UpstreamDiscovery_Linux_Fallback asserts the documented
+// fallback when $XDG_RUNTIME_DIR is unset: /run/user/<uid>/podman/podman.sock.
+// The numeric uid is whatever os.Getuid() returns in this process; we just
+// check the prefix and suffix shape, not the literal value, so the test is
+// reproducible across CI / dev hosts.
+func TestPodmanProxy_UpstreamDiscovery_Linux_Fallback(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	sc := New(Config{
+		SessionName: "prism-test@fallback",
+		Harness:     newSSEHarness(),
+	})
+	got := sc.resolvePodmanUpstreamLinux()
+	if !strings.HasPrefix(got, "/run/user/") || !strings.HasSuffix(got, "/podman/podman.sock") {
+		t.Errorf("resolvePodmanUpstreamLinux fallback = %q, want /run/user/<uid>/podman/podman.sock shape", got)
+	}
+}
+
+// TestPodmanProxy_UpstreamDiscovery_Darwin_MissingPodmanReturnsPlaceholder
+// asserts the Darwin failure-mode AC from #2317 sec.3e: when `podman` is not
+// on PATH (or `podman machine inspect` exits non-zero) the discovery returns
+// a stable placeholder string so the proxy's friendly 503 envelope fires
+// instead of the sidecar refusing to start. We engineer the "podman not
+// found" condition by shrinking PATH to an empty tempdir.
+//
+// The test is GOOS-agnostic: it exercises the function directly, regardless
+// of whether the developer's host has podman installed.
+func TestPodmanProxy_UpstreamDiscovery_Darwin_MissingPodmanReturnsPlaceholder(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	sc := New(Config{
+		SessionName: "prism-test@darwin-missing",
+		Harness:     newSSEHarness(),
+	})
+	got := sc.resolvePodmanUpstreamDarwin()
+	// We do NOT assert the literal placeholder string here; the
+	// guarantee that matters for #2320 is "discovery never returns a
+	// path that points at the real host podman socket when discovery
+	// fails". An absolute, non-existent path satisfies that contract,
+	// and the proxy package's friendly 503 then fires.
+	if _, err := os.Stat(got); err == nil {
+		t.Errorf("resolvePodmanUpstreamDarwin returned an EXISTING path %q on a host with no podman; the friendly 503 path would not fire", got)
+	}
+	if got == "" || got[0] != '/' {
+		t.Errorf("resolvePodmanUpstreamDarwin returned non-absolute path %q", got)
+	}
+}
+
+// TestPodmanProxy_UpstreamPathNotInSidecarLog verifies the security AC:
+// even when the proxy is started and audited, the rendered sidecar log
+// must NOT contain the real upstream socket path verbatim. The audit log
+// may reference proxied endpoints (e.g. /v1.41/_ping), but the upstream
+// path itself is a host secret -- leaking it via the sidecar log would
+// undo part of the isolation story.
+//
+// We pick an upstream path with a distinctive sentinel substring so a
+// naive substring search is precise.
+func TestPodmanProxy_UpstreamPathNotInSidecarLog(t *testing.T) {
+	session := "prism-test@" + t.Name()
+	bus := sidecartest.NewIsolated(t, session)
+
+	sentinel := "PODMAN_UPSTREAM_SENTINEL_DO_NOT_LOG"
+	upstream := filepath.Join(bus.XDGStateHome, sentinel+".sock")
+
+	sc, listenerPath := newPodmanProxyTestSidecar(t, bus, session, upstream)
+	// captureLog rewrites sc.cfg.Logger to a buffer-backed log.Logger and
+	// returns a snapshot accessor that drains notifyWG before reading; this
+	// is the canonical race-safe log capture in this package (issues #1713 /
+	// #1716). Call it BEFORE Run so the proxy goroutine writes through the
+	// captured logger from the start.
+	getLogs := captureLog(sc)
+	setContainersEnabled(t, bus, session, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := runSidecarBackground(t, sc, ctx)
+	if !waitForPath(listenerPath, 3*time.Second) {
+		t.Fatalf("podman.sock listener did not appear at %s", listenerPath)
+	}
+
+	// Fire a probe so the audit + proxy paths are exercised in full.
+	client := proxyClientFor(listenerPath)
+	resp, err := client.Get("http://podman.sock/v1.41/_ping")
+	if err != nil {
+		t.Fatalf("GET /_ping: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	cancel()
+	<-done
+
+	got := getLogs()
+	if strings.Contains(got, sentinel) {
+		t.Errorf("sidecar log contains the upstream sentinel %q -- the real upstream socket path leaked into the log surface\nlog:\n%s", sentinel, got)
+	}
+}

--- a/modules/programs/prism/prism/internal/sidecar/sidecar.go
+++ b/modules/programs/prism/prism/internal/sidecar/sidecar.go
@@ -325,6 +325,39 @@ type Config struct {
 	// paths, even when $HOME is unwritable (e.g. /homeless-shelter in the nix
 	// sandbox). See dashboard.go and issue #1851 for the footgun analysis.
 	DashboardSink DashboardSink
+
+	// BareRoot is the bare repository root for sessions in the bare+worktree
+	// layout. When non-empty it is added to the podman proxy's allowed bind
+	// sources so the agent can mount the bare repo into a container alongside
+	// the worktree. Empty for sessions that are not in a bare+worktree layout.
+	// Wired by cmd/sidecar.go from git.BareRoot(worktree). Read by
+	// runPodmanProxyIfEnabled.
+	BareRoot string
+
+	// PodmanProxyListenerPath is the Unix socket path the per-session
+	// filtering podman API socket proxy listens on when containers are
+	// enabled for the session (#2317 / #2320). When empty the proxy is
+	// never started, regardless of the agent_status.containers_enabled
+	// gate. Typically set to session.SidecarPodmanProxyPath(sessionName).
+	PodmanProxyListenerPath string
+
+	// PodmanUpstreamPath, when non-empty, overrides the platform-specific
+	// upstream socket discovery in runPodmanProxyIfEnabled. The primary
+	// purpose is test isolation: a sidecar test can point the proxy at a
+	// stub upstream (or at a non-existent path to exercise the 503
+	// envelope) without depending on a real podman socket on the host
+	// (AGENTS.md "Test-suite isolation (#1608)"). Step 6 will reuse the
+	// same override as the conduit for a future
+	// `prism spawn --containers --podman-upstream <path>` flag.
+	PodmanUpstreamPath string
+
+	// PodmanMachineName is the Darwin podman-machine name probed by the
+	// upstream discovery shellout when PodmanUpstreamPath is empty. When
+	// empty, defaultPodmanMachineName ("podman-machine-default") is used.
+	// Step 6 will surface a `--podman-machine` spawn flag whose value is
+	// forwarded into this field for per-spawn machine selection. No-op on
+	// non-Darwin platforms.
+	PodmanMachineName string
 }
 
 // seenUnknownCap is the maximum number of unique unknown event types tracked
@@ -626,6 +659,19 @@ type Sidecar struct {
 	// the coordinator notify path — do not extend this to other
 	// notify* methods without a separate justification.
 	notifyCoordinatorDeliverFn func(sessionName string, status *db.Status, text string, buildHTTPBody func(string, *db.Status) map[string]any, source string, deliverAs string) error
+
+	// podmanProxyAuditFile is the open audit-log file handle held by the
+	// per-session podman proxy (#2317 / #2320). Set by
+	// runPodmanProxyIfEnabled when the proxy is started; closed by Shutdown
+	// after the proxy goroutine has exited so the last audit line is
+	// flushed. nil when the proxy is not started (containers_enabled=0) or
+	// when audit-file open failed at startup. Protected by s.mu.
+	podmanProxyAuditFile *os.File
+
+	// podmanProxyAuditPath is the absolute path of the audit log opened by
+	// runPodmanProxyIfEnabled. Held only for log/diagnostic surfaces.
+	// Protected by s.mu.
+	podmanProxyAuditPath string
 }
 
 // defaultReviewRecoveryInterval is how often the worker-sidecar recovery
@@ -868,6 +914,14 @@ func (s *Sidecar) Run(ctx context.Context) error {
 			s.logger().Printf("sidecar: warning: InsertSession for instance %s failed (FK-guard): %v", s.cfg.InstanceID, err)
 		}
 	}
+
+	// Start the per-session filtering podman API socket proxy when the
+	// agent_status.containers_enabled gate is set (Step 3 of #2317 / #2320).
+	// Placed after the FK guard so the audit log path's instance_id-derived
+	// directory is safe to create. The call is a no-op when the gate is off,
+	// when PodmanProxyListenerPath is empty, or when DB is nil — see
+	// runPodmanProxyIfEnabled for the gate logic.
+	s.runPodmanProxyIfEnabled(ctx)
 
 	// B.3 Stage 2: Start the merge-queue watcher for coordinator sessions.
 	// This is transport-agnostic and must run for ALL transport shapes so that
@@ -1297,6 +1351,16 @@ func (s *Sidecar) Shutdown() {
 			_ = os.Remove(s.cfg.HarnessPipeSockPath)
 		}
 	}
+
+	// Defensive close of the podman-proxy audit log. In the happy path the
+	// goNotify wrapper around proxy.Serve already closed it after Serve
+	// returned on ctx cancellation; this call is a no-op then (the handle
+	// is nilled under s.mu so a double close cannot occur). The defensive
+	// path covers Shutdown invocations that race with Run failure-modes
+	// where the goroutine was never spawned (e.g. NewProxy returned an
+	// error after the file was opened) — closePodmanProxyAuditFile reads
+	// the handle under s.mu so the second writer is safe.
+	s.closePodmanProxyAuditFile()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

Step 3 of the podman-proxy train (#2317). Plumbs the standalone
`internal/podmanproxy` package (Step 1 / #2318) into the per-session
sidecar, gated on the `agent_status.containers_enabled` column
(Step 2 / #2319). Policy and request inspection stay in the proxy package
unchanged; this PR only adds the lifecycle glue.

## What lands here

- **`session.SidecarPodmanProxyPath`** — new helper returning
  `$XDG_STATE_HOME/prism/run/<SessionDirName>/podman.sock`. Co-located with
  `hostapi.sock` and `pipe.sock`, so the existing bind-mount (bwrap) and
  SBPL subpath rule (sandbox-exec) cover it automatically — no extra
  mount/allow rule in Step 4 / 5.

- **`internal/sidecar/podman_proxy.go`** — owns the DB-gate read, upstream
  discovery, audit-log open, allowed-bind-source assembly, and the
  `goNotify`-tracked `proxy.Serve` goroutine. Upstream discovery is:
  - **Linux**: `$XDG_RUNTIME_DIR/podman/podman.sock`, falling back to
    `/run/user/<uid>/podman/podman.sock` when the env var is unset.
  - **Darwin**: shells out to
    `podman machine inspect <name> --format '{{.ConnectionInfo.PodmanSocket.Path}}'`.

- **`sidecar.Config` additions**: `BareRoot`, `PodmanProxyListenerPath`,
  `PodmanUpstreamPath`, `PodmanMachineName`. `PodmanUpstreamPath` is the
  test seam from AGENTS.md "Test-suite isolation (#1608)" — Step 6 will
  reuse it for a future `prism spawn --containers --podman-upstream` flag.

- **`Shutdown()`** closes the audit file defensively; the happy path closes
  it inside the `goNotify` wrapper after `proxy.Serve` returns.

- **`cmd/sidecar.go`** wires `SidecarPodmanProxyPath` and
  `git.BareRoot(worktree)` into the Config unconditionally. The runtime
  gate is purely the DB column.

## Failure-mode behaviour

Matches the #2320 ACs and the #2317 §3e "friendly failure" contract:

- **`containers_enabled=0`** (default for every existing session): no
  listener, no audit log, no goroutine. Greppable AC.
- **`containers_enabled=1` + upstream missing** (Darwin machine off, NixOS
  user systemd not running): proxy still starts; listener binds; every
  request returns the friendly 503 envelope from the proxy package. Not a
  sidecar launch failure.
- **`ctx` cancellation**: proxy goroutine drains within 5 s and unlinks
  the listener socket.
- **Security**: rendered sidecar log does NOT contain the upstream socket
  path verbatim. We only log the listener path, audit path, and the
  allowed-bind-source count. `podman machine inspect` failures are
  classified to short tokens (`binary-not-found`, `exit-status-N`) rather
  than printing `err.Error()` which could leak the upstream path via
  stderr.

## Tests

New `internal/sidecar/podman_proxy_test.go` covers every #2320 AC with 8
tests. All use `sidecartest.NewIsolated` plus the `PodmanUpstreamPath`
override, so no test touches a real podman socket.

Each test was verified non-vacuous by reverting the corresponding production
behaviour and watching the test fail:

- Comment out the call to `runPodmanProxyIfEnabled` → 3 of 4 lifecycle
  tests fail (the `DefaultOff` test still passes — as it should, with no
  proxy starter the gate is trivially honoured).
- Bypass the `containers_enabled` gate → `TestPodmanProxy_DefaultOff_NoListener`
  fails because the proxy starts even though the column is false.
- Add a `s.logger().Printf(... upstream ...)` leak → the log-leak test
  fails with the sentinel in the captured log.

Also added 4 new `session` package tests for `SidecarPodmanProxyPath`
(default-XDG, custom-XDG, length-invariant, co-location with `hostapi.sock`).

## Process discipline

- `gofmt -l .` → clean
- `go vet ./...` → clean
- `go test -race ./...` → all packages green
- `nix build .#prism` → ok

## Out of scope (handled in later steps)

- bwrap `CONTAINER_HOST` / `DOCKER_HOST` env + container-scratch bind — Step 4
- sandbox-exec SBPL allow + env injection — Step 5
- `prism spawn --containers` CLI flag — Step 6
- orphan-container cleanup sweep — Step 7
- AGENTS.md / docs updates and parent-AC closer — Step 8 (#2325)

Refs #2317
Refs #2320

(Not `Closes` — Step 8 / #2325 closes #2317.)
