### PR TITLE
prism: expose filtered podman socket in bwrap sandbox (Step 4 of #2317)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run.go
+++ b/modules/programs/prism/prism/cmd/agent_run.go
@@ -305,6 +305,26 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 	if status.HarnessSessionID != nil {
 		harnessSessionID = *status.HarnessSessionID
 	}
+
+	// Resolve InstanceID from DB status. Required so the per-session work dir
+	// is namespaced by the same instance_id that prism cleanup uses (#2317 /
+	// #2321: bwrap with containers_enabled needs the work dir for the
+	// container-scratch bind mount). Sandbox-exec already populates this on
+	// the same path (cmd/agent_run_sandbox_exec_darwin.go).
+	instanceID := ""
+	if status.InstanceID != nil {
+		instanceID = *status.InstanceID
+	}
+
+	// Resolve the filtered podman API socket path so bwrap can emit
+	// CONTAINER_HOST / DOCKER_HOST when containers_enabled is set. Resolution
+	// failure is non-fatal at this layer — PrepareBwrap re-validates the
+	// containers_enabled invariants and produces the surfaced error.
+	podmanProxySockPath := ""
+	if p, podmanErr := session.SidecarPodmanProxyPath(sessionName); podmanErr == nil {
+		podmanProxySockPath = p
+	}
+
 	ctrCfg := container.Config{
 		SessionName:         sessionName,
 		Worktree:            worktree,
@@ -319,6 +339,9 @@ func runAgentRunBwrapHandler(ctx context.Context, opts container.AgentRunOpts) e
 		GitHubTokenPath:     cfg.GitHubTokenPath,
 		HostAPISockPath:     hostAPISockPath,
 		HarnessPipeSockPath: harnessPipeSockPath,
+		InstanceID:          instanceID,
+		ContainersEnabled:   status.ContainersEnabled,
+		PodmanProxySockPath: podmanProxySockPath,
 		RuntimeEnv:          runtimeEnv,
 		AgentEnvVars:        agentEnvVars,
 		Harness:             harnessName,

--- a/modules/programs/prism/prism/internal/container/bwrap.go
+++ b/modules/programs/prism/prism/internal/container/bwrap.go
@@ -566,6 +566,50 @@ func (b *bwrapIsolator) BuildArgs(m *Manager) []string {
 		args = append(args, "--setenv", "PRISM_HARNESS_PIPE", "unix://"+cfg.HarnessPipeSockPath)
 	}
 
+	// ── Containers-enabled surface (#2317 / #2321) ───────────────────
+	// Wires the per-session FILTERED podman socket and the writable
+	// container-scratch dir into the sandbox. Three argv emissions are
+	// gated on cfg.ContainersEnabled:
+	//
+	//   --setenv CONTAINER_HOST unix://<PodmanProxySockPath>
+	//   --setenv DOCKER_HOST    unix://<PodmanProxySockPath>   (docker-CLI compat)
+	//   --bind   <sessionDir>/container-scratch <sessionDir>/container-scratch
+	//
+	// Critical security invariant (#2321 greppable AC): the REAL upstream
+	// podman socket path ($XDG_RUNTIME_DIR/podman/podman.sock or whatever
+	// the sidecar resolved) must NEVER appear in the rendered argv — only
+	// the filtered PodmanProxySockPath the sidecar's proxy goroutine
+	// listens on. The proxy is the agent's only container API surface; a
+	// stray --bind of the upstream socket would let the agent `connect()`
+	// directly and bypass every default-deny policy in
+	// internal/podmanproxy. Do not add any code path here that reads or
+	// references $XDG_RUNTIME_DIR or any host-side podman socket path.
+	//
+	// No new bind-mount is needed for the proxy socket itself: it lives in
+	// the per-session run directory that the PRISM_HOST_API block above
+	// already binds (HostAPISockPath's parent dir), so the proxy socket
+	// file appears inside the sandbox the moment the sidecar's listener
+	// creates it.
+	if cfg.ContainersEnabled && cfg.PodmanProxySockPath != "" {
+		containerHost := "unix://" + cfg.PodmanProxySockPath
+		args = append(args, "--setenv", "CONTAINER_HOST", containerHost)
+		args = append(args, "--setenv", "DOCKER_HOST", containerHost)
+
+		// The bind source is <sessionDir>/container-scratch where
+		// <sessionDir> = SessionWorkDirPath(InstanceID) (or the manager's
+		// fallback when InstanceID is empty). bwrapIsolator.Prepare has
+		// already validated the sessionDir resolves and mkdir'd the scratch
+		// subdir; if resolution fails here we record the error on the
+		// Manager so Prepare can surface it (BuildArgs has no error
+		// return). Mirrors the appendPIBwrapMounts error-stashing pattern.
+		if sessionDir, err := m.sessionWorkDirPath(); err == nil {
+			scratch := SessionWorkDirContainerScratchPath(sessionDir)
+			args = append(args, "--bind", scratch, scratch)
+		} else {
+			m.piBwrapErr = fmt.Errorf("resolve session work dir for container-scratch: %w", err)
+		}
+	}
+
 	// ── PI-specific bind mounts (harness=pi only) ────────────────────────
 	// Note: the host's ~/.pi/agent/sessions/ directory is now overlaid onto
 	// $PI_CODING_AGENT_DIR/sessions/ inside the sandbox by

--- a/modules/programs/prism/prism/internal/container/bwrap_test.go
+++ b/modules/programs/prism/prism/internal/container/bwrap_test.go
@@ -2891,3 +2891,274 @@ func TestBwrapBuildArgs_PISharedMount_OmittedForNonPI(t *testing.T) {
 		}
 	}
 }
+
+// ── ContainersEnabled (#2317 / #2321) ───────────────────────────────
+//
+// These tests cover Step 4 of #2317. They assert the bwrap surface for the
+// per-session filtering podman API socket proxy:
+//
+//   - When ContainersEnabled is true, the rendered argv contains the
+//     CONTAINER_HOST / DOCKER_HOST setenv pairs pointing at the FILTERED
+//     socket and the container-scratch bind, and PrepareBwrap creates the
+//     scratch directory on disk.
+//   - When ContainersEnabled is false (the default), none of those three
+//     substrings appear — the existing argv is unchanged.
+//   - The real upstream podman socket path ($XDG_RUNTIME_DIR/podman/podman.sock
+//     or any value the sidecar resolves) NEVER appears in the rendered argv,
+//     regardless of ContainersEnabled. This is the greppable security AC
+//     from #2321: if anyone ever adds `--bind $XDG_RUNTIME_DIR/podman ...`
+//     to bwrap.go BuildArgs, this test fails.
+//   - PrepareBwrap returns an error when ContainersEnabled=true but the
+//     run-directory the proxy socket lives in does not exist (defence
+//     against rendering an argv that would fail at bwrap exec time).
+
+// containersBwrapFixture extends bwrapFixture for ContainersEnabled tests:
+// it sets XDG_STATE_HOME to a writable temp dir so PrepareSessionWorkDir
+// resolves a tractable per-session work path, materialises the per-session
+// run directory (where HostAPISockPath and the proxy socket live), and
+// returns the resolved sessionDir + scratch path so each test can assert
+// against them directly.
+//
+// The fixture sets a known InstanceID so SessionWorkDirPath is deterministic
+// rather than falling back to the container name (m.name) when InstanceID
+// is empty (sessionWorkDirPath fallback).
+func containersBwrapFixture(t *testing.T, opts containersFixtureOpts) (m *Manager, sessionDir, scratchDir, sockDir, proxySockPath string, cleanup func()) {
+	t.Helper()
+
+	stateHome := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(stateHome, 0o755); err != nil {
+		t.Fatalf("containersBwrapFixture: MkdirAll stateHome: %v", err)
+	}
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	runRoot := filepath.Join(t.TempDir(), "run")
+	sockDir = filepath.Join(runRoot, "abc123def456")
+	if err := os.MkdirAll(sockDir, 0o700); err != nil {
+		t.Fatalf("containersBwrapFixture: MkdirAll sockDir: %v", err)
+	}
+	sockPath := filepath.Join(sockDir, "hostapi.sock")
+	proxySockPath = filepath.Join(sockDir, "podman.sock")
+
+	instanceID := opts.instanceID
+	if instanceID == "" {
+		instanceID = "containers-test-instance-id"
+	}
+
+	cfg := Config{
+		SessionName:         "repo@feat",
+		InstanceID:          instanceID,
+		Worktree:            t.TempDir(),
+		AllocatedPort:       14010,
+		HostAPISockPath:     sockPath,
+		ContainersEnabled:   opts.containersEnabled,
+		PodmanProxySockPath: proxySockPath,
+		// Required by PrepareSessionWorkDir's writeGitconfigArtefacts hard
+		// check on missing identity (#1960). Tests that route through
+		// PrepareBwrap need these set.
+		GitUserName:  "Test User",
+		GitUserEmail: "test@example.com",
+	}
+	if opts.overridePodmanProxySockPath != "" {
+		cfg.PodmanProxySockPath = opts.overridePodmanProxySockPath
+		proxySockPath = opts.overridePodmanProxySockPath
+	}
+
+	var fakeHome string
+	m, fakeHome, cleanup = bwrapFixture(t, cfg)
+	_ = fakeHome
+
+	sessionDir = filepath.Join(stateHome, "prism", "sessions", instanceID)
+	scratchDir = SessionWorkDirContainerScratchPath(sessionDir)
+	return m, sessionDir, scratchDir, sockDir, proxySockPath, cleanup
+}
+
+type containersFixtureOpts struct {
+	containersEnabled bool
+	instanceID        string
+	// overridePodmanProxySockPath, when set, replaces the default
+	// <sockDir>/podman.sock path. Used by the missing-runDir negative
+	// test to point at a non-existent directory.
+	overridePodmanProxySockPath string
+}
+
+// TestBwrapBuildArgs_ContainersEnabled_EmitsAllThreeSubstrings asserts the
+// three positive ACs from #2321 in one test: with ContainersEnabled=true the
+// rendered argv contains --setenv CONTAINER_HOST unix://<proxy>,
+// --setenv DOCKER_HOST unix://<proxy>, and
+// --bind <sessionDir>/container-scratch <sessionDir>/container-scratch.
+func TestBwrapBuildArgs_ContainersEnabled_EmitsAllThreeSubstrings(t *testing.T) {
+	m, _, scratchDir, _, proxySockPath, cleanup := containersBwrapFixture(t, containersFixtureOpts{
+		containersEnabled: true,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+	if m.piBwrapErr != nil {
+		t.Fatalf("BuildArgs surfaced piBwrapErr unexpectedly: %v", m.piBwrapErr)
+	}
+
+	wantContainerHost := "unix://" + proxySockPath
+	if !hasSetenv(args, "CONTAINER_HOST", wantContainerHost) {
+		t.Errorf("missing --setenv CONTAINER_HOST %q in args:\n  %v", wantContainerHost, args)
+	}
+	if !hasSetenv(args, "DOCKER_HOST", wantContainerHost) {
+		t.Errorf("missing --setenv DOCKER_HOST %q in args:\n  %v", wantContainerHost, args)
+	}
+	if !hasBind(args, scratchDir) {
+		t.Errorf("missing --bind %s %s (container-scratch) in args:\n  %v", scratchDir, scratchDir, args)
+	}
+}
+
+// TestBwrapBuildArgs_ContainersDisabled_NoContainerSurface asserts that with
+// ContainersEnabled=false (the default) NONE of CONTAINER_HOST, DOCKER_HOST,
+// or the container-scratch bind appear. This is the "no behavioural change
+// when the flag is unset" AC from #2321.
+func TestBwrapBuildArgs_ContainersDisabled_NoContainerSurface(t *testing.T) {
+	m, _, scratchDir, _, _, cleanup := containersBwrapFixture(t, containersFixtureOpts{
+		containersEnabled: false,
+	})
+	defer cleanup()
+
+	b := &bwrapIsolator{name: m.name}
+	args := b.BuildArgs(m)
+
+	for i := 0; i+2 < len(args); i++ {
+		if args[i] != "--setenv" {
+			continue
+		}
+		if args[i+1] == "CONTAINER_HOST" {
+			t.Errorf("unexpected --setenv CONTAINER_HOST when ContainersEnabled=false: %q", args[i+2])
+		}
+		if args[i+1] == "DOCKER_HOST" {
+			t.Errorf("unexpected --setenv DOCKER_HOST when ContainersEnabled=false: %q", args[i+2])
+		}
+	}
+	if hasBind(args, scratchDir) {
+		t.Errorf("unexpected --bind %s when ContainersEnabled=false: %v", scratchDir, args)
+	}
+}
+
+// TestPrepareBwrap_ContainersEnabled_CreatesScratchDirOnDisk asserts the
+// disk-state AC: after PrepareBwrap returns successfully with
+// ContainersEnabled=true, <sessionDir>/container-scratch exists on disk so
+// bwrap does not abort on a missing bind source at exec time.
+func TestPrepareBwrap_ContainersEnabled_CreatesScratchDirOnDisk(t *testing.T) {
+	m, _, scratchDir, _, _, cleanup := containersBwrapFixture(t, containersFixtureOpts{
+		containersEnabled: true,
+	})
+	defer cleanup()
+
+	// Pre-condition: scratch dir must NOT exist yet — PrepareBwrap is the
+	// thing that creates it.
+	if _, err := os.Stat(scratchDir); err == nil {
+		t.Fatalf("pre-condition violated: %s already exists before PrepareBwrap", scratchDir)
+	}
+
+	args, err := m.PrepareBwrap()
+	if err != nil {
+		t.Fatalf("PrepareBwrap: %v", err)
+	}
+	if len(args) == 0 {
+		t.Fatalf("PrepareBwrap returned empty arg list")
+	}
+
+	info, err := os.Stat(scratchDir)
+	if err != nil {
+		t.Fatalf("container-scratch dir not created after PrepareBwrap: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("%q is not a directory: mode=%v", scratchDir, info.Mode())
+	}
+}
+
+// TestPrepareBwrap_ContainersEnabled_MissingRunDirIsError asserts the
+// edge-case AC: when ContainersEnabled=true but the per-session run
+// directory (the parent of PodmanProxySockPath) does not exist on disk at
+// PrepareBwrap time, the function returns a clear error rather than
+// rendering an argv that would fail at bwrap exec time.
+func TestPrepareBwrap_ContainersEnabled_MissingRunDirIsError(t *testing.T) {
+	// Point PodmanProxySockPath at a path whose parent does not exist.
+	// We pre-create HostAPISockPath's parent in containersBwrapFixture
+	// (that's how prepareVolumeDirs is satisfied), but the containers
+	// edge-case AC validates the proxy's runDir separately — if the two
+	// diverged in the path scheme, PrepareBwrap must catch it.
+	nonExistent := filepath.Join(t.TempDir(), "does-not-exist", "podman.sock")
+	m, _, _, _, _, cleanup := containersBwrapFixture(t, containersFixtureOpts{
+		containersEnabled:           true,
+		overridePodmanProxySockPath: nonExistent,
+	})
+	defer cleanup()
+
+	_, err := m.PrepareBwrap()
+	if err == nil {
+		t.Fatalf("expected PrepareBwrap to error when proxy run dir is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("expected error to mention the missing run dir, got: %v", err)
+	}
+}
+
+// TestBwrapBuildArgs_NoUpstreamPodmanSocketLeak is the greppable security
+// AC from #2321: the REAL upstream podman socket path
+// ($XDG_RUNTIME_DIR/podman/podman.sock or whatever the sidecar resolves)
+// must NOT appear anywhere in the rendered bwrap argv for ANY value of
+// ContainersEnabled. If someone ever adds `--bind $XDG_RUNTIME_DIR/podman ...`
+// to bwrap.go BuildArgs by accident, this test fails.
+//
+// The proxy's whole point is that the agent only sees the filtered socket.
+// If the upstream socket path leaked into the rendered argv (even by
+// accident), the agent could `connect()` directly and bypass every
+// default-deny policy in internal/podmanproxy. The proxy IS the agent's
+// only container API surface.
+//
+// We use a recognisable sentinel value for XDG_RUNTIME_DIR so the assertion
+// is unambiguous: no chance of accidental substring overlap with the
+// resolved filtered-socket path (which sits under the t.TempDir() tree).
+func TestBwrapBuildArgs_NoUpstreamPodmanSocketLeak(t *testing.T) {
+	const xdgRuntimeSentinel = "/sentinel-xdg-runtime-podman-leak-canary"
+	t.Setenv("XDG_RUNTIME_DIR", xdgRuntimeSentinel)
+
+	for _, enabled := range []bool{false, true} {
+		name := "ContainersDisabled"
+		if enabled {
+			name = "ContainersEnabled"
+		}
+		t.Run(name, func(t *testing.T) {
+			m, _, _, _, _, cleanup := containersBwrapFixture(t, containersFixtureOpts{
+				containersEnabled: enabled,
+			})
+			defer cleanup()
+
+			b := &bwrapIsolator{name: m.name}
+			args := b.BuildArgs(m)
+
+			// The sentinel XDG_RUNTIME_DIR value must never appear anywhere
+			// in the rendered argv. If bwrap.go ever reads
+			// os.Getenv("XDG_RUNTIME_DIR") (now or in the future) and
+			// composes a path from it, this assertion fires.
+			for i, a := range args {
+				if strings.Contains(a, xdgRuntimeSentinel) {
+					t.Errorf("upstream socket sentinel %q leaked into bwrap argv at index %d: %q",
+						xdgRuntimeSentinel, i, a)
+				}
+			}
+
+			// The canonical NixOS upstream path shape is
+			// `$XDG_RUNTIME_DIR/podman/podman.sock` — i.e. a path ending in
+			// `/podman/podman.sock`. The FILTERED socket the proxy listens
+			// on is at `<runDir>/podman.sock` (no `podman/` segment), so
+			// the two-segment substring is a stable canary for the upstream
+			// path regardless of how XDG_RUNTIME_DIR is configured on the
+			// host. The filtered socket WILL be in args when enabled=true,
+			// but it won't contain `/podman/podman.sock` — only
+			// `/podman.sock`.
+			for i, a := range args {
+				if strings.Contains(a, "/podman/podman.sock") {
+					t.Errorf("upstream podman socket path pattern \"/podman/podman.sock\" leaked at index %d: %q",
+						i, a)
+				}
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -184,6 +184,36 @@ type Config struct {
 	// be used here). On Linux this is zero.
 	HarnessPipeTCPPort int
 
+	// ContainersEnabled is the per-session runtime gate for the filtering
+	// podman API socket proxy (#2317 / #2321). When true, BuildArgs (bwrap)
+	// emits:
+	//
+	//   --setenv CONTAINER_HOST unix://<PodmanProxySockPath>
+	//   --setenv DOCKER_HOST    unix://<PodmanProxySockPath>
+	//   --bind   <sessionDir>/container-scratch <sessionDir>/container-scratch
+	//
+	// and the bwrap isolator's Prepare hook calls PrepareSessionWorkDir +
+	// mkdirs the container-scratch subdirectory so the bind source exists on
+	// disk before bwrap is execed. Defaults to false; sourced from
+	// agent_status.containers_enabled (the live DB gate read by
+	// cmd/agent_run.go on the bwrap path).
+	//
+	// Critically, the upstream podman socket path is NEVER passed into the
+	// sandbox — only the filtered PodmanProxySockPath the sidecar's proxy
+	// goroutine listens on. The proxy is the agent's only container API
+	// surface. See #2317 §4 for the threat model.
+	ContainersEnabled bool
+
+	// PodmanProxySockPath is the absolute host path of the per-session
+	// filtering podman API socket created by the sidecar's podman-proxy
+	// goroutine (#2317 §3b / #2320). The socket sits in the same per-session
+	// run directory as HostAPISockPath, so the directory bind that already
+	// exposes the host-API socket also exposes this socket — no additional
+	// bind-mount is required. Typically populated via
+	// session.SidecarPodmanProxyPath. Consumed only when ContainersEnabled
+	// is true; ignored otherwise.
+	PodmanProxySockPath string
+
 	// InstanceID is the UUID instance identifier for the prism session that owns
 	// this container. When non-empty it is written as a
 	// "prism.instance-id=<uuid>" label on the container so that EnsureRemoved

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -149,6 +150,46 @@ func (b *bwrapIsolator) Prepare(ctx context.Context, m *Manager) ([]string, erro
 	// so the caller sees the real cause rather than a confusing bwrap exec failure.
 	if err := m.prepareVolumeDirs(false); err != nil {
 		return nil, fmt.Errorf("container: bwrap: %w", err)
+	}
+
+	// ── Containers-enabled prep (#2317 / #2321) ──────────────────────
+	// When the session's agent_status.containers_enabled gate is set, the
+	// bwrap profile binds <sessionDir>/container-scratch read-write so the
+	// agent can use it as a `podman run -v ...` source. The directory must
+	// exist before bwrap is execed — bwrap aborts with a confusing error if a
+	// bind source is missing. Per #2321 we converge on the same
+	// per-session-work-dir story sandbox-exec uses (option (a)) rather than
+	// inlining a one-off mkdir here, so the lifecycle (PrepareSessionWorkDir
+	// + RemoveSessionWorkDir) is shared between the two isolation modes.
+	//
+	// Validation order:
+	//   1. PodmanProxySockPath must be set (config error if absent).
+	//   2. <runDir> = filepath.Dir(PodmanProxySockPath) must already exist on
+	//      disk — prepareVolumeDirs above creates the per-session run dir from
+	//      HostAPISockPath, and PodmanProxySockPath shares the same parent
+	//      directory in the sidecar's path scheme
+	//      (session.SidecarPodmanProxyPath). A missing runDir at this point
+	//      indicates the two paths disagree and the rendered argv would fail
+	//      at bwrap exec time — surface it now as a clear Prepare error.
+	//   3. PrepareSessionWorkDir + mkdir of the container-scratch subdir.
+	if m.cfg.ContainersEnabled {
+		if m.cfg.PodmanProxySockPath == "" {
+			return nil, fmt.Errorf("container: bwrap: containers_enabled=true but PodmanProxySockPath is empty")
+		}
+		runDir := filepath.Dir(m.cfg.PodmanProxySockPath)
+		if info, err := os.Stat(runDir); err != nil {
+			return nil, fmt.Errorf("container: bwrap: containers_enabled=true but podman proxy run dir %q does not exist: %w", runDir, err)
+		} else if !info.IsDir() {
+			return nil, fmt.Errorf("container: bwrap: containers_enabled=true but podman proxy run dir %q is not a directory", runDir)
+		}
+		sessionDir, err := m.PrepareSessionWorkDir()
+		if err != nil {
+			return nil, fmt.Errorf("container: bwrap: prepare session work dir for containers_enabled: %w", err)
+		}
+		scratch := SessionWorkDirContainerScratchPath(sessionDir)
+		if err := os.MkdirAll(scratch, 0o700); err != nil {
+			return nil, fmt.Errorf("container: bwrap: create container-scratch dir %q: %w", scratch, err)
+		}
 	}
 
 	// Build the bwrap args. For PI sessions, BuildArgs stores any

--- a/modules/programs/prism/prism/internal/container/session_work_dir.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir.go
@@ -135,6 +135,24 @@ func SessionWorkDirAllowedSignersPath(sessionDir string) string {
 	return filepath.Join(sessionDir, "allowed_signers")
 }
 
+// SessionWorkDirContainerScratchPath returns the per-session container
+// scratch directory inside the given session work dir (#2317 / #2321):
+//
+//	<sessionDir>/container-scratch
+//
+// This is the writable mount-source the bwrap profile binds Dst==Src into
+// the sandbox when ContainersEnabled is true, so an agent can
+// `podman run -v <sessionDir>/container-scratch:/x ...` without granting
+// the wider worktree to the spawned container. The directory is owned by
+// the per-session work dir lifecycle — RemoveSessionWorkDir wipes it on
+// cleanup along with the rest of the work dir tree (#2317 §3c).
+//
+// Sandbox-exec (Step 5 / #2322) consumes the same helper so both isolation
+// modes share a single per-session container scratch story.
+func SessionWorkDirContainerScratchPath(sessionDir string) string {
+	return filepath.Join(sessionDir, "container-scratch")
+}
+
 // SessionWorkDirKubeCacheDirPath returns the kubectl cache directory inside
 // the given session work dir (issue #2235, Step 3b of #2132):
 //


### PR DESCRIPTION
Step 4 of the #2317 train. Exposes the per-session filtering podman API socket proxy inside the bwrap (NixOS) sandbox, gated on `agent_status.containers_enabled`.

## What changes

`internal/container/bwrap.go` `BuildArgs` now conditionally appends three argv entries when `cfg.ContainersEnabled` is true:

- `--setenv CONTAINER_HOST unix://<runDir>/podman.sock`
- `--setenv DOCKER_HOST unix://<runDir>/podman.sock` (docker-CLI compat)
- `--bind <sessionDir>/container-scratch <sessionDir>/container-scratch`

The proxy socket file is reachable inside the sandbox via the existing per-session run-dir bind (`HostAPISockPath`'s parent directory). No new mount is needed — the socket file simply appears the moment the sidecar's listener creates it.

`container.Config` gains:

- `ContainersEnabled bool` — sourced from `agent_status.containers_enabled` (the DB gate from #2327).
- `PodmanProxySockPath string` — sourced from `session.SidecarPodmanProxyPath` (the helper from PR #2328).

`cmd/agent_run.go` (bwrap path) populates both, and also pipes `InstanceID` through from `status.InstanceID` so the per-session work dir resolves to the same path `prism cleanup` uses — matching the sandbox-exec path.

## Scratch-dir lifecycle

Per the issue's design discussion I went with option (a): when `ContainersEnabled=true`, the bwrap isolator's `Prepare` calls `Manager.PrepareSessionWorkDir` and `mkdir`s `<sessionDir>/container-scratch` (mode `0o700`) before bwrap is execed. This converges bwrap and sandbox-exec on a single per-session-work-dir story:

- `PrepareSessionWorkDir` is already idempotent (mkdir of `<sessionDir>` + write of git/ssh configs).
- `RemoveSessionWorkDir` already wipes the whole tree on cleanup, so the scratch dir cleanup rides on existing machinery.
- A new helper `SessionWorkDirContainerScratchPath(sessionDir)` returns the canonical path; Step 5 (#2322, sandbox-exec) will reuse the same helper.

`Prepare` hard-fails when `ContainersEnabled=true` but `PodmanProxySockPath` is empty or `<runDir>` does not exist on disk — catching divergence between the sidecar's path scheme and the bwrap path scheme at Prepare time rather than at bwrap exec time (where the error would be opaque).

## Security AC — the upstream socket path never leaks

The proxy is the agent's only container API surface. If the real upstream `$XDG_RUNTIME_DIR/podman/podman.sock` ever leaked into the bwrap argv (even by accident), the agent could `connect()` directly and bypass every default-deny policy in `internal/podmanproxy`.

The greppable security test `TestBwrapBuildArgs_NoUpstreamPodmanSocketLeak`:

- Sets a recognisable sentinel `XDG_RUNTIME_DIR=/sentinel-xdg-runtime-podman-leak-canary` and asserts the sentinel string appears in no argv element.
- Asserts the canonical `/podman/podman.sock` two-segment substring (distinct from our `/podman.sock` single-segment filtered path) appears in no argv element.

The test runs against both `ContainersEnabled=true` and `ContainersEnabled=false`. I verified it is non-vacuous by injecting two canary mutations and confirming both fail the test:

1. `args = append(args, "--bind", filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "podman"), …)` — sentinel canary fires.
2. `args = append(args, "--ro-bind", "/var/run/podman/podman.sock", …)` — `/podman/podman.sock` canary fires.

Both canaries removed before commit.

## ACs from #2321

All 8 ACs from the issue covered by tests in `internal/container/bwrap_test.go`:

- [x] `[functional]` `CONTAINER_HOST unix://<runDir>/podman.sock` present when enabled — `TestBwrapBuildArgs_ContainersEnabled_EmitsAllThreeSubstrings`.
- [x] `[functional]` `DOCKER_HOST unix://<runDir>/podman.sock` present when enabled — same test.
- [x] `[functional]` `--bind <sessionDir>/container-scratch …` present when enabled — same test.
- [x] `[functional]` None of the three substrings present when disabled — `TestBwrapBuildArgs_ContainersDisabled_NoContainerSurface`.
- [x] `[functional]` `<sessionDir>/container-scratch/` exists on disk after `PrepareBwrap` returns — `TestPrepareBwrap_ContainersEnabled_CreatesScratchDirOnDisk`.
- [x] `[security]` Upstream podman socket path absent from argv for ANY value of `ContainersEnabled` — `TestBwrapBuildArgs_NoUpstreamPodmanSocketLeak`.
- [x] `[edge-case]` `PrepareBwrap` returns an error when `<runDir>` is missing — `TestPrepareBwrap_ContainersEnabled_MissingRunDirIsError`.
- [x] `[functional]` Existing bwrap tests unmodified — full `internal/container/...` suite green (45+ pre-existing bwrap tests).

## Process discipline

- `gofmt -l .` clean.
- `go build ./...` from `modules/programs/prism/prism/` — green.
- `go test ./...` from `modules/programs/prism/prism/` — green (Darwin host, all packages).
- `go test ./internal/container/ -race` — green.
- `nix build .#prism` from the repo root — green.

## Out of scope

- sandbox-exec profile (Step 5, #2322 — spawning in parallel).
- `prism spawn --containers` CLI flag (Step 6, #2323 — spawning in parallel).
- Cleanup integration (Step 7).

Refs #2317
Refs #2321
