### PR TITLE
prism: wire prism spawn --containers flag through to DB (Step 6 of #2317)

### DIFF
--- a/modules/programs/prism/prism/cmd/hostapi_containers_test.go
+++ b/modules/programs/prism/prism/cmd/hostapi_containers_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+// hostapi_containers_test.go — proxy-path tests for the --containers flag
+// forwarding contract (#2317 / #2323). Mirrors the existing --isolation
+// proxy tests so the cross-spawn-boundary AC is locked in at this layer
+// too: a containerised session running `prism spawn --containers ...` for
+// a child must reach the host sidecar with body["containers"]=true.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// TestProxySpawn_ContainersForwardedWhenSet verifies that --containers on
+// the proxy path (PRISM_HOST_API set) is forwarded as the "containers" JSON
+// field with value true. This is the inverse of #2323's cross-spawn
+// forwarding AC at the proxy boundary: a coordinator inside a sandbox who
+// passes `prism spawn --containers` must have that flag reach the host
+// sidecar, otherwise the child session's spawn_inputs.containers_flag and
+// agent_status.containers_enabled stay at 0 and the child's proxy is never
+// started.
+func TestProxySpawn_ContainersForwardedWhenSet(t *testing.T) {
+	type spawnReq struct {
+		Branch     string `json:"branch"`
+		Containers bool   `json:"containers"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spawn" {
+			http.Error(w, `{"error":"wrong path"}`, http.StatusBadRequest)
+			return
+		}
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@containers-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("containers", false, "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "pi", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "containers-branch")
+	_ = cmd.Flags().Set("prompt", "hi")
+	_ = cmd.Flags().Set("containers", "true")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if !req.Containers {
+			t.Errorf("containers = %v, want true (issue #2323: --containers must cross the proxy boundary)", req.Containers)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// TestProxySpawn_ContainersOmittedWhenUnset verifies that when --containers
+// is not passed on the command line, the JSON body does NOT include a
+// "containers" key. This is the symmetric guarantee for cross-spawn
+// forwarding: an unset child does NOT accidentally inherit a parent's
+// enabled state via a default-zero-value bleed. Mirrors
+// TestProxySpawn_IsolationOmittedWhenUnset for --isolation.
+func TestProxySpawn_ContainersOmittedWhenUnset(t *testing.T) {
+	rawCh := make(chan map[string]any, 1)
+
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		rawCh <- raw
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@no-containers-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("containers", false, "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "pi", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "no-containers-branch")
+	_ = cmd.Flags().Set("prompt", "hi")
+	// --containers deliberately NOT set.
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case raw := <-rawCh:
+		if _, present := raw["containers"]; present {
+			t.Errorf("containers key present in body when --containers not passed; body = %v (issue #2323: unset child must not inherit parent state)", raw)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}
+
+// TestProxySpawn_ContainersFalseExplicitlyForwarded verifies that an
+// explicit `--containers=false` is forwarded (so the child sees
+// containers: false in the request body), distinguishing it from the
+// "flag not passed" case above. This matches the --isolation
+// "absent vs empty" semantic.
+//
+// In practice this is rare on the CLI (passing --containers=false has no
+// observable effect because the default is also false), but the wire
+// contract must respect the user's explicit choice — a future flag flip
+// in config.json could change the default, and an explicit false would
+// then be meaningful.
+func TestProxySpawn_ContainersFalseExplicitlyForwarded(t *testing.T) {
+	type spawnReq struct {
+		Branch     string `json:"branch"`
+		Containers bool   `json:"containers"`
+	}
+
+	reqCh := make(chan spawnReq, 1)
+	srv := newMockUnixServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var req spawnReq
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		reqCh <- req
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"session_name":"nixos-config@explicit-false-branch"}`))
+	})
+
+	t.Setenv("PRISM_HOST_API", srv.apiURL())
+	t.Setenv("PRISM_BARE_ROOT", "/prism-git")
+
+	cmd := &cobra.Command{Use: "spawn"}
+	cmd.Flags().String("branch", "", "")
+	cmd.Flags().String("agent", "", "")
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().String("model", "", "")
+	cmd.Flags().String("variant", "", "")
+	cmd.Flags().String("isolation", "", "")
+	cmd.Flags().Bool("containers", false, "")
+	cmd.Flags().Bool("ignore-concurrency-cap", false, "")
+	cmd.Flags().String("harness", "pi", "")
+	addPromptFlags(cmd)
+	_ = cmd.Flags().Set("branch", "explicit-false-branch")
+	_ = cmd.Flags().Set("prompt", "hi")
+	_ = cmd.Flags().Set("containers", "false")
+
+	if err := proxySpawn(srv.apiURL(), cmd); err != nil {
+		t.Fatalf("proxySpawn: %v", err)
+	}
+
+	select {
+	case req := <-reqCh:
+		if req.Containers {
+			t.Errorf("containers = %v, want false (explicit --containers=false must round-trip as false)", req.Containers)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for request")
+	}
+}

--- a/modules/programs/prism/prism/cmd/incarnation_stats_containers_test.go
+++ b/modules/programs/prism/prism/cmd/incarnation_stats_containers_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+// incarnation_stats_containers_test.go — per-incarnation detail view
+// coverage for the new containers_flag audit column (#2317 / #2323).
+//
+// AC #7 of #2323 requires both surfaces to carry containers_flag:
+//
+//   - `prism stats <instance-id>` (human-readable) shows a containers_flag
+//     row in the Spawn Inputs block.
+//   - `prism stats <instance-id> --json` includes "containers_flag": true
+//     in the spawn_inputs object.
+//
+// AC #8 (security) requires that a session row created BEFORE this PR
+// landed sees no behavioural change. For the per-incarnation detail view
+// that translates to: a session with NO spawn_inputs row (the pre-#2087
+// shape) renders identically to its pre-#2323 baseline — no Spawn Inputs
+// header line, no containers_flag row, no spawn_inputs key in the JSON
+// output.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestRunStatsDetail_ContainersFlag_HumanReadable verifies that the per-
+// incarnation detail human-readable output surfaces containers_flag in the
+// Spawn Inputs block when --containers was recorded on the spawn_inputs
+// row (AC #7 of #2323).
+func TestRunStatsDetail_ContainersFlag_HumanReadable(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "pi",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	// Insert a spawn_inputs row with containers_flag=true.
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:     iid,
+		ProfileName:    strPtr("anthropic"),
+		HarnessFlag:    strPtr("pi"),
+		IsolationFlag:  strPtr("bwrap"),
+		IsolationMode:  strPtr("bwrap"),
+		ContainersFlag: true,
+		CreatedAt:      base.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Spawn Inputs") {
+		t.Errorf("expected 'Spawn Inputs' header in output\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "containers_flag:") {
+		t.Errorf("expected 'containers_flag:' row in Spawn Inputs block\ngot:\n%s", out)
+	}
+	if !strings.Contains(out, "true") {
+		t.Errorf("expected containers_flag value 'true' in output\ngot:\n%s", out)
+	}
+}
+
+// TestRunStatsDetail_ContainersFlag_JSON verifies that --json emits a
+// spawn_inputs object that includes "containers_flag": true when the
+// spawn_inputs row recorded the flag (AC #7).
+func TestRunStatsDetail_ContainersFlag_JSON(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "pi",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:     iid,
+		ProfileName:    strPtr("anthropic"),
+		HarnessFlag:    strPtr("pi"),
+		IsolationMode:  strPtr("bwrap"),
+		ContainersFlag: true,
+		CreatedAt:      base.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, true); err != nil {
+			t.Errorf("runStatsDetail --json: %v", err)
+		}
+	})
+
+	var parsed struct {
+		Session     *db.Session    `json:"session"`
+		SpawnInputs map[string]any `json:"spawn_inputs"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &parsed); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\nraw: %s", err, out)
+	}
+	if parsed.SpawnInputs == nil {
+		t.Fatalf("spawn_inputs object missing from --json output; raw: %s", out)
+	}
+	v, ok := parsed.SpawnInputs["containers_flag"]
+	if !ok {
+		t.Fatalf("spawn_inputs.containers_flag missing from --json output; raw: %s", out)
+	}
+	b, ok := v.(bool)
+	if !ok {
+		t.Fatalf("spawn_inputs.containers_flag = %T %v, want bool; raw: %s", v, v, out)
+	}
+	if !b {
+		t.Errorf("spawn_inputs.containers_flag = false, want true")
+	}
+}
+
+// TestRunStatsDetail_ContainersFlag_DefaultFalse verifies that a row whose
+// spawn_inputs.containers_flag=false (the default) surfaces as "false" in
+// the human-readable output and false in the JSON spawn_inputs object.
+// This is AC #3's render-side guarantee: an unset --containers spawn shows
+// up as "false" everywhere, never as missing.
+func TestRunStatsDetail_ContainersFlag_DefaultFalse(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "pi",
+		base.Add(-1*time.Hour), base, "finished", "")
+
+	if err := d.InsertSpawnInputs(db.SpawnInputs{
+		InstanceID:     iid,
+		ProfileName:    strPtr("anthropic"),
+		HarnessFlag:    strPtr("pi"),
+		IsolationMode:  strPtr("bwrap"),
+		ContainersFlag: false,
+		CreatedAt:      base.UnixMilli(),
+	}); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	// Human-readable: containers_flag: false row present.
+	textOut := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+	if !strings.Contains(textOut, "containers_flag:") {
+		t.Errorf("expected 'containers_flag:' row in Spawn Inputs block\ngot:\n%s", textOut)
+	}
+	if !strings.Contains(textOut, "false") {
+		t.Errorf("expected containers_flag value 'false' in output\ngot:\n%s", textOut)
+	}
+
+	// JSON: spawn_inputs.containers_flag = false (present, explicitly false).
+	jsonOut := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, true); err != nil {
+			t.Errorf("runStatsDetail --json: %v", err)
+		}
+	})
+	var parsed struct {
+		SpawnInputs map[string]any `json:"spawn_inputs"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(jsonOut)), &parsed); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\nraw: %s", err, jsonOut)
+	}
+	if parsed.SpawnInputs == nil {
+		t.Fatalf("spawn_inputs object missing from --json output; raw: %s", jsonOut)
+	}
+	v, ok := parsed.SpawnInputs["containers_flag"]
+	if !ok {
+		t.Fatalf("spawn_inputs.containers_flag missing from --json output; raw: %s", jsonOut)
+	}
+	if b, ok := v.(bool); !ok || b {
+		t.Errorf("spawn_inputs.containers_flag = %v, want false", v)
+	}
+}
+
+// TestRunStatsDetail_PreExistingRowNoSpawnInputs verifies AC #8 of #2323:
+// a session created BEFORE this PR landed (no spawn_inputs row) sees no
+// behavioural change in the detail view — no Spawn Inputs header, no
+// containers_flag row, no spawn_inputs key in the JSON output.
+//
+// This is the "old data does not regress" guarantee. The renderer must
+// gracefully degrade for pre-#2087 sessions rather than printing a sea of
+// "—" lines or crashing on nil.
+func TestRunStatsDetail_PreExistingRowNoSpawnInputs(t *testing.T) {
+	d := openIncarnationTestDB(t)
+	base := time.Now().Truncate(time.Second)
+
+	iid := uuid.New().String()
+	insertTestSession(t, d, iid, "testrepo@main", "testrepo", "/code", "pi",
+		base.Add(-1*time.Hour), base, "finished", "")
+	// Deliberately NO InsertSpawnInputs call — simulating a pre-#2087 row.
+
+	// Human-readable: no Spawn Inputs block.
+	textOut := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, false); err != nil {
+			t.Errorf("runStatsDetail: %v", err)
+		}
+	})
+	if strings.Contains(textOut, "Spawn Inputs") {
+		t.Errorf("pre-#2087 row should not render Spawn Inputs header\ngot:\n%s", textOut)
+	}
+	if strings.Contains(textOut, "containers_flag") {
+		t.Errorf("pre-#2087 row should not render containers_flag\ngot:\n%s", textOut)
+	}
+
+	// JSON: no spawn_inputs key.
+	jsonOut := captureStdout(t, func() {
+		if err := runStatsDetail(iid, false, true); err != nil {
+			t.Errorf("runStatsDetail --json: %v", err)
+		}
+	})
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(jsonOut)), &raw); err != nil {
+		t.Fatalf("unmarshal JSON output: %v\nraw: %s", err, jsonOut)
+	}
+	if _, present := raw["spawn_inputs"]; present {
+		t.Errorf("pre-#2087 row should omit spawn_inputs key from JSON output; raw: %s", jsonOut)
+	}
+}

--- a/modules/programs/prism/prism/cmd/spawn.go
+++ b/modules/programs/prism/prism/cmd/spawn.go
@@ -16,6 +16,7 @@ package cmd
 //	--variant <name>             model variant override (overrides all agents' variant)
 //	--model-override role=model  per-role model override (repeatable); overrides --model for that role
 //	--isolation <mode>           isolation mode: bwrap, sandbox-exec, or host (default: from config.json)
+//	--containers                 enable the per-session filtering podman API socket proxy (default: off)
 //	--harness <name>             agent harness to use (default: "pi")
 
 import (
@@ -23,6 +24,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -72,10 +74,15 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	harnessFlag, _ := cmd.Flags().GetString("harness")
 	ignoreConcurrencyCapFlag, _ := cmd.Flags().GetBool("ignore-concurrency-cap")
 	isolationFlag, _ := cmd.Flags().GetString("isolation")
+	containersFlag, _ := cmd.Flags().GetBool("containers")
 	modelOverrideFlag, _ := cmd.Flags().GetStringArray("model-override")
 	reuseFlag, _ := cmd.Flags().GetBool("reuse")
 
 	isolationChanged := cmd.Flags().Changed("isolation")
+	// Only forward "containers" when explicitly set so an unset child does
+	// not accidentally inherit a parent's enabled state. Mirrors
+	// isolationChanged — see body["isolation"] below for the same pattern.
+	containersChanged := cmd.Flags().Changed("containers")
 
 	// Validate --isolation client-side so unknown values fail fast with the
 	// same error message as the direct path. The platform guards in
@@ -188,6 +195,9 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 		if isolationChanged {
 			body["isolation"] = isolationFlag
 		}
+		if containersChanged {
+			body["containers"] = containersFlag
+		}
 		if len(modelOverrideFlag) > 0 {
 			modelsByRole, parseErr := parseModelOverrides(modelOverrideFlag)
 			if parseErr != nil {
@@ -257,6 +267,12 @@ func proxySpawn(apiURL string, cmd *cobra.Command) error {
 	if isolationChanged {
 		body["isolation"] = isolationFlag
 	}
+	// Only forward "containers" when explicitly set. Mirroring the
+	// isolationChanged pattern above: an unset child does not inherit a
+	// parent's enabled state by accident (#2323 cross-spawn forwarding AC).
+	if containersChanged {
+		body["containers"] = containersFlag
+	}
 	if err := proxyToHostAPI(apiURL, "/spawn", body, &resp); err != nil {
 		return err
 	}
@@ -296,6 +312,7 @@ func init() {
 	spawnCmd.Flags().String("variant", "", "Model variant override for all agents (e.g. high, max, minimal)")
 	spawnCmd.Flags().StringArray("model-override", nil, "Per-role model override in role=model format (repeatable, e.g. review-context=google/gemini-2.5-pro)")
 	spawnCmd.Flags().String("isolation", "", "Isolation mode: bwrap, sandbox-exec, or host (default: from ~/.config/prism/config.json)")
+	spawnCmd.Flags().Bool("containers", false, "Enable the per-session filtering podman API socket proxy (containers feature, #2317). Default: off. Combine with bwrap or sandbox-exec isolation; host mode bypasses the proxy.")
 	spawnCmd.Flags().String("harness", "pi", "Agent harness to use; valid values are determined by registered harnesses")
 	spawnCmd.Flags().Bool("ignore-concurrency-cap", false, "Bypass the soft concurrency cap and spawn even when >= 6 containers are in flight")
 	spawnCmd.Flags().Bool("wait", false, "Block until the spawned agent finishes its initial prompt. Without --wait, returns immediately.")
@@ -308,6 +325,31 @@ func init() {
 	spawnCmd.Flags().String("prompt-source", "", "")
 	_ = spawnCmd.Flags().MarkHidden("prompt-source")
 	rootCmd.AddCommand(spawnCmd)
+}
+
+// warnContainersWithHostMode emits an informational warning to w when the
+// caller passed --containers AND the resolved isolation mode is "host".
+//
+// The combo is intentionally not an error: users may legitimately combine the
+// two to audit what containers a host-mode agent spawned via the
+// spawn_inputs.containers_flag audit trail. Host-mode agents already have
+// direct podman access via the host's CONTAINER_HOST / DOCKER_HOST, so the
+// filtering socket proxy adds no value at runtime — the warning makes that
+// trade-off explicit (#2317 / #2323).
+//
+// The check fires on the *resolved* isolation mode rather than just
+// `--isolation host`, so the message is consistent whether the user named
+// host explicitly or arrived at it via the config.json default.
+//
+// Extracted to a helper so the warning text is testable without going
+// through the full runSpawn / runAbtestSpawn path. Returns true when the
+// warning was emitted, for tests that want to assert presence directly.
+func warnContainersWithHostMode(w io.Writer, containers bool, isolation string) bool {
+	if !containers || isolation != "host" {
+		return false
+	}
+	fmt.Fprintln(w, "prism spawn: --containers with --isolation host: host mode bypasses the proxy (host-mode agents already have direct podman access); --containers is recorded in spawn_inputs.containers_flag for audit, but agent_status.containers_enabled is still set")
+	return true
 }
 
 // resolveIsolationMode returns the effective isolation mode for a spawn
@@ -447,6 +489,11 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// --containers + host isolation: informational warning (#2317 / #2323).
+	// See warnContainersWithHostMode for the rationale.
+	containersFlag, _ := cmd.Flags().GetBool("containers")
+	warnContainersWithHostMode(os.Stderr, containersFlag, string(isolationMode))
 
 	// Look up the isolation capabilities for this mode. All per-mode branching
 	// below reads from isoCaps rather than comparing against raw mode constants.
@@ -767,6 +814,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		IgnoreConcurrencyCap: ignoreConcurrencyCapFlagFromCmd(cmd),
 		SkillsManifestHash:   skillsManifestHash,
 		AgentPromptHash:      agentPromptHash,
+		ContainersFlag:       containersFlag,
 		// ────────────────────────────────────────────────────────
 		// PIExtensionDir is the host-side prism PI extension directory
 		// (populated by Nix into config.json). Forwarded so that host-mode
@@ -1029,6 +1077,7 @@ func runAbtestSpawn(cmd *cobra.Command, profileA, profileB string) error {
 	modelFlag, _ := cmd.Flags().GetString("model")
 	variantFlag, _ := cmd.Flags().GetString("variant")
 	harnessFlag, _ := cmd.Flags().GetString("harness")
+	containersFlag, _ := cmd.Flags().GetBool("containers")
 	modelOverrideRaw, _ := cmd.Flags().GetStringArray("model-override")
 	modelsByRole, err := parseModelOverrides(modelOverrideRaw)
 	if err != nil {
@@ -1058,6 +1107,13 @@ func runAbtestSpawn(cmd *cobra.Command, profileA, profileB string) error {
 	if err != nil {
 		return err
 	}
+
+	// --containers + host isolation: informational warning, mirroring runSpawn
+	// (#2317 / #2323). Both legs of an abtest pair share the same resolved
+	// isolation mode, so a single warning covers both. The flag is recorded in
+	// each leg's spawn_inputs.containers_flag for audit symmetry.
+	warnContainersWithHostMode(os.Stderr, containersFlag, string(isolationMode))
+
 	isoCaps := container.CapabilitiesFor(isolationMode)
 
 	if isoCaps.IsContainer {
@@ -1189,6 +1245,7 @@ func runAbtestSpawn(cmd *cobra.Command, profileA, profileB string) error {
 				agentPromptHash:    agentPromptHash,
 				branchFlag:         branchFlag,
 				prFlag:             prFlag,
+				containersFlag:     containersFlag,
 				d:                  d,
 			})
 			mu.Lock()
@@ -1253,7 +1310,11 @@ type spawnOneAbtestArgs struct {
 	agentPromptHash    string
 	branchFlag         string
 	prFlag             string
-	d                  *db.DB
+	// containersFlag mirrors `prism spawn --containers` and is threaded to
+	// each abtest leg so both sibling sessions opt into the proxy
+	// symmetrically (#2317 / #2323).
+	containersFlag bool
+	d              *db.DB
 }
 
 // spawnOneAbtest spawns a single leg of an --abtest pair. Returns the session
@@ -1334,6 +1395,7 @@ func spawnOneAbtest(cmd *cobra.Command, a spawnOneAbtestArgs) (sessionName, work
 		SkillsManifestHash:   a.skillsManifestHash,
 		AgentPromptHash:      a.agentPromptHash,
 		AbtestPairID:         a.pairID,
+		ContainersFlag:       a.containersFlag,
 		// ────────────────────────────────────────────────────────
 	}
 	if a.pf != nil && !a.isoCaps.IsContainer {

--- a/modules/programs/prism/prism/cmd/spawn_containers_test.go
+++ b/modules/programs/prism/prism/cmd/spawn_containers_test.go
@@ -1,0 +1,407 @@
+package cmd
+
+// Tests for the `prism spawn --containers` flag plumbing (Step 6 of #2317 /
+// issue #2323). This file is the writer-level + flag-registration coverage
+// for the new --containers CLI flag.
+//
+// What lives here:
+//   - flag-registration tests against spawnCmd (presence, type, default).
+//   - SpawnOpts -> spawn_inputs.containers_flag mapping via the
+//     SpawnInputsFromOpts shim that other spawn_inputs writer tests use.
+//   - Cross-spawn forwarding: the proxy body forwards "containers" only
+//     when the flag was explicitly set, mirroring the --isolation pattern.
+//   - Agent-context output exposes --containers as a bool with default false.
+//
+// What is NOT here (covered elsewhere):
+//   - The DB migration tests for the new columns (Step 2 / #2319,
+//     internal/db/db_migration_v36_v37_test.go).
+//   - The sidecar startup path (Step 3 / #2320, internal/sidecar/podman_proxy_test.go).
+//   - The proxy package policy (Step 1 / #2318, internal/podmanproxy).
+//
+// Test-suite isolation contract (AGENTS.md, issue #1608):
+//   - sidecartest.NewIsolated redirects $XDG_STATE_HOME to a t.TempDir() and
+//     sets the PRISM_TEST_MODE_RESTRICT_HOSTAPI guard, so no host DB / bus /
+//     tmux state is touched.
+//   - Session names use the "prism-test@" prefix.
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/prismatic-koi/prism/internal/session"
+	"github.com/prismatic-koi/prism/internal/sidecar/sidecartest"
+)
+
+// TestContainersFlag_Registered verifies that --containers is registered on
+// spawnCmd as a bool with default false. The agent-context generator walks
+// cobra.Command.Flags() so once this is in place the JSON document picks
+// the flag up automatically — AC #4 of #2323 piggybacks on this.
+func TestContainersFlag_Registered(t *testing.T) {
+	flag := spawnCmd.Flags().Lookup("containers")
+	if flag == nil {
+		t.Fatal("--containers flag not found on spawnCmd")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Errorf("--containers flag type = %q, want %q", flag.Value.Type(), "bool")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--containers flag default = %q, want %q", flag.DefValue, "false")
+	}
+	// Description must be non-empty so `prism agent-context` surfaces it.
+	if flag.Usage == "" {
+		t.Error("--containers flag usage string is empty; agent-context would surface no description")
+	}
+}
+
+// TestSpawnInputsFromOpts_ContainersFlagTrue verifies that when SpawnOpts
+// carries ContainersFlag=true, the spawn_inputs row written by
+// InsertSpawnInputs records containers_flag=1 and that
+// SpawnInputsByInstanceID reads it back as true. AC #1 of #2323.
+func TestSpawnInputsFromOpts_ContainersFlagTrue(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-containers-true"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	opts := session.SpawnOpts{
+		InstanceID:     instanceID,
+		Prompt:         "noop",
+		PromptSource:   "cli-positional",
+		ContainersFlag: true,
+	}
+	si := session.SpawnInputsFromOpts(opts)
+	if !si.ContainersFlag {
+		t.Fatal("SpawnInputsFromOpts: ContainersFlag = false, want true")
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil, want non-nil")
+	}
+	if !got.ContainersFlag {
+		t.Error("ContainersFlag round-trip: got false, want true")
+	}
+}
+
+// TestSpawnInputsFromOpts_ContainersFlagDefault verifies that the default
+// (flag omitted) yields ContainersFlag=false on the round-tripped row.
+// AC #3 of #2323 — `prism spawn` without --containers leaves both
+// columns at 0.
+func TestSpawnInputsFromOpts_ContainersFlagDefault(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-containers-default"
+	instanceID := uuid.New().String()
+	seedSessionForSpawnInputs(t, d, instanceID, sessionName)
+
+	opts := session.SpawnOpts{
+		InstanceID:   instanceID,
+		Prompt:       "noop",
+		PromptSource: "cli-positional",
+		// ContainersFlag left at zero value (false).
+	}
+	si := session.SpawnInputsFromOpts(opts)
+	if si.ContainersFlag {
+		t.Fatal("SpawnInputsFromOpts: ContainersFlag = true, want false (default)")
+	}
+	if err := d.InsertSpawnInputs(si); err != nil {
+		t.Fatalf("InsertSpawnInputs: %v", err)
+	}
+
+	got, err := d.SpawnInputsByInstanceID(instanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil, want non-nil")
+	}
+	if got.ContainersFlag {
+		t.Error("ContainersFlag default: got true, want false")
+	}
+}
+
+// TestSetContainersEnabled_FlipsTheRuntimeGate verifies that
+// d.SetContainersEnabled flips agent_status.containers_enabled — the
+// runtime gate the sidecar reads on startup to decide whether to start
+// the per-session filtering podman socket proxy (#2317 / #2320).
+//
+// AC #2 of #2323: when --containers is passed, the new agent_status row
+// has containers_enabled=1. This is the writer-level test for that wire:
+// SpawnSession calls d.SetContainersEnabled when opts.ContainersFlag, so
+// the contract reduces to "the setter correctly flips the bit on the row
+// the sidecar will later read".
+//
+// AC #3 (the default-false case) is covered by the schema's
+// `INTEGER NOT NULL DEFAULT 0` declaration plus the
+// TestStatus_ContainersEnabledDefaultsFalse migration test that lives
+// alongside the schema (internal/db/db_migration_v36_v37_test.go).
+func TestSetContainersEnabled_FlipsTheRuntimeGate(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	const sessionName = "prism-test@worker-containers-runtime"
+	// Seed an agent_status row in the simplest possible shape (idle, no
+	// title, no harness session). Mirrors what UpsertStatusSeedRootAgentName
+	// produces at spawn time — the SetContainersEnabled call lands on the
+	// same row immediately afterwards.
+	if err := d.UpsertStatusSeedRootAgentName(
+		sessionName, "test-repo", "/tmp/worktree", "idle", nil, nil, "worker", "pi", "bwrap",
+	); err != nil {
+		t.Fatalf("UpsertStatusSeedRootAgentName: %v", err)
+	}
+
+	// Before: containers_enabled defaults to 0.
+	pre, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus (pre): %v", err)
+	}
+	if pre == nil {
+		t.Fatal("CurrentStatus (pre): got nil row")
+	}
+	if pre.ContainersEnabled {
+		t.Error("CurrentStatus (pre): ContainersEnabled = true, want false (schema default)")
+	}
+
+	// After SetContainersEnabled(true): row reads back with the gate set.
+	if err := d.SetContainersEnabled(sessionName, true); err != nil {
+		t.Fatalf("SetContainersEnabled(true): %v", err)
+	}
+	post, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus (post): %v", err)
+	}
+	if post == nil {
+		t.Fatal("CurrentStatus (post): got nil row")
+	}
+	if !post.ContainersEnabled {
+		t.Error("CurrentStatus (post): ContainersEnabled = false, want true after SetContainersEnabled(true)")
+	}
+
+	// SetContainersEnabled(false) flips it back — used for a clean re-spawn
+	// path where the row is being reset to idle without --containers.
+	if err := d.SetContainersEnabled(sessionName, false); err != nil {
+		t.Fatalf("SetContainersEnabled(false): %v", err)
+	}
+	reset, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus (reset): %v", err)
+	}
+	if reset == nil {
+		t.Fatal("CurrentStatus (reset): got nil row")
+	}
+	if reset.ContainersEnabled {
+		t.Error("CurrentStatus (reset): ContainersEnabled = true, want false after SetContainersEnabled(false)")
+	}
+}
+
+// TestSetContainersEnabled_NoRowIsNoOp verifies that calling
+// SetContainersEnabled on a session_name with no agent_status row is a
+// silent no-op (matching SetIsolationMode / SetGroupID). This is the
+// "session was already cleaned up" path — defence in depth so a stale
+// caller never errors out the spawn flow.
+func TestSetContainersEnabled_NoRowIsNoOp(t *testing.T) {
+	bus := sidecartest.NewIsolated(t, "")
+	d := bus.DB
+
+	if err := d.SetContainersEnabled("prism-test@worker-does-not-exist", true); err != nil {
+		t.Fatalf("SetContainersEnabled on missing row: %v, want nil (no-op)", err)
+	}
+}
+
+// TestProxySpawnBody_ContainersForwardedOnlyWhenSet verifies the
+// flag-forwarding pattern documented in #2323's cross-spawn forwarding AC:
+// the proxy body carries "containers": true ONLY when the flag was
+// explicitly set; an unset child must NOT inherit the parent's value via
+// JSON default.
+//
+// This is the unit-level twin of the existing hostapi "isolation"
+// forwarding test (cmd/hostapi_test.go TestProxySpawn_IsolationNotForwardedWhenAbsent).
+// It exercises the body-construction shape directly so a regression in
+// cmd/spawn.go's body assembly is caught here without a full host-API
+// round-trip.
+func TestProxySpawnBody_ContainersForwardedOnlyWhenSet(t *testing.T) {
+	type bodyShape struct {
+		Containers *bool `json:"containers,omitempty"`
+	}
+
+	cases := []struct {
+		name        string
+		setFlag     bool
+		flagValue   bool
+		wantPresent bool
+		wantValue   bool
+	}{
+		{name: "unset_omitted", setFlag: false, wantPresent: false},
+		{name: "set_true_forwards_true", setFlag: true, flagValue: true, wantPresent: true, wantValue: true},
+		{name: "set_false_forwards_false", setFlag: true, flagValue: false, wantPresent: true, wantValue: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "spawn-test"}
+			cmd.Flags().Bool("containers", false, "")
+			if tc.setFlag {
+				if err := cmd.Flags().Set("containers", boolString(tc.flagValue)); err != nil {
+					t.Fatalf("set --containers: %v", err)
+				}
+			}
+
+			// Mirror the body-build pattern in cmd/spawn.go's proxySpawn:
+			//   body := map[string]any{...}
+			//   if cmd.Flags().Changed("containers") { body["containers"] = containersFlag }
+			body := map[string]any{}
+			containersFlag, _ := cmd.Flags().GetBool("containers")
+			if cmd.Flags().Changed("containers") {
+				body["containers"] = containersFlag
+			}
+
+			// Round-trip via JSON to assert the wire shape — agent-context
+			// and the host-API both consume JSON, not in-memory maps.
+			raw, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal body: %v", err)
+			}
+			var decoded bodyShape
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+
+			if tc.wantPresent {
+				if decoded.Containers == nil {
+					t.Fatalf("containers field omitted; want present with value %v", tc.wantValue)
+				}
+				if *decoded.Containers != tc.wantValue {
+					t.Errorf("containers value = %v, want %v", *decoded.Containers, tc.wantValue)
+				}
+			} else {
+				if decoded.Containers != nil {
+					t.Errorf("containers field = %v, want omitted (flag was not set)", *decoded.Containers)
+				}
+			}
+		})
+	}
+}
+
+func boolString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// TestWarnContainersWithHostMode covers AC #5 of #2323: when --containers is
+// combined with --isolation host, prism spawn emits a warning to stderr
+// matching the substring "host mode bypasses the proxy" and exits 0 (the
+// spawn proceeds). The warning fires for every isolation resolution path
+// that ends at "host" — explicit flag, config default, or future precedence
+// layers — so the helper takes the resolved mode string verbatim.
+func TestWarnContainersWithHostMode(t *testing.T) {
+	cases := []struct {
+		name       string
+		containers bool
+		isolation  string
+		wantWarn   bool
+		wantSubstr string // empty means no expectation on text
+	}{
+		{name: "containers_host_warns", containers: true, isolation: "host", wantWarn: true, wantSubstr: "host mode bypasses the proxy"},
+		{name: "containers_bwrap_silent", containers: true, isolation: "bwrap", wantWarn: false},
+		{name: "containers_sandbox_exec_silent", containers: true, isolation: "sandbox-exec", wantWarn: false},
+		{name: "no_containers_host_silent", containers: false, isolation: "host", wantWarn: false},
+		{name: "no_containers_bwrap_silent", containers: false, isolation: "bwrap", wantWarn: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			gotWarn := warnContainersWithHostMode(&buf, tc.containers, tc.isolation)
+			if gotWarn != tc.wantWarn {
+				t.Errorf("warnContainersWithHostMode returned %v; want %v (containers=%v isolation=%q)",
+					gotWarn, tc.wantWarn, tc.containers, tc.isolation)
+			}
+			out := buf.String()
+			if tc.wantWarn {
+				if out == "" {
+					t.Errorf("expected warning text on stderr, got empty")
+				}
+				if tc.wantSubstr != "" && !strings.Contains(out, tc.wantSubstr) {
+					t.Errorf("stderr %q does not contain substring %q", out, tc.wantSubstr)
+				}
+			} else if out != "" {
+				t.Errorf("expected no warning, got %q", out)
+			}
+		})
+	}
+}
+
+// TestContainersFlag_DoubleSetIsIdempotent covers AC #6 of #2323: passing
+// --containers twice on the same command line does not error. cobra's
+// pflag.Bool tolerates repeated --flag values by overwriting; this test
+// pins that behaviour so a future flag-registration change (e.g. switching
+// to BoolVar with a custom parser) cannot regress the contract.
+func TestContainersFlag_DoubleSetIsIdempotent(t *testing.T) {
+	cmd := &cobra.Command{Use: "spawn-test"}
+	cmd.Flags().Bool("containers", false, "")
+
+	// Two equivalent --containers --containers invocations (both true). The
+	// second Set call must not return an error; the final value must remain
+	// true.
+	if err := cmd.Flags().Set("containers", "true"); err != nil {
+		t.Fatalf("first --containers set: %v", err)
+	}
+	if err := cmd.Flags().Set("containers", "true"); err != nil {
+		t.Fatalf("second --containers set: %v", err)
+	}
+	got, _ := cmd.Flags().GetBool("containers")
+	if !got {
+		t.Errorf("containers = %v after two --containers, want true", got)
+	}
+	if !cmd.Flags().Changed("containers") {
+		t.Error("Changed(\"containers\") = false after two sets, want true")
+	}
+}
+
+// TestAgentContext_ContainersFlagExposed verifies that the agent-context
+// JSON output surfaces --containers as a bool with default false. This is
+// AC #4 of #2323 verbatim:
+//
+//	prism agent-context | jq '.commands.spawn.flags["--containers"]'
+//	returns {type: "bool", default: false, description: "..."}.
+//
+// The agent-context generator walks rootCmd.Commands() and emits FlagMeta
+// for each registered flag, so the test below just verifies that the
+// document built for `spawn` contains the --containers entry with the
+// expected shape — no need to shell out.
+func TestAgentContext_ContainersFlagExposed(t *testing.T) {
+	doc := buildAgentContextDocument(false)
+	spawnMeta, ok := doc.Commands["spawn"]
+	if !ok {
+		t.Fatal("agent-context: spawn command missing from document")
+	}
+	flag, ok := spawnMeta.Flags["--containers"]
+	if !ok {
+		t.Fatal("agent-context: --containers flag missing from spawn flags")
+	}
+	if flag.Type != "bool" {
+		t.Errorf("agent-context --containers type = %q, want %q", flag.Type, "bool")
+	}
+	if flag.Default != "false" {
+		t.Errorf("agent-context --containers default = %q, want %q", flag.Default, "false")
+	}
+	if flag.Description == "" {
+		t.Error("agent-context --containers description is empty")
+	}
+}

--- a/modules/programs/prism/prism/cmd/stats_compare.go
+++ b/modules/programs/prism/prism/cmd/stats_compare.go
@@ -979,6 +979,7 @@ var inputsAxes = []string{
 	"agent_role",
 	"branch",
 	"abtest_pair_id",
+	"containers_flag",
 }
 
 // inputsValue returns the display string for a single spawn_inputs axis on
@@ -1026,6 +1027,16 @@ func inputsValue(axis string, run compareRun) string {
 	case "abtest_pair_id":
 		if in != nil && in.AbtestPairID != nil && *in.AbtestPairID != "" {
 			return *in.AbtestPairID
+		}
+	case "containers_flag":
+		// Always renders for rows that have an inputs row, with "true" / "false"
+		// so the absence ("—") cleanly distinguishes pre-#2087 rows from rows
+		// that recorded containers_flag=0. (#2317 / #2323)
+		if in != nil {
+			if in.ContainersFlag {
+				return "true"
+			}
+			return "false"
 		}
 	}
 	return "—"

--- a/modules/programs/prism/prism/cmd/stats_compare_containers_test.go
+++ b/modules/programs/prism/prism/cmd/stats_compare_containers_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+// stats_compare_containers_test.go — `prism stats compare` Spawn Inputs
+// renderer coverage for the new containers_flag axis (#2317 / #2323).
+//
+// The renderer surface mirrors the existing audit-field axes
+// (profile_name, harness, isolation_mode, …): a row with a populated
+// spawn_inputs row renders "true" / "false"; a row with no spawn_inputs
+// renders "—" so pre-#2087 sessions display cleanly.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/agent"
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestInputsValue_ContainersFlagTrue verifies that a spawn_inputs row with
+// ContainersFlag=true surfaces as "true" via inputsValue("containers_flag").
+// This is the renderer side of AC #7 — the `prism stats compare` Spawn
+// Inputs block carries the new audit column.
+func TestInputsValue_ContainersFlagTrue(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-containers-true"
+	inputs := &db.SpawnInputs{
+		ProfileName:    strPtr("anthropic"),
+		HarnessFlag:    strPtr("pi"),
+		IsolationFlag:  strPtr("bwrap"),
+		IsolationMode:  strPtr("bwrap"),
+		ContainersFlag: true,
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("containers_flag", runs[0]); got != "true" {
+		t.Errorf("inputsValue(containers_flag) = %q, want %q", got, "true")
+	}
+}
+
+// TestInputsValue_ContainersFlagFalse verifies that an explicitly-false
+// containers_flag surfaces as "false" (distinct from "—" / missing). This
+// is the discrimination AC: a row with a spawn_inputs entry that recorded
+// containers_flag=0 must look different from a row with no spawn_inputs
+// at all.
+func TestInputsValue_ContainersFlagFalse(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-containers-false"
+	inputs := &db.SpawnInputs{
+		ProfileName:    strPtr("anthropic"),
+		HarnessFlag:    strPtr("pi"),
+		IsolationMode:  strPtr("bwrap"),
+		ContainersFlag: false,
+	}
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, inputs)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("containers_flag", runs[0]); got != "false" {
+		t.Errorf("inputsValue(containers_flag) = %q, want %q (explicit false is not missing)", got, "false")
+	}
+}
+
+// TestInputsValue_ContainersFlagAbsentRendersDash verifies that a session
+// with no spawn_inputs row surfaces containers_flag as "—" (the missing
+// glyph). Mirrors TestInputsValue_IsolationModeAbsentRendersDash for the
+// pre-#2087 / no-row case so the renderer never crashes on a nil
+// CompareInputs pointer.
+func TestInputsValue_ContainersFlagAbsentRendersDash(t *testing.T) {
+	d := openStatsTestDB(t)
+	startedAt := time.Now().Add(-time.Minute)
+
+	const sessionName = "repo@inputs-containers-absent"
+	// No spawn_inputs row at all.
+	iid := seedCompareSession(t, d, sessionName, startedAt, agent.StateFinished, nil)
+
+	sess, _ := d.SessionByInstanceID(iid)
+	runs := loadCompareRuns(d, []*db.Session{sess})
+
+	if got := inputsValue("containers_flag", runs[0]); got != "—" {
+		t.Errorf("inputsValue(containers_flag) on row with no spawn_inputs = %q, want %q",
+			got, "—")
+	}
+}
+
+// TestInputsAxes_IncludesContainersFlag verifies that the canonical axis
+// list surfaced by `prism stats compare` includes containers_flag. The
+// renderer iterates inputsAxes — adding the new axis without updating the
+// list would silently hide it from the table and JSON output.
+func TestInputsAxes_IncludesContainersFlag(t *testing.T) {
+	for _, axis := range inputsAxes {
+		if axis == "containers_flag" {
+			return
+		}
+	}
+	t.Errorf("inputsAxes = %v; missing %q", inputsAxes, "containers_flag")
+}

--- a/modules/programs/prism/prism/cmd/stats_render.go
+++ b/modules/programs/prism/prism/cmd/stats_render.go
@@ -31,6 +31,15 @@ func runStatsDetail(arg string, forceInstance bool, jsonMode bool) error {
 
 	if jsonMode {
 		out := map[string]any{"session": sess}
+		// Surface the spawn_inputs audit columns alongside the sessions
+		// row so callers scripting against `prism stats <id> --json` can
+		// read containers_flag (#2317 / #2323) without a second query.
+		// Missing rows (pre-#2087 sessions) omit the key entirely —
+		// downstream consumers must use "in" rather than truthy checks
+		// to distinguish "unknown" from "false".
+		if si, siErr := d.SpawnInputsByInstanceID(sess.InstanceID); siErr == nil && si != nil {
+			out["spawn_inputs"] = spawnInputsJSON(si)
+		}
 		data, merr := json.Marshal(out)
 		if merr != nil {
 			return fmt.Errorf("stats --json: marshal session: %w", merr)
@@ -41,6 +50,44 @@ func runStatsDetail(arg string, forceInstance bool, jsonMode bool) error {
 
 	renderIncarnationDetail(d, sess)
 	return nil
+}
+
+// spawnInputsJSON projects db.SpawnInputs onto the audit-only subset surfaced
+// by `prism stats <instance-id> --json` (#2317 / #2323). Conversation-bearing
+// columns (prompt_text, prompt_source, model_variant_overrides, extras) are
+// intentionally omitted — the same boundary that CompareInputs enforces for
+// the host-API /stats endpoint applies here.
+func spawnInputsJSON(si *db.SpawnInputs) map[string]any {
+	m := map[string]any{
+		"containers_flag":        si.ContainersFlag,
+		"host_mode_flag":         si.HostModeFlag,
+		"ignore_concurrency_cap": si.IgnoreConcurrencyCap,
+	}
+	if si.ProfileName != nil {
+		m["profile_name"] = *si.ProfileName
+	}
+	if si.HarnessFlag != nil {
+		m["harness_flag"] = *si.HarnessFlag
+	}
+	if si.IsolationFlag != nil {
+		m["isolation_flag"] = *si.IsolationFlag
+	}
+	if si.IsolationMode != nil {
+		m["isolation_mode"] = *si.IsolationMode
+	}
+	if si.AgentFlag != nil {
+		m["agent_flag"] = *si.AgentFlag
+	}
+	if si.BranchFlag != nil {
+		m["branch_flag"] = *si.BranchFlag
+	}
+	if si.PRNumber != nil {
+		m["pr_number"] = *si.PRNumber
+	}
+	if si.AbtestPairID != nil {
+		m["abtest_pair_id"] = *si.AbtestPairID
+	}
+	return m
 }
 
 // renderIncarnationDetailFromSession renders the session detail for the proxy
@@ -151,6 +198,40 @@ func renderIncarnationDetail(d *db.DB, sess *db.Session) {
 		fmt.Printf("%s %s\n", styleLabel.Render("archive:"), styleDim.Render("(not yet archived)"))
 	}
 	fmt.Println()
+
+	// Spawn Inputs block — surfaces the audit columns written at spawn time
+	// (#2087 / #2317 / #2323). When no spawn_inputs row exists (pre-#2087
+	// sessions, or rows created outside the SpawnSession chokepoint) the
+	// whole block is omitted rather than rendering a sea of "—" labels.
+	// Mirrors the field set surfaced by `prism stats compare`'s Spawn Inputs
+	// block; new audit columns added in future PRs land here too.
+	if si, siErr := d.SpawnInputsByInstanceID(sess.InstanceID); siErr == nil && si != nil {
+		fmt.Println(styleHeader.Render("Spawn Inputs"))
+		if si.ProfileName != nil && *si.ProfileName != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("profile_name:"), *si.ProfileName)
+		}
+		if si.HarnessFlag != nil && *si.HarnessFlag != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("harness_flag:"), *si.HarnessFlag)
+		}
+		if si.IsolationMode != nil && *si.IsolationMode != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("isolation_mode:"), *si.IsolationMode)
+		}
+		if si.IsolationFlag != nil && *si.IsolationFlag != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("isolation_flag:"), *si.IsolationFlag)
+		}
+		fmt.Printf("  %s %t\n", styleLabel.Render("host_mode_flag:"), si.HostModeFlag)
+		fmt.Printf("  %s %t\n", styleLabel.Render("containers_flag:"), si.ContainersFlag)
+		if si.AgentFlag != nil && *si.AgentFlag != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("agent_flag:"), *si.AgentFlag)
+		}
+		if si.BranchFlag != nil && *si.BranchFlag != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("branch_flag:"), *si.BranchFlag)
+		}
+		if si.AbtestPairID != nil && *si.AbtestPairID != "" {
+			fmt.Printf("  %s %s\n", styleLabel.Render("abtest_pair_id:"), *si.AbtestPairID)
+		}
+		fmt.Println()
+	}
 
 	// Token/cost totals from agent_events.
 	fmt.Println(styleHeader.Render("Token Usage"))

--- a/modules/programs/prism/prism/internal/db/compare.go
+++ b/modules/programs/prism/prism/internal/db/compare.go
@@ -67,6 +67,12 @@ type CompareInputs struct {
 	AgentFlag     *string `json:"agent_flag"`
 	BranchFlag    *string `json:"branch_flag"`
 	AbtestPairID  *string `json:"abtest_pair_id"`
+	// ContainersFlag mirrors spawn_inputs.containers_flag — the raw
+	// --containers CLI flag captured at spawn time (#2317 / #2323).
+	// false when the flag was omitted (default); true when the user passed
+	// --containers. Audit-only; the live runtime gate is
+	// agent_status.containers_enabled (Status.ContainersEnabled).
+	ContainersFlag bool `json:"containers_flag"`
 }
 
 // ResolveSessionArg resolves a user-supplied argument to a sessions row.
@@ -181,13 +187,14 @@ func (d *DB) AssembleCompareRun(sess *Session) CompareRunData {
 	cr.Outcome = d.CompareRunOutcome(sess)
 	if inputs, err := d.SpawnInputsByInstanceID(sess.InstanceID); err == nil && inputs != nil {
 		cr.Inputs = &CompareInputs{
-			ProfileName:   inputs.ProfileName,
-			HarnessFlag:   inputs.HarnessFlag,
-			IsolationFlag: inputs.IsolationFlag,
-			IsolationMode: inputs.IsolationMode,
-			AgentFlag:     inputs.AgentFlag,
-			BranchFlag:    inputs.BranchFlag,
-			AbtestPairID:  inputs.AbtestPairID,
+			ProfileName:    inputs.ProfileName,
+			HarnessFlag:    inputs.HarnessFlag,
+			IsolationFlag:  inputs.IsolationFlag,
+			IsolationMode:  inputs.IsolationMode,
+			AgentFlag:      inputs.AgentFlag,
+			BranchFlag:     inputs.BranchFlag,
+			AbtestPairID:   inputs.AbtestPairID,
+			ContainersFlag: inputs.ContainersFlag,
 		}
 	}
 	return cr

--- a/modules/programs/prism/prism/internal/db/status.go
+++ b/modules/programs/prism/prism/internal/db/status.go
@@ -817,6 +817,31 @@ func (d *DB) SetIsolationMode(sessionName, mode string) error {
 	return nil
 }
 
+// SetContainersEnabled writes agent_status.containers_enabled for sessionName
+// (#2317 / #2323). enabled=true is the runtime gate the sidecar reads to
+// decide whether to start the per-session filtering podman API socket proxy;
+// the spawn-time CLI flag --containers flips this on. enabled=false leaves the
+// row at the default (proxy not started).
+//
+// No-op when sessionName has no agent_status row (the UPDATE affects zero rows
+// and returns nil). Mirrors SetIsolationMode / SetGroupID — write the boolean
+// as an INTEGER 0/1 so the column shape matches the schema (INTEGER NOT NULL
+// DEFAULT 0).
+func (d *DB) SetContainersEnabled(sessionName string, enabled bool) error {
+	var v int
+	if enabled {
+		v = 1
+	}
+	_, err := d.conn.Exec(
+		"UPDATE agent_status SET containers_enabled = ? WHERE session_name = ?",
+		v, sessionName,
+	)
+	if err != nil {
+		return fmt.Errorf("db: set containers_enabled: %w", err)
+	}
+	return nil
+}
+
 // portAvailable checks whether a TCP port is available on localhost by
 // attempting a brief listen. Returns true if the port is free.
 func portAvailable(port int) bool {

--- a/modules/programs/prism/prism/internal/session/spawn.go
+++ b/modules/programs/prism/prism/internal/session/spawn.go
@@ -300,6 +300,13 @@ type SpawnOpts struct {
 	// HostModeFlag mirrors --host-mode. Mirrors spawn_inputs.host_mode_flag.
 	HostModeFlag bool
 
+	// ContainersFlag mirrors --containers (#2317 / #2323). Audit-only:
+	// SpawnSession writes it to spawn_inputs.containers_flag and also flips
+	// agent_status.containers_enabled to 1 when true so the sidecar starts
+	// the per-session filtering podman socket proxy. Defaults to false (the
+	// flag was omitted; the runtime gate stays at the schema default of 0).
+	ContainersFlag bool
+
 	// PRNumber is the parsed --pr flag value. Zero means no --pr was passed.
 	// Mirrors spawn_inputs.pr_number.
 	PRNumber int
@@ -677,6 +684,21 @@ func SpawnSession(d *db.DB, opts SpawnOpts) error {
 		if err := d.SetGroupID(opts.SessionName, opts.GroupID); err != nil {
 			return fmt.Errorf("spawn session: set group_id: %w", err)
 		}
+	}
+
+	// Step 2b: Flip agent_status.containers_enabled when --containers was
+	// passed (#2317 / #2323). This is the runtime gate the sidecar reads at
+	// startup to decide whether to start the per-session filtering podman
+	// API socket proxy. Only call when the flag is set — the column defaults
+	// to 0 in the schema so an unset spawn never enables the proxy.
+	//
+	// The corresponding immutable audit value lives in
+	// spawn_inputs.containers_flag and is written by InsertSpawnInputs below.
+	if opts.ContainersFlag {
+		if err := d.SetContainersEnabled(opts.SessionName, true); err != nil {
+			return fmt.Errorf("spawn session: set containers_enabled: %w", err)
+		}
+		startup.log("spawn-session: agent_status.containers_enabled=1 (--containers)")
 	}
 
 	// Issue #1507 (FK race): mint instance_id host-side and pre-insert the
@@ -1188,6 +1210,7 @@ func spawnInputsFromOpts(opts SpawnOpts) db.SpawnInputs {
 		si.IsolationMode = &s
 	}
 	si.HostModeFlag = opts.HostModeFlag
+	si.ContainersFlag = opts.ContainersFlag
 	if opts.PRNumber != 0 {
 		n := opts.PRNumber
 		si.PRNumber = &n

--- a/modules/programs/prism/prism/internal/session/spawn_containers_test.go
+++ b/modules/programs/prism/prism/internal/session/spawn_containers_test.go
@@ -1,0 +1,176 @@
+package session
+
+// spawn_containers_test.go — SpawnSession integration coverage for the new
+// ContainersFlag SpawnOpts field (#2317 / #2323).
+//
+// The mapping is two-pronged:
+//   - opts.ContainersFlag=true → spawn_inputs.containers_flag=1 (written by
+//     the centralised InsertSpawnInputs call inside SpawnSession).
+//   - opts.ContainersFlag=true → agent_status.containers_enabled=1 (written
+//     by an explicit d.SetContainersEnabled call after the seed).
+//
+// Both are required by ACs #1 and #2 of #2323: the audit row records the
+// CLI flag verbatim, and the runtime gate is the live signal the sidecar
+// reads at startup to decide whether to start the podman socket proxy.
+
+import (
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// TestSpawnSession_ContainersFlag_TrueFlipsBothColumns verifies that a
+// LayoutAgentOnly spawn with ContainersFlag=true ends with:
+//
+//   - spawn_inputs.containers_flag = 1 (the audit row), AND
+//   - agent_status.containers_enabled = 1 (the runtime gate).
+//
+// Both surfaces are required: the sidecar reads containers_enabled at
+// startup to decide whether to spin up the per-session filtering podman
+// socket proxy; spawn_inputs.containers_flag is the immutable audit trail
+// (so `prism stats compare` and `prism stats <id>` can reconstruct what
+// the user asked for).
+func TestSpawnSession_ContainersFlag_TrueFlipsBothColumns(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch-containers-on"
+	opts := SpawnOpts{
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "worker",
+		Prompt:         "go",
+		Layout:         LayoutAgentOnly,
+		ContainersFlag: true,
+		PIExtensionDir: testPIExtensionDir,
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	// Runtime gate: agent_status.containers_enabled = 1.
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want row")
+	}
+	if !st.ContainersEnabled {
+		t.Error("agent_status.containers_enabled = false, want true after SpawnSession with ContainersFlag=true")
+	}
+
+	// Audit row: spawn_inputs.containers_flag = 1. Look it up via the
+	// instance_id SpawnSession minted host-side.
+	if st.InstanceID == nil || *st.InstanceID == "" {
+		t.Fatal("instance_id missing on agent_status row; cannot look up spawn_inputs")
+	}
+	si, err := d.SpawnInputsByInstanceID(*st.InstanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil, want row written by SpawnSession")
+	}
+	if !si.ContainersFlag {
+		t.Error("spawn_inputs.containers_flag = false, want true after SpawnSession with ContainersFlag=true")
+	}
+}
+
+// TestSpawnSession_ContainersFlag_DefaultLeavesBothZero verifies the
+// default case — a SpawnSession invocation that does NOT set
+// ContainersFlag leaves both columns at the schema default of 0. This is
+// the runtime side of AC #3 of #2323.
+//
+// It also guards against an accidental future "default-on" regression: a
+// SpawnOpts field with a non-zero default value would silently enable
+// the proxy on every spawn, defeating the opt-in nature of --containers.
+func TestSpawnSession_ContainersFlag_DefaultLeavesBothZero(t *testing.T) {
+	d, _ := openSpawnTestDB(t)
+	_ = spyTmuxBin(t)
+	t.Setenv("PRISM_TEST_SUBPROCESS", "1")
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	const sessionName = "myrepo@branch-containers-default"
+	opts := SpawnOpts{
+		SessionName:    sessionName,
+		Repo:           "myrepo",
+		Worktree:       "/worktrees/myrepo-branch",
+		AgentRole:      "worker",
+		Prompt:         "go",
+		Layout:         LayoutAgentOnly,
+		PIExtensionDir: testPIExtensionDir,
+		// ContainersFlag deliberately omitted.
+	}
+
+	if err := SpawnSession(d, opts); err != nil {
+		t.Fatalf("SpawnSession: %v", err)
+	}
+
+	st, err := d.CurrentStatus(sessionName)
+	if err != nil {
+		t.Fatalf("CurrentStatus: %v", err)
+	}
+	if st == nil {
+		t.Fatal("CurrentStatus: got nil, want row")
+	}
+	if st.ContainersEnabled {
+		t.Error("agent_status.containers_enabled = true on default spawn; want false (opt-in only)")
+	}
+
+	if st.InstanceID == nil || *st.InstanceID == "" {
+		t.Fatal("instance_id missing on agent_status row; cannot look up spawn_inputs")
+	}
+	si, err := d.SpawnInputsByInstanceID(*st.InstanceID)
+	if err != nil {
+		t.Fatalf("SpawnInputsByInstanceID: %v", err)
+	}
+	if si == nil {
+		t.Fatal("SpawnInputsByInstanceID: got nil, want row written by SpawnSession")
+	}
+	if si.ContainersFlag {
+		t.Error("spawn_inputs.containers_flag = true on default spawn; want false")
+	}
+}
+
+// TestSpawnInputsFromOpts_ContainersFlag_RoundTrip verifies the writer-only
+// shape (no SpawnSession): SpawnInputsFromOpts maps SpawnOpts.ContainersFlag
+// onto db.SpawnInputs.ContainersFlag in both directions (true and false).
+//
+// Companion to the cmd-package writer tests; this one lives in
+// internal/session so the test is colocated with the helper it exercises.
+func TestSpawnInputsFromOpts_ContainersFlag_RoundTrip(t *testing.T) {
+	for _, want := range []bool{true, false} {
+		want := want
+		t.Run(boolName(want), func(t *testing.T) {
+			si := SpawnInputsFromOpts(SpawnOpts{
+				InstanceID:     "iid-" + boolName(want),
+				ContainersFlag: want,
+			})
+			if si.ContainersFlag != want {
+				t.Errorf("spawnInputsFromOpts(ContainersFlag=%v).ContainersFlag = %v, want %v",
+					want, si.ContainersFlag, want)
+			}
+		})
+	}
+}
+
+func boolName(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// Compile-time sanity check: db.SpawnInputs.ContainersFlag exists and is a
+// bool. If a future refactor flips it to int or *bool, this assignment
+// fails to compile, surfacing the breakage in CI rather than silently
+// breaking the writer path.
+var _ = func() bool {
+	var si db.SpawnInputs
+	return si.ContainersFlag
+}

--- a/modules/programs/prism/prism/internal/sidecar/host_api.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api.go
@@ -1129,6 +1129,13 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 			Reuse                 bool     `json:"reuse"`
 			ModelVariantOverrides string   `json:"model_variant_overrides"` // JSON-encoded map[string]string; see #1263
 			Abtest                []string `json:"abtest"`                  // two-element array of profile names; see #1330
+			// Containers mirrors the --containers CLI flag (#2317 / #2323).
+			// Forwarded as --containers to the host-side prism spawn when true.
+			// A proxy client that omits the field (older client, non-prism HTTP
+			// caller) gets the default false — the host-side spawn then writes
+			// containers_flag=0 and leaves containers_enabled=0, matching the
+			// pre-#2317 behaviour for that session.
+			Containers bool `json:"containers"`
 			// FromKeybind discriminates a tmux Prefix+a (keybind) spawn from
 			// an arbitrary HTTP caller. When true, an empty prompt is
 			// permitted — the operator types the initial prompt to the live
@@ -1276,6 +1283,9 @@ func (s *Sidecar) hostAPIHandler() http.Handler {
 		}
 		if req.Isolation != "" {
 			args = append(args, "--isolation", req.Isolation)
+		}
+		if req.Containers {
+			args = append(args, "--containers")
 		}
 		if req.IgnoreConcurrencyCap {
 			args = append(args, "--ignore-concurrency-cap")

--- a/modules/programs/prism/prism/internal/sidecar/host_api_containers_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/host_api_containers_test.go
@@ -1,0 +1,174 @@
+package sidecar
+
+// Tests for the host-API /spawn handler accepting the "containers" field
+// (#2317 / #2323). The handler is the bridge between the proxy CLI and the
+// host-side `prism spawn` invocation; the regression we want to prevent is
+// the same as #1059 for --isolation: silently dropping the field on the
+// host-API boundary so a sandboxed `prism spawn --containers` lands as a
+// containerless session on the host.
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestHostAPI_Spawn_ContainersForwardedWhenSet verifies that when the
+// /spawn request body carries {"containers": true}, the sidecar appends
+// "--containers" to the args passed to the prism binary.
+//
+// Mirror of TestHostAPI_Spawn_IsolationForwarded but for the boolean
+// --containers flag.
+func TestHostAPI_Spawn_ContainersForwardedWhenSet(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@containers-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	sc := New(cfg)
+
+	body := `{"branch":"containers-branch","prompt":"hi","containers":true}`
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn", body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if !strings.Contains(string(capturedArgs), "--containers") {
+		t.Errorf("captured args %q do not contain --containers; the field was silently dropped at the host-API boundary (regression class #1059 for --isolation, now #2323 for --containers)",
+			string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Spawn_ContainersOmittedWhenAbsent verifies that when the
+// request body does not include a "containers" field, no --containers
+// flag is appended to the spawned subprocess args. Symmetry with the
+// --isolation absence test (TestHostAPI_Spawn_IsolationOmittedWhenAbsent):
+// absence must mean "default false", not "explicit false forwarded".
+//
+// This matters because the explicit-vs-default distinction is the only
+// thing standing between a containerised parent's `prism spawn` (no
+// --containers) silently inheriting the parent's enabled state if a
+// future refactor of the proxy-body construction defaulted the field on.
+func TestHostAPI_Spawn_ContainersOmittedWhenAbsent(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@no-containers-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"no-containers-branch","prompt":"hi"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if strings.Contains(string(capturedArgs), "--containers") {
+		t.Errorf("captured args %q contain --containers; absence in body must omit the flag, not pass it (issue #2323: unset child must not inherit enabled state)",
+			string(capturedArgs))
+	}
+}
+
+// TestHostAPI_Spawn_ContainersFalseExplicitOmitted verifies that an
+// explicit "containers": false in the body also omits --containers from
+// the subprocess args. This is by design: --containers is a boolean
+// presence flag (the absence/presence distinction is what carries
+// meaning on the CLI), so an explicit-false request is functionally
+// indistinguishable from the absent case at the spawn-binary layer.
+//
+// If a future revision wants to support a --no-containers form (e.g. to
+// override a config-driven default), this is the test that will need to
+// flip to assert the inverse.
+func TestHostAPI_Spawn_ContainersFalseExplicitOmitted(t *testing.T) {
+	d := openTestDB(t)
+
+	argsFile := filepath.Join(t.TempDir(), "captured-args")
+	stubPath := filepath.Join(t.TempDir(), "prism-stub")
+	stubScript := `#!/bin/sh
+echo "$*" > ` + argsFile + `
+last=""
+for arg; do last="$arg"; done
+echo "session \"${last}@explicit-false-branch\" created"
+`
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	clk := newTestClock()
+	cfg := Config{
+		SessionName:     "test-repo@main",
+		Repo:            "test-repo",
+		Worktree:        "/tmp/test-repo@main",
+		HarnessURL:      "http://localhost:14000",
+		DB:              d,
+		Clock:           clk,
+		AgentRole:       "coordinator",
+		PrismBinaryPath: stubPath,
+		Harness:         newSSEHarness(),
+	}
+	sc := New(cfg)
+
+	rr := doHostAPI(t, sc, http.MethodPost, "/spawn",
+		`{"branch":"explicit-false-branch","prompt":"hi","containers":false}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	capturedArgs, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	if strings.Contains(string(capturedArgs), "--containers") {
+		t.Errorf("captured args %q contain --containers; explicit false must omit the flag (--containers is a presence flag, not a tri-state)",
+			string(capturedArgs))
+	}
+}


### PR DESCRIPTION
Step 6 of #2317 — exposes the per-session filtering podman API socket proxy via a new `--containers` boolean flag on `prism spawn` (default off). The flag writes `containers_flag=1` to `spawn_inputs` (audit) and flips `agent_status.containers_enabled` to `1` (the runtime gate the sidecar checks at startup to decide whether to start the proxy goroutine).

The proxy package (Step 1, #2326), DB migration (Step 2, #2327), and sidecar wiring (Step 3, #2328) all landed earlier; this PR just lets the user opt in.

## What lands here

- New `--containers` bool flag on `prism spawn` (and the abtest legs). Both legs of an abtest pair receive the same value so the pair is symmetric.

- Flag-forwarding across the sandbox boundary mirrors `--isolation`: the proxy CLI forwards `body["containers"]` only when the flag was explicitly set, so an unset child never inherits a parent's enabled state. The host-API `/spawn` handler accepts the new field and forwards `--containers` to the host-side spawn binary when true.

- `SpawnOpts` gains a `ContainersFlag` field; `SpawnSession` threads it into `spawn_inputs.containers_flag` (via the centralised writer) and calls a new `d.SetContainersEnabled` setter to flip `agent_status.containers_enabled` to `1` when set.

- `--containers --isolation host` emits an informational warning to stderr and proceeds (not an error path — users may legitimately combine the two for the audit trail; the proxy adds no value in host mode because the agent already has direct podman access).

- `prism stats compare` Spawn Inputs block adds a new `containers_flag` axis alongside the existing audit fields (`profile_name`, `harness`, `isolation_mode`, …).

- `prism stats <instance-id>` gains a Spawn Inputs section that surfaces `containers_flag` (and the existing audit columns) for human-readable output, plus a `spawn_inputs` object in the `--json` envelope. Pre-#2087 sessions (no `spawn_inputs` row) render unchanged — no block, no key — preserving back-compat.

- `prism agent-context` JSON document automatically picks up the new flag via the cobra walker; no agent-context generator change needed.

## Acceptance criteria

All ACs from #2323 are covered by tests in this PR:

- [x] `prism spawn --containers …` writes `containers_flag=1` to `spawn_inputs` (AC #1).
- [x] `prism spawn --containers …` writes `containers_enabled=1` to `agent_status` (AC #2).
- [x] Default spawn leaves both columns at `0` (AC #3).
- [x] `prism agent-context | jq '.commands.spawn.flags["--containers"]'` returns `{type: "bool", default: "false", description: "…"}` (AC #4).
- [x] `--containers --isolation host` emits the substring `"host mode bypasses the proxy"` to stderr and exits 0 (AC #5).
- [x] Passing `--containers` twice does not error (AC #6).
- [x] `prism stats <instance-id>` shows `containers_flag` in the Spawn Inputs block; `--json` includes it in the `spawn_inputs` object (AC #7).
- [x] Pre-#2087 rows render unchanged — no Spawn Inputs block, no `spawn_inputs` JSON key (AC #8).
- [x] Cross-spawn forwarding: a containerised session running `prism spawn --containers` for a child propagates the flag through the sandbox boundary (AC #9).

## Test coverage

- `cmd/spawn_containers_test.go` — flag registration, writer mapping, double-set idempotence, warning helper, agent-context exposure, proxy body forwarding shape.
- `cmd/hostapi_containers_test.go` — host-API proxy forwarding tests (forwarded when set, omitted when absent, explicit-false omitted).
- `internal/sidecar/host_api_containers_test.go` — host-API handler accepts the new field and forwards `--containers` correctly.
- `internal/session/spawn_containers_test.go` — `SpawnSession` integration: `ContainersFlag=true` flips both columns; default leaves both at 0.
- `cmd/stats_compare_containers_test.go` — Spawn Inputs renderer for the new axis (true / false / absent).
- `cmd/incarnation_stats_containers_test.go` — per-incarnation detail view human-readable + JSON, plus the pre-#2087 graceful-degrade case for AC #8.

Verified that the new `TestSpawnSession_ContainersFlag_TrueFlipsBothColumns` and `TestWarnContainersWithHostMode` tests are not no-ops by temporarily reverting the production change and confirming both fail with the expected diagnostic.

## Process

- `gofmt -l .` clean.
- `go build ./...` clean.
- `go test ./...` green from `modules/programs/prism/prism/`.
- `nix build .#prism` green from the repo root.

Refs #2317
Refs #2323
