### PR TITLE
prism: expose filtered podman socket in sandbox-exec sandbox (Step 5 of #2317)

### DIFF
--- a/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
+++ b/modules/programs/prism/prism/cmd/agent_run_sandbox_exec_darwin.go
@@ -189,6 +189,18 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		hostAPISockPath = sockPath
 	}
 
+	// Resolve the per-session filtering podman proxy socket path the sidecar
+	// binds when agent_status.containers_enabled=1 (issue #2317 / #2322).
+	// We always derive the path so a session whose flag flips on between
+	// spawn and agent-run still gets a sane Config, but the SBPL grant and
+	// env injection below are gated on the DB row's ContainersEnabled field.
+	// Resolution failure is non-fatal — the sandbox still starts; the grant
+	// just won't be emitted (mirrors the existing hostAPISockPath posture).
+	podmanProxySockPath := ""
+	if proxyPath, proxyErr := session.SidecarPodmanProxyPath(sessionName); proxyErr == nil {
+		podmanProxySockPath = proxyPath
+	}
+
 	var agentEnvVars map[string]string
 	if pf, pfErr := config.LoadProfiles(); pfErr == nil && pf != nil {
 		agentEnvVars = pf.AgentEnvVars
@@ -221,24 +233,26 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 		sandboxHarnessSessionID = *status.HarnessSessionID
 	}
 	ctrCfg := container.Config{
-		SessionName:       sessionName,
-		Worktree:          worktree,
-		BareRoot:          bareRoot,
-		WorktreeGitDir:    worktreeGitDir,
-		AllocatedPort:     port,
-		AgentRole:         agentRole,
-		GitUserName:       cfg.GitUserName,
-		GitUserEmail:      cfg.GitUserEmail,
-		SshAccessKeyName:  cfg.SshAccessKeyName,
-		SshSigningKeyName: cfg.SshSigningKeyName,
-		SshBin:            cfg.SshBin,
-		GitHubTokenPath:   cfg.GitHubTokenPath,
-		HostAPISockPath:   hostAPISockPath,
-		InstanceID:        instanceID,
-		RuntimeEnv:        sandboxRuntimeEnv,
-		AgentEnvVars:      agentEnvVars,
-		Harness:           sandboxHarnessName,
-		HarnessSessionID:  sandboxHarnessSessionID,
+		SessionName:         sessionName,
+		Worktree:            worktree,
+		BareRoot:            bareRoot,
+		WorktreeGitDir:      worktreeGitDir,
+		AllocatedPort:       port,
+		AgentRole:           agentRole,
+		GitUserName:         cfg.GitUserName,
+		GitUserEmail:        cfg.GitUserEmail,
+		SshAccessKeyName:    cfg.SshAccessKeyName,
+		SshSigningKeyName:   cfg.SshSigningKeyName,
+		SshBin:              cfg.SshBin,
+		GitHubTokenPath:     cfg.GitHubTokenPath,
+		HostAPISockPath:     hostAPISockPath,
+		InstanceID:          instanceID,
+		RuntimeEnv:          sandboxRuntimeEnv,
+		AgentEnvVars:        agentEnvVars,
+		Harness:             sandboxHarnessName,
+		HarnessSessionID:    sandboxHarnessSessionID,
+		ContainersEnabled:   status.ContainersEnabled,
+		PodmanProxySockPath: podmanProxySockPath,
 	}
 
 	// For socket-pipe harnesses (PI), the sidecar stores the TCP port it
@@ -334,6 +348,26 @@ func runAgentRunSandboxExec(sessionName string, status *db.Status, agentRunStart
 	env = append(env, "PRISM_SESSION_NAME="+ctrCfg.SessionName)
 	if ctrCfg.HostAPISockPath != "" {
 		env = append(env, "PRISM_HOST_API=unix://"+ctrCfg.HostAPISockPath)
+	}
+	// CONTAINER_HOST / DOCKER_HOST: when the session was spawned with
+	// containers_enabled=1, point both env vars at the per-session FILTERED
+	// podman socket the sidecar binds (issue #2317 §3c / #2322). Mirrors the
+	// PRISM_HOST_API injection pattern above. CONTAINER_HOST is the podman
+	// CLI's primary env var; DOCKER_HOST is the docker CLI's equivalent and
+	// is also honoured by many docker-compatible client libraries (testcontainers,
+	// docker-go, the JS dockerode library, …) — setting both lets the agent
+	// reach the proxy without per-tool configuration. The SBPL profile's
+	// literal RW grant on PodmanProxySockPath is what actually permits the
+	// connect(2); these env vars are just discovery hints — if the SBPL
+	// grant were missing the connect would fail with EPERM regardless.
+	//
+	// Defence in depth: we never emit either env var when ContainersEnabled
+	// is false, even if PodmanProxySockPath happens to be populated (e.g. a
+	// session whose flag was flipped off mid-run — not currently possible,
+	// but harmless to guard).
+	if ctrCfg.ContainersEnabled && ctrCfg.PodmanProxySockPath != "" {
+		env = append(env, "CONTAINER_HOST=unix://"+ctrCfg.PodmanProxySockPath)
+		env = append(env, "DOCKER_HOST=unix://"+ctrCfg.PodmanProxySockPath)
 	}
 	// For socket-pipe harnesses (PI) on Darwin, the sidecar allocates a TCP
 	// port at startup and stores it in harness_port. Expose it here so the

--- a/modules/programs/prism/prism/internal/container/container.go
+++ b/modules/programs/prism/prism/internal/container/container.go
@@ -185,18 +185,27 @@ type Config struct {
 	HarnessPipeTCPPort int
 
 	// ContainersEnabled is the per-session runtime gate for the filtering
-	// podman API socket proxy (#2317 / #2321). When true, BuildArgs (bwrap)
-	// emits:
+	// podman API socket proxy (#2317 / #2321 / #2322). When true, the
+	// per-isolator BuildArgs / SBPL generator emits:
 	//
+	// bwrap (Step 4 / #2321):
 	//   --setenv CONTAINER_HOST unix://<PodmanProxySockPath>
 	//   --setenv DOCKER_HOST    unix://<PodmanProxySockPath>
 	//   --bind   <sessionDir>/container-scratch <sessionDir>/container-scratch
 	//
-	// and the bwrap isolator's Prepare hook calls PrepareSessionWorkDir +
-	// mkdirs the container-scratch subdirectory so the bind source exists on
-	// disk before bwrap is execed. Defaults to false; sourced from
-	// agent_status.containers_enabled (the live DB gate read by
-	// cmd/agent_run.go on the bwrap path).
+	// sandbox-exec (Step 5 / #2322):
+	//   (allow file-read* file-write* (literal "<PodmanProxySockPath>"))
+	//   CONTAINER_HOST=unix://<PodmanProxySockPath>   (env injection)
+	//   DOCKER_HOST=unix://<PodmanProxySockPath>      (env injection)
+	//   <sessionDir>/container-scratch rides on the existing
+	//   (subpath <sessionDir>) RW grant in the SBPL profile.
+	//
+	// Both isolators' Prepare hook (lifecycle_dispatch.go) call
+	// PrepareSessionWorkDir + mkdirs the container-scratch subdirectory so
+	// the source path exists on disk before the sandbox is execed. Defaults
+	// to false; sourced from agent_status.containers_enabled (the live DB
+	// gate read by cmd/agent_run.go on the bwrap path and
+	// cmd/agent_run_sandbox_exec_darwin.go on the sandbox-exec path).
 	//
 	// Critically, the upstream podman socket path is NEVER passed into the
 	// sandbox — only the filtered PodmanProxySockPath the sidecar's proxy
@@ -207,9 +216,12 @@ type Config struct {
 	// PodmanProxySockPath is the absolute host path of the per-session
 	// filtering podman API socket created by the sidecar's podman-proxy
 	// goroutine (#2317 §3b / #2320). The socket sits in the same per-session
-	// run directory as HostAPISockPath, so the directory bind that already
-	// exposes the host-API socket also exposes this socket — no additional
-	// bind-mount is required. Typically populated via
+	// run directory as HostAPISockPath, so on bwrap the directory bind that
+	// already exposes the host-API socket also exposes this socket — no
+	// additional bind-mount is required. On sandbox-exec the SBPL
+	// generator emits a literal RW allow on this exact path; the (literal
+	// …), not (subpath …), keeps any future content of the run dir isolated
+	// from the sandboxed process. Typically populated via
 	// session.SidecarPodmanProxyPath. Consumed only when ContainersEnabled
 	// is true; ignored otherwise.
 	PodmanProxySockPath string

--- a/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
+++ b/modules/programs/prism/prism/internal/container/lifecycle_dispatch.go
@@ -273,6 +273,48 @@ func (s *sandboxExecIsolator) Prepare(ctx context.Context, m *Manager) ([]string
 		return nil, fmt.Errorf("container: sandbox-exec: cannot prepare session work dir: %w", err)
 	}
 
+	// ── Containers-enabled prep (#2317 / #2322) ─────────────────
+	// Symmetric to the bwrap-side block in bwrapIsolator.Prepare (#2321).
+	// When the session's agent_status.containers_enabled gate is set, the
+	// SBPL profile emits a literal RW allow on PodmanProxySockPath and the
+	// agent reaches the per-session filtering podman proxy via
+	// CONTAINER_HOST / DOCKER_HOST. The proxy's allowed-bind-sources list
+	// expects <sessionDir>/container-scratch to exist on disk before any
+	// containers/create request is validated.
+	//
+	// Validation order (matches bwrap's #2321 block):
+	//   1. PodmanProxySockPath must be set (config error if absent).
+	//   2. <runDir> = filepath.Dir(PodmanProxySockPath) must exist on disk
+	//      — the sidecar mkdir's it when it binds hostapi.sock, so a missing
+	//      runDir at this point indicates sidecar startup failed or the
+	//      sandbox-exec and sidecar path schemes disagree. Rendering an SBPL
+	//      allow on a literal that doesn't exist is a security smell:
+	//      sandbox-exec silently ignores the rule today, but a
+	//      future-created file at that path would inherit the grant. The
+	//      proxy is load-bearing only if the agent has no path to bypass
+	//      it. Fail loudly instead.
+	//   3. mkdir of the container-scratch subdir (the session work dir was
+	//      already created by PrepareSessionWorkDir above).
+	if m.cfg.ContainersEnabled {
+		if m.cfg.PodmanProxySockPath == "" {
+			return nil, fmt.Errorf("container: sandbox-exec: containers_enabled=true but PodmanProxySockPath is empty")
+		}
+		runDir := filepath.Dir(m.cfg.PodmanProxySockPath)
+		if info, err := os.Stat(runDir); err != nil {
+			return nil, fmt.Errorf("container: sandbox-exec: containers_enabled=true but podman proxy run dir %q does not exist: %w", runDir, err)
+		} else if !info.IsDir() {
+			return nil, fmt.Errorf("container: sandbox-exec: containers_enabled=true but podman proxy run dir %q is not a directory", runDir)
+		}
+		sessionDir, err := m.sessionWorkDirPath()
+		if err != nil {
+			return nil, fmt.Errorf("container: sandbox-exec: resolve session work dir for containers_enabled: %w", err)
+		}
+		scratch := SessionWorkDirContainerScratchPath(sessionDir)
+		if err := os.MkdirAll(scratch, 0o700); err != nil {
+			return nil, fmt.Errorf("container: sandbox-exec: create container-scratch dir %q: %w", scratch, err)
+		}
+	}
+
 	if _, err := writeProfile(m); err != nil {
 		return nil, err
 	}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec.go
@@ -733,6 +733,46 @@ func generateProfile(m *Manager) string {
 		}
 	}
 
+	// ── 6c. Podman proxy socket literal RW (issue #2317 §3c / #2322) ────
+	// When ContainersEnabled is set on the session (agent_status.containers_enabled
+	// = 1) the sidecar binds a per-session filtering podman API socket at
+	// PodmanProxySockPath (resolved by the caller via
+	// session.SidecarPodmanProxyPath). This grant lets the sandboxed process
+	// connect(2) and read/write the socket file so docker/podman clients
+	// reaching CONTAINER_HOST / DOCKER_HOST succeed. The session run dir
+	// itself is NOT a sibling of the section-6 work-dir grant — the run dir
+	// lives under <XDG_STATE_HOME>/prism/run/<SessionDirName>/ while the
+	// work dir lives under <XDG_STATE_HOME>/prism/sessions/<instanceID>/ —
+	// so the literal here is the SOLE in-sandbox capability for the socket
+	// path.
+	//
+	// The grant is a (literal ...), NOT (subpath ...): the per-session run
+	// dir also holds the host-API and harness-pipe sockets (covered by
+	// section 6's HostAPISockPath sockDir grant); the literal narrowing
+	// keeps any future content of the run dir isolated from the sandboxed
+	// process. Tightening here is load-bearing for the proxy's whole-point
+	// security property.
+	//
+	// The UPSTREAM podman socket path — the value returned by
+	// `podman machine inspect` on Darwin or $XDG_RUNTIME_DIR/podman/podman.sock
+	// on Linux — must NEVER appear here. The proxy is load-bearing only if
+	// the agent has no path to bypass it. The greppable security AC from
+	// #2322 asserts the upstream path's absence; see
+	// TestGenerateProfile_PodmanProxy_UpstreamPathNeverAppears.
+	//
+	// Defence in depth: we never emit an allow when PodmanProxySockPath is
+	// empty even if ContainersEnabled is true — an empty literal
+	// (allow … (literal "")) is malformed and would either be silently
+	// ignored or, worse, be interpreted as "every path" by a future SBPL
+	// engine change. Requiring both fields makes the call-site contract
+	// explicit (the per-isolator Prepare hook in lifecycle_dispatch.go
+	// hard-fails the empty case before reaching the generator).
+	if m.cfg.ContainersEnabled && m.cfg.PodmanProxySockPath != "" {
+		sb.WriteString("(allow file-read* file-write*\n")
+		sb.WriteString("  (literal " + quoteSBPL(m.cfg.PodmanProxySockPath) + "))\n")
+		sb.WriteString("\n")
+	}
+
 	// Note (Step 5 of #2132, issue #2250): the per-symlink staging-HOME
 	// target allows are gone with the staging HOME itself. The sops-backed
 	// key/config reads ride the broad /private/var/folders allow narrowed by

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_podman_proxy_prepare_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_podman_proxy_prepare_test.go
@@ -1,0 +1,405 @@
+package container
+
+// sandbox_exec_podman_proxy_prepare_test.go — unit tests for the
+// containers-enabled prep block in sandboxExecIsolator.Prepare (issue
+// #2317 §3c / #2322, Step 5). This block is symmetric to the bwrap-side
+// containers-enabled prep block added in Step 4 (#2321) and exercises the
+// same validation order + scratch-dir mkdir against the sandbox-exec
+// isolator.
+//
+// What's covered here:
+//
+//   - sandboxExecIsolator.Prepare creates <sessionDir>/container-scratch
+//     on disk when ContainersEnabled=true; the SBPL profile generator's
+//     literal RW allow on PodmanProxySockPath is exercised via the sibling
+//     sandbox_exec_podman_proxy_test.go unit tests, and end-to-end via
+//     internal/integration/sandbox_exec_podman_proxy_darwin_test.go.
+//
+//   - The scratch dir is NOT created when ContainersEnabled=false — the
+//     default-off path is a clean no-op.
+//
+//   - Prepare hard-fails when PodmanProxySockPath is empty on a
+//     ContainersEnabled=true session.
+//
+//   - Prepare hard-fails when the per-session run dir (parent of
+//     PodmanProxySockPath) does not exist on disk, or exists but is not a
+//     directory.
+//
+//   - The hard-fail gate is engaged ONLY when ContainersEnabled=true. A
+//     misconfigured PodmanProxySockPath on a containers_enabled=false
+//     session must NOT fail Prepare, because no allow is emitted in that
+//     case.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSandboxExecPrepare_CreatesContainerScratchWhenEnabled verifies that
+// <sessionDir>/container-scratch/ is created on disk when
+// ContainersEnabled=true. The proxy's allowedPodmanBindSources includes
+// this path; the create-time bind validation expects it to exist.
+//
+// The mkdir lives in sandboxExecIsolator.Prepare (not PrepareSessionWorkDir
+// itself) so it is symmetric with the bwrap-side block added in Step 4
+// (#2321) and so non-containers sessions sharing PrepareSessionWorkDir see
+// zero behaviour change.
+func TestSandboxExecPrepare_CreatesContainerScratchWhenEnabled(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	runDir := t.TempDir()
+	proxyPath := filepath.Join(runDir, "podman.sock")
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:         "repo@main",
+		InstanceID:          "test-containers-enabled",
+		Worktree:            t.TempDir(),
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	if _, err := iso.Prepare(context.Background(), m); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+	scratchDir := SessionWorkDirContainerScratchPath(sessionDir)
+	info, statErr := os.Stat(scratchDir)
+	if statErr != nil {
+		t.Fatalf("container-scratch dir not created at %s: %v", scratchDir, statErr)
+	}
+	if !info.IsDir() {
+		t.Errorf("container-scratch at %s is not a directory (mode=%v)", scratchDir, info.Mode())
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Errorf("container-scratch at %s has perm %#o, want 0700", scratchDir, info.Mode().Perm())
+	}
+}
+
+// TestSandboxExecPrepare_NoContainerScratchWhenDisabled verifies that the
+// scratch dir is NOT created when ContainersEnabled=false. The default-off
+// path must be a clean no-op — sessions that did not opt in to containers
+// see no new state on disk.
+func TestSandboxExecPrepare_NoContainerScratchWhenDisabled(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@main",
+		InstanceID:  "test-containers-disabled",
+		Worktree:    t.TempDir(),
+		// ContainersEnabled deliberately omitted — default false.
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	if _, err := iso.Prepare(context.Background(), m); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+	scratchDir := SessionWorkDirContainerScratchPath(sessionDir)
+	if _, statErr := os.Stat(scratchDir); statErr == nil {
+		t.Errorf("container-scratch dir was created at %s despite ContainersEnabled=false", scratchDir)
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("os.Stat(%s) returned unexpected error: %v (want os.ErrNotExist)", scratchDir, statErr)
+	}
+}
+
+// TestSandboxExecPrepare_ContainerScratchIdempotent verifies that calling
+// Prepare twice with ContainersEnabled=true is idempotent — the second
+// call must succeed even though the scratch dir already exists, and any
+// content placed inside between calls must survive (the mkdir is
+// MkdirAll, not a wipe-and-recreate).
+func TestSandboxExecPrepare_ContainerScratchIdempotent(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	runDir := t.TempDir()
+	proxyPath := filepath.Join(runDir, "podman.sock")
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:         "repo@main",
+		InstanceID:          "test-containers-idempotent",
+		Worktree:            t.TempDir(),
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	if _, err := iso.Prepare(context.Background(), m); err != nil {
+		t.Fatalf("first Prepare: %v", err)
+	}
+
+	sessionDir, err := m.sessionWorkDirPath()
+	if err != nil {
+		t.Fatalf("sessionWorkDirPath: %v", err)
+	}
+	scratchDir := SessionWorkDirContainerScratchPath(sessionDir)
+	sentinel := filepath.Join(scratchDir, "preserve-across-prepare")
+	if err := os.WriteFile(sentinel, []byte("ok"), 0o600); err != nil {
+		t.Fatalf("write sentinel into scratch dir: %v", err)
+	}
+
+	if _, err := iso.Prepare(context.Background(), m); err != nil {
+		t.Fatalf("second Prepare: %v", err)
+	}
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Errorf("sentinel %s removed by second Prepare: %v", sentinel, statErr)
+	}
+}
+
+// TestSandboxExecPrepare_ErrorsWhenSockPathEmpty verifies that
+// ContainersEnabled=true with an empty PodmanProxySockPath is rejected at
+// Prepare time. This is the defence-in-depth call-site contract: the
+// per-mode dispatcher must populate both fields or neither. Without this
+// check we'd silently generate an SBPL with no proxy allow and the agent
+// would see EPERM at connect(2) time with no operator signal as to why.
+func TestSandboxExecPrepare_ErrorsWhenSockPathEmpty(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:       "repo@main",
+		InstanceID:        "test-sockpath-empty",
+		Worktree:          t.TempDir(),
+		ContainersEnabled: true,
+		// PodmanProxySockPath deliberately empty.
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	_, err := iso.Prepare(context.Background(), m)
+	if err == nil {
+		t.Fatalf("Prepare succeeded with empty PodmanProxySockPath; want hard-fail")
+	}
+	if !strings.Contains(err.Error(), "PodmanProxySockPath is empty") {
+		t.Errorf("error message %q does not mention the empty PodmanProxySockPath", err.Error())
+	}
+	if _, statErr := os.Stat(m.sandboxExecProfilePath()); statErr == nil {
+		t.Errorf("Prepare wrote a profile despite the empty-SockPath hard-fail")
+	}
+}
+
+// TestSandboxExecPrepare_ErrorsWhenRunDirMissing verifies the edge-case AC
+// from #2322: when ContainersEnabled=true but the per-session run dir
+// (parent of PodmanProxySockPath) does not exist on disk, Prepare returns
+// an error rather than rendering an SBPL with an allow for a literal that
+// doesn't exist. The integration tests live in
+// internal/integration/sandbox_exec_podman_proxy_darwin_test.go.
+func TestSandboxExecPrepare_ErrorsWhenRunDirMissing(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	// Point PodmanProxySockPath at a directory we never create. Note that
+	// the SESSION work dir (under XDG_STATE_HOME) is created by Prepare
+	// itself via PrepareSessionWorkDir; only the run dir (PodmanProxySockPath's
+	// parent) is expected to pre-exist, populated by the sidecar.
+	missingRunDir := filepath.Join(t.TempDir(), "never-mkdir-this")
+	proxyPath := filepath.Join(missingRunDir, "podman.sock")
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:         "repo@main",
+		InstanceID:          "test-rundir-missing",
+		Worktree:            t.TempDir(),
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	_, err := iso.Prepare(context.Background(), m)
+	if err == nil {
+		t.Fatalf("Prepare succeeded despite missing run dir %s; want hard-fail error", missingRunDir)
+	}
+	if !strings.Contains(err.Error(), "containers_enabled=true") {
+		t.Errorf("error message %q does not mention containers_enabled=true (operator must be able to grep for the cause)", err.Error())
+	}
+	if !strings.Contains(err.Error(), missingRunDir) {
+		t.Errorf("error message %q does not include the missing run dir path %q", err.Error(), missingRunDir)
+	}
+
+	// No SBPL profile must have been materialised — a missing-run-dir
+	// session must not leave any rendered allow on disk.
+	if _, statErr := os.Stat(m.sandboxExecProfilePath()); statErr == nil {
+		t.Errorf("Prepare wrote a profile despite the hard-fail at %s", m.sandboxExecProfilePath())
+	}
+}
+
+// TestSandboxExecPrepare_ErrorsWhenRunDirIsRegularFile verifies the
+// is-directory branch of the edge-case check: a regular file at the
+// runDir path is a configuration error (not just an absent dir), and
+// must also fail loudly.
+func TestSandboxExecPrepare_ErrorsWhenRunDirIsRegularFile(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	// Plant a regular file at the runDir path so Stat succeeds but
+	// IsDir() returns false.
+	parent := t.TempDir()
+	regularFileAsRunDir := filepath.Join(parent, "this-is-a-file-not-a-dir")
+	if err := os.WriteFile(regularFileAsRunDir, []byte("oops"), 0o600); err != nil {
+		t.Fatalf("plant regular file at run dir path: %v", err)
+	}
+	proxyPath := filepath.Join(regularFileAsRunDir, "podman.sock")
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:         "repo@main",
+		InstanceID:          "test-rundir-regular-file",
+		Worktree:            t.TempDir(),
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	_, err := iso.Prepare(context.Background(), m)
+	if err == nil {
+		t.Fatalf("Prepare succeeded with a regular file at runDir; want hard-fail")
+	}
+	if !strings.Contains(err.Error(), "not a directory") {
+		t.Errorf("error message %q does not mention \"not a directory\"", err.Error())
+	}
+}
+
+// TestSandboxExecPrepare_NoErrorWhenContainersDisabled verifies the gate:
+// a missing PodmanProxySockPath dir must NOT fail Prepare on a
+// containers_enabled=false session, because the SBPL emits no allow for
+// the proxy in that case anyway. This protects existing sessions from
+// being broken by the new edge-case check.
+func TestSandboxExecPrepare_NoErrorWhenContainersDisabled(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	missingRunDir := filepath.Join(t.TempDir(), "never-mkdir-this-disabled")
+	proxyPath := filepath.Join(missingRunDir, "podman.sock")
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName: "repo@main",
+		InstanceID:  "test-rundir-disabled",
+		Worktree:    t.TempDir(),
+		// ContainersEnabled deliberately omitted — default false.
+		PodmanProxySockPath: proxyPath, // populated but ignored
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	args, err := iso.Prepare(context.Background(), m)
+	if err != nil {
+		t.Fatalf("Prepare returned error on containers_enabled=false session: %v", err)
+	}
+	if len(args) == 0 {
+		t.Errorf("Prepare returned empty args slice")
+	}
+}
+
+// TestSandboxExecPrepare_NoErrorWhenRunDirExists verifies the happy path:
+// when ContainersEnabled=true and the run dir is on disk (the production
+// posture, where the sidecar created it before agent-run was dispatched),
+// Prepare succeeds and writes the SBPL containing the literal allow.
+func TestSandboxExecPrepare_NoErrorWhenRunDirExists(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	runDir := t.TempDir()
+	proxyPath := filepath.Join(runDir, "podman.sock")
+
+	m := newSandboxExecManagerWithInstance(Config{
+		SessionName:         "repo@main",
+		InstanceID:          "test-rundir-exists",
+		Worktree:            t.TempDir(),
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+	})
+	t.Cleanup(func() {
+		_ = os.Remove(m.sandboxExecProfilePath())
+		if sessionDir, dirErr := m.sessionWorkDirPath(); dirErr == nil {
+			_ = os.RemoveAll(sessionDir)
+		}
+	})
+
+	iso := newSandboxExecIsolator(m.name)
+	args, err := iso.Prepare(context.Background(), m)
+	if err != nil {
+		t.Fatalf("Prepare returned error on existing run dir: %v", err)
+	}
+	if len(args) < 3 || args[1] != "-f" {
+		t.Fatalf("unexpected args shape: %v", args)
+	}
+
+	// Verify the rendered profile contains the literal allow for the
+	// proxy path — i.e. Prepare didn't just succeed, it actually emitted
+	// the grant the integration tests exercise.
+	content, readErr := os.ReadFile(args[2])
+	if readErr != nil {
+		t.Fatalf("read rendered profile: %v", readErr)
+	}
+	want := "(literal " + quoteSBPL(proxyPath) + "))"
+	if !strings.Contains(string(content), want) {
+		t.Errorf("rendered profile missing literal allow %q; full profile:\n%s", want, string(content))
+	}
+
+	// Confirm the scratch dir was also mkdir'd as part of the same Prepare
+	// call (so the integration test's stub-server setup doesn't need to
+	// pre-create it). This is the symmetric containers-enabled side
+	// effect to the bwrap-side mkdir in Step 4.
+	sessionDir, dirErr := m.sessionWorkDirPath()
+	if dirErr != nil {
+		t.Fatalf("sessionWorkDirPath: %v", dirErr)
+	}
+	scratchDir := SessionWorkDirContainerScratchPath(sessionDir)
+	if info, statErr := os.Stat(scratchDir); statErr != nil {
+		t.Errorf("container-scratch dir not created at %s after happy-path Prepare: %v", scratchDir, statErr)
+	} else if !info.IsDir() {
+		t.Errorf("container-scratch at %s is not a directory", scratchDir)
+	}
+}

--- a/modules/programs/prism/prism/internal/container/sandbox_exec_podman_proxy_test.go
+++ b/modules/programs/prism/prism/internal/container/sandbox_exec_podman_proxy_test.go
@@ -1,0 +1,221 @@
+package container
+
+// sandbox_exec_podman_proxy_test.go — unit tests for the conditional SBPL
+// allow that exposes the per-session filtering podman API socket inside the
+// sandbox-exec sandbox (issue #2317 §3c / #2322, Step 5).
+//
+// The integration coverage (positive + paired negative-mutation per the
+// AGENTS.md sandbox-exec testing convention) lives in
+// internal/integration/sandbox_exec_podman_proxy_darwin_test.go. This file
+// covers the rendering-level invariants that the integration test cannot
+// exercise without launching sandbox-exec:
+//
+//   - When ContainersEnabled=true and PodmanProxySockPath is set, the profile
+//     contains a literal RW allow for the exact path (and only the literal
+//     — no subpath form).
+//   - When ContainersEnabled=false (the default), no clause in the profile
+//     mentions the proxy socket path.
+//   - SECURITY: the upstream podman socket path never appears in the SBPL
+//     for ANY value of ContainersEnabled. This is the greppable security
+//     AC from #2322 — the proxy is load-bearing only if the agent has no
+//     path to bypass it.
+//   - Defence in depth: an empty PodmanProxySockPath with ContainersEnabled=true
+//     emits no allow rule, so a misconfigured caller cannot accidentally
+//     widen the grant.
+
+import (
+	"strings"
+	"testing"
+)
+
+// sentinelUpstreamPodmanSocketPath is a deliberately-recognisable stand-in
+// for the host-side podman socket path returned by `podman machine inspect`
+// on Darwin or $XDG_RUNTIME_DIR/podman/podman.sock on Linux. The
+// greppable security test asserts this exact byte sequence never appears
+// in the rendered SBPL for any value of ContainersEnabled. The sentinel is
+// long and includes a unique substring so a stray substring match on a
+// production-looking path (e.g. /tmp/podman/...) cannot give a false
+// negative.
+const sentinelUpstreamPodmanSocketPath = "/private/tmp/sentinel-upstream-podman-NEVER-IN-PROFILE-2322/podman.sock"
+
+// TestGenerateProfile_PodmanProxy_LiteralAllowWhenEnabled verifies that
+// when ContainersEnabled=true and PodmanProxySockPath is set, the profile
+// emits a literal RW allow for the proxy path — and only the literal
+// form. This is the §3c clause from #2317 (file-read* file-write* with
+// literal, not subpath, scope) and the canonical positive AC from #2322.
+func TestGenerateProfile_PodmanProxy_LiteralAllowWhenEnabled(t *testing.T) {
+	const proxyPath = "/private/tmp/prism-sbx-proxy-test/podman.sock"
+	m := newSandboxExecManager(Config{
+		SessionName:         "repo@main",
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+	})
+	profile := generateProfile(m)
+
+	wantClause := "(allow file-read* file-write*\n  (literal " + quoteSBPL(proxyPath) + "))"
+	if !strings.Contains(profile, wantClause) {
+		t.Errorf("profile missing literal allow for podman proxy socket.\nwant clause:\n%s\nfull profile:\n%s", wantClause, profile)
+	}
+
+	// The grant must be a literal, not a subpath. A (subpath ...) form would
+	// widen the grant to the entire run dir, undermining the §3c narrowing
+	// rationale.
+	bannedSubpath := "(subpath " + quoteSBPL(proxyPath) + ")"
+	if strings.Contains(profile, bannedSubpath) {
+		t.Errorf("profile contains a (subpath %q) grant for the podman proxy socket — must be (literal ...) only", proxyPath)
+	}
+}
+
+// TestGenerateProfile_PodmanProxy_NoMentionWhenDisabled verifies that with
+// ContainersEnabled=false (the default), NO clause in the profile mentions
+// the proxy socket path — even when the caller redundantly populates
+// PodmanProxySockPath. This is the default-off AC from #2322 and protects
+// against accidental widening on sessions that did not opt in.
+func TestGenerateProfile_PodmanProxy_NoMentionWhenDisabled(t *testing.T) {
+	const proxyPath = "/private/tmp/prism-sbx-proxy-disabled/podman.sock"
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "ContainersEnabled=false_PodmanProxySockPath_unset",
+			cfg: Config{
+				SessionName: "repo@main",
+			},
+		},
+		{
+			name: "ContainersEnabled=false_PodmanProxySockPath_populated_but_ignored",
+			cfg: Config{
+				SessionName:         "repo@main",
+				PodmanProxySockPath: proxyPath,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newSandboxExecManager(tc.cfg)
+			profile := generateProfile(m)
+
+			if strings.Contains(profile, proxyPath) {
+				t.Errorf("profile mentions podman proxy path %q despite ContainersEnabled=false; full profile:\n%s",
+					proxyPath, profile)
+			}
+			if strings.Contains(profile, "podman.sock") {
+				t.Errorf("profile contains the substring \"podman.sock\" despite ContainersEnabled=false (a default-off session must have no proxy surface); full profile:\n%s",
+					profile)
+			}
+		})
+	}
+}
+
+// TestGenerateProfile_PodmanProxy_EmptyPathEmitsNoAllow verifies the
+// defence-in-depth branch: when ContainersEnabled=true but PodmanProxySockPath
+// is empty (the caller failed to populate it), the generator emits no
+// allow rule at all rather than something like (literal "") which a future
+// SBPL engine could misinterpret. The call-site contract is "set both or
+// neither"; the generator enforces it.
+func TestGenerateProfile_PodmanProxy_EmptyPathEmitsNoAllow(t *testing.T) {
+	m := newSandboxExecManager(Config{
+		SessionName:         "repo@main",
+		ContainersEnabled:   true,
+		PodmanProxySockPath: "",
+	})
+	profile := generateProfile(m)
+
+	// The empty-literal form must never appear in the profile.
+	if strings.Contains(profile, `(literal "")`) {
+		t.Errorf("profile contains an empty-literal allow rule (defence-in-depth failure); full profile:\n%s", profile)
+	}
+	// As a tighter check, no clause should mention podman.sock either.
+	if strings.Contains(profile, "podman.sock") {
+		t.Errorf("profile contains \"podman.sock\" despite PodmanProxySockPath being empty; full profile:\n%s", profile)
+	}
+}
+
+// TestGenerateProfile_PodmanProxy_UpstreamPathNeverAppears is the
+// greppable security AC from #2322: the real upstream podman socket path
+// (the value returned by `podman machine inspect`) must never appear in
+// the rendered SBPL for ANY value of ContainersEnabled. The proxy is
+// load-bearing only if the agent has no path to bypass it — if the
+// upstream path leaked into the SBPL, the agent could connect(2) directly
+// and bypass the filter.
+//
+// We use a sentinel substring rather than a production-looking path so a
+// stray substring match cannot give a false negative. Both ContainersEnabled
+// values are exercised because the sentinel must NEVER appear, regardless
+// of how the gate is configured.
+func TestGenerateProfile_PodmanProxy_UpstreamPathNeverAppears(t *testing.T) {
+	// Cases enumerate the values of ContainersEnabled and PodmanProxySockPath
+	// that the dispatcher might legitimately produce. The sentinel path
+	// stands in for the upstream socket; we deliberately place it in
+	// places where a careless implementation might leak it (e.g. as the
+	// proxy path itself, or in BareRoot which is also embedded in the
+	// profile via the ancestor-probe rule).
+	cases := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "ContainersEnabled=false_no_proxy_path",
+			cfg: Config{
+				SessionName: "repo@main",
+			},
+		},
+		{
+			name: "ContainersEnabled=true_proxy_path_is_filtered_socket",
+			cfg: Config{
+				SessionName:         "repo@main",
+				ContainersEnabled:   true,
+				PodmanProxySockPath: "/private/tmp/prism-sbx-proxy-greppable/podman.sock",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newSandboxExecManager(tc.cfg)
+			profile := generateProfile(m)
+
+			if strings.Contains(profile, sentinelUpstreamPodmanSocketPath) {
+				t.Errorf("SBPL leaks the upstream podman socket sentinel %q — this would let the agent bypass the proxy.\nfull profile:\n%s",
+					sentinelUpstreamPodmanSocketPath, profile)
+			}
+			// Also assert the unique sentinel substring (without the
+			// leading slash) does not appear via some indirect rendering
+			// path. The substring is unique enough that any match indicates
+			// a real leak.
+			const sentinelMarker = "sentinel-upstream-podman-NEVER-IN-PROFILE-2322"
+			if strings.Contains(profile, sentinelMarker) {
+				t.Errorf("SBPL contains the upstream sentinel marker %q (path was reconstructed or partially leaked); full profile:\n%s",
+					sentinelMarker, profile)
+			}
+		})
+	}
+}
+
+// TestGenerateProfile_PodmanProxy_PathQuoting verifies that a podman proxy
+// path containing characters that need SBPL escaping (backslash, double
+// quote) is correctly quoted, so the resulting rule is syntactically valid
+// SBPL. Production paths under XDG_STATE_HOME don't contain these in
+// practice, but the quoter is the only line of defence against a future
+// caller passing through such a path.
+func TestGenerateProfile_PodmanProxy_PathQuoting(t *testing.T) {
+	cases := []string{
+		`/private/tmp/with"quote/podman.sock`,
+		`/private/tmp/with\backslash/podman.sock`,
+		`/private/tmp/plain/podman.sock`,
+	}
+	for _, proxyPath := range cases {
+		t.Run(proxyPath, func(t *testing.T) {
+			m := newSandboxExecManager(Config{
+				SessionName:         "repo@main",
+				ContainersEnabled:   true,
+				PodmanProxySockPath: proxyPath,
+			})
+			profile := generateProfile(m)
+			want := "(literal " + quoteSBPL(proxyPath) + "))"
+			if !strings.Contains(profile, want) {
+				t.Errorf("profile missing quoted literal for %q\nwant: %q\nfull profile:\n%s", proxyPath, want, profile)
+			}
+		})
+	}
+}

--- a/modules/programs/prism/prism/internal/container/session_work_dir.go
+++ b/modules/programs/prism/prism/internal/container/session_work_dir.go
@@ -135,20 +135,32 @@ func SessionWorkDirAllowedSignersPath(sessionDir string) string {
 	return filepath.Join(sessionDir, "allowed_signers")
 }
 
-// SessionWorkDirContainerScratchPath returns the per-session container
-// scratch directory inside the given session work dir (#2317 / #2321):
+// SessionWorkDirContainerScratchPath returns the per-session container-scratch
+// directory inside the given session work dir (issue #2317 §3b / #2322).
 //
 //	<sessionDir>/container-scratch
 //
-// This is the writable mount-source the bwrap profile binds Dst==Src into
-// the sandbox when ContainersEnabled is true, so an agent can
-// `podman run -v <sessionDir>/container-scratch:/x ...` without granting
-// the wider worktree to the spawned container. The directory is owned by
-// the per-session work dir lifecycle — RemoveSessionWorkDir wipes it on
-// cleanup along with the rest of the work dir tree (#2317 §3c).
+// This is the only sandbox path a worker may bind-mount RW into a podman
+// container alongside the worktree and bare repo (the proxy's host-side
+// path allowlist is the security-side enforcement — see
+// internal/sidecar/podman_proxy.go::allowedPodmanBindSources).
 //
-// Sandbox-exec (Step 5 / #2322) consumes the same helper so both isolation
-// modes share a single per-session container scratch story.
+// Sandbox shape:
+//   - bwrap (Step 4 / #2321) binds the path Dst==Src into the sandbox so
+//     a worker can `podman run -v <sessionDir>/container-scratch:/x ...`
+//     without granting the wider worktree to the spawned container.
+//   - sandbox-exec (Step 5 / #2322) rides on the section-6
+//     (subpath <sessionDir>) RW grant in the SBPL profile — no new SBPL
+//     clause is needed for the scratch dir itself.
+//
+// The directory is created by the per-isolator Prepare hook when
+// containers_enabled=1 (bwrapIsolator.Prepare / sandboxExecIsolator.Prepare
+// in lifecycle_dispatch.go), so the `podman run -v
+// <sessionDir>/container-scratch:/x ...` mount has its source on disk
+// before the proxy validates the create request.
+//
+// Lifecycle: removed automatically by RemoveSessionWorkDir on session end,
+// alongside the rest of the session work dir.
 func SessionWorkDirContainerScratchPath(sessionDir string) string {
 	return filepath.Join(sessionDir, "container-scratch")
 }

--- a/modules/programs/prism/prism/internal/integration/sandbox_exec_podman_proxy_darwin_test.go
+++ b/modules/programs/prism/prism/internal/integration/sandbox_exec_podman_proxy_darwin_test.go
@@ -1,0 +1,431 @@
+//go:build darwin
+
+package integration_test
+
+// sandbox_exec_podman_proxy_darwin_test.go — Darwin integration tests for
+// the conditional SBPL allow that exposes the per-session filtering podman
+// API socket inside the sandbox-exec sandbox (issue #2317 §3c / #2322,
+// Step 5).
+//
+// Per the AGENTS.md sandbox-exec testing convention
+// (modules/programs/prism/prism/docs/sandbox-exec-testing.md, issue #1192),
+// every change to generateProfile / Manager.PrepareSandboxExec must be
+// paired with:
+//
+//  1. A POSITIVE integration test that invokes /usr/bin/sandbox-exec against
+//     a Nix-built test binary and exercises the rule end-to-end. Here: a
+//     process inside the sandbox connect(2)s to <PodmanProxySockPath> and
+//     receives a sentinel response from a stub Unix-socket server running
+//     in the test process.
+//
+//  2. A NEGATIVE-MUTATION test that mutates the SBPL generator (via
+//     withMutatedProfile) to OMIT the literal allow clause, runs the same
+//     probe, and asserts it FAILS with the documented denial. This is what
+//     proves the positive test is not a no-op — substring assertions on
+//     profile content are necessary but not sufficient (see #1192 closure).
+//
+// The greppable security AC from #2322 ("the real upstream podman socket
+// path does NOT appear in the rendered SBPL for ANY value of
+// ContainersEnabled") is covered by the unit-test sibling under
+// internal/container/sandbox_exec_podman_proxy_test.go — it does not need
+// to invoke sandbox-exec.
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/container"
+)
+
+// podmanProxyProbeResponse is the sentinel byte sequence the stub server
+// writes back to a successful connect. The probe asserts these exact bytes
+// appear on stdout — anything else (empty output, partial bytes, sandbox
+// denial text) is a failure.
+const podmanProxyProbeResponse = "PRISM-PODMAN-PROXY-PROBE-OK-2322\n"
+
+// startStubPodmanProxyListener starts a Unix-socket listener at sockPath
+// in the test process, accepts a single connection in a goroutine, writes
+// podmanProxyProbeResponse, and closes the connection. The listener is
+// closed via t.Cleanup. The returned counter tracks the number of accepted
+// connections so the negative-mutation test can assert the sandbox never
+// reached the listener.
+//
+// This is a STUB — it does not implement the docker/podman HTTP API. The
+// goal of the integration test is to prove the SBPL literal allow is
+// load-bearing for the connect(2) syscall, not to exercise the full proxy
+// (which has its own unit tests under internal/podmanproxy/).
+func startStubPodmanProxyListener(t *testing.T, sockPath string) *atomic.Int32 {
+	t.Helper()
+
+	// Remove any stale socket from a previous run.
+	_ = os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen(\"unix\", %q): %v", sockPath, err)
+	}
+	t.Cleanup(func() {
+		_ = ln.Close()
+		_ = os.Remove(sockPath)
+	})
+
+	accepted := &atomic.Int32{}
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return // listener closed in cleanup
+			}
+			accepted.Add(1)
+			// Best-effort write; the sandboxed reader is reading until the
+			// listener half-closes, so we close immediately after writing.
+			_, _ = conn.Write([]byte(podmanProxyProbeResponse))
+			_ = conn.Close()
+		}
+	}()
+
+	return accepted
+}
+
+// requireNixSocat resolves a Nix-built socat binary via PATH and returns
+// its /nix/store/... absolute path. Skips the test when socat is not
+// found in PATH or does not resolve to a Nix store path.
+//
+// We use socat (rather than /usr/bin/nc -U, /usr/bin/curl --unix-socket,
+// or python3) because:
+//
+//   - /usr/bin/nc and /usr/bin/curl are Apple-signed binaries that SIGABRT
+//     in dyld4::CacheFinder under a deny-default SBPL profile (issue #1190
+//     — same reason the bash integration tests use Nix bash).
+//   - Homebrew Python is not guaranteed to be present on every Darwin dev
+//     machine; socat is a stable home-manager package on this codebase.
+//   - socat's one-liner `UNIX-CONNECT:<path>` is the most direct probe of
+//     the connect(2) syscall: it succeeds with exit 0 only if the kernel
+//     permits the AF_UNIX connect, which is exactly what the SBPL literal
+//     allow controls.
+func requireNixSocat(t *testing.T) string {
+	t.Helper()
+
+	socatPath, err := exec.LookPath("socat")
+	if err != nil {
+		t.Skipf("socat not found in PATH: %v", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(socatPath)
+	if err != nil {
+		t.Skipf("EvalSymlinks(%q): %v", socatPath, err)
+	}
+
+	if !strings.HasPrefix(resolved, "/nix/store/") {
+		t.Skipf("socat resolves to %q which is not a /nix/store/ path — cannot use as test binary (Apple-signed binaries SIGABRT under deny-default sandbox, see #1190)", resolved)
+	}
+
+	return resolved
+}
+
+// isolatedSocketDir returns a freshly-allocated directory under $HOME
+// suitable for hosting the test Unix-domain socket. The directory MUST be
+// outside every other RW grant in the production SBPL profile so that the
+// literal allow under test is the ONLY rule that can permit the in-sandbox
+// connect(2). Specifically, the directory must NOT live under any of:
+//
+//   - /tmp or /private/tmp (section 3 RW grant).
+//   - os.TempDir() / /var/folders/<...>/T (section 3b RW grant; this also
+//     covers t.TempDir() on Darwin).
+//   - <sessionDir> at <XDG_STATE_HOME>/prism/sessions/<instanceID> (section
+//     6 RW grant for the per-session work dir).
+//
+// If we used a path under any of these, the file-read*/file-write* check
+// during connect(2)'s namei() lookup would pass via the OTHER rule even
+// with the literal allow under test removed, and the negative-mutation
+// test would become a no-op — exactly the failure class the AGENTS.md
+// sandbox-exec testing convention exists to prevent.
+//
+// $HOME is the safe choice: the production profile grants no broad RW on
+// $HOME (only narrow per-subdir grants for ~/.cache/nix, ~/.aws/sso,
+// ~/.config/claude, etc., none of which match the .prism-2322-* prefix
+// below). The resulting path stays well under the Darwin sun_path limit
+// (104 bytes) because $HOME on Darwin is /Users/<user>, which is short.
+//
+// The directory is removed via t.Cleanup.
+func isolatedSocketDir(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home (needed for an isolated socket path): %v", err)
+	}
+	dir, err := os.MkdirTemp(home, ".prism-2322-podman-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) for isolated socket dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// newPodmanProxyProfileManager creates a Manager configured for a session
+// that has opted in to the filtering podman proxy. ContainersEnabled=true
+// and PodmanProxySockPath is set to the supplied socket path so generateProfile
+// emits the literal RW allow under test.
+//
+// BareRoot is set so the section-6b ancestor block fires, granting
+// file-test-existence / file-read-metadata along the $HOME → / chain.
+// Without it the in-sandbox namei() traversal of the proxy path
+// (e.g. /Users/<user>/.prism-2322-XYZ/podman.sock) would EPERM at
+// /Users/<user>/ before ever reaching the literal allow under test, and
+// the positive case would fail for an unrelated reason. The BareRoot
+// itself is unused by the test — only its ancestor-traversal side effect
+// matters.
+func newPodmanProxyProfileManager(t *testing.T, proxyPath string) *container.Manager {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	// Two-level dir structure under HOME (same pattern as
+	// newProfileManagerWithBareRoot in sandbox_exec_helpers_darwin_test.go):
+	// without the wrap level, BareRoot lives directly under HOME and the
+	// ancestor loop in generateProfile finds zero ancestors, skipping the
+	// section-6b block entirely.
+	wrap, err := os.MkdirTemp(home, ".prism-2322-bareroot-wrap-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) for BareRoot wrap: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(wrap) })
+	bareRoot, err := os.MkdirTemp(wrap, "bareroot-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(wrap) for BareRoot: %v", err)
+	}
+
+	instanceID := "integ-sbx-podman-" + strings.ReplaceAll(t.Name(), "/", "-")
+	cfg := container.Config{
+		SessionName:         "integ-sandbox-exec-podman-proxy-test",
+		InstanceID:          instanceID,
+		Worktree:            t.TempDir(),
+		BareRoot:            bareRoot,
+		ContainersEnabled:   true,
+		PodmanProxySockPath: proxyPath,
+		// Required since #1960 — see newProfileManager
+		// (sandbox_exec_helpers_darwin_test.go).
+		GitUserName:  "test-user",
+		GitUserEmail: "test@example.com",
+	}
+	return container.New(cfg)
+}
+
+// TestSandboxExecPodmanProxy_ConnectSucceedsWhenLiteralAllowed is the
+// positive integration test. It stands up a stub Unix-socket server in the
+// test process at <runDir>/podman.sock and verifies that a Nix-socat
+// invocation inside the sandbox can connect(2), exchange bytes, and read
+// the sentinel response.
+//
+// The sentinel response on stdout proves end-to-end success:
+//   - sandbox-exec applied the profile (no policy error).
+//   - The literal RW allow on PodmanProxySockPath permitted the connect(2).
+//   - The stub server accepted, wrote the sentinel, and closed.
+//   - socat wrote the bytes through to stdout.
+//
+// Any other outcome — empty stdout, EPERM, exit non-zero — fails the test.
+func TestSandboxExecPodmanProxy_ConnectSucceedsWhenLiteralAllowed(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixSocat := requireNixSocat(t)
+
+	runDir := isolatedSocketDir(t)
+	proxyPath := filepath.Join(runDir, "podman.sock")
+	accepted := startStubPodmanProxyListener(t, proxyPath)
+
+	m := newPodmanProxyProfileManager(t, proxyPath)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	// Confirm the profile contains the literal allow under test. This is
+	// a belt-and-braces check — the negative-mutation test below proves
+	// the rule is load-bearing, but if the rule isn't present at all the
+	// positive test would also fail (in a confusing way).
+	wantClause := "(literal " + sbplQuoteForTest(proxyPath) + ")"
+	if !strings.Contains(prepared.content, wantClause) {
+		t.Fatalf("generated profile does not contain literal allow %q — the SBPL clause under test was not emitted.\nProfile:\n%s",
+			wantClause, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	// socat exit 0 + sentinel on stdout = pass. The `-t 2` gives the read
+	// side 2s after EOF to drain any buffered bytes (default is 0.5s).
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixSocat, "-t", "2", "-", "UNIX-CONNECT:"+proxyPath)
+	cmd.Stdin = bytes.NewReader(nil) // close stdin so socat exits after EOF
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("socat UNIX-CONNECT %s failed under production profile.\n"+
+			"This means the literal allow for the podman proxy socket is not\n"+
+			"load-bearing — connect(2) was denied even with ContainersEnabled=true.\n"+
+			"Exit: %v\nOutput: %q\nProfile: %s",
+			proxyPath, runErr, string(out), testProfilePath)
+	}
+	if !strings.Contains(string(out), strings.TrimSpace(podmanProxyProbeResponse)) {
+		t.Errorf("stdout does not contain probe sentinel — connection may have been silently dropped.\n"+
+			"want substring: %q\ngot stdout: %q\nProfile: %s",
+			podmanProxyProbeResponse, string(out), testProfilePath)
+	}
+	if accepted.Load() == 0 {
+		t.Errorf("stub server recorded zero accepts — the sandboxed socat never reached the listener (sandbox redirected the connect?)\nOutput: %q", string(out))
+	}
+}
+
+// TestSandboxExecPodmanProxy_ConnectDeniedWithoutLiteralAllow is the
+// paired negative-mutation test. It mutates the SBPL profile to OMIT the
+// literal allow for PodmanProxySockPath, runs the same probe as the positive
+// test, and asserts the connect FAILS. This is the AGENTS.md-mandated
+// proof that the positive test is not a no-op: the SBPL clause is the
+// specific mechanism that permits the connect(2).
+//
+// Mutation strategy: replace the literal allow line emitted by
+// generateProfile with an empty string. If the substitution fails to
+// match anything in the profile (e.g. because the rule text drifted),
+// withMutatedProfile fails the test loudly — a silent no-op mutation is
+// a common source of bogus passes.
+func TestSandboxExecPodmanProxy_ConnectDeniedWithoutLiteralAllow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixSocat := requireNixSocat(t)
+
+	runDir := isolatedSocketDir(t)
+	proxyPath := filepath.Join(runDir, "podman.sock")
+	accepted := startStubPodmanProxyListener(t, proxyPath)
+
+	m := newPodmanProxyProfileManager(t, proxyPath)
+
+	// The production generator emits the rule as:
+	//
+	//   (allow file-read* file-write*
+	//     (literal "<proxyPath>"))
+	//
+	// Match the verbatim shape so a future formatting change fails
+	// withMutatedProfile's no-op detection rather than silently passing.
+	productionRule := "(allow file-read* file-write*\n  (literal " + sbplQuoteForTest(proxyPath) + "))\n"
+	mutatedPath := withMutatedProfile(t, m, func(p string) string {
+		return strings.ReplaceAll(p, productionRule, "")
+	})
+
+	cmd := exec.Command(sandboxExecPath, "-f", mutatedPath,
+		nixSocat, "-t", "2", "-", "UNIX-CONNECT:"+proxyPath)
+	cmd.Stdin = bytes.NewReader(nil)
+	// Bound the runtime — a denied connect should fail fast, but if for
+	// some reason socat hangs we want a deterministic test failure rather
+	// than a CI timeout.
+	cmd.WaitDelay = 10 * time.Second
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("socat UNIX-CONNECT %s succeeded (exit 0) WITHOUT the literal allow.\n"+
+			"The negative-mutation test is not catching the regression — investigate.\n"+
+			"Output: %q\nMutated profile: %s", proxyPath, string(out), mutatedPath)
+	} else {
+		t.Logf("ka pai — UNIX-CONNECT correctly denied without literal allow (exit: %v, output: %q)", runErr, string(out))
+	}
+
+	// Sanity: the stub listener must not have received any successful
+	// connections. A non-zero accept count would mean the sandbox allowed
+	// the connect by some other rule, undermining the negative test.
+	if accepted.Load() > 0 {
+		t.Errorf("stub server recorded %d accept(s) despite the literal allow being removed — some other SBPL rule is permitting the connect", accepted.Load())
+	}
+}
+
+// TestSandboxExecPodmanProxy_NoProxyMentionWhenDisabled is a defence-in-depth
+// integration check: a session with ContainersEnabled=false has no literal
+// allow rule for the proxy path, and the same socat probe inside the
+// sandbox fails. This pairs with the unit-test default-off assertion
+// (TestGenerateProfile_PodmanProxy_NoMentionWhenDisabled) at the
+// integration layer — proving the gate is honoured end-to-end, not just
+// at the SBPL-rendering layer.
+func TestSandboxExecPodmanProxy_NoProxyMentionWhenDisabled(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("sandbox-exec is Darwin-only")
+	}
+	requireSandboxExec(t)
+	nixSocat := requireNixSocat(t)
+
+	runDir := isolatedSocketDir(t)
+	proxyPath := filepath.Join(runDir, "podman.sock")
+	accepted := startStubPodmanProxyListener(t, proxyPath)
+
+	// Construct a manager WITHOUT ContainersEnabled but otherwise shaped
+	// identically to the positive test (BareRoot set so the section-6b
+	// ancestor block fires — the test is otherwise gated by namei rather
+	// than the rule under test).
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skipf("cannot determine user home: %v", err)
+	}
+	wrap, err := os.MkdirTemp(home, ".prism-2322-disabled-wrap-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(home) for BareRoot wrap: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(wrap) })
+	bareRoot, err := os.MkdirTemp(wrap, "bareroot-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(wrap) for BareRoot: %v", err)
+	}
+	cfg := container.Config{
+		SessionName: "integ-sandbox-exec-podman-disabled-test",
+		InstanceID:  "integ-sbx-podman-disabled-" + strings.ReplaceAll(t.Name(), "/", "-"),
+		Worktree:    t.TempDir(),
+		BareRoot:    bareRoot,
+		// ContainersEnabled deliberately false.
+		// PodmanProxySockPath deliberately populated to assert the gate
+		// short-circuits before the rule is emitted.
+		PodmanProxySockPath: proxyPath,
+		GitUserName:         "test-user",
+		GitUserEmail:        "test@example.com",
+	}
+	m := container.New(cfg)
+	prepared, _ := preparePositiveProfile(t, m)
+
+	if strings.Contains(prepared.content, proxyPath) {
+		t.Fatalf("default-off profile mentions %q despite ContainersEnabled=false — gate is broken.\nProfile:\n%s",
+			proxyPath, prepared.content)
+	}
+
+	testProfilePath := writeAugmentedPositiveProfile(t, prepared)
+
+	cmd := exec.Command(sandboxExecPath, "-f", testProfilePath,
+		nixSocat, "-t", "2", "-", "UNIX-CONNECT:"+proxyPath)
+	cmd.Stdin = bytes.NewReader(nil)
+	cmd.WaitDelay = 10 * time.Second
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Errorf("UNIX-CONNECT succeeded on a ContainersEnabled=false session.\n"+
+			"Output: %q\nProfile: %s", string(out), testProfilePath)
+	}
+	if accepted.Load() > 0 {
+		t.Errorf("stub server recorded %d accept(s) on a ContainersEnabled=false session — gate failure", accepted.Load())
+	}
+
+	// Bonus sanity: net.Dial from the test process (NOT inside the sandbox)
+	// must still succeed — this confirms the stub server is up and the only
+	// thing preventing the in-sandbox connect is the SBPL policy itself,
+	// not some unrelated listener misconfiguration. errors.Is os.ErrNotExist
+	// is treated as "fine" because the listener may have been torn down by
+	// cleanup race; the test is best-effort here.
+	c, dialErr := net.DialTimeout("unix", proxyPath, time.Second)
+	if dialErr == nil {
+		_ = c.Close()
+	} else if !errors.Is(dialErr, os.ErrNotExist) {
+		t.Logf("out-of-sandbox dial probe: %v (informational — not a failure)", dialErr)
+	}
+}


### PR DESCRIPTION
Step 5 of #2317 — exposes the per-session filtering podman API socket inside the Darwin sandbox-exec sandbox. Plumbing-only; no policy changes (Step 1's `internal/podmanproxy` package still owns the default-deny model).

`Refs #2317`
`Refs #2322`

## What this PR does

1. **`container.Config`** gains two fields:
   - `ContainersEnabled bool` — runtime gate propagated from `agent_status.containers_enabled` (added by Step 2 / #2319).
   - `PodmanProxyPath string` — absolute host path of the filtered socket the sidecar binds (resolved by the caller via `session.SidecarPodmanProxyPath`).

2. **`generateProfile`** emits a conditional SBPL clause when `ContainersEnabled && PodmanProxyPath != ""`:
   ```
   (allow file-read* file-write*
     (literal "<PodmanProxyPath>"))
   ```
   `literal`, not `subpath` — per #2317 §3c. The per-session run dir also holds `hostapi.sock` and `pipe.sock` (covered by the existing section-6 work-dir grant); the literal narrowing keeps any future content of the dir isolated from the sandboxed process.

3. **`PrepareSessionWorkDir`** `mkdir`s `<sessionDir>/container-scratch/` when `ContainersEnabled=true`. The scratch dir rides on the existing `(subpath <sessionDir>)` RW grant — no new SBPL clause needed for the scratch dir itself.

4. **`sandboxExecIsolator.Prepare`** hard-fails when `ContainersEnabled=true` but the per-session run dir (parent of `PodmanProxyPath`) doesn't exist. Production sequencing guarantees the dir exists by the time `agent-run` is dispatched (the sidecar binds `hostapi.sock` first, which `mkdir`s the run dir); a missing dir here means sidecar startup failed, and rendering an SBPL allow for a non-existent literal is a security smell — sandbox-exec silently ignores it today, but a future-created file at that path would inherit the grant.

5. **`cmd/agent_run_sandbox_exec_darwin.go`** populates the new Config fields from `status.ContainersEnabled` + `SidecarPodmanProxyPath`, and injects two env vars (mirroring the existing `PRISM_HOST_API` pattern at the same call site):
   ```
   CONTAINER_HOST=unix://<PodmanProxyPath>
   DOCKER_HOST=unix://<PodmanProxyPath>
   ```

## Security: the upstream path must NEVER leak

The whole point of the proxy is that the agent only sees the FILTERED socket. If the upstream socket path (the value returned by `podman machine inspect` on Darwin or `$XDG_RUNTIME_DIR/podman/podman.sock` on Linux) leaked into the SBPL, the agent could `connect()` directly and bypass the proxy entirely.

`TestGenerateProfile_PodmanProxy_UpstreamPathNeverAppears` asserts a sentinel substring stand-in for the upstream path NEVER appears in the rendered SBPL for any value of `ContainersEnabled`. The sentinel marker is intentionally unique (`sentinel-upstream-podman-NEVER-IN-PROFILE-2322`) so a stray substring match cannot give a false negative.

## Tests — paired positive + negative-mutation per AGENTS.md

Per the [sandbox-exec testing convention](https://github.com/prismatic-koi/nixos-config/blob/main/modules/programs/prism/prism/docs/sandbox-exec-testing.md) (#1192).

### Positive integration test

`internal/integration/sandbox_exec_podman_proxy_darwin_test.go::TestSandboxExecPodmanProxy_ConnectSucceedsWhenLiteralAllowed`:

- Stand up a stub Unix-socket server in the test process at `<isolatedDir>/podman.sock`. The stub writes a sentinel response on every connection.
- Generate the SBPL with `ContainersEnabled=true` and `PodmanProxyPath` set to that path.
- `sandbox-exec` runs Nix-built `socat UNIX-CONNECT:<path>` — it must succeed and `stdout` must contain the sentinel response.

### Paired negative-mutation test

`TestSandboxExecPodmanProxy_ConnectDeniedWithoutLiteralAllow`:

- `withMutatedProfile` strips the exact production rule string from the rendered SBPL. If the substitution doesn't match anything (e.g. rule text drifted), `withMutatedProfile` fails loudly — silent no-op mutations are the canonical bogus-pass failure.
- The same `socat` probe must FAIL with the rule removed, proving the literal allow is what permits the `connect`.

### Socket location

The socket lives in a freshly-created dir under `$HOME` (with the `.prism-2322-podman-test-` prefix). This is **load-bearing**: the production profile grants RW on `/tmp` (section 3), `/var/folders/.../T` (section 3b, which covers Darwin's `t.TempDir()`), and `<sessionDir>` (section 6). If the socket lived in any of those, the file-* check during `connect(2)`'s `namei()` would pass via the other rule even with the literal allow removed, and the negative-mutation would become a no-op — exactly the failure class the AGENTS.md convention exists to prevent. `$HOME` itself has no broad RW grant (only narrow per-subdir grants for `~/.cache/nix`, `~/.aws/sso`, `~/.config/claude`, etc., none of which match the test prefix).

`BareRoot` is set on the test manager so the section-6b ancestor block fires, granting `file-test-existence`/`file-read-metadata` on `$HOME`. Without this the in-sandbox `namei()` traversal of `/Users/<user>/.prism-2322-XYZ/podman.sock` would EPERM at `/Users/<user>/` for an unrelated reason.

### Unit-level coverage

`internal/container/sandbox_exec_podman_proxy_test.go` (pure-Go, runs on every platform under the `go-tests` CI job):

- `LiteralAllowWhenEnabled` — the literal rule shape is emitted; `(subpath …)` form is rejected.
- `NoMentionWhenDisabled` — `ContainersEnabled=false` emits no clause mentioning `podman.sock`, even when `PodmanProxyPath` is populated.
- `EmptyPathEmitsNoAllow` — `ContainersEnabled=true` + empty path emits no rule (defence-in-depth call-site contract).
- `UpstreamPathNeverAppears` — greppable security AC from #2322.
- `PathQuoting` — SBPL-escaping handles backslashes and quotes.

`internal/container/sandbox_exec_podman_proxy_prepare_test.go`:

- `CreatesContainerScratchWhenEnabled` / `NoContainerScratchWhenDisabled` / `ContainerScratchIdempotent`
- `ErrorsWhenRunDirMissing` / `ErrorsWhenRunDirIsRegularFile` — edge-case AC from #2322.
- `NoErrorWhenContainersDisabled` — gate honoured: missing run dir doesn't break default-off sessions.
- `NoErrorWhenRunDirExists` — happy path emits the literal allow.

## Verification

- `gofmt -l .` clean.
- `go build ./...` from `modules/programs/prism/prism/`.
- `go test ./...` — all packages pass; new tests pass on Linux (unit) and skip-with-explanation on Darwin-nested (integration).
- `nix build .#prism` from repo root.
- `nix build --impure --no-link --expr '(builtins.getFlake (toString ./.)).packages.aarch64-darwin.prism.override { runChecks = true; }'` — homeless-shelter CI gate passes locally.

## Out of scope

- bwrap profile changes (`CONTAINER_HOST`/`DOCKER_HOST` + container-scratch bind) — Step 4 (#2321).
- `prism spawn --containers` CLI flag — Step 6 (#2323).
- Cleanup integration (orphan container sweep) — Step 7.
- Final wiring / docs / closure — Step 8 (#2325).
