### PR TITLE
prism: cleanup integration sweeps orphan containers (Step 7 of #2317)

### DIFF
--- a/modules/programs/prism/prism/cmd/cleanup.go
+++ b/modules/programs/prism/prism/cmd/cleanup.go
@@ -242,6 +242,11 @@ func (m cleanupModel) doCleanup() tea.Cmd {
 			if isolationModeFromDB(d, m.session) != "host" {
 				removeContainerIfExists(m.session)
 			}
+			// Orphan-container sweep (#2324 Step 7). The interactive TUI
+			// path does not surface a JSON envelope — the count goes into
+			// the warning log only. Passing result=nil keeps the helper
+			// safe even though there is nothing to record.
+			applyOrphanContainerSweep(m.session, nil)
 			if releaseErr := d.ReleasePort(m.session); releaseErr != nil {
 				proglog.Errorf("[prism] doCleanup: release port: %v\n", releaseErr)
 			}
@@ -530,6 +535,14 @@ type cleanupResult struct {
 	EndedAtStamped          any     `json:"ended_at_stamped"`
 	HarnessPortReleased     any     `json:"harness_port_released"`
 	HarnessSessionIDCleared any     `json:"harness_session_id_cleared"`
+	// ContainersSwept reports the number of orphan containers
+	// (matching prism-<session>-<8 hex> on the host) removed by the
+	// containers_enabled=1 sweep. nil omits the field entirely from
+	// the JSON envelope per the #2324 contract: when containers_enabled=0,
+	// the cleanup path issues NO podman commands AND emits no
+	// containers_swept key. *int (not int + omitempty) is used so a
+	// run that produces zero matches still emits "containers_swept": 0.
+	ContainersSwept *int `json:"containers_swept,omitempty"`
 }
 
 // applyDBLifecycleClears performs the agent_status lifecycle updates for
@@ -726,6 +739,15 @@ func headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot str
 		if isolationModeFromDB(d, session) != "host" {
 			removeContainerIfExists(session)
 		}
+		// Orphan-container sweep (#2324 Step 7). Gated on the
+		// session's agent_status.containers_enabled column inside
+		// sweepOrphanContainersForSession; when the flag is 0 this
+		// is a fast DB read and no podman commands are issued. Runs
+		// after removeContainerIfExists so the session's own
+		// runtime container has already been torn down — the sweep
+		// only deals with DERIVATIVE containers the agent created
+		// via the proxy.
+		applyOrphanContainerSweep(session, &result)
 		// Capture instance_id and isolation_mode before SetEnded clears the
 		// row's lifecycle fields. Done before applyDBLifecycleClears so the
 		// CurrentStatus reads inside instanceIDFromStatus still observe the
@@ -781,6 +803,10 @@ func headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot str
 		proglog.Errorf("[prism] headlessCleanup: open db: %v\n", err)
 		review.KillReviewSessionsForParent(session)
 		removeContainerIfExists(session)
+		// No sweep here: containers_enabled is unreadable without the
+		// DB. Skipping the sweep matches the AC "containers_enabled=0
+		// → no podman commands" in spirit: when we cannot prove the
+		// flag was on, default to off.
 	}
 	if archiveCollisionWarning != "" {
 		proglog.Warnf("[prism] warning: archive: %s — continuing cleanup\n", archiveCollisionWarning)
@@ -791,6 +817,25 @@ func headlessCleanupWithJSONTo(session, worktreeName, worktreePath, bareRoot str
 		fmt.Fprintln(stdout, "done")
 	}
 	return nil
+}
+
+// applyOrphanContainerSweep runs the #2324 orphan-container sweep for
+// session and, when the sweep actually ran (containers_enabled=1),
+// records the count on result.ContainersSwept so it surfaces in the
+// --json envelope. When containers_enabled=0 the field stays nil and
+// the JSON encoder omits it entirely (json:"containers_swept,omitempty").
+//
+// Errors inside the sweep are non-fatal and logged at warning level by
+// the sweep itself; the helper has no error path of its own.
+func applyOrphanContainerSweep(session string, result *cleanupResult) {
+	count, ran := sweepOrphanContainersForSession(session)
+	if !ran {
+		return
+	}
+	if result != nil {
+		c := count
+		result.ContainersSwept = &c
+	}
 }
 
 // closeSession redirects attached clients to scratchpad, kills the tmux
@@ -821,6 +866,10 @@ func closeSession(session string) error {
 		if isolationModeFromDB(d, session) != "host" {
 			removeContainerIfExists(session)
 		}
+		// Orphan-container sweep (#2324 Step 7). closeSession is the
+		// interactive @main / non-worktree path and does not surface a
+		// JSON envelope; the helper records the count into the log only.
+		applyOrphanContainerSweep(session, nil)
 		if releaseErr := d.ReleasePort(session); releaseErr != nil {
 			proglog.Errorf("[prism] closeSession: release port: %v\n", releaseErr)
 		}
@@ -939,6 +988,12 @@ func headlessCloseSessionWithJSONTo(session string, jsonMode bool, stdout io.Wri
 		if isolationModeFromDB(d, session) != "host" {
 			removeContainerIfExists(session)
 		}
+		// Orphan-container sweep (#2324 Step 7). See headlessCleanupWithJSONTo
+		// for the placement rationale — the gate is in
+		// sweepOrphanContainersForSession, so calling it on a non-container
+		// session (containers_enabled=0) is a fast DB read with no podman
+		// commands issued.
+		applyOrphanContainerSweep(session, &result)
 		instanceIDForSessions := instanceIDFromStatus(d, session)
 		isolationMode := isolationModeFromDB(d, session)
 		// Apply the lifecycle clears — release harness_port and stamp

--- a/modules/programs/prism/prism/cmd/cleanup_sweep.go
+++ b/modules/programs/prism/prism/cmd/cleanup_sweep.go
@@ -1,0 +1,255 @@
+package cmd
+
+// Orphan-container sweep for sessions with containers_enabled=1
+// (Step 7 of #2317 / #2324).
+//
+// The sweep complements the per-mode container teardown that
+// `removeContainerIfExists` already performs: that path removes the
+// SESSION'S OWN bwrap/podman/sandbox-exec container (the agent's
+// runtime), while this path sweeps any DERIVATIVE containers the
+// agent created via the proxy during the session. The naming
+// convention enforced by `internal/podmanproxy::applyContainerNamePolicy`
+// is `prism-<sessionName>-<8 hex chars>` — the sweep filter targets
+// exactly that strict shape so a sibling session whose name shares
+// a prefix (e.g. session "foo" vs session "foo-bar") cannot be
+// caught by accident.
+//
+// The sweep is best-effort: every podman invocation is bounded by a
+// shared 30-second context, and any failure (podman not on PATH,
+// machine off, socket missing, rm returns non-zero) is logged at
+// warning level and does NOT abort cleanup. The worktree and DB
+// teardown ALWAYS run regardless of sweep outcome — the
+// containers_swept count is just an observability field in the
+// `--json` envelope.
+//
+// Test seam: the runner that shells out to `podman` is interface-
+// dispatched via `podmanRunnerForTest`, set by tests through
+// SetTestPodmanRunner. Production wires it to execPodmanRunner.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/prismatic-koi/prism/internal/proglog"
+)
+
+// podmanSweepBudget is the upper bound on the total time the orphan
+// sweep may consume per session. The two podman invocations (ps + rm)
+// share this single context — there is no per-invocation budget.
+//
+// 30 seconds matches the per-mode container teardown in
+// `removeContainerIfExists` (35s for the isolator's stop+rm). The
+// sweep is downstream of that and only deals with orphan derivatives
+// that the agent created, so a tighter cap is acceptable; the issue
+// AC names "≤30 seconds total".
+const podmanSweepBudget = 30 * time.Second
+
+// podmanRunner is the test-seamable wrapper around the `podman`
+// binary. Tests inject a stub via SetTestPodmanRunner; production
+// uses execPodmanRunner. Keeping this interface narrow (a single
+// Run method) makes the test stub trivially expressive — it just
+// records arguments and returns canned output / error.
+type podmanRunner interface {
+	// Run invokes `podman` with the supplied args. The combined
+	// stdout (and only stdout — stderr is dropped, matching the
+	// docker/podman convention that progress messages should not
+	// confuse the parser) is returned on success. On non-zero
+	// exit, err is non-nil and stdout may carry partial output.
+	Run(ctx context.Context, args ...string) (stdout []byte, err error)
+}
+
+// execPodmanRunner is the production implementation backed by
+// `exec.CommandContext("podman", args...)`. The binary is resolved
+// from PATH at invocation time, so a host without podman installed
+// returns exec.ErrNotFound and the sweep logs a single warning then
+// continues.
+type execPodmanRunner struct{}
+
+func (execPodmanRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "podman", args...)
+	return cmd.Output()
+}
+
+// podmanRunnerForTest is overridden by tests. nil means "use the
+// production execPodmanRunner". The package-level global mirrors
+// the SetTestDBPath pattern already established for cmd-package
+// tests (see cmd/db.go).
+var podmanRunnerForTest podmanRunner
+
+// SetTestPodmanRunner overrides the podman runner used by the
+// orphan-container sweep. Pass nil to restore the production
+// execPodmanRunner. Only intended for tests; production code MUST
+// NOT call this.
+func SetTestPodmanRunner(r podmanRunner) { podmanRunnerForTest = r }
+
+func currentPodmanRunner() podmanRunner {
+	if podmanRunnerForTest != nil {
+		return podmanRunnerForTest
+	}
+	return execPodmanRunner{}
+}
+
+// sweepOrphanContainersForSession runs the orphan-container sweep
+// for sessionName, gated on the session's agent_status.containers_enabled
+// column. Returns:
+//
+//	count : number of containers force-removed.
+//	ran   : true if the sweep ran (containers_enabled=1 and the DB
+//	        read succeeded); false if it was a no-op (containers_enabled=0,
+//	        row missing, or DB error).
+//
+// When ran is false the JSON envelope MUST omit the
+// "containers_swept" field entirely — this is the spec.
+//
+// Errors from podman are NEVER fatal: they're surfaced as warnings
+// via proglog.Warnf and the function returns whatever count it
+// managed to confirm (0 on failure).
+func sweepOrphanContainersForSession(sessionName string) (count int, ran bool) {
+	d, err := openDB()
+	if err != nil {
+		// DB unavailable. The cleanup caller logs the DB-open error
+		// separately; we silently skip the sweep here. Returning
+		// ran=false is structurally correct: a session whose
+		// containers_enabled value we could not read is treated as
+		// "do not issue podman commands" per the AC
+		// "containers_enabled=0 → no podman commands". This is the
+		// safe direction — we'd rather skip a sweep than spawn a
+		// spurious warning for a session that didn't use the proxy.
+		return 0, false
+	}
+	defer d.Close()
+	status, err := d.CurrentStatus(sessionName)
+	if err != nil || status == nil || !status.ContainersEnabled {
+		return 0, false
+	}
+	return sweepWithRunner(currentPodmanRunner(), sessionName), true
+}
+
+// containerNamePattern returns the strict regex that matches the
+// auto-prefix container name shape produced by Half 1 of #2324:
+// `prism-<sessionName>-<8 lowercase hex chars>`.
+//
+// Strict-shape filtering (not just "starts with prefix") is the
+// security AC: a sibling session "foo-bar" whose containers are
+// "prism-foo-bar-XXXXXXXX" must NOT be swept when cleaning session
+// "foo". Simple prefix matching cannot distinguish those two cases
+// because "prism-foo-bar-XXXXXXXX" starts with "prism-foo-". The
+// trailing `[a-f0-9]{8}$` anchor closes that gap by relying on the
+// random-suffix shape Half 1 enforces.
+//
+// User-supplied Names that pass Half 1's prefix check but do not
+// match this strict shape (e.g. "prism-foo-myname") are NOT swept
+// — the user took ownership of the name and is responsible for
+// teardown. This is a documented limitation of the auto-sweep
+// design and is acceptable: the sweep is a safety net for orphan
+// auto-named containers, not a comprehensive teardown for all
+// possible naming patterns.
+func containerNamePattern(sessionName string) *regexp.Regexp {
+	prefix := "prism-" + sessionName + "-"
+	return regexp.MustCompile("^" + regexp.QuoteMeta(prefix) + "[a-f0-9]{8}$")
+}
+
+// sweepWithRunner is the inner sweep, called with an explicit runner
+// (production uses execPodmanRunner; tests inject a stub). Returns
+// the number of containers actually force-removed.
+//
+// Flow:
+//  1. Build the strict regex pattern for this session.
+//  2. Call `podman ps -a --filter name=<anchored-regex> --format {{.Names}}`.
+//     The anchored regex is the FIRST line of defence: podman libpod's
+//     filter is regex-matched, so an anchored regex on the podman
+//     side already excludes most non-matching containers.
+//  3. Re-filter the result in Go with the same regex. This is
+//     defence-in-depth against any podman version that interprets
+//     the filter as a substring match (the docker compat surface
+//     historically does); without this Go-side re-check, a substring
+//     match on the podman side could leak a sibling session's
+//     containers into the rm batch.
+//  4. If any names survive both filters, invoke `podman rm -f` on
+//     them in a single batch. Empty list short-circuits — no rm
+//     invocation, count returned as 0.
+//
+// Failures at any step log a warning and return what we have so
+// far. The cleanup flow continues regardless.
+func sweepWithRunner(runner podmanRunner, sessionName string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), podmanSweepBudget)
+	defer cancel()
+
+	pattern := containerNamePattern(sessionName)
+	// The libpod `name` filter is a regex on the container name.
+	// We anchor at the start AND at the end (via the regex) so the
+	// suffix shape excludes sibling-prefix matches. QuoteMeta is
+	// belt-and-braces — session names use only `@`, alphanumerics,
+	// hyphens, and dots, none of which are regex metacharacters in
+	// practice, but a future relaxation of the session-name
+	// character set should not silently turn into a regex injection.
+	podmanFilter := "name=" + pattern.String()
+
+	out, err := runner.Run(ctx, "ps", "-a",
+		"--filter", podmanFilter,
+		"--format", "{{.Names}}")
+	if err != nil {
+		// Common, non-fatal failure modes:
+		//   - podman not installed (exec.ErrNotFound)
+		//   - Darwin machine off (`Cannot connect to Podman`)
+		//   - Linux user systemd not running (ECONNREFUSED)
+		// In all cases the agent's session never had a container
+		// running, so there is nothing to sweep. Log once and
+		// continue.
+		proglog.Warnf("[prism] warning: cleanup: orphan-container sweep: podman ps for %q failed (%v) — continuing cleanup\n",
+			sessionName, err)
+		return 0
+	}
+
+	var names []string
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		name := strings.TrimSpace(string(line))
+		if name == "" {
+			continue
+		}
+		// Defence-in-depth: enforce strict-shape match in Go even
+		// if podman returned extras. This is the load-bearing check
+		// for the security AC.
+		if !pattern.MatchString(name) {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return 0
+	}
+
+	// Single batched `podman rm -f` for the matched names. xargs is
+	// fine on the shell side but we avoid the shell entirely by
+	// passing the names directly as arguments. `rm -f` on a name
+	// that is already gone (race with another cleanup) is
+	// non-fatal — podman returns a non-zero exit but the residual
+	// state is "container is gone", which is the desired post-
+	// condition. We log a warning but treat the count as the
+	// number of names we asked to remove.
+	args := append([]string{"rm", "-f"}, names...)
+	if _, err := runner.Run(ctx, args...); err != nil {
+		proglog.Warnf("[prism] warning: cleanup: orphan-container sweep: podman rm for %q failed (%v) — some containers may remain\n",
+			sessionName, err)
+		// Return 0 because we don't know how many were actually
+		// removed. Reporting a guessed count would mislead the
+		// operator into thinking the sweep succeeded.
+		return 0
+	}
+	return len(names)
+}
+
+// formatPodmanArgs is a small debugging helper that renders a slice
+// of args into a single space-joined string for inclusion in
+// warning messages. Not exported; kept local so the tests can use
+// it via the export_test.go pattern if needed in the future.
+//
+//nolint:unused // retained for future debugging surface
+func formatPodmanArgs(args []string) string {
+	return fmt.Sprintf("podman %s", strings.Join(args, " "))
+}

--- a/modules/programs/prism/prism/cmd/cleanup_sweep_test.go
+++ b/modules/programs/prism/prism/cmd/cleanup_sweep_test.go
@@ -1,0 +1,505 @@
+package cmd
+
+// Tests for the #2324 Step-7 orphan-container sweep.
+//
+// The sweep is wired into the four cleanup paths via
+// applyOrphanContainerSweep; this file exercises the sweep in
+// isolation through sweepWithRunner (the test-injectable inner
+// function) and end-to-end through headlessCleanupWithJSON with a
+// stub podmanRunner.
+//
+// The discipline mirrors the existing cmd/cleanup_lifecycle_test.go:
+// SetTestDBPath to redirect openDB at a temp DB, withNoopTmux to
+// neutralise tmux side effects, and captureStdoutDuringFn for the
+// JSON envelope assertion. The new piece is the stub podmanRunner
+// in fakePodmanRunner: it records every Run invocation and returns
+// scripted outputs so the test can assert exactly which podman args
+// were sent.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prismatic-koi/prism/internal/db"
+)
+
+// fakePodmanRunner is the test stub for podmanRunner. Every Run call
+// appends a copy of args to invocations and returns the next
+// scripted (stdout, err) pair from responses; if responses is empty,
+// Run returns ([]byte{}, nil).
+//
+// Concurrent calls are guarded by mu; the sweep is sequential in
+// production but defensive locking keeps the stub honest if a future
+// caller parallelises.
+type fakePodmanRunner struct {
+	mu          sync.Mutex
+	invocations [][]string
+	// scripted is a FIFO of (stdout, err) pairs returned by Run, in
+	// invocation order. Run pops the front of the slice per call.
+	scripted []scriptedResponse
+}
+
+type scriptedResponse struct {
+	stdout []byte
+	err    error
+}
+
+func (f *fakePodmanRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	captured := make([]string, len(args))
+	copy(captured, args)
+	f.invocations = append(f.invocations, captured)
+	if len(f.scripted) == 0 {
+		return []byte{}, nil
+	}
+	resp := f.scripted[0]
+	f.scripted = f.scripted[1:]
+	return resp.stdout, resp.err
+}
+
+func (f *fakePodmanRunner) script(responses ...scriptedResponse) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.scripted = append(f.scripted, responses...)
+}
+
+func (f *fakePodmanRunner) calls() [][]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([][]string, len(f.invocations))
+	for i, args := range f.invocations {
+		out[i] = append([]string(nil), args...)
+	}
+	return out
+}
+
+// seedContainerSession is a small variant of seedRowWithLifecycleFields
+// (from cleanup_lifecycle_test.go) that flips containers_enabled to
+// the supplied value at seed time so the sweep gate fires.
+func seedContainerSession(t *testing.T, dbFile, session string, containersEnabled bool) {
+	t.Helper()
+	d, err := db.Open(dbFile)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+	if err := d.UpsertStatus(session, "prism-test", "", "running", nil, nil); err != nil {
+		t.Fatalf("UpsertStatus(%q): %v", session, err)
+	}
+	if _, err := d.AllocatePort(session); err != nil {
+		t.Fatalf("AllocatePort(%q): %v", session, err)
+	}
+	if err := d.SetContainersEnabled(session, containersEnabled); err != nil {
+		t.Fatalf("SetContainersEnabled(%q, %v): %v", session, containersEnabled, err)
+	}
+}
+
+// installFakeRunner sets podmanRunnerForTest for the duration of the
+// test and returns the runner so tests can script responses and read
+// invocations.
+func installFakeRunner(t *testing.T) *fakePodmanRunner {
+	t.Helper()
+	r := &fakePodmanRunner{}
+	SetTestPodmanRunner(r)
+	t.Cleanup(func() { SetTestPodmanRunner(nil) })
+	return r
+}
+
+// ── sweepWithRunner: filter shape ─────────────────────────────────────────
+
+// TestSweep_FilterUsesAnchoredRegex verifies that the podman ps
+// invocation passes an anchored regex through --filter name=<regex>,
+// not a plain substring. This is the security AC's first line of
+// defence: podman libpod's filter is regex-matched, so anchoring on
+// the podman side already excludes most non-matching containers
+// before the Go-side re-filter sees them.
+func TestSweep_FilterUsesAnchoredRegex(t *testing.T) {
+	r := installFakeRunner(t)
+	r.script(scriptedResponse{stdout: []byte("")}) // ps returns nothing
+
+	session := "prism-test@filter-shape"
+	_ = sweepWithRunner(r, session)
+
+	calls := r.calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one podman invocation (ps); got %d: %v", len(calls), calls)
+	}
+	args := calls[0]
+	if len(args) < 1 || args[0] != "ps" {
+		t.Fatalf("first arg should be \"ps\"; got %v", args)
+	}
+	if !containsArgValue(args, "--filter", "name=^prism-prism-test@filter-shape-[a-f0-9]{8}$") {
+		t.Errorf("--filter not anchored to the strict per-session shape; args=%v", args)
+	}
+	if !containsArg(args, "--format") {
+		t.Errorf("--format flag missing; args=%v", args)
+	}
+}
+
+// ── sweepWithRunner: empty result ─────────────────────────────────────────
+
+// TestSweep_ZeroMatches_NoRmInvocation verifies the AC: "When the
+// prefix-filter sweep returns zero matches, cleanup does not invoke
+// podman rm and reports containers_swept=0."
+func TestSweep_ZeroMatches_NoRmInvocation(t *testing.T) {
+	r := installFakeRunner(t)
+	r.script(scriptedResponse{stdout: []byte("\n")}) // ps returns just newlines
+
+	got := sweepWithRunner(r, "prism-test@empty")
+
+	if got != 0 {
+		t.Errorf("count: got %d, want 0", got)
+	}
+	calls := r.calls()
+	if len(calls) != 1 {
+		t.Errorf("expected one podman invocation (ps only); got %d: %v", len(calls), calls)
+	}
+	for _, args := range calls {
+		if len(args) >= 1 && args[0] == "rm" {
+			t.Errorf("unexpected podman rm invocation: %v", args)
+		}
+	}
+}
+
+// ── sweepWithRunner: happy path ───────────────────────────────────────────
+
+// TestSweep_MatchedContainersRemoved verifies the AC: with
+// containers_enabled=1 and ps returning matching names, the sweep
+// invokes podman rm -f on each name and reports the count.
+func TestSweep_MatchedContainersRemoved(t *testing.T) {
+	session := "prism-test@happy"
+	r := installFakeRunner(t)
+	// ps returns three valid names matching the strict shape.
+	psOut := strings.Join([]string{
+		"prism-prism-test@happy-aaaaaaaa",
+		"prism-prism-test@happy-bbbbbbbb",
+		"prism-prism-test@happy-cccccccc",
+	}, "\n") + "\n"
+	r.script(
+		scriptedResponse{stdout: []byte(psOut)},
+		scriptedResponse{stdout: []byte("")}, // rm returns empty
+	)
+
+	got := sweepWithRunner(r, session)
+	if got != 3 {
+		t.Errorf("count: got %d, want 3", got)
+	}
+	calls := r.calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected two podman invocations (ps + rm); got %d: %v", len(calls), calls)
+	}
+	rm := calls[1]
+	if len(rm) < 2 || rm[0] != "rm" || rm[1] != "-f" {
+		t.Fatalf("second invocation must start with \"rm -f\"; got %v", rm)
+	}
+	wantNames := []string{
+		"prism-prism-test@happy-aaaaaaaa",
+		"prism-prism-test@happy-bbbbbbbb",
+		"prism-prism-test@happy-cccccccc",
+	}
+	got2 := rm[2:]
+	if len(got2) != len(wantNames) {
+		t.Fatalf("rm args: got %v, want %v", got2, wantNames)
+	}
+	for i, want := range wantNames {
+		if got2[i] != want {
+			t.Errorf("rm arg %d: got %q, want %q", i, got2[i], want)
+		}
+	}
+}
+
+// ── sweepWithRunner: security AC — sibling session not swept ──────────────
+
+// TestSweep_SiblingPrefixSessionNotSwept is the load-bearing security
+// AC test: when two sessions exist whose names are in a prefix
+// relationship (session "foo" vs session "foo-bar"), the sweep for
+// "foo" must NOT touch "foo-bar"'s containers.
+//
+// The stub returns BOTH containers regardless of the filter — this
+// simulates a worst-case scenario where podman's filter is a
+// substring match (the docker compat surface historically behaved
+// this way). The production code's Go-side re-filter using the
+// strict regex `^prism-<session>-[a-f0-9]{8}$` is what closes the
+// gap; this test fails if the regex is loosened to a plain prefix.
+func TestSweep_SiblingPrefixSessionNotSwept(t *testing.T) {
+	r := installFakeRunner(t)
+	// Both containers appear in podman's output. The session being
+	// cleaned is "foo"; "foo-with-suffix" is the sibling session.
+	// A naive prefix match on "prism-foo-" matches BOTH names; the
+	// strict regex `^prism-foo-[a-f0-9]{8}$` only matches the
+	// 8-hex-suffix one.
+	psOut := strings.Join([]string{
+		"prism-foo-aaaaaaaa",             // belongs to session "foo" — should be swept
+		"prism-foo-with-suffix-bbbbbbbb", // belongs to session "foo-with-suffix" — must NOT be swept
+		"prism-foo-with-suffix-cccccccc", // ditto
+	}, "\n") + "\n"
+	r.script(
+		scriptedResponse{stdout: []byte(psOut)},
+		scriptedResponse{stdout: []byte("")},
+	)
+
+	got := sweepWithRunner(r, "foo")
+	if got != 1 {
+		t.Errorf("count: got %d, want 1 (only foo's container should be swept)", got)
+	}
+	calls := r.calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected two podman invocations (ps + rm); got %d: %v", len(calls), calls)
+	}
+	rmArgs := calls[1][2:] // strip "rm" "-f"
+	if len(rmArgs) != 1 || rmArgs[0] != "prism-foo-aaaaaaaa" {
+		t.Errorf("rm args: got %v, want [prism-foo-aaaaaaaa]", rmArgs)
+	}
+	for _, name := range rmArgs {
+		if strings.HasPrefix(name, "prism-foo-with-suffix-") {
+			t.Errorf("SECURITY AC VIOLATION: sweep removed sibling-session container %q", name)
+		}
+	}
+}
+
+// TestSweep_SubstringTrapNotSwept covers the related "substring trap"
+// case: a container whose name CONTAINS the session prefix but does
+// not START with it (e.g. "user-prism-foo-aaaaaaaa") must NOT be
+// swept. This complements the sibling-prefix case above.
+func TestSweep_SubstringTrapNotSwept(t *testing.T) {
+	r := installFakeRunner(t)
+	psOut := strings.Join([]string{
+		"prism-foo-aaaaaaaa",      // legit
+		"user-prism-foo-bbbbbbbb", // substring trap — must NOT be swept
+	}, "\n") + "\n"
+	r.script(
+		scriptedResponse{stdout: []byte(psOut)},
+		scriptedResponse{stdout: []byte("")},
+	)
+
+	got := sweepWithRunner(r, "foo")
+	if got != 1 {
+		t.Errorf("count: got %d, want 1", got)
+	}
+	rmArgs := r.calls()[1][2:]
+	for _, name := range rmArgs {
+		if strings.HasPrefix(name, "user-") {
+			t.Errorf("SECURITY AC VIOLATION: sweep removed substring-trap container %q", name)
+		}
+	}
+}
+
+// ── sweepWithRunner: ps failure is non-fatal ──────────────────────────────
+
+// TestSweep_PsFailureIsNonFatal verifies the AC: "When podman ps
+// fails (machine off, socket down), cleanup logs a warning and
+// completes successfully." The sweep returns 0 and does NOT
+// subsequently invoke rm.
+func TestSweep_PsFailureIsNonFatal(t *testing.T) {
+	r := installFakeRunner(t)
+	r.script(scriptedResponse{
+		stdout: []byte("Cannot connect to Podman\n"),
+		err:    errors.New("exit status 125"),
+	})
+
+	got := sweepWithRunner(r, "prism-test@ps-fails")
+	if got != 0 {
+		t.Errorf("count on ps failure: got %d, want 0", got)
+	}
+	calls := r.calls()
+	if len(calls) != 1 {
+		t.Errorf("expected only ps invocation on failure; got %d calls: %v", len(calls), calls)
+	}
+}
+
+// TestSweep_RmFailureIsNonFatal verifies that when podman rm fails
+// after a successful ps, cleanup logs a warning and returns 0
+// (count of "definitely removed") rather than aborting cleanup.
+func TestSweep_RmFailureIsNonFatal(t *testing.T) {
+	r := installFakeRunner(t)
+	r.script(
+		scriptedResponse{stdout: []byte("prism-foo-aaaaaaaa\n")},
+		scriptedResponse{stdout: []byte(""), err: errors.New("exit status 1")},
+	)
+
+	got := sweepWithRunner(r, "foo")
+	if got != 0 {
+		t.Errorf("count on rm failure: got %d, want 0 (we don't know how many were removed)", got)
+	}
+	if len(r.calls()) != 2 {
+		t.Errorf("expected ps + rm invocations; got %d", len(r.calls()))
+	}
+}
+
+// ── end-to-end: containers_enabled gating through headlessCleanup ─────────
+
+// TestHeadlessCleanup_ContainersDisabled_NoPodmanInvocation verifies
+// the CRITICAL AC: "When the session has containers_enabled=0,
+// cleanup issues NO podman commands. (No new warnings about podman
+// being unavailable on sessions that did not enable containers.)"
+//
+// Seeds a session with containers_enabled=0 (the default) and
+// asserts the stub runner was NEVER invoked, AND the JSON envelope
+// omits the containers_swept key.
+func TestHeadlessCleanup_ContainersDisabled_NoPodmanInvocation(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	r := installFakeRunner(t)
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	session := "prism-test@no-containers"
+	seedContainerSession(t, dbFile, session, false)
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdoutDuringFn(t, func() {
+		if err := headlessCleanupWithJSON(session, "no-containers", "", "", true); err != nil {
+			t.Fatalf("headlessCleanupWithJSON: %v", err)
+		}
+	})
+
+	// AC: NO podman commands issued.
+	if calls := r.calls(); len(calls) != 0 {
+		t.Errorf("AC VIOLATION: containers_enabled=0 must not issue podman commands; got: %v", calls)
+	}
+
+	// AC: containers_swept key is OMITTED from the envelope.
+	var env map[string]any
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\nraw: %q", err, out)
+	}
+	if _, present := env["containers_swept"]; present {
+		t.Errorf("containers_swept key should be omitted when containers_enabled=0; envelope=%v", env)
+	}
+}
+
+// TestHeadlessCleanup_ContainersEnabled_EmptySweepReportsZero verifies
+// the AC: "[edge-case] When the prefix-filter sweep returns zero
+// matches, cleanup does not invoke podman rm and reports
+// containers_swept=0."
+func TestHeadlessCleanup_ContainersEnabled_EmptySweepReportsZero(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	r := installFakeRunner(t)
+	r.script(scriptedResponse{stdout: []byte("")})
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	session := "prism-test@empty-sweep"
+	seedContainerSession(t, dbFile, session, true)
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdoutDuringFn(t, func() {
+		if err := headlessCleanupWithJSON(session, "empty-sweep", "", "", true); err != nil {
+			t.Fatalf("headlessCleanupWithJSON: %v", err)
+		}
+	})
+
+	// AC: containers_swept=0 present in envelope.
+	var env map[string]any
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\nraw: %q", err, out)
+	}
+	got, present := env["containers_swept"]
+	if !present {
+		t.Fatalf("containers_swept key must be present (containers_enabled=1) in envelope=%v", env)
+	}
+	// JSON numbers decode as float64 in map[string]any.
+	f, isNum := got.(float64)
+	if !isNum {
+		t.Fatalf("containers_swept must be a number; got %v (%T)", got, got)
+	}
+	if int(f) != 0 {
+		t.Errorf("containers_swept: got %v, want 0", f)
+	}
+
+	// AC: only ps invoked, no rm.
+	calls := r.calls()
+	if len(calls) != 1 {
+		t.Errorf("expected one podman invocation (ps); got %d: %v", len(calls), calls)
+	}
+	for _, args := range calls {
+		if len(args) >= 1 && args[0] == "rm" {
+			t.Errorf("zero matches must not trigger podman rm; got: %v", args)
+		}
+	}
+}
+
+// TestHeadlessCleanup_ContainersEnabled_SweepReportsCount verifies the
+// AC: "prism cleanup --yes --session <name> --json for a
+// containers-enabled session includes \"containers_swept\": <n> in the
+// JSON envelope."
+func TestHeadlessCleanup_ContainersEnabled_SweepReportsCount(t *testing.T) {
+	t.Setenv("PRISM_HOST_API", "")
+	withNoopTmux(t)
+	r := installFakeRunner(t)
+	psOut := strings.Join([]string{
+		"prism-prism-test@swept-11111111",
+		"prism-prism-test@swept-22222222",
+	}, "\n") + "\n"
+	r.script(
+		scriptedResponse{stdout: []byte(psOut)},
+		scriptedResponse{stdout: []byte("")},
+	)
+
+	dbFile := filepath.Join(t.TempDir(), "prism.db")
+	session := "prism-test@swept"
+	seedContainerSession(t, dbFile, session, true)
+
+	SetTestDBPath(dbFile)
+	t.Cleanup(func() { SetTestDBPath("") })
+
+	out := captureStdoutDuringFn(t, func() {
+		if err := headlessCleanupWithJSON(session, "swept", "", "", true); err != nil {
+			t.Fatalf("headlessCleanupWithJSON: %v", err)
+		}
+	})
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\nraw: %q", err, out)
+	}
+	got, present := env["containers_swept"]
+	if !present {
+		t.Fatalf("containers_swept key must be present in envelope=%v", env)
+	}
+	f := got.(float64)
+	if int(f) != 2 {
+		t.Errorf("containers_swept: got %v, want 2", f)
+	}
+
+	calls := r.calls()
+	if len(calls) != 2 {
+		t.Fatalf("expected ps + rm invocations; got %d: %v", len(calls), calls)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+// containsArgValue returns true if args contains a `flag` token
+// immediately followed by `value`. Used to assert on
+// --filter / --format pairs without depending on flag ordering.
+func containsArgValue(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Compile-time guard: keep fmt imported for ad-hoc debugging.
+var _ = fmt.Sprintf

--- a/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/endpoints.go
@@ -102,6 +102,16 @@ const (
 	// via this endpoint without explicit admission in
 	// networkCreateBody.
 	endpointPolicyNetworkCreate
+
+	// endpointPolicyRename means "inspect the `?name=` query parameter
+	// against ContainerNamePrefix before forwarding". Used for POST
+	// /containers/{id}/rename. Closes the cycle-7 post-creation
+	// escape from the auto-prefix policy: without this kind, an agent
+	// could create a correctly-prefixed container and then immediately
+	// rename it out of the prefix, leaving an orphan that the cleanup
+	// sweep cannot find. (Spotted by review-security on PR #2332
+	// round 1.)
+	endpointPolicyRename
 )
 
 // normalisePath strips a leading docker/podman API version segment and
@@ -275,9 +285,16 @@ func classifyPOST(normPath string) endpointKind {
 		matchPath(normPath, "containers/+/pause"),
 		matchPath(normPath, "containers/+/unpause"),
 		matchPath(normPath, "containers/+/wait"),
-		matchPath(normPath, "containers/+/rename"),
 		matchPath(normPath, "containers/+/resize"):
 		return endpointAllow
+	}
+
+	// Rename is its own classification because its `?name=` query
+	// must be validated against ContainerNamePrefix — the agent must
+	// not be able to escape the cycle-7 auto-prefix policy by
+	// post-create rename. See endpointPolicyRename.
+	if matchPath(normPath, "containers/+/rename") {
+		return endpointPolicyRename
 	}
 
 	// Streaming endpoints: no body parsing — see endpointAllowStreaming

--- a/modules/programs/prism/prism/internal/podmanproxy/handler.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/handler.go
@@ -54,6 +54,9 @@ func (p *Proxy) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case endpointPolicyNetworkCreate:
 		p.handlePolicyNetworkCreate(w, r)
 
+	case endpointPolicyRename:
+		p.handlePolicyRename(w, r)
+
 	case endpointDeny:
 		fallthrough
 	default:
@@ -82,27 +85,45 @@ func (p *Proxy) handlePolicyCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dec, rewritten := p.inspectCreate(body)
+	res := p.inspectCreate(body, r.URL.Query())
+	if !res.decision.allow {
+		p.emitAudit(r, auditDeny, res.decision.reason)
+		writeJSONError(w, res.decision.status, res.decision.message)
+		return
+	}
+
+	// inspectCreate may have rewritten the body and/or the URL query
+	// when the cycle-7 Name-prefix policy injected an auto-prefixed
+	// Name. The injection branch writes the same name into BOTH
+	// channels so the upstream sees a consistent name no matter
+	// which channel (libpod body Name vs docker-compat ?name=) its
+	// handler reads. When either rewritten field is empty the
+	// original is forwarded unchanged.
+	forwardBody := body
+	if res.rewrittenBody != nil {
+		forwardBody = res.rewrittenBody
+	}
+	if res.rewrittenQuery != "" {
+		r.URL.RawQuery = res.rewrittenQuery
+	}
+	r.Body = io.NopCloser(bytes.NewReader(forwardBody))
+	r.ContentLength = int64(len(forwardBody))
+
+	p.emitAudit(r, auditAllow, res.decision.reason)
+	p.upstream.ServeHTTP(w, r)
+}
+
+// handlePolicyRename is the query-inspecting branch for POST
+// /containers/{id}/rename. The body is empty for this endpoint, so
+// the policy check operates purely on the URL query and forwards
+// the request unmodified on allow.
+func (p *Proxy) handlePolicyRename(w http.ResponseWriter, r *http.Request) {
+	dec := p.inspectRename(r.URL.Query())
 	if !dec.allow {
 		p.emitAudit(r, auditDeny, dec.reason)
 		writeJSONError(w, dec.status, dec.message)
 		return
 	}
-
-	// inspectCreate returns a non-nil rewritten body when the cycle-7
-	// Name-prefix policy injected an auto-prefixed Name into the
-	// request. When rewritten is nil the original body is forwarded
-	// unchanged. Either way: restore the body for the reverse proxy
-	// using a fresh Reader (the proxy re-reads from offset 0) and set
-	// ContentLength explicitly because http.MaxBytesReader does NOT
-	// update it for us.
-	forwardBody := body
-	if rewritten != nil {
-		forwardBody = rewritten
-	}
-	r.Body = io.NopCloser(bytes.NewReader(forwardBody))
-	r.ContentLength = int64(len(forwardBody))
-
 	p.emitAudit(r, auditAllow, dec.reason)
 	p.upstream.ServeHTTP(w, r)
 }

--- a/modules/programs/prism/prism/internal/podmanproxy/handler.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/handler.go
@@ -82,18 +82,26 @@ func (p *Proxy) handlePolicyCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dec := p.inspectCreate(body)
+	dec, rewritten := p.inspectCreate(body)
 	if !dec.allow {
 		p.emitAudit(r, auditDeny, dec.reason)
 		writeJSONError(w, dec.status, dec.message)
 		return
 	}
 
-	// Restore the body for the reverse proxy. Use a fresh Reader so
-	// the proxy can re-read from offset 0; the ContentLength is set
-	// explicitly because http.MaxBytesReader leaves it as it was.
-	r.Body = io.NopCloser(bytes.NewReader(body))
-	r.ContentLength = int64(len(body))
+	// inspectCreate returns a non-nil rewritten body when the cycle-7
+	// Name-prefix policy injected an auto-prefixed Name into the
+	// request. When rewritten is nil the original body is forwarded
+	// unchanged. Either way: restore the body for the reverse proxy
+	// using a fresh Reader (the proxy re-reads from offset 0) and set
+	// ContentLength explicitly because http.MaxBytesReader does NOT
+	// update it for us.
+	forwardBody := body
+	if rewritten != nil {
+		forwardBody = rewritten
+	}
+	r.Body = io.NopCloser(bytes.NewReader(forwardBody))
+	r.ContentLength = int64(len(forwardBody))
 
 	p.emitAudit(r, auditAllow, dec.reason)
 	p.upstream.ServeHTTP(w, r)

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -2,6 +2,8 @@ package podmanproxy
 
 import (
 	"bytes"
+	cryptorand "crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -234,7 +236,14 @@ type containerCreateBody struct {
 	Shell            json.RawMessage `json:"Shell"`
 	NetworkingConfig json.RawMessage `json:"NetworkingConfig"`
 	// podman libpod additions
-	Name json.RawMessage `json:"Name"` // libpod allows Name in body (in addition to ?name=)
+	//
+	// Name is INSPECTED when Config.ContainerNamePrefix is non-empty:
+	// missing / empty triggers auto-prefix injection; an explicit value
+	// must start with the configured prefix or the request is rejected.
+	// The pointer type distinguishes "absent" (nil) from "explicitly
+	// empty" (*"") so the injection branch can fire on both without
+	// having to inspect the raw bytes a second time.
+	Name *string `json:"Name"` // libpod allows Name in body (in addition to ?name=)
 }
 
 // containerExecBody is the explicit allowlist for POST
@@ -268,34 +277,148 @@ type containerExecBody struct {
 // nested. A flat single-pass parser would accept ANY shape inside
 // HostConfig if the top-level admits HostConfig as RawMessage. The
 // second pass is where the per-field allowlist actually fires.
-func (p *Proxy) inspectCreate(body []byte) policyDecision {
+//
+// After all policy checks pass, the container-name auto-prefix
+// policy runs when Config.ContainerNamePrefix is non-empty (step 7
+// of #2317). The function returns the (possibly rewritten) body
+// bytes the caller MUST forward upstream:
+//
+//   - rewritten == nil means "forward the original body unchanged".
+//   - rewritten != nil means "forward rewritten instead of body"
+//     (the proxy injected an auto-generated Name).
+//
+// On any deny decision rewritten is nil and the caller must NOT
+// forward.
+func (p *Proxy) inspectCreate(body []byte) (policyDecision, []byte) {
 	if len(bytes.TrimSpace(body)) == 0 {
 		return denyDecision(http.StatusBadRequest,
 			"malformed_body:empty",
-			"containers/create request body is empty")
+			"containers/create request body is empty"), nil
 	}
 
 	var req containerCreateBody
 	if dec := decodeStrict(body, &req); !dec.allow {
 		dec.reason = "create_top:" + dec.reason
 		dec.message = "containers/create top-level body: " + dec.message
-		return dec
+		return dec, nil
 	}
 
-	if req.HostConfig == nil || len(*req.HostConfig) == 0 {
-		// No HostConfig is harmless — a container without any host
-		// configuration cannot bind-mount or request privileges.
-		return allowDecision("policy:containers/create:no_host_config")
+	if req.HostConfig != nil && len(*req.HostConfig) > 0 {
+		var hc hostConfig
+		if dec := decodeStrict(*req.HostConfig, &hc); !dec.allow {
+			dec.reason = "create_hostconfig:" + dec.reason
+			dec.message = "containers/create HostConfig: " + dec.message
+			return dec, nil
+		}
+		if dec := p.checkHostConfig(&hc); !dec.allow {
+			return dec, nil
+		}
 	}
 
-	var hc hostConfig
-	if dec := decodeStrict(*req.HostConfig, &hc); !dec.allow {
-		dec.reason = "create_hostconfig:" + dec.reason
-		dec.message = "containers/create HostConfig: " + dec.message
-		return dec
+	// HostConfig (when present) is policy-clean. Apply the
+	// container-name auto-prefix policy last so a bind-source or
+	// privileged-flag violation surfaces in the audit log before the
+	// name-prefix mismatch — the worst violation wins, matching the
+	// existing field-ordering convention in checkHostConfig.
+	return p.applyContainerNamePolicy(body, &req)
+}
+
+// applyContainerNamePolicy implements the cycle-7 value-level Name
+// check on POST /containers/create. The Name field has been admitted
+// at the schema level since cycle-5 (containerCreateBody.Name); this
+// function adds a field-value layer on top in the same six-layer
+// model the rest of the policy code uses (cycle 6 added field-value
+// checks for LogConfig.Type, NetworkMode, etc. — this is the same
+// shape on Name).
+//
+// Behaviour is gated on Config.ContainerNamePrefix:
+//
+//   - empty prefix → no-op; the original body forwards unchanged.
+//     Preserves back-compat for out-of-tree callers that construct
+//     the proxy without session scoping.
+//   - non-empty prefix, req.Name nil or empty → inject a name of the
+//     form prefix + 8 hex chars from crypto/rand into the body, and
+//     return the rewritten bytes.
+//   - non-empty prefix, req.Name set without the configured prefix
+//     → deny with reason "name_prefix_mismatch".
+//   - non-empty prefix, req.Name correctly prefixed → allow; original
+//     body forwards unchanged.
+func (p *Proxy) applyContainerNamePolicy(body []byte, req *containerCreateBody) (policyDecision, []byte) {
+	prefix := p.cfg.ContainerNamePrefix
+	if prefix == "" {
+		return allowDecision("policy:containers/create:ok"), nil
 	}
 
-	return p.checkHostConfig(&hc)
+	if req.Name == nil || *req.Name == "" {
+		suffix, err := randomHexSuffix(8)
+		if err != nil {
+			return denyDecision(http.StatusInternalServerError,
+				"name_inject_random_failed",
+				"could not generate random container name suffix"), nil
+		}
+		injected := prefix + suffix
+		rewritten, err := injectNameIntoBody(body, injected)
+		if err != nil {
+			return denyDecision(http.StatusInternalServerError,
+				"name_inject_marshal_failed",
+				"could not inject auto-prefixed container name into request body"), nil
+		}
+		return allowDecision("policy:containers/create:name_injected"), rewritten
+	}
+
+	if !strings.HasPrefix(*req.Name, prefix) {
+		return denyDecision(http.StatusForbidden,
+			"name_prefix_mismatch",
+			fmt.Sprintf("containers/create Name=%q does not start with the required prefix %q (the proxy is session-scoped; either omit Name to receive an auto-prefixed one, or supply a Name that begins with the required prefix)", *req.Name, prefix)), nil
+	}
+
+	return allowDecision("policy:containers/create:ok"), nil
+}
+
+// randomHexSuffix returns n hex characters drawn from crypto/rand.
+// n must be even; this is enforced by the only call site (8).
+//
+// Defined at package scope so the proxy tests can swap it for a
+// deterministic generator without reaching into the proxy struct.
+var randomHexSuffix = func(n int) (string, error) {
+	if n <= 0 || n%2 != 0 {
+		return "", fmt.Errorf("randomHexSuffix: n must be a positive even number, got %d", n)
+	}
+	b := make([]byte, n/2)
+	if _, err := cryptorand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// injectNameIntoBody returns body with a top-level "Name" key set to
+// name. All other top-level fields are preserved verbatim because
+// the unmarshal target is map[string]json.RawMessage — each value's
+// original bytes round-trip through json.Marshal unchanged.
+//
+// Field order is NOT preserved (encoding/json sorts map keys), which
+// is fine because the upstream docker/podman API is JSON-object-
+// semantic, not byte-comparison-semantic. The proxy emits the
+// rewritten body via httputil.ReverseProxy in the same Content-Length
+// path as the unchanged body.
+func injectNameIntoBody(body []byte, name string) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return nil, fmt.Errorf("unmarshal top-level: %w", err)
+	}
+	if obj == nil {
+		obj = map[string]json.RawMessage{}
+	}
+	encodedName, err := json.Marshal(name)
+	if err != nil {
+		return nil, fmt.Errorf("marshal Name: %w", err)
+	}
+	obj["Name"] = encodedName
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("marshal top-level: %w", err)
+	}
+	return out, nil
 }
 
 // decodeStrict runs json.Decoder.DisallowUnknownFields against body

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -482,16 +482,20 @@ func (p *Proxy) inspectRename(query url.Values) policyDecision {
 }
 
 // injectNameIntoQuery returns the URL-encoded query string with the
-// `name` parameter set to name. Any pre-existing `name` value (which
-// will have been the empty string — a non-empty value would have
-// already been validated and approved) is replaced.
+// `name` parameter set to name. Any pre-existing case-variant of
+// `name` ("Name", "NAME", …) is dropped before the canonical
+// lowercase key is added. HTTP query parameters are case-sensitive
+// per RFC 3986 and Go's net/url + podman's `r.URL.Query().Get("name")`
+// both handle them that way, so a `?Name=evil` should be ignored by
+// podman regardless — but stripping case-variants is defence-in-
+// depth, mirroring injectNameIntoBody's discipline. (Round-2 fix.)
 //
 // The function does not mutate the input url.Values so the caller
 // can keep its own reference unchanged.
 func injectNameIntoQuery(query url.Values, name string) string {
 	clone := make(url.Values, len(query)+1)
 	for k, v := range query {
-		if k == "name" {
+		if strings.EqualFold(k, "name") {
 			continue
 		}
 		clone[k] = append([]string(nil), v...)
@@ -526,6 +530,33 @@ var randomHexSuffix = func(n int) (string, error) {
 // semantic, not byte-comparison-semantic. The proxy emits the
 // rewritten body via httputil.ReverseProxy in the same Content-Length
 // path as the unchanged body.
+//
+// # Case-variant Name keys (round-2 fix)
+//
+// All case-variants of the top-level "Name" key ("name", "NAME",
+// "nAme", …) are STRIPPED from the map before the canonical "Name"
+// is added. This closes a third-channel bypass discovered by
+// review-security on PR #2332 round 2: Go's encoding/json struct
+// decoder applies case-INsensitive last-wins matching, and
+// json.Marshal sorts map keys alphabetically with uppercase before
+// lowercase. Without the strip:
+//
+//  1. Agent sends body `{"Image":"alpine","name":""}`.
+//  2. applyContainerNamePolicy's struct decode sees Name="" (case-
+//     insensitive match from "name"), so bodyHasName=false and the
+//     inject branch fires.
+//  3. injectNameIntoBody (pre-fix) adds the canonical "Name":"<…>"
+//     but leaves the original "name":"" in the map.
+//  4. json.Marshal sorts to `{"Image":"…","Name":"<…>","name":""}`.
+//  5. Upstream's struct decoder processes keys in JSON order;
+//     "Name" sets the field, then "name" overwrites it with ""
+//     via case-insensitive last-wins. Podman generates a random
+//     `adjective_noun` name. Cleanup sweep misses it.
+//
+// Stripping every case-variant key before adding the canonical one
+// closes the bypass: the re-marshalled body has exactly one
+// "Name"-equivalent key and the upstream sees the injected value
+// unambiguously.
 func injectNameIntoBody(body []byte, name string) ([]byte, error) {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(body, &obj); err != nil {
@@ -533,6 +564,13 @@ func injectNameIntoBody(body []byte, name string) ([]byte, error) {
 	}
 	if obj == nil {
 		obj = map[string]json.RawMessage{}
+	}
+	// Strip every case-variant of "Name" so the canonical key added
+	// below is the only Name-equivalent key the upstream sees.
+	for k := range obj {
+		if strings.EqualFold(k, "Name") {
+			delete(obj, k)
+		}
 	}
 	encodedName, err := json.Marshal(name)
 	if err != nil {

--- a/modules/programs/prism/prism/internal/podmanproxy/policy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/policy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -267,6 +268,27 @@ type containerExecBody struct {
 	ConsoleSize  json.RawMessage `json:"ConsoleSize"`
 }
 
+// createInspectionResult bundles the outputs of inspectCreate. When
+// allow is true the handler forwards using rewrittenBody (or the
+// original body if rewrittenBody is nil) and the URL query in
+// rewrittenQuery (or the original URL query if rewrittenQuery is
+// ""). When allow is false both rewritten fields are zero and the
+// handler must NOT forward.
+//
+// The two rewrite fields are coupled: the cycle-7 Name auto-injection
+// branch sets BOTH so the upstream sees a consistent name no matter
+// which podman endpoint variant (libpod / docker-compat /
+// future) the request was destined for. See applyContainerNamePolicy
+// for the rationale.
+type createInspectionResult struct {
+	decision       policyDecision
+	rewrittenBody  []byte
+	rewrittenQuery string // empty if the original URL query should be reused
+	injectedName   string // observability only; non-empty when injection fired
+	appliedToBody  bool   // true iff rewrittenBody embeds an injected Name
+	appliedToQuery bool   // true iff rewrittenQuery embeds an injected ?name=
+}
+
 // inspectCreate parses body as a containers/create request and
 // applies the HostConfig policy. Two-stage parse: first the
 // top-level body with DisallowUnknownFields (rejects unknown
@@ -280,27 +302,22 @@ type containerExecBody struct {
 //
 // After all policy checks pass, the container-name auto-prefix
 // policy runs when Config.ContainerNamePrefix is non-empty (step 7
-// of #2317). The function returns the (possibly rewritten) body
-// bytes the caller MUST forward upstream:
-//
-//   - rewritten == nil means "forward the original body unchanged".
-//   - rewritten != nil means "forward rewritten instead of body"
-//     (the proxy injected an auto-generated Name).
-//
-// On any deny decision rewritten is nil and the caller must NOT
-// forward.
-func (p *Proxy) inspectCreate(body []byte) (policyDecision, []byte) {
+// of #2317). The function returns either a deny decision OR an allow
+// decision paired with the bytes / query the handler MUST forward
+// upstream (see createInspectionResult for the meaning of the
+// rewritten fields).
+func (p *Proxy) inspectCreate(body []byte, query url.Values) createInspectionResult {
 	if len(bytes.TrimSpace(body)) == 0 {
-		return denyDecision(http.StatusBadRequest,
+		return createInspectionResult{decision: denyDecision(http.StatusBadRequest,
 			"malformed_body:empty",
-			"containers/create request body is empty"), nil
+			"containers/create request body is empty")}
 	}
 
 	var req containerCreateBody
 	if dec := decodeStrict(body, &req); !dec.allow {
 		dec.reason = "create_top:" + dec.reason
 		dec.message = "containers/create top-level body: " + dec.message
-		return dec, nil
+		return createInspectionResult{decision: dec}
 	}
 
 	if req.HostConfig != nil && len(*req.HostConfig) > 0 {
@@ -308,10 +325,10 @@ func (p *Proxy) inspectCreate(body []byte) (policyDecision, []byte) {
 		if dec := decodeStrict(*req.HostConfig, &hc); !dec.allow {
 			dec.reason = "create_hostconfig:" + dec.reason
 			dec.message = "containers/create HostConfig: " + dec.message
-			return dec, nil
+			return createInspectionResult{decision: dec}
 		}
 		if dec := p.checkHostConfig(&hc); !dec.allow {
-			return dec, nil
+			return createInspectionResult{decision: dec}
 		}
 	}
 
@@ -320,7 +337,7 @@ func (p *Proxy) inspectCreate(body []byte) (policyDecision, []byte) {
 	// privileged-flag violation surfaces in the audit log before the
 	// name-prefix mismatch — the worst violation wins, matching the
 	// existing field-ordering convention in checkHostConfig.
-	return p.applyContainerNamePolicy(body, &req)
+	return p.applyContainerNamePolicy(body, &req, query)
 }
 
 // applyContainerNamePolicy implements the cycle-7 value-level Name
@@ -331,48 +348,156 @@ func (p *Proxy) inspectCreate(body []byte) (policyDecision, []byte) {
 // checks for LogConfig.Type, NetworkMode, etc. — this is the same
 // shape on Name).
 //
+// # Both `?name=` query and body Name
+//
+// Both the libpod (`/libpod/containers/create`) and docker-compat
+// (`/containers/create`) endpoints accept the container name via two
+// orthogonal channels: the `?name=` URL query parameter and the body
+// `Name` field. Behaviour is well documented for the libpod surface
+// (body wins when both are present) but varies subtly across podman
+// versions for the docker-compat surface and across docker-API
+// versions for clients that target it. The conservative posture is
+// to apply the SAME prefix policy to BOTH channels:
+//
+//   - Either channel being set with a value that does not start with
+//     ContainerNamePrefix is a 403 deny (audit reasons
+//     `name_prefix_mismatch_query` and `name_prefix_mismatch_body` so
+//     the failing channel is identifiable).
+//   - Both being set with values that start with the prefix is
+//     allowed: cleanup will find the resulting container regardless
+//     of which name podman ends up using.
+//   - Both being absent / empty triggers the inject branch. The
+//     auto-generated `prefix + 8 hex chars` is written into BOTH the
+//     body (`Name`) and the URL query (`name=`) so the upstream sees
+//     a consistent prefixed name no matter which channel its
+//     handler reads.
+//
+// The belt-and-braces injection is what closes the docker-compat
+// gap surfaced by review-security / review-context on round 1 of
+// PR #2332: an agent posting `POST /containers/create?name=evil`
+// with no body Name cannot end up with an unprefixed container; an
+// agent posting `POST /containers/create` with no Name in either
+// channel cannot end up with a random podman-generated name like
+// `interesting_curie` either.
+//
 // Behaviour is gated on Config.ContainerNamePrefix:
 //
-//   - empty prefix → no-op; the original body forwards unchanged.
-//     Preserves back-compat for out-of-tree callers that construct
-//     the proxy without session scoping.
-//   - non-empty prefix, req.Name nil or empty → inject a name of the
-//     form prefix + 8 hex chars from crypto/rand into the body, and
-//     return the rewritten bytes.
-//   - non-empty prefix, req.Name set without the configured prefix
-//     → deny with reason "name_prefix_mismatch".
-//   - non-empty prefix, req.Name correctly prefixed → allow; original
-//     body forwards unchanged.
-func (p *Proxy) applyContainerNamePolicy(body []byte, req *containerCreateBody) (policyDecision, []byte) {
+//   - empty prefix → no-op; the original body / query forward
+//     unchanged. Preserves back-compat for out-of-tree callers.
+//   - non-empty prefix, both channels nil/empty → inject into BOTH.
+//   - non-empty prefix, either channel set without the prefix → deny.
+//   - non-empty prefix, at least one channel set with the prefix →
+//     allow; original body / query forward unchanged.
+func (p *Proxy) applyContainerNamePolicy(body []byte, req *containerCreateBody, query url.Values) createInspectionResult {
 	prefix := p.cfg.ContainerNamePrefix
 	if prefix == "" {
-		return allowDecision("policy:containers/create:ok"), nil
+		return createInspectionResult{decision: allowDecision("policy:containers/create:ok")}
 	}
 
-	if req.Name == nil || *req.Name == "" {
-		suffix, err := randomHexSuffix(8)
-		if err != nil {
-			return denyDecision(http.StatusInternalServerError,
-				"name_inject_random_failed",
-				"could not generate random container name suffix"), nil
-		}
-		injected := prefix + suffix
-		rewritten, err := injectNameIntoBody(body, injected)
-		if err != nil {
-			return denyDecision(http.StatusInternalServerError,
-				"name_inject_marshal_failed",
-				"could not inject auto-prefixed container name into request body"), nil
-		}
-		return allowDecision("policy:containers/create:name_injected"), rewritten
+	queryName := query.Get("name")
+	bodyHasName := req.Name != nil && *req.Name != ""
+
+	// Validation pass: a non-empty value in EITHER channel must start
+	// with the configured prefix. Order: query first, body second, so
+	// if both are mismatching the audit reason names the query side
+	// (the channel docker-CLI uses by default).
+	if queryName != "" && !strings.HasPrefix(queryName, prefix) {
+		return createInspectionResult{decision: denyDecision(http.StatusForbidden,
+			"name_prefix_mismatch_query",
+			fmt.Sprintf("containers/create ?name=%q does not start with the required prefix %q (the proxy is session-scoped; either omit ?name= and the body Name to receive an auto-prefixed one, or supply a name that begins with the required prefix)", queryName, prefix))}
+	}
+	if bodyHasName && !strings.HasPrefix(*req.Name, prefix) {
+		return createInspectionResult{decision: denyDecision(http.StatusForbidden,
+			"name_prefix_mismatch_body",
+			fmt.Sprintf("containers/create body Name=%q does not start with the required prefix %q (the proxy is session-scoped; either omit Name to receive an auto-prefixed one, or supply a Name that begins with the required prefix)", *req.Name, prefix))}
 	}
 
-	if !strings.HasPrefix(*req.Name, prefix) {
+	// Both channels carry a correctly-prefixed value (or one is
+	// empty). No injection needed; forward as-is.
+	if queryName != "" || bodyHasName {
+		return createInspectionResult{decision: allowDecision("policy:containers/create:ok")}
+	}
+
+	// Inject branch: neither channel carries a Name. Generate one
+	// and write it into BOTH so the upstream sees a consistent
+	// prefixed name regardless of which channel its handler reads.
+	suffix, err := randomHexSuffix(8)
+	if err != nil {
+		return createInspectionResult{decision: denyDecision(http.StatusInternalServerError,
+			"name_inject_random_failed",
+			"could not generate random container name suffix")}
+	}
+	injected := prefix + suffix
+	rewrittenBody, err := injectNameIntoBody(body, injected)
+	if err != nil {
+		return createInspectionResult{decision: denyDecision(http.StatusInternalServerError,
+			"name_inject_marshal_failed",
+			"could not inject auto-prefixed container name into request body")}
+	}
+	rewrittenQuery := injectNameIntoQuery(query, injected)
+	return createInspectionResult{
+		decision:       allowDecision("policy:containers/create:name_injected"),
+		rewrittenBody:  rewrittenBody,
+		rewrittenQuery: rewrittenQuery,
+		injectedName:   injected,
+		appliedToBody:  true,
+		appliedToQuery: true,
+	}
+}
+
+// inspectRename implements the cycle-7 value-level Name check on
+// POST /containers/{id}/rename. The endpoint takes the new name via
+// the `?name=` URL query (the body is empty per docker spec); rename
+// is the only post-creation surface that can change the container's
+// name out of the auto-prefix shape, so it is the second pillar of
+// the cleanup-correctness guarantee alongside the create-time check.
+//
+// Behaviour is gated on Config.ContainerNamePrefix:
+//
+//   - empty prefix → no-op; rename forwards unchanged.
+//   - non-empty prefix, `?name=` missing or empty → 400 deny
+//     (`rename_missing_name`) because the upstream would also reject
+//     and the proxy prefers an actionable 4xx over a runc-internal
+//     error.
+//   - non-empty prefix, `?name=` does not start with the prefix →
+//     403 deny (`rename_prefix_mismatch`).
+//   - non-empty prefix, `?name=` starts with the prefix → allow.
+func (p *Proxy) inspectRename(query url.Values) policyDecision {
+	prefix := p.cfg.ContainerNamePrefix
+	if prefix == "" {
+		return allowDecision("policy:containers/rename:ok")
+	}
+	name := query.Get("name")
+	if name == "" {
+		return denyDecision(http.StatusBadRequest,
+			"rename_missing_name",
+			"containers/rename requires a non-empty `name` query parameter")
+	}
+	if !strings.HasPrefix(name, prefix) {
 		return denyDecision(http.StatusForbidden,
-			"name_prefix_mismatch",
-			fmt.Sprintf("containers/create Name=%q does not start with the required prefix %q (the proxy is session-scoped; either omit Name to receive an auto-prefixed one, or supply a Name that begins with the required prefix)", *req.Name, prefix)), nil
+			"rename_prefix_mismatch",
+			fmt.Sprintf("containers/rename target name %q does not start with the required prefix %q (the proxy is session-scoped; renaming a container out of the per-session prefix would leave it past session teardown)", name, prefix))
 	}
+	return allowDecision("policy:containers/rename:ok")
+}
 
-	return allowDecision("policy:containers/create:ok"), nil
+// injectNameIntoQuery returns the URL-encoded query string with the
+// `name` parameter set to name. Any pre-existing `name` value (which
+// will have been the empty string — a non-empty value would have
+// already been validated and approved) is replaced.
+//
+// The function does not mutate the input url.Values so the caller
+// can keep its own reference unchanged.
+func injectNameIntoQuery(query url.Values, name string) string {
+	clone := make(url.Values, len(query)+1)
+	for k, v := range query {
+		if k == "name" {
+			continue
+		}
+		clone[k] = append([]string(nil), v...)
+	}
+	clone.Set("name", name)
+	return clone.Encode()
 }
 
 // randomHexSuffix returns n hex characters drawn from crypto/rand.

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy.go
@@ -75,6 +75,23 @@ type Config struct {
 	// disables the cap.
 	MaxNanoCpus int64
 
+	// ContainerNamePrefix, when non-empty, activates the
+	// container-name auto-prefix policy on POST /containers/create:
+	//
+	//   - A request body with no Name (or Name="") gets a Name of
+	//     ContainerNamePrefix + <8 hex chars from crypto/rand> injected
+	//     into the forwarded body.
+	//   - A request body with an explicit Name MUST start with
+	//     ContainerNamePrefix; otherwise the request is rejected with 403
+	//     and audit reason "name_prefix_mismatch".
+	//
+	// Production wires this from the sidecar to "prism-<sessionName>-"
+	// so the cleanup sweep can locate every container belonging to the
+	// session. Out-of-tree callers may leave it empty — the prefix logic
+	// is then a no-op, preserving the cycle-5 schema-inversion behaviour
+	// for any consumer that does not need session-scoped naming.
+	ContainerNamePrefix string
+
 	// AllowedSecurityOpts is the set of HostConfig.SecurityOpt entries
 	// that may appear on a containers/create body. Comparison is
 	// case-sensitive and matches the full entry string (e.g.

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_name_prefix_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_name_prefix_test.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -268,9 +269,12 @@ func TestNamePrefix_NonMatchingName_Denied(t *testing.T) {
 
 	// Audit log must record the structured reason. The audit
 	// envelope is one JSON line per request — we read the last line
-	// and check its `reason` field.
-	if got := lastAuditReason(t, h.audit); got != "name_prefix_mismatch" {
-		t.Errorf("audit reason: got %q, want \"name_prefix_mismatch\"", got)
+	// and check its `reason` field. The cycle-7 v2 implementation
+	// distinguishes body-side from query-side mismatches in the
+	// audit so an operator can tell which channel the agent used;
+	// the body-side reason is `name_prefix_mismatch_body`.
+	if got := lastAuditReason(t, h.audit); got != "name_prefix_mismatch_body" {
+		t.Errorf("audit reason: got %q, want \"name_prefix_mismatch_body\"", got)
 	}
 }
 
@@ -327,6 +331,345 @@ func TestNamePrefix_NonMatchingName_Denied_RevertGuard(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status: got %d, want 403 (the prefix check did not fire)", resp.StatusCode)
 	}
+}
+
+// ── round-2 fixes: ?name= query parameter on /containers/create ──────────
+//
+// review-security and review-context both flagged that
+// applyContainerNamePolicy on round 1 inspected only the body Name,
+// not the URL query. Docker-compat clients (and `docker run --name`
+// against DOCKER_HOST=podman.sock, which Step 4 of #2317 wires into
+// the bwrap sandbox) set the name via `?name=` with NO body Name. The
+// fix inspects both channels, and on the inject branch writes the
+// auto-generated name into BOTH the body Name AND the URL query so
+// the upstream sees a consistent name regardless of which it reads.
+
+// postCreateRawWithQuery is the same as postCreateRaw but lets the
+// test set arbitrary URL-query parameters on the request — used by
+// the round-2 query-name tests. body=nil sends `{}` so the upstream
+// (when reached) gets a valid empty JSON object.
+func postCreateRawWithQuery(t *testing.T, sock string, query url.Values, body any) *http.Response {
+	t.Helper()
+	var reqBody []byte
+	if body == nil {
+		reqBody = []byte("{}")
+	} else {
+		var err error
+		reqBody, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+	}
+	urlStr := "http://podman.sock/v1.41/containers/create"
+	if len(query) > 0 {
+		urlStr += "?" + query.Encode()
+	}
+	req, err := http.NewRequest(http.MethodPost, urlStr, bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return doRequest(t, sock, req)
+}
+
+// readUpstreamRequest captures the most-recent request the fake
+// upstream observed and returns its rendered URL.RawQuery plus the
+// captured body bytes. Used by the inject-into-both tests to assert
+// the upstream sees the auto-generated name on both channels.
+func readUpstreamRequest(t *testing.T, fu *fakeUpstream) (rawQuery string, body []byte) {
+	t.Helper()
+	body, _ = fu.lastBody.Load().([]byte)
+	rawQuery, _ = fu.lastRawQuery.Load().(string)
+	return rawQuery, body
+}
+
+// TestNamePrefix_QueryName_NonMatching_Denied verifies the round-2
+// security fix: a request with `?name=<not-prefixed>` is rejected
+// with 403 + audit reason `name_prefix_mismatch_query`. The body has
+// no Name field — only the query carries a (mismatching) value, so
+// without the round-2 fix this case would silently fall through into
+// the inject branch and end up with a docker-compat container named
+// after the query value instead of the injected body Name.
+func TestNamePrefix_QueryName_NonMatching_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@query-deny-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	query := url.Values{"name": []string{"evil-orphan"}}
+	resp := postCreateRawWithQuery(t, h.sock, query, map[string]any{"Image": "alpine"})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403", resp.StatusCode)
+	}
+	env := readEnvelope(t, resp)
+	if !strings.Contains(env.Message, "evil-orphan") {
+		t.Errorf("error message should name the rejected query value, got %q", env.Message)
+	}
+	assertNoForward(t, fu)
+	if got := lastAuditReason(t, h.audit); got != "name_prefix_mismatch_query" {
+		t.Errorf("audit reason: got %q, want \"name_prefix_mismatch_query\"", got)
+	}
+}
+
+// TestNamePrefix_QueryName_Matching_Allowed verifies the positive
+// control: a request with `?name=<correctly-prefixed>` is allowed
+// and forwarded without rewriting either channel.
+func TestNamePrefix_QueryName_Matching_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@query-allow-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	want := prefix + "explicit-suffix"
+	query := url.Values{"name": []string{want}}
+	resp := postCreateRawWithQuery(t, h.sock, query, map[string]any{"Image": "alpine"})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	gotQuery, _ := readUpstreamRequest(t, fu)
+	gotName := url.Values{}
+	if parsed, err := url.ParseQuery(gotQuery); err == nil {
+		gotName = parsed
+	}
+	if gotName.Get("name") != want {
+		t.Errorf("upstream ?name=: got %q, want %q (must forward unchanged on the matching path)",
+			gotName.Get("name"), want)
+	}
+}
+
+// TestNamePrefix_QueryName_Inject_RewritesBothChannels verifies the
+// load-bearing belt-and-braces injection: when neither the body Name
+// nor the `?name=` query carry a value, the proxy injects the
+// auto-generated `prefix + 8 hex chars` into BOTH the body AND the
+// URL query. The upstream test stub captures both channels and the
+// assertion is that they carry the SAME injected value.
+//
+// This is the cycle-7 round-2 fix for the docker-compat path:
+// without the query-side injection, docker-compat would either pick
+// the empty query (and generate a random name like
+// "interesting_curie") or honour the query over the body and end up
+// with the agent's empty name. Either way the cleanup sweep filter
+// would miss the orphan container.
+func TestNamePrefix_QueryName_Inject_RewritesBothChannels(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@inject-both-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRawWithQuery(t, h.sock, nil, map[string]any{"Image": "alpine"})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	gotQuery, gotBody := readUpstreamRequest(t, fu)
+
+	// Body Name must be set to a prefixed 8-hex name.
+	var obj map[string]any
+	if err := json.Unmarshal(gotBody, &obj); err != nil {
+		t.Fatalf("unmarshal upstream body: %v", err)
+	}
+	bodyName, _ := obj["Name"].(string)
+	if !strings.HasPrefix(bodyName, prefix) {
+		t.Errorf("upstream body Name %q does not start with prefix %q", bodyName, prefix)
+	}
+
+	// Query ?name= must be set to the SAME value as the body Name.
+	parsed, err := url.ParseQuery(gotQuery)
+	if err != nil {
+		t.Fatalf("parse upstream query %q: %v", gotQuery, err)
+	}
+	queryName := parsed.Get("name")
+	if queryName == "" {
+		t.Errorf("upstream ?name= was empty after inject (round-2 fix not wired); query=%q", gotQuery)
+	}
+	if queryName != bodyName {
+		t.Errorf("upstream body Name %q != upstream ?name=%q (inject must write the SAME value to both channels)",
+			bodyName, queryName)
+	}
+}
+
+// TestNamePrefix_QueryName_Inject_OverwritesEmptyQueryName covers the
+// edge case where the agent sends `?name=` with no value (a literal
+// empty string). The proxy must treat this the same as "absent" and
+// inject; the upstream must not see the original empty `?name=`.
+func TestNamePrefix_QueryName_Inject_OverwritesEmptyQueryName(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@empty-query-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	query := url.Values{"name": []string{""}}
+	resp := postCreateRawWithQuery(t, h.sock, query, map[string]any{"Image": "alpine"})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	gotQuery, _ := readUpstreamRequest(t, fu)
+	parsed, _ := url.ParseQuery(gotQuery)
+	name := parsed.Get("name")
+	if !strings.HasPrefix(name, prefix) {
+		t.Errorf("empty ?name= must be overwritten by inject; got %q", name)
+	}
+}
+
+// TestNamePrefix_QueryName_BodyName_Both_Allowed verifies that when
+// both the body Name and the ?name= query are set with correctly-
+// prefixed values, the request is allowed (we do not enforce strict
+// equality across channels because the cleanup security guarantee
+// holds either way: any name on the resulting container is
+// prefix-anchored and the sweep regex finds it).
+func TestNamePrefix_QueryName_BodyName_Both_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@both-set-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	query := url.Values{"name": []string{prefix + "queryname"}}
+	resp := postCreateRawWithQuery(t, h.sock, query, map[string]any{
+		"Image": "alpine",
+		"Name":  prefix + "bodyname",
+	})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	// The upstream sees BOTH values as-supplied; no rewrite.
+	gotQuery, gotBody := readUpstreamRequest(t, fu)
+	parsed, _ := url.ParseQuery(gotQuery)
+	if got := parsed.Get("name"); got != prefix+"queryname" {
+		t.Errorf("upstream ?name=: got %q, want %q", got, prefix+"queryname")
+	}
+	var obj map[string]any
+	_ = json.Unmarshal(gotBody, &obj)
+	if got, _ := obj["Name"].(string); got != prefix+"bodyname" {
+		t.Errorf("upstream body Name: got %q, want %q", got, prefix+"bodyname")
+	}
+}
+
+// TestNamePrefix_QueryName_NonMatching_Denied_RevertGuard is the
+// revert-and-watch-fail discipline check for the round-2 query-name
+// inspection. Replaces randomHexSuffix with a panic stub so if the
+// production code stops inspecting `?name=` and falls into the
+// inject branch on a non-matching query value, the panic surfaces.
+func TestNamePrefix_QueryName_NonMatching_Denied_RevertGuard(t *testing.T) {
+	origGen := randomHexSuffix
+	randomHexSuffix = func(_ int) (string, error) {
+		panic("randomHexSuffix called when explicit non-matching ?name= was supplied; the query prefix check has been removed")
+	}
+	t.Cleanup(func() { randomHexSuffix = origGen })
+
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@query-revert-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	query := url.Values{"name": []string{"not-our-prefix-container"}}
+	resp := postCreateRawWithQuery(t, h.sock, query, map[string]any{"Image": "alpine"})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (the query prefix check did not fire)", resp.StatusCode)
+	}
+}
+
+// ── round-2 fixes: POST /containers/{id}/rename inspected ────────────────
+//
+// review-security flagged that POST /containers/{id}/rename was
+// classified as endpointAllow with no inspection — a one-call escape
+// from the auto-prefix policy. The fix reclassifies it as
+// endpointPolicyRename and validates the `?name=` query against the
+// configured ContainerNamePrefix.
+
+// postRename is a tiny helper for the rename endpoint. The endpoint
+// has no body per docker spec, so the request body is empty.
+func postRename(t *testing.T, sock, containerID string, query url.Values) *http.Response {
+	t.Helper()
+	urlStr := "http://podman.sock/v1.41/containers/" + containerID + "/rename"
+	if len(query) > 0 {
+		urlStr += "?" + query.Encode()
+	}
+	req, err := http.NewRequest(http.MethodPost, urlStr, nil)
+	if err != nil {
+		t.Fatalf("new rename request: %v", err)
+	}
+	return doRequest(t, sock, req)
+}
+
+// TestRename_NonMatchingName_Denied verifies that a rename request
+// whose `?name=` does not start with the configured prefix is
+// rejected with 403 + audit reason `rename_prefix_mismatch`. Without
+// this fix an agent could create a correctly-prefixed container and
+// then immediately rename it out of the prefix, leaving an orphan.
+func TestRename_NonMatchingName_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@rename-deny-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postRename(t, h.sock, "abc123", url.Values{"name": []string{"evil-name"}})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403", resp.StatusCode)
+	}
+	env := readEnvelope(t, resp)
+	if !strings.Contains(env.Message, "evil-name") {
+		t.Errorf("error message should name the rejected value, got %q", env.Message)
+	}
+	assertNoForward(t, fu)
+	if got := lastAuditReason(t, h.audit); got != "rename_prefix_mismatch" {
+		t.Errorf("audit reason: got %q, want \"rename_prefix_mismatch\"", got)
+	}
+}
+
+// TestRename_MatchingName_Allowed verifies the positive control: a
+// rename to a value that does start with the prefix is forwarded.
+// Proves the deny above is not a no-op resulting from an unrelated
+// 4xx path firing first.
+func TestRename_MatchingName_Allowed(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@rename-allow-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	want := prefix + "newname"
+	resp := postRename(t, h.sock, "abc123", url.Values{"name": []string{want}})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	if fu.captured() != 1 {
+		t.Errorf("upstream request count: got %d, want 1", fu.captured())
+	}
+}
+
+// TestRename_MissingName_Denied verifies that a rename with no
+// `?name=` query parameter is rejected with 400 (not 403 — the
+// upstream would also reject; the proxy synthesises a 4xx with a
+// useful message instead).
+func TestRename_MissingName_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@rename-missing-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postRename(t, h.sock, "abc123", nil)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
+	if got := lastAuditReason(t, h.audit); got != "rename_missing_name" {
+		t.Errorf("audit reason: got %q, want \"rename_missing_name\"", got)
+	}
+}
+
+// TestRename_EmptyPrefix_NoOp verifies the back-compat branch: when
+// ContainerNamePrefix is empty (out-of-tree caller), rename forwards
+// unchanged regardless of the `?name=` value. This matches the
+// containers/create back-compat path.
+func TestRename_EmptyPrefix_NoOp(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxyWithPrefix(t, fu, "")
+	resp := postRename(t, h.sock, "abc123", url.Values{"name": []string{"anything-goes"}})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q) — empty prefix should be a no-op", resp.StatusCode, b)
+	}
+}
+
+// TestRename_NonMatching_Denied_RevertGuard is the revert-and-watch-
+// fail discipline check for the rename inspector. The test
+// re-classifies the endpoint by name and asserts the deny path:
+// if the rename inspector is removed the test will fail because the
+// upstream stub records a forward (assertNoForward catches it).
+func TestRename_NonMatching_Denied_RevertGuard(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@rename-revert-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postRename(t, h.sock, "abc123", url.Values{"name": []string{"not-our-prefix-rename"}})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 — the rename inspector did not fire", resp.StatusCode)
+	}
+	assertNoForward(t, fu)
 }
 
 // ── audit log helpers ────────────────────────────────────────────────────

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_name_prefix_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_name_prefix_test.go
@@ -1,0 +1,359 @@
+package podmanproxy
+
+// Cycle-7 / #2324 tests for the container-name auto-prefix policy.
+//
+// The policy lives in policy.go::applyContainerNamePolicy and is gated
+// on Config.ContainerNamePrefix. These tests cover the four documented
+// branches:
+//
+//   1. Prefix empty (back-compat) — body forwards unchanged.
+//   2. Prefix non-empty, Name absent — proxy injects an auto-name.
+//   3. Prefix non-empty, Name explicitly empty (""), same as absent.
+//   4. Prefix non-empty, Name set without the prefix — 403 deny.
+//   5. Prefix non-empty, Name set with the correct prefix — forward
+//      unchanged.
+//
+// The injection tests verify the rewritten body on the UPSTREAM side
+// (via fakeUpstream.lastBody) so the round-trip from policy decision
+// through handler body-restore to upstream forward is end-to-end
+// covered. Per the cycle-6 schema-inversion discipline (see
+// policy.go top-of-file comment), value-level checks added to an
+// already-admitted schema field need a revert-and-watch-fail test:
+// the matching "explicit Name without prefix" deny case is the
+// load-bearing assertion for that discipline.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// startProxyWithPrefix stands up a proxy harness identical to
+// startProxy but with the supplied ContainerNamePrefix wired in.
+// Other policy fields are left at their defaults; bind sources are
+// empty because the cycle-7 tests do not exercise HostConfig at all
+// (every test body is `{"Image": "alpine"}` only).
+func startProxyWithPrefix(t *testing.T, fu *fakeUpstream, prefix string) *proxyHarness {
+	t.Helper()
+	dir := shortSocketDir(t)
+	listenPath := filepath.Join(dir, "proxy.sock")
+	auditBuf := &bytes.Buffer{}
+	cfg := Config{
+		ListenerPath:        listenPath,
+		UpstreamPath:        fu.sockPath,
+		ContainerNamePrefix: prefix,
+		AuditWriter:         auditBuf,
+	}
+	startProxyWithConfig(t, cfg, auditBuf, listenPath)
+	return &proxyHarness{
+		sock:  listenPath,
+		audit: auditBuf,
+	}
+}
+
+// postCreateRaw posts an arbitrary JSON body to /containers/create.
+// Unlike postCreate (which fabricates an Image+HostConfig shape), this
+// helper lets the cycle-7 tests express body shape directly so
+// "Name absent" vs "Name empty string" vs "Name with value" are
+// expressible as plain maps.
+func postCreateRaw(t *testing.T, sock string, body any) *http.Response {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		"http://podman.sock/v1.41/containers/create",
+		bytes.NewReader(buf))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return doRequest(t, sock, req)
+}
+
+// readUpstreamName parses fu.lastBody as JSON and returns the Name
+// field (or "" if absent). Used by the auto-inject assertions to
+// prove the rewritten body reached the upstream verbatim.
+func readUpstreamName(t *testing.T, fu *fakeUpstream) string {
+	t.Helper()
+	raw, _ := fu.lastBody.Load().([]byte)
+	if len(raw) == 0 {
+		t.Fatalf("upstream received no body")
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal upstream body: %v (raw=%q)", err, raw)
+	}
+	if v, ok := obj["Name"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// ── back-compat: empty prefix is a no-op ─────────────────────────────────
+
+// TestNamePrefix_EmptyPrefix_NoOp verifies the back-compat path:
+// when ContainerNamePrefix is empty the proxy does NOT inject a Name
+// and does NOT reject a body that omits Name. This is the contract
+// for out-of-tree callers that construct the proxy without session
+// scoping.
+func TestNamePrefix_EmptyPrefix_NoOp(t *testing.T) {
+	fu := newFakeUpstream(t)
+	h := startProxyWithPrefix(t, fu, "")
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, body)
+	}
+	if got := readUpstreamName(t, fu); got != "" {
+		t.Errorf("upstream Name: got %q, want empty (no injection when prefix is empty)", got)
+	}
+}
+
+// ── inject branches: Name absent / Name="" ──────────────────────────────
+
+// TestNamePrefix_MissingName_Injects verifies that when the body has
+// no Name field at all, the proxy injects an auto-generated name of
+// the form prefix + 8 hex chars and forwards the rewritten body.
+func TestNamePrefix_MissingName_Injects(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@cycle7-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, body)
+	}
+	got := readUpstreamName(t, fu)
+	if !strings.HasPrefix(got, prefix) {
+		t.Errorf("upstream Name %q does not start with %q", got, prefix)
+	}
+	// The injected suffix must be exactly 8 hex chars from crypto/rand
+	// so the cleanup sweep can target the strict form
+	// ^prism-<session>-[a-f0-9]{8}$. (Step 7 of #2317.)
+	suffix := strings.TrimPrefix(got, prefix)
+	if len(suffix) != 8 {
+		t.Errorf("injected suffix %q has length %d, want 8", suffix, len(suffix))
+	}
+	for _, c := range suffix {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("injected suffix %q is not lowercase hex (offending char %q)", suffix, string(c))
+			break
+		}
+	}
+}
+
+// TestNamePrefix_EmptyName_Injects verifies that an explicit empty
+// string Name="" is treated identically to a missing Name field —
+// both trigger the inject branch.
+func TestNamePrefix_EmptyName_Injects(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@cycle7-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"Name":  "",
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, body)
+	}
+	if got := readUpstreamName(t, fu); !strings.HasPrefix(got, prefix) {
+		t.Errorf("upstream Name %q does not start with %q", got, prefix)
+	}
+}
+
+// TestNamePrefix_Injects_PreservesOtherFields verifies that the
+// rewritten body preserves every other top-level field the agent
+// sent verbatim. The Image and a small HostConfig (with no policy
+// violations) round-trip through the upstream unchanged.
+func TestNamePrefix_Injects_PreservesOtherFields(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@roundtrip-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine:3.20",
+		"Cmd":   []string{"echo", "hi"},
+		"Labels": map[string]string{
+			"prism.test": "true",
+		},
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, body)
+	}
+	raw, _ := fu.lastBody.Load().([]byte)
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal upstream body: %v", err)
+	}
+	if obj["Image"] != "alpine:3.20" {
+		t.Errorf("Image: got %v, want alpine:3.20", obj["Image"])
+	}
+	cmd, _ := obj["Cmd"].([]any)
+	if len(cmd) != 2 || cmd[0] != "echo" || cmd[1] != "hi" {
+		t.Errorf("Cmd: got %v, want [echo hi]", obj["Cmd"])
+	}
+	labels, _ := obj["Labels"].(map[string]any)
+	if labels["prism.test"] != "true" {
+		t.Errorf("Labels[prism.test]: got %v, want \"true\"", labels["prism.test"])
+	}
+}
+
+// TestNamePrefix_Injects_UniqueAcrossCalls verifies that two
+// consecutive auto-inject calls do not collide on the suffix. This
+// guards against an accidental seeded-once stateful generator that
+// would produce the same value on every call.
+func TestNamePrefix_Injects_UniqueAcrossCalls(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@uniq-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	post := func() string {
+		t.Helper()
+		resp := postCreateRaw(t, h.sock, map[string]any{"Image": "alpine"})
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("post: status %d", resp.StatusCode)
+		}
+		return readUpstreamName(t, fu)
+	}
+	a := post()
+	b := post()
+	if a == b {
+		t.Errorf("two consecutive auto-inject calls produced the SAME name %q — randomness is not wired", a)
+	}
+}
+
+// ── deny branch: explicit Name without the configured prefix ─────────────
+
+// TestNamePrefix_NonMatchingName_Denied verifies the security AC: a
+// request with an explicit Name that does not start with the
+// configured prefix is rejected with 403 and the audit log records
+// the reason "name_prefix_mismatch".
+//
+// This is the load-bearing test for the cycle-7 value-level check.
+// Per the cycle-6 discipline (see policy.go), value-level checks on
+// already-admitted fields must be paired with a test that fails when
+// the production check is removed — see the matching revert-watch
+// exercise in TestNamePrefix_NonMatchingName_Denied_RevertGuard.
+func TestNamePrefix_NonMatchingName_Denied(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@deny-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"Name":  "evil-container",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403", resp.StatusCode)
+	}
+	env := readEnvelope(t, resp)
+	if !strings.Contains(env.Message, "evil-container") {
+		t.Errorf("error message should name the rejected value, got %q", env.Message)
+	}
+	if !strings.Contains(env.Message, prefix) {
+		t.Errorf("error message should name the required prefix, got %q", env.Message)
+	}
+	assertNoForward(t, fu)
+
+	// Audit log must record the structured reason. The audit
+	// envelope is one JSON line per request — we read the last line
+	// and check its `reason` field.
+	if got := lastAuditReason(t, h.audit); got != "name_prefix_mismatch" {
+		t.Errorf("audit reason: got %q, want \"name_prefix_mismatch\"", got)
+	}
+}
+
+// TestNamePrefix_MatchingName_Forwarded verifies the positive control
+// for the explicit-Name path: a body whose Name correctly starts with
+// the configured prefix forwards unchanged. This proves the deny in
+// the test above is not a no-op resulting from some unrelated 403
+// path firing first.
+func TestNamePrefix_MatchingName_Forwarded(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@allow-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	explicitName := prefix + "explicit-suffix"
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"Name":  explicitName,
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, body)
+	}
+	if got := readUpstreamName(t, fu); got != explicitName {
+		t.Errorf("upstream Name: got %q, want %q (no rewrite for correctly-prefixed Name)", got, explicitName)
+	}
+}
+
+// TestNamePrefix_NonMatchingName_Denied_RevertGuard is the
+// revert-and-watch-fail discipline check for the cycle-7 name-prefix
+// policy. The test temporarily replaces randomHexSuffix with a panic
+// stub so the inject branch CANNOT silently accept a non-matching
+// Name; if the production prefix check is ever removed, the body
+// would fall through to the inject branch and panic instead of
+// returning 403. Either way the test fails — proving the assertion
+// is not a no-op.
+//
+// This complements the load-bearing assertion in
+// TestNamePrefix_NonMatchingName_Denied above.
+func TestNamePrefix_NonMatchingName_Denied_RevertGuard(t *testing.T) {
+	origGen := randomHexSuffix
+	randomHexSuffix = func(_ int) (string, error) {
+		// If the production code reaches this on a non-matching
+		// Name, the prefix check has been removed.
+		panic("randomHexSuffix called when explicit non-matching Name was supplied; the prefix check has been removed")
+	}
+	t.Cleanup(func() { randomHexSuffix = origGen })
+
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@revert-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"Name":  "not-our-prefix-container",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (the prefix check did not fire)", resp.StatusCode)
+	}
+}
+
+// ── audit log helpers ────────────────────────────────────────────────────
+
+// lastAuditReason returns the `reason` field of the most recent audit
+// line written to buf. Used by tests that assert on the structured
+// audit token rather than the full JSON line.
+func lastAuditReason(t *testing.T, buf *bytes.Buffer) string {
+	t.Helper()
+	lines := splitNonEmptyLines(buf.String())
+	if len(lines) == 0 {
+		t.Fatal("audit buffer is empty")
+	}
+	var entry struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &entry); err != nil {
+		t.Fatalf("unmarshal last audit line: %v (raw=%q)", err, lines[len(lines)-1])
+	}
+	return entry.Reason
+}
+
+// ── compile-time guards ──────────────────────────────────────────────────
+//
+// fmt and context are imported for parity with the rest of the test
+// package — both surface in scaffolding helpers above. Keep the
+// imports honest so future additions to this file have them already
+// available.
+var _ = fmt.Sprintf
+var _ = context.TODO

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_name_prefix_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_name_prefix_test.go
@@ -672,6 +672,196 @@ func TestRename_NonMatching_Denied_RevertGuard(t *testing.T) {
 	assertNoForward(t, fu)
 }
 
+// ── round-3 fix: case-variant body "name" bypass (review-security) ────────
+//
+// review-security on PR #2332 round 2 found a third-channel bypass
+// in injectNameIntoBody: the function added a canonical "Name" key
+// but did not strip case-variants like lowercase "name". Go's
+// encoding/json struct decoder matches keys case-INsensitively with
+// last-wins, and json.Marshal sorts map keys alphabetically with
+// uppercase before lowercase — so a lowercase "name":"" survived in
+// the re-marshalled body and overwrote the canonical Name on the
+// upstream side, leaving the container with a random podman-
+// generated name that the cleanup sweep regex cannot match.
+//
+// The fix strips every case-variant of "Name" from the map before
+// adding the canonical key.
+
+// readUpstreamBodyMap parses the most-recent upstream-side body as
+// a generic map and returns it. Used by the case-variant tests to
+// assert which keys actually reached the upstream after the proxy
+// rewrote.
+func readUpstreamBodyMap(t *testing.T, fu *fakeUpstream) map[string]any {
+	t.Helper()
+	raw, _ := fu.lastBody.Load().([]byte)
+	if len(raw) == 0 {
+		t.Fatalf("upstream received no body")
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal upstream body: %v (raw=%q)", err, raw)
+	}
+	return obj
+}
+
+// readUpstreamName_StructDecode parses the upstream body using the
+// SAME case-insensitive last-wins discipline podman's struct
+// decoders use, returning the value the upstream would see for the
+// container Name. This is the load-bearing assertion for the round-3
+// fix: it must equal the injected prefix, NOT the empty case-variant
+// value the agent supplied.
+func readUpstreamName_StructDecode(t *testing.T, fu *fakeUpstream) string {
+	t.Helper()
+	raw, _ := fu.lastBody.Load().([]byte)
+	if len(raw) == 0 {
+		t.Fatalf("upstream received no body")
+	}
+	var decoded struct {
+		Name string `json:"Name"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("struct-decode upstream body: %v (raw=%q)", err, raw)
+	}
+	return decoded.Name
+}
+
+// TestNamePrefix_LowercaseName_Inject_NoLeftoverCaseVariant verifies
+// the round-3 fix: a body with lowercase `"name":""` triggers the
+// inject branch (the struct decoder normalises case-insensitively
+// and sees empty). After rewrite, the upstream body must:
+//
+//	(a) contain the canonical "Name" key with the injected prefix
+//	(b) NOT contain any case-variant of Name (no leftover "name")
+//	(c) struct-decode to the injected prefix, NOT to empty
+func TestNamePrefix_LowercaseName_Inject_NoLeftoverCaseVariant(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@lower-name-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"name":  "",
+	})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	upstreamBody := readUpstreamBodyMap(t, fu)
+
+	// (a) canonical Name key present and prefixed.
+	canonical, _ := upstreamBody["Name"].(string)
+	if !strings.HasPrefix(canonical, prefix) {
+		t.Errorf("upstream Name %q does not start with prefix %q", canonical, prefix)
+	}
+
+	// (b) NO case-variant of Name in the rewritten map.
+	for k := range upstreamBody {
+		if k == "Name" {
+			continue
+		}
+		if strings.EqualFold(k, "Name") {
+			t.Errorf("upstream body has leftover case-variant key %q (round-3 fix did not strip it); full body=%v", k, upstreamBody)
+		}
+	}
+
+	// (c) struct-decode (mirroring podman's case-insensitive last-
+	//     wins) lands on the injected prefix, NOT on empty. This is
+	//     the load-bearing assertion for the bypass closure.
+	decoded := readUpstreamName_StructDecode(t, fu)
+	if !strings.HasPrefix(decoded, prefix) {
+		t.Errorf("struct-decoded upstream Name = %q (want prefix %q); the case-variant bypass is still open", decoded, prefix)
+	}
+}
+
+// TestNamePrefix_UppercaseName_Inject_NoLeftoverCaseVariant is the
+// symmetric test for uppercase `"NAME":""` — also a case-variant of
+// Name that Go's struct decoder normalises case-insensitively.
+func TestNamePrefix_UppercaseName_Inject_NoLeftoverCaseVariant(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@upper-name-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"NAME":  "",
+	})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	upstreamBody := readUpstreamBodyMap(t, fu)
+	for k := range upstreamBody {
+		if k == "Name" {
+			continue
+		}
+		if strings.EqualFold(k, "Name") {
+			t.Errorf("upstream body has leftover case-variant key %q; full body=%v", k, upstreamBody)
+		}
+	}
+	if decoded := readUpstreamName_StructDecode(t, fu); !strings.HasPrefix(decoded, prefix) {
+		t.Errorf("struct-decoded upstream Name = %q (want prefix %q)", decoded, prefix)
+	}
+}
+
+// TestNamePrefix_MixedCaseName_Inject_NoLeftoverCaseVariant covers
+// the mixed-case shape `"nAme":""` — same bypass class.
+func TestNamePrefix_MixedCaseName_Inject_NoLeftoverCaseVariant(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@mixed-name-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"nAme":  "",
+	})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	if decoded := readUpstreamName_StructDecode(t, fu); !strings.HasPrefix(decoded, prefix) {
+		t.Errorf("struct-decoded upstream Name = %q (want prefix %q)", decoded, prefix)
+	}
+}
+
+// TestNamePrefix_CaseVariantBodyName_StructDecodeRevertGuard is the
+// revert-and-watch-fail discipline check for the round-3 fix.
+// Validates that struct-decoding the upstream-side body lands on
+// the injected prefix and NOT on the empty case-variant value — if
+// the case-variant strip in injectNameIntoBody is removed, the
+// upstream-side struct decode falls back to the empty case-variant
+// (last-wins) and this assertion fails.
+//
+// We use the struct-decode path explicitly (rather than the
+// map-decode path used by the upstream-body-key check above)
+// because the case-variant strip's load-bearing guarantee is what
+// the struct decoder sees, not what the JSON object contains.
+func TestNamePrefix_CaseVariantBodyName_StructDecodeRevertGuard(t *testing.T) {
+	fu := newFakeUpstream(t)
+	prefix := "prism-prism-test@revert3-"
+	h := startProxyWithPrefix(t, fu, prefix)
+	resp := postCreateRaw(t, h.sock, map[string]any{
+		"Image": "alpine",
+		"name":  "", // lowercase case-variant
+	})
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 200 (body=%q)", resp.StatusCode, b)
+	}
+	decoded := readUpstreamName_StructDecode(t, fu)
+	if decoded == "" {
+		t.Fatalf("REGRESSION: upstream struct-decode resolved Name to empty (the case-variant bypass is reopened); raw upstream body=%s",
+			string(mustLastBody(t, fu)))
+	}
+	if !strings.HasPrefix(decoded, prefix) {
+		t.Errorf("struct-decoded upstream Name = %q (want prefix %q)", decoded, prefix)
+	}
+}
+
+// mustLastBody fetches the upstream stub's lastBody for diagnostic
+// inclusion in failure messages.
+func mustLastBody(t *testing.T, fu *fakeUpstream) []byte {
+	t.Helper()
+	raw, _ := fu.lastBody.Load().([]byte)
+	return raw
+}
+
 // ── audit log helpers ────────────────────────────────────────────────────
 
 // lastAuditReason returns the `reason` field of the most recent audit

--- a/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
+++ b/modules/programs/prism/prism/internal/podmanproxy/proxy_security_test.go
@@ -76,6 +76,11 @@ type fakeUpstream struct {
 	// the "forward unmodified" tests to assert the proxy didn't mangle
 	// a legitimate body en route.
 	lastBody atomic.Value // []byte
+
+	// lastRawQuery captures the URL.RawQuery of the most recent
+	// request. Used by the cycle-7 round-2 tests that assert the
+	// `?name=` channel was rewritten alongside the body Name.
+	lastRawQuery atomic.Value // string
 }
 
 func newFakeUpstream(t *testing.T) *fakeUpstream {
@@ -96,6 +101,7 @@ func newFakeUpstream(t *testing.T) *fakeUpstream {
 		fu.requests.Add(1)
 		body, _ := io.ReadAll(r.Body)
 		fu.lastBody.Store(body)
+		fu.lastRawQuery.Store(r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"Id":"deadbeef"}`))

--- a/modules/programs/prism/prism/internal/sidecar/podman_proxy.go
+++ b/modules/programs/prism/prism/internal/sidecar/podman_proxy.go
@@ -127,6 +127,13 @@ func (s *Sidecar) runPodmanProxyIfEnabled(ctx context.Context) {
 		ListenerPath:       listenerPath,
 		UpstreamPath:       upstream,
 		AllowedBindSources: allowed,
+		// Step 7 of #2317 / #2324 — wire the per-session container
+		// name prefix. The proxy auto-injects this prefix into
+		// containers/create requests with no Name field, and rejects
+		// any explicit Name that does not start with it. Cleanup
+		// (`cmd/cleanup.go`) sweeps any orphan container matching the
+		// same prefix at session teardown.
+		ContainerNamePrefix: "prism-" + s.cfg.SessionName + "-",
 		// Step 3 ships with the default-deny policy from Step 1. No
 		// AllowedCaps, no AllowedSecurityOpts, no MaxMemoryBytes etc.
 		// Step 6 / Step 7 may revisit cap defaults once real workloads

--- a/modules/programs/prism/prism/internal/sidecar/podman_proxy_test.go
+++ b/modules/programs/prism/prism/internal/sidecar/podman_proxy_test.go
@@ -405,6 +405,67 @@ func TestPodmanProxy_UpstreamDiscovery_Darwin_MissingPodmanReturnsPlaceholder(t 
 	}
 }
 
+// TestPodmanProxy_ContainerNamePrefix_WiredFromSession verifies the
+// #2324 Step-7 wiring: when the sidecar starts the proxy, the
+// proxy's Config.ContainerNamePrefix is set to
+// "prism-<sessionName>-" so the cleanup sweep can locate every
+// container belonging to this session. We probe the live behaviour
+// by POSTing a containers/create request with an explicit Name that
+// does NOT start with the session prefix — the proxy must reject
+// with 403 and audit reason name_prefix_mismatch.
+//
+// The test uses a real (test) upstream socket so the proxy's policy
+// path runs end-to-end rather than short-circuiting on dial failure.
+// We do not need the upstream to respond meaningfully; we just need
+// the policy to fire BEFORE the upstream is dialled.
+func TestPodmanProxy_ContainerNamePrefix_WiredFromSession(t *testing.T) {
+	session := "prism-test@" + t.Name()
+	bus := sidecartest.NewIsolated(t, session)
+
+	// A non-existent upstream is fine: the policy rejection fires
+	// before any dial attempt, so the friendly 503 path does not run.
+	upstream := filepath.Join(bus.XDGStateHome, "unused-upstream.sock")
+
+	sc, listenerPath := newPodmanProxyTestSidecar(t, bus, session, upstream)
+	setContainersEnabled(t, bus, session, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := runSidecarBackground(t, sc, ctx)
+	if !waitForPath(listenerPath, 3*time.Second) {
+		t.Fatalf("podman.sock listener did not appear at %s", listenerPath)
+	}
+
+	client := proxyClientFor(listenerPath)
+	body := strings.NewReader(`{"Image":"alpine","Name":"not-our-prefix"}`)
+	resp, err := client.Post("http://podman.sock/v1.41/containers/create",
+		"application/json", body)
+	if err != nil {
+		t.Fatalf("POST containers/create: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		got, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: got %d, want 403 (body=%q) — the sidecar did not wire ContainerNamePrefix",
+			resp.StatusCode, got)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	var env struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(respBody, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v (raw=%q)", err, respBody)
+	}
+	wantPrefix := "prism-" + session + "-"
+	if !strings.Contains(env.Message, wantPrefix) {
+		t.Errorf("envelope message does not name the wired prefix %q; got %q",
+			wantPrefix, env.Message)
+	}
+
+	cancel()
+	<-done
+}
+
 // TestPodmanProxy_UpstreamPathNotInSidecarLog verifies the security AC:
 // even when the proxy is started and audited, the rendered sidecar log
 // must NOT contain the real upstream socket path verbatim. The audit log


### PR DESCRIPTION
Step 7 of #2317 / implements #2324. Has two halves that have to land together because each is a no-op without the other.

## Half 1 — container-name auto-prefix in the proxy

`internal/podmanproxy`:

- New `Config.ContainerNamePrefix string`. Empty → back-compat no-op; non-empty → enforced on `POST /containers/create`.
- `containerCreateBody.Name` switched from `json.RawMessage` to `*string` so missing / explicit-empty / explicit-set are distinguishable in a single parse pass.
- New `applyContainerNamePolicy`: missing or empty `Name` → inject `<prefix> + 8 hex chars from crypto/rand`. Explicit `Name` without the prefix → 403, audit reason `name_prefix_mismatch`. Explicit `Name` with the prefix → forward unchanged.
- `inspectCreate` now returns `(decision, rewrittenBody)`; the handler forwards the rewritten body when non-nil so the injected Name reaches the upstream.

This is a field-value layer on an already-admitted schema field (cycle-5 admitted `Name`; cycle-7 adds value-level validation), matching the existing six-layer model.

`internal/sidecar/podman_proxy.go`:

- Wires `ContainerNamePrefix = "prism-" + s.cfg.SessionName + "-"` so every per-session proxy is session-scoped.

## Half 2 — cleanup sweep for orphan containers

`cmd/cleanup_sweep.go` (new):

- `podmanRunner` interface + production `execPodmanRunner` + test seam `SetTestPodmanRunner`. Cleanup tests never touch a real podman socket.
- `sweepOrphanContainersForSession`: gated on `agent_status.containers_enabled`. When the flag is 0 (the default) the function returns immediately and issues **NO** podman commands.
- `containerNamePattern`: strict regex `^prism-<session>-[a-f0-9]{8}$`. The trailing 8-hex anchor is the security guarantee — a sibling session `foo-with-suffix` whose containers are `prism-foo-with-suffix-XXXXXXXX` is NOT swept when cleaning session `foo`. Plain prefix match would falsely match.
- Filter is passed to `podman ps --filter name=<anchored-regex>` AND re-applied in Go for defence-in-depth against any podman version that treats `name=` as a substring match.
- 30-second context budget shared by `ps` + `rm`. All failures are non-fatal warnings — the worktree and DB teardown always run.

`cmd/cleanup.go`:

- New `cleanupResult.ContainersSwept *int` with `omitempty`. `nil` → key omitted from JSON envelope (the `containers_enabled=0` contract). `*0` → `"containers_swept": 0` (zero-matches case).
- New helper `applyOrphanContainerSweep` wired into the four cleanup paths: `doCleanup` (TUI), `closeSession` (TUI), `headlessCleanupWithJSONTo`, `headlessCloseSessionWithJSONTo`.

## Tests

`internal/podmanproxy/proxy_name_prefix_test.go`:

- Inject branches (missing / empty `Name`)
- Deny branch (explicit non-matching `Name` → 403 + audit reason `name_prefix_mismatch`)
- Positive control (matching `Name` forwards unchanged)
- Round-trip preservation of other fields
- Uniqueness across calls
- Revert-guard with a panicking `randomHexSuffix` proving the prefix check is load-bearing.

Verified by temporarily removing the prefix check — both denial tests fail.

`cmd/cleanup_sweep_test.go`:

- Filter shape (anchored regex on the podman side)
- Zero matches → no `rm` invocation
- Happy path (count returned, `rm` called with matched names)
- **Sibling-prefix session NOT swept** — the load-bearing security AC
- Substring-trap NOT swept
- `ps` / `rm` failure non-fatal
- End-to-end through `headlessCleanupWithJSON` for both `containers_enabled=0` (no podman commands, no envelope key) and `containers_enabled=1` (envelope key present)

Verified by temporarily loosening the strict regex to a plain prefix — the sibling-prefix test fails.

`internal/sidecar/podman_proxy_test.go`:

- New end-to-end wiring test posting a non-matching `Name` through the sidecar-started proxy and asserting the 403 envelope names the expected `prism-<session>-` prefix.

## Critical ACs covered

- ✅ `containers_enabled=0` → cleanup issues NO podman commands (no spurious warnings).
- ✅ Anchored filter — sibling session containers NOT swept (strict 8-hex regex).
- ✅ Empty sweep reports `containers_swept: 0`.
- ✅ `podman ps` failure logs warning and completes cleanup.
- ✅ Sweep bounded by 30-second context.
- ✅ `--json` envelope includes `containers_swept` on containers-enabled sessions.
- ✅ Auto-prefix injects on missing `Name`; rejects explicit `Name` not matching prefix.

## Quality gates

- `gofmt -l .` clean
- `go build ./...` clean
- `go test ./...` clean
- `go test -race ./...` clean
- `nix build .#prism` clean
- Homeless-shelter checked build (`packages.aarch64-darwin.prism.override { runChecks = true; }`) clean

Refs #2317
Refs #2324
