### PR TITLE
prism: docs, nix housekeeping, end-to-end acceptance (Step 8 of #2317, Closes #2317)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,7 +413,7 @@ Every request the proxy sees writes exactly one JSON line to
 resolve the `<instance_id>` for a session by reading the
 `agent_status.instance_id` column from `prism.db` (e.g. `sqlite3
 ~/.local/state/prism/prism.db "SELECT instance_id FROM agent_status
-WHERE name = '<session>'"`). The structured `reason` field names the
+WHERE session_name = '<session>'"`). The structured `reason` field names the
 specific policy check that fired; see
 [`docs/podman-proxy.md` §7](modules/programs/prism/prism/docs/podman-proxy.md#7-troubleshooting--reading-the-audit-log)
 for the common rejection classes and how to read them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -409,9 +409,11 @@ intentionally NOT shipped in this train.
 #### Debugging rejections
 
 Every request the proxy sees writes exactly one JSON line to
-`<sessionDir>/podman-proxy.log` — typically resolvable from a session
-name via `prism checkin <session>` then crossing-reference
-`agent_status.work_dir`. The structured `reason` field names the
+`<XDG_STATE_HOME>/prism/sessions/<instance_id>/podman-proxy.log` —
+resolve the `<instance_id>` for a session by reading the
+`agent_status.instance_id` column from `prism.db` (e.g. `sqlite3
+~/.local/state/prism/prism.db "SELECT instance_id FROM agent_status
+WHERE name = '<session>'"`). The structured `reason` field names the
 specific policy check that fired; see
 [`docs/podman-proxy.md` §7](modules/programs/prism/prism/docs/podman-proxy.md#7-troubleshooting--reading-the-audit-log)
 for the common rejection classes and how to read them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,169 @@ The "verify your tests aren't no-ops" discipline (revert fix → rerun test →
 re-apply) is the common trigger for reaching for a stash — use one of the
 patterns above instead.
 
+### Podman support for workers
+
+A worker spawned with `prism spawn --containers` gets a filtered podman API
+socket exposed inside its sandbox so it can spin up throwaway containers
+(integration-test Postgres, build-matrix toolchains, etc.) without escaping
+the sandbox. The real host podman socket is NEVER bound into the worker's
+sandbox — the only socket reachable is a per-session **filtering proxy**
+that enforces a default-deny policy at six layers before any byte reaches
+the upstream. The full security spec — threat table, layer-by-layer
+model, field-admission process for future docker-/podman-API fields, and
+the audit-log debugging notes — lives at
+[`modules/programs/prism/prism/docs/podman-proxy.md`](modules/programs/prism/prism/docs/podman-proxy.md);
+this section is the operational summary.
+
+The feature is opt-in and per-spawn: omit `--containers` and the worker
+behaves identically to before the train landed (no proxy goroutine, no
+`CONTAINER_HOST` / `DOCKER_HOST` env, no scratch bind, no audit-log file).
+The train is tracked by #2317 and shipped as #2326, #2327, #2328, #2329,
+#2330, #2331, #2332, and the closing docs/housekeeping PR.
+
+#### Using `--containers`
+
+```bash
+prism spawn --containers --prompt 'run the test suite against a throwaway postgres'
+```
+
+The flag flips two DB columns at spawn time —
+`spawn_inputs.containers_flag = 1` (audit) and
+`agent_status.containers_enabled = 1` (runtime gate). The sidecar reads
+the runtime gate on startup and conditionally:
+
+- binds a fourth Unix listener at
+  `<XDG_STATE_HOME>/prism/run/<sessionDirName>/podman.sock`,
+- exposes that socket inside the sandbox (bwrap bind / sandbox-exec
+  SBPL literal allow),
+- injects `CONTAINER_HOST=unix://<…>/podman.sock` and the matching
+  `DOCKER_HOST` env vars,
+- conditionally binds a per-session scratch dir at
+  `<sessionDir>/container-scratch/` into the sandbox, RW, so the agent
+  has a writable place to point bind mounts that does not need to live
+  in the worktree, and
+- opens an audit-log file at `<sessionDir>/podman-proxy.log` (one JSON
+  line per request: timestamp, method, endpoint, decision, reason).
+
+The `--containers` flag is independent of `--isolation`. Combining
+`--containers --isolation host` produces a warning (host mode has direct
+podman access already, the proxy is redundant) but does not error — see
+#2330 for the rationale.
+
+#### Default-deny at six layers (summary)
+
+The proxy's job is to make the threat table in
+[`docs/podman-proxy.md`](modules/programs/prism/prism/docs/podman-proxy.md#2-threat-model)
+true for an attacker controlling the agent. Six independent layers do
+that work; each was added or inverted in response to a class of finding
+in one of the six review-security cycles of PR #2326:
+
+1. **Endpoint layer** — positive allowlist via `classifyRequest`; any
+   unknown path/method pair rejects.
+2. **Field-name layer** — `json.Decoder.DisallowUnknownFields()` + typed
+   struct per body-bearing endpoint. The structs in
+   `internal/podmanproxy/policy.go` (`hostConfig`,
+   `containerCreateBody`, `containerExecBody`, `volumeCreateBody`,
+   `networkCreateBody`) are the canonical security spec — every
+   admitted field is annotated `INSPECTED` / `DENIED` / `FORWARDED`
+   with a rationale comment.
+3. **Field-value layer** — per-field literal allowlists for
+   enumerable values (`Mount.Type`, the six `*Mode` fields,
+   `LogConfig.Type`). Closes the cycle-6 CRITICAL where
+   `Mount.Type=glob` was forwarded because the parser was deny-list,
+   not allowlist.
+4. **Body-content layer** — `checkHostConfig` walks the parsed
+   HostConfig and rejects dangerous values (`Privileged: true`, host
+   namespaces, non-empty `Devices`/`DeviceCgroupRules`/`DeviceRequests`/
+   `VolumesFrom`, present `MaskedPaths`/`ReadonlyPaths`, non-empty
+   `Sysctls`, cap-add outside allowlist, `SecurityOpt` outside
+   allowlist, resource caps in strict mode).
+5. **Path-resolution layer** — `filepath.EvalSymlinks` on both bind
+   sources AND allowlist entries before the prefix comparison.
+   Relative paths, broken symlink chains, and non-existent sources all
+   deny. Closes the cycle-3 CRITICAL symlink-bypass.
+6. **Query layer** — `PUT /containers/{id}/archive` `path` query
+   parameter is checked against the same bind-source allowlist with
+   the same canonicalised-prefix logic. `POST /containers/create?name=`
+   is covered by the container-name auto-prefix policy.
+
+A residual TOCTOU window remains between `EvalSymlinks` and runc's
+`mount(2)`. It is accepted for v1 because the agent is otherwise
+sandboxed and the bind target inside the container is fixed at create
+time. Future hardening directions (Linux `nosymfollow` /
+Darwin SBPL restriction on the scratch dir) are documented in the proxy
+doc, §5.
+
+#### Field-admission process
+
+The cycle-5 schema inversion makes every NEW docker-/podman-API field
+upstream **rejected by default** until it has been audited and admitted
+to the relevant typed struct in `internal/podmanproxy/policy.go`. A
+workflow that surfaces a needed field sees a 403 with `"unknown field
+<Name>"` in the response body and matching audit-log line. The process:
+
+1. File an issue describing the workflow and the field.
+2. Audit the field against the threat table in
+   [`docs/podman-proxy.md` §2](modules/programs/prism/prism/docs/podman-proxy.md#2-threat-model).
+   Classify as `INSPECTED` / `DENIED` / `FORWARDED`.
+3. Open a follow-up PR adding the field to the struct in `policy.go`
+   with a rationale comment matching the existing style. `INSPECTED`
+   additions need a positive + revert-and-watch-fail test pair as
+   proof the new check is not a no-op.
+
+Do NOT loosen the policy in a worker PR without an audit — the struct
+is the security spec, and the cycle-6 history demonstrates that quiet
+field admissions are how CRITICALs ship.
+
+#### Platform prerequisites
+
+**NixOS.** `virtualisation.podman.enable = true` (already set in
+`modules/programs/podman.nix`) wires the rootless socket-activated user
+unit, so the upstream socket is available as soon as the user systemd
+instance has `podman.socket` in `sockets.target`. The user account
+needs to be in the `podman` group — this is set in
+`modules/system/users.nix` so it applies to every NixOS host built
+from this flake. If the upstream socket is not active when the proxy
+first dials, the proxy stays up and synthesises a friendly 503 with
+actionable text per request until the upstream comes up:
+
+```
+{"message": "podman socket unavailable: <reason>; on macOS run 'podman machine start', on Linux check 'systemctl --user status podman.socket'"}
+```
+
+**No linger for v1.** `loginctl enable-linger <user>` is NOT set on any
+host in this flake. The proxy is only used by interactive prism
+sessions; users running long-lived background agents that need podman
+across SSH-out can re-evaluate later. See
+[`docs/podman-proxy.md` §10](modules/programs/prism/prism/docs/podman-proxy.md#10-linger-decision).
+
+**Darwin.** `nix-darwin` ships no first-class podman-machine module. The
+machine is user-managed:
+
+```bash
+podman machine init      # one-time setup
+podman machine start     # per boot
+```
+
+If the machine is not running when the worker dials, the proxy returns
+the same friendly 503 envelope above. Bring the machine up and retry
+— no restart of the worker session is required, the proxy re-dials
+lazily.
+
+An optional launchd user agent that runs `podman machine start || true`
+at login is an obvious follow-up if friction warrants. It is
+intentionally NOT shipped in this train.
+
+#### Debugging rejections
+
+Every request the proxy sees writes exactly one JSON line to
+`<sessionDir>/podman-proxy.log` — typically resolvable from a session
+name via `prism checkin <session>` then crossing-reference
+`agent_status.work_dir`. The structured `reason` field names the
+specific policy check that fired; see
+[`docs/podman-proxy.md` §7](modules/programs/prism/prism/docs/podman-proxy.md#7-troubleshooting--reading-the-audit-log)
+for the common rejection classes and how to read them.
+
 ### File naming and organisation
 
 Names of files and directories should be in lowercase, with dashes between words — kebab case, not camel case.

--- a/modules/programs/prism/prism/docs/podman-proxy.md
+++ b/modules/programs/prism/prism/docs/podman-proxy.md
@@ -324,15 +324,19 @@ to a session.
 ## 9. Configuration knobs
 
 The proxy's `Config` struct in `internal/podmanproxy/proxy.go` carries
-the per-session knobs that the sidecar wires. The Step 3 wiring
-(`internal/sidecar/podman_proxy.go::buildProxyConfig`) sets:
+the per-session knobs that the sidecar wires. The Step 3 wiring lives
+in `internal/sidecar/podman_proxy.go::runPodmanProxyIfEnabled`, which
+constructs a `podmanproxy.Config` literal inline (no separate builder
+function — the `runPodmanProxyIfEnabled` body itself is the
+spec) and sets:
 
 - `AllowedBindSources` — the per-session worktree path, the bare repo
   path, and the per-session scratch directory.
 - `ContainerNamePrefix` — `"prism-" + sessionName + "-"`, which
   activates the cycle-7 auto-prefix policy and lets the cleanup sweep
-  (`cmd/cleanup.go::sweepOrphanContainersForSession`) find every
-  container belonging to the session.
+  (`cmd/cleanup_sweep.go::sweepOrphanContainersForSession`, called
+  from `cmd/cleanup.go`) find every container belonging to the
+  session.
 - `AllowedCaps` — empty by default; deny-all.
 - `AllowedSecurityOpts` — empty by default; deny-all.
 - `MaxMemoryBytes` / `MaxCPUQuota` / `MaxNanoCpus` — unset by default
@@ -369,7 +373,7 @@ that.
 - Step 6 PR: [#2330](https://github.com/prismatic-koi/nixos-config/pull/2330) — `--containers` spawn flag.
 - Step 7 PR: [#2332](https://github.com/prismatic-koi/nixos-config/pull/2332) — orphan-container cleanup sweep + auto-prefix on `Name`.
 - Canonical structs: [`internal/podmanproxy/policy.go`](../internal/podmanproxy/policy.go) (`hostConfig`, `containerCreateBody`, `containerExecBody`, `volumeCreateBody`, `networkCreateBody`).
-- Package doc: [`internal/podmanproxy/doc.go`](../internal/podmanproxy/doc.go) (cross-references this document for the threat table; the package doc is the in-tree summary).
-- Sidecar wiring: [`internal/sidecar/podman_proxy.go`](../internal/sidecar/podman_proxy.go).
-- Cleanup sweep: [`cmd/cleanup.go`](../cmd/cleanup.go) (`sweepOrphanContainersForSession`).
+- Package doc: [`internal/podmanproxy/doc.go`](../internal/podmanproxy/doc.go) — the in-tree summary of the threat model; references `#2317 §4` directly. The shipped threat table in this document (§2) explicitly supersedes `#2317 §4` after cycles 2–6. Consider `doc.go` the inline summary and this document the canonical reference.
+- Sidecar wiring: [`internal/sidecar/podman_proxy.go`](../internal/sidecar/podman_proxy.go) — `runPodmanProxyIfEnabled`.
+- Cleanup sweep: [`cmd/cleanup_sweep.go`](../cmd/cleanup_sweep.go) — `sweepOrphanContainersForSession` (called from `cmd/cleanup.go`).
 - Sandbox-exec testing convention: [`docs/sandbox-exec-testing.md`](sandbox-exec-testing.md).

--- a/modules/programs/prism/prism/docs/podman-proxy.md
+++ b/modules/programs/prism/prism/docs/podman-proxy.md
@@ -1,0 +1,350 @@
+# Podman proxy — security spec
+
+This document is the formal security specification for the per-session
+filtering podman API socket proxy that ships with prism. It is the reference
+that future docker-/podman-API admission work must be audited against, and
+the place to start when debugging a rejection in the wild.
+
+The proxy is implemented in `modules/programs/prism/prism/internal/podmanproxy/`
+and is wired into the per-session prism sidecar
+(`modules/programs/prism/prism/internal/sidecar/podman_proxy.go`). The
+combined train is tracked by [#2317](https://github.com/prismatic-koi/nixos-config/issues/2317);
+the eight implementation PRs are #2326, #2327, #2328, #2329, #2330, #2331,
+#2332, and the closing docs/housekeeping PR.
+
+For the operational story — when to enable, how, prerequisites per platform —
+see the "Podman support for workers" section in the repo root `AGENTS.md`.
+
+## 1. What the proxy is
+
+A worker agent — by design — runs inside `bwrap` (Linux) or `sandbox-exec`
+(Darwin), with the host's real podman socket NOT exposed inside the sandbox.
+When a session is spawned with `--containers`, prism's sidecar starts a
+per-session HTTP reverse proxy bound to a Unix socket at
+`<XDG_STATE_HOME>/prism/run/<sessionDirName>/podman.sock`, and the sandbox
+profile exposes only that socket to the worker. The proxy reverse-proxies
+the host's real podman socket, but enforces a **default-deny** policy at
+six layers before any byte reaches the upstream.
+
+The agent's `CONTAINER_HOST` and `DOCKER_HOST` env vars point at the
+filtered socket. The real podman socket path appears in NEITHER the rendered
+bwrap argv NOR the rendered sandbox-exec profile — that absence is asserted
+by tests in `internal/sidecar` and the platform-specific
+`cmd/agent_run_sandbox_exec_darwin_test.go` / bwrap test files.
+
+## 2. Threat model
+
+This table is the shipped model, not the design. It supersedes #2317 §4 —
+which was written before review-security cycles 2–6 surfaced four
+structural classes of permissiveness that were closed in PR #2326. Where a
+threat is covered by a typed struct field, the canonical reference is the
+struct in `internal/podmanproxy/policy.go`; the comments on each admission
+record the rationale.
+
+| # | Threat | Mitigation | Canonical reference |
+|---|---|---|---|
+| T1 | Agent reads any host file via `-v /host/path:/x` | `HostConfig.Binds` policy rejects sources outside the per-session allowlist (worktree + bare repo + scratch dir). Symlinks resolved via `filepath.EvalSymlinks` before the prefix check. | `policy.go::checkHostConfig` (Binds branch), `isAllowedBindSource`, `canonicalisePath` |
+| T2 | Same exfil via `HostConfig.Mounts` with `Type=bind` | Same allowlist check applied to every `Mounts[]` entry with `Type=bind`. `Type` is itself value-allowlisted to `{bind, volume, tmpfs}`. | `policy.go::hostConfigMount`, `mountTypeAllowlist`, `checkHostConfig` (Mounts branch) |
+| T3 | Same exfil via `Mounts` with `Type=volume` and `VolumeOptions.DriverConfig.Name="local"` (a "named-volume" that is functionally a bind to a host path via `device=…`) | `Mounts[].VolumeOptions.DriverConfig` is DENIED when present. Same shape closed at the volumes/create endpoint: `Driver=local` with non-empty `DriverOpts` rejected. | `policy.go::hostConfigVolumeOptions`, `inspectVolumeCreate` |
+| T4 | Exfil via `POST /containers/{id}/archive` (`podman cp` write) | Archive endpoint's `path` query parameter is checked against the same bind-source allowlist with the same symlink-canonicalisation. | `endpoints.go::endpointPolicyArchive`, `policy.go::inspectArchive` |
+| T5 | Container escape via `HostConfig.Privileged: true` | Boolean check; any `true` rejects. | `policy.go::checkHostConfig` (Privileged branch) |
+| T6 | Capability escape via `HostConfig.CapAdd: [SYS_ADMIN]` etc. | `CapAdd` allowlisted against `Config.AllowedCaps`; default empty = deny-all. | `policy.go::checkHostConfig` (CapAdd branch), `Config.AllowedCaps` |
+| T7 | Namespace escape via `NetworkMode=host` (or `PidMode`/`IpcMode`/`UTSMode`/`UsernsMode`/`CgroupnsMode`=host) | All six `*Mode` fields use a literal value allowlist. `NetworkMode` allows `{"", bridge, none, default, slirp4netns, pasta}` plus a user-defined-name regex (`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$`). The other five allow `{"", "private"}` only. | `policy.go::checkNetworkMode`, `checkSimpleNamespaceMode`, the constants `networkModeAllowlist`, `simpleNamespaceModeAllowlist` |
+| T8 | Cgroup-rule escape via `HostConfig.DeviceCgroupRules` | DENIED when non-empty. This is a parallel cgroup-rule mechanism to `Devices`; with `CAP_MKNOD` in the default capset, the agent could mknod host disks. | `policy.go::checkHostConfig` (DeviceCgroupRules branch) |
+| T9 | Device passthrough via `HostConfig.Devices` or `DeviceRequests` (GPU / nvidia-container-runtime) | Both DENIED when non-empty. | `policy.go::checkHostConfig` (Devices, DeviceRequests branches) |
+| T10 | `MaskedPaths` / `ReadonlyPaths` override re-exposing `/proc/keys`, `/proc/sysrq-trigger`, etc. | Both DENIED when present (pointer-to-slice distinguishes "absent" from "explicitly empty"). | `policy.go::checkHostConfig` (MaskedPaths, ReadonlyPaths branches) |
+| T11 | Transitive mount inheritance via `HostConfig.VolumesFrom` | DENIED when non-empty — impossible to audit the source container's mounts transitively. | `policy.go::checkHostConfig` (VolumesFrom branch) |
+| T12 | Non-namespaced sysctl write via `HostConfig.Sysctls` | DENIED when non-empty. Some sysctls are not namespaced. | `policy.go::checkHostConfig` (Sysctls branch) |
+| T13 | Sandbox bypass via `HostConfig.SecurityOpt: [seccomp=unconfined]` / `apparmor=unconfined` / `no-new-privileges=false` / `label=disable` / `systempaths=unconfined` | Allowlisted against `Config.AllowedSecurityOpts`; default empty = deny-all. | `policy.go::checkHostConfig` (SecurityOpt branch), `Config.AllowedSecurityOpts` |
+| T14 | Resource exhaustion via `HostConfig.Memory=10TB`, `CpuQuota=very-large`, `NanoCpus=very-large` | Cap-strict-mode: when the corresponding `Config.Max*` cap is set, the field MUST be present and a positive value within the cap. The docker-semantic "0 means unbounded" bypass is closed for all three. | `policy.go::checkHostConfig` (Memory, CpuQuota, NanoCpus branches), `Config.MaxMemoryBytes` / `MaxCPUQuota` / `MaxNanoCpus` |
+| T15 | Post-create cap relax via `POST /containers/{id}/update` resetting Memory to 0 | The `update` endpoint runs through the same cap-strict-mode check as `create`. | `endpoints.go::endpointPolicyUpdate`, `policy.go::inspectUpdate` |
+| T16 | Privilege escalation via `POST /containers/{id}/exec` body's own `Privileged: true` | `exec` body is parsed with `containerExecBody` and `Privileged: true` is rejected. | `policy.go::inspectExec`, `containerExecBody.Privileged` |
+| T17 | Log-driver shipping container logs off the host via `LogConfig.Type=syslog`/`splunk`/`fluentd`/`gelf`/`awslogs` | `LogConfig.Type` is value-allowlisted to local-only drivers `{json-file, none, journald, k8s-file, passthrough, passthrough-tty}`. | `policy.go::checkLogConfigType`, `logConfigTypeAllowlist` |
+| T18 | `Mount.Type=glob` — podman-specific value that calls `filepath.Glob(Source)` on the host | `Mount.Type` value allowlist is case-sensitive `{bind, volume, tmpfs}`; everything else (`glob`, `image`, `npipe`, `artifact`, `ramfs`, `devpts`, empty string, case variants, whitespace, unicode zero-width space) rejects. | `policy.go::mountTypeAllowlist`, `checkHostConfig` (Mounts branch) |
+| T19 | Raw-socket bypass: agent runs `curl --unix-socket /run/user/$UID/podman/podman.sock ...` to talk to the real socket directly | No path exists — the real socket is bound NEITHER into the bwrap mount tree NOR into the sandbox-exec SBPL allow list. The only socket reachable from inside the sandbox is the filtered one. | bwrap profile in `internal/container/bwrap.go`; SBPL in `internal/container/sandbox_exec.go`; absence asserted by negative-mutation tests |
+| T20 | CLI-wrapper bypass: agent runs a custom HTTP client bypassing `podman`/`docker` CLI | Same answer as T19. The wrapper IS the only reachable surface. |
+| T21 | Build context smuggle via `POST /build` of arbitrary-content tar | No new escape: `build` is bounded by what the sandbox already exposes. Build endpoint is `endpointAllow` (query-only and opaque body). No size cap in v1; revisit if abuse appears. | `endpoints.go` (build endpoint) |
+| T22 | Schema drift: a new docker-/podman-API field upstream introduces a new escape vector without anyone in this repo noticing | `json.Decoder.DisallowUnknownFields()` runs on every parsed body. A new unknown field rejects with 403 and audit reason `unknown_field:<json error>` until it is admitted via the field-admission process (§4). | `policy.go::decodeStrict`, plus every typed struct |
+| T23 | Proxy itself has a parsing bug | Default-deny — every unknown endpoint, unknown field, unknown enumerable value, malformed JSON, missing required value rejects before forwarding. Test suite exercises every documented escape and asserts it is blocked, plus a negative-control meta-test that verifies the positive tests are not no-ops. | `proxy_security_test.go::TestSecurity_NegativeControl_RootAllowlistPasses` |
+
+**Network egress** is not restricted: containers get whatever network the
+host podman gives them (default: full internet). This is strictly broader
+than what the sandbox would otherwise allow at the policy layer
+(`(allow network*)` in sandbox-exec, no `--unshare-net` in bwrap), so no
+*new* egress capability is introduced. If we later want egress restrictions
+they belong in a follow-up issue.
+
+## 3. Default-deny is enforced at six layers
+
+The proxy enforces default-deny at six independent layers. Each layer was
+added or inverted in response to a class of finding that the prior layers
+could not cover. The shipped model is materially stronger than the original
+design (#2317 §4) — that design described the body-content layer (layer 4)
+and assumed a permissive parser; cycles 2–6 added the four layers around
+it.
+
+| # | Layer | Mechanism | First added |
+|---|---|---|---|
+| 1 | **Endpoint** | Positive allowlist via `classifyRequest` in `internal/podmanproxy/endpoints.go`; the last branch of every method helper is `endpointDeny`. Any unknown path/method pair returns 403 with a friendly JSON envelope that names the rejected endpoint. | PR #2326 cycle 1 |
+| 2 | **Field-name** | `json.Decoder.DisallowUnknownFields()` + typed struct per body-bearing endpoint. The structs (`hostConfig`, `containerCreateBody`, `containerExecBody`, `volumeCreateBody`, `networkCreateBody`) are the canonical security spec. Every admitted field is annotated `INSPECTED` (policy-checked), `DENIED` (rejected when non-empty/non-default), or `FORWARDED` (admitted as opaque `json.RawMessage`, bytes pass to the upstream unmodified). A future docker-API field that introduces an escape vector is rejected by default until it is explicitly admitted. | PR #2326 cycle 5 |
+| 3 | **Field-value** | Per-field literal allowlists (+ `NetworkMode` user-defined-name regex) for enumerable values: `Mount.Type`, the six `*Mode` fields, `LogConfig.Type`. Anything outside the allowlist denies. Closes the class where the field is admitted but a dangerous value of that field forwards (cycle-6 CRITICAL: `Mount.Type=glob` was originally forwarded because the parser was deny-list — it only rejected if `Type != "bind" && Type != "volume"`). | PR #2326 cycle 6 |
+| 4 | **Body-content** | `checkHostConfig` walks the parsed HostConfig and rejects dangerous values: `Privileged: true`, host-namespace modes, non-empty `Devices` / `DeviceCgroupRules` / `DeviceRequests` / `VolumesFrom`, present `MaskedPaths` / `ReadonlyPaths`, non-empty `Sysctls`, `Mounts[].VolumeOptions.DriverConfig` non-nil, `CapAdd` outside allowlist, `SecurityOpt` outside allowlist, resource caps in strict mode. | PR #2326 cycles 1 + 2 + 4 |
+| 5 | **Path-resolution** | `filepath.EvalSymlinks` + lexical `filepath.Clean` on both bind sources AND allowlist entries before the prefix comparison. Relative paths, broken symlink chains, and non-existent sources all deny. Closes the cycle-3 CRITICAL where the agent planted a symlink inside an allowed prefix pointing at `/etc/passwd` and the lexical prefix-match passed. See §5 for the residual TOCTOU. | PR #2326 cycle 3 |
+| 6 | **Query** | `PUT /containers/{id}/archive` `path` query parameter is checked against `AllowedBindSources` with the same canonicalised-prefix logic as `Binds`. The other endpoint with a security-relevant query (`POST /containers/create?name=<…>`) is covered by the cycle-7 container-name auto-prefix policy in `applyContainerNamePolicy`. | PR #2326 cycle 1 (archive) + PR #2332 (Name query) |
+
+## 4. Field-admission process
+
+The cycle-5 schema inversion means any new docker-/podman-API field
+introduced upstream is rejected by default until it has been audited
+against the threat table above and explicitly admitted to the relevant
+typed struct in `internal/podmanproxy/policy.go`.
+
+A workflow that surfaces a needed field will see a 403 response with a body
+like:
+
+```json
+{"message": "containers/create HostConfig: unknown field \"NewField\""}
+```
+
+and a matching audit-log line containing
+`reason=create_hostconfig:unknown_field:json: unknown field "NewField"`.
+
+### Walkthrough — admitting a hypothetical new field
+
+Suppose podman 6.0 adds a new HostConfig field `CgroupBudget` (made up for
+this example) that takes an integer share-weight.
+
+1. **File an issue** describing the workflow that wants the field and the
+   docker/podman API reference for it.
+2. **Audit the field against the threat table in §2.** For `CgroupBudget`,
+   the question is: can a large value exhaust host resources (→ T14:
+   resource-exhaustion class), can it reach into another cgroup
+   hierarchy (→ T8: cgroup-rule class), or can it interact with namespace
+   escapes (→ T7)? Classify accordingly. In this case it's a per-container
+   CPU weighting and behaves like the existing `CpuShares` admission, so
+   the answer is FORWARDED.
+3. **Open a PR adding the field to `hostConfig`** in `policy.go`:
+
+   ```go
+   // FORWARDED — per-container CPU share weighting, equivalent to
+   // CpuShares; no escape vector against #2317 §4 / the threat table.
+   // Admitted under the same rationale as CpuShares — podman 6.0
+   // renamed the field. Audit ticket: #NNNN.
+   CgroupBudget json.RawMessage `json:"CgroupBudget"`
+   ```
+
+   The rationale comment matches the existing style: classification,
+   one-line justification, ticket reference.
+4. **Field requiring a policy check?** If the audit classifies the new
+   field as INSPECTED rather than FORWARDED, add a typed field (not
+   `json.RawMessage`), extend `checkHostConfig` with the policy, and add
+   a positive + revert-and-watch-fail test pair as proof the new check is
+   not a no-op (see §6).
+5. **Field requiring a value allowlist?** If the field is enumerable (a
+   handful of well-known values), add the literal allowlist alongside
+   `mountTypeAllowlist` / `networkModeAllowlist` / `logConfigTypeAllowlist`
+   and wire the check from `checkHostConfig`.
+
+The single most important reviewer task on a change to `policy.go` is
+**reading the struct and confirming the rationale comments**, not guessing
+what the proxy admits. The struct is the security spec.
+
+## 5. Residual TOCTOU between `EvalSymlinks` and `mount(2)`
+
+The bind-source allowlist resolves symlinks at policy time. The container
+runtime (runc, crun) calls `mount(2)` some milliseconds later. An agent
+that wins the race can swap a resolved-safe symlink for a dangerous one
+between the two moments.
+
+For v1 this residual is **accepted** because:
+
+- The agent is otherwise sandboxed by bwrap / sandbox-exec.
+- The bind target inside the container is fixed at create time, so a
+  changed symlink cannot retarget the agent's reach to a different
+  in-container path.
+- The sandbox layer sits in front of the proxy, so the agent's filesystem
+  reach inside the sandbox is already constrained.
+
+The correct architectural home for the proper mitigation is the surrounding
+sandbox profile, not the proxy. Two future directions:
+
+- **Linux**: mount the per-session scratch directory with `nosymfollow`
+  via `bwrap --bind-try`/`--ro-bind-try` extensions or a paired
+  `mount --make-rslave` / `mount -o nosymfollow` pre-step. Tracked
+  informally; will become a Step-N+1 issue if/when the gap is exercised.
+- **Darwin**: equivalent SBPL restriction on the scratch directory via
+  `(deny file-issue-extension*)` / `(deny file-link*)` clauses. Same
+  status: future hardening, not gated on a concrete report.
+
+The `internal/podmanproxy/doc.go` package doc carries the same note;
+both surfaces are intentionally redundant so the residual is hard to
+miss.
+
+## 6. Verification — the test suite as the spec
+
+The body of evidence for "this policy is enforced" is the test suite at
+`internal/podmanproxy/proxy_security_test.go` (100 top-level test
+functions, 276 RUN entries with subtests, all green under `-race`). The
+key meta-test is:
+
+```go
+// TestSecurity_NegativeControl_RootAllowlistPasses mutates Config.AllowedBindSources
+// to ["/"] and asserts that the same /etc/passwd bind request that returns
+// 403 in TestSecurity_HostBindOutsideAllowlist_Denied now PASSES to the
+// upstream. This proves the positive denial tests are not no-ops from an
+// unrelated policy code path.
+```
+
+This is the load-bearing "tests are not vacuous" check. The
+revert-and-watch-fail discipline (revert the fix → re-run the test → see
+it fail → re-apply the fix → see it pass) was applied to every cycle-2-
+through-6 closure in PR #2326; commit messages in that PR carry the
+per-cycle matrix.
+
+Tests for sidecar wiring live at
+`internal/sidecar/podman_proxy_test.go` (Step 3) and assert that:
+
+- `containers_enabled=0` sessions do NOT bind a `podman.sock` listener
+  in the per-session run dir, and emit NO audit-log file.
+- `containers_enabled=1` sessions DO bind the listener and the audit
+  file appears at `<sessionDir>/podman-proxy.log`.
+- A request to the filtered socket reaches the (fake) upstream and the
+  audit log records the call.
+
+Tests for the bwrap profile additions live at
+`internal/container/bwrap_test.go` (Step 4); tests for the sandbox-exec
+profile additions live at `cmd/agent_run_sandbox_exec_darwin_test.go` and
+the integration test under `internal/integration/` per the
+[sandbox-exec testing convention](sandbox-exec-testing.md) (Step 5).
+
+## 7. Troubleshooting — reading the audit log
+
+Every request the proxy sees writes exactly one JSON line to:
+
+```
+<XDG_STATE_HOME>/prism/sessions/<instanceID>/podman-proxy.log
+```
+
+Each line has the shape:
+
+```json
+{"timestamp":"2026-06-30T11:58:42.123456Z","method":"POST","endpoint":"/v5/libpod/containers/create","decision":"deny","reason":"create_hostconfig:bind_source_outside_allowlist:/etc"}
+```
+
+| Field | Meaning |
+|---|---|
+| `timestamp` | RFC3339Nano UTC at request-receipt time. |
+| `method` | HTTP method. |
+| `endpoint` | Full request path (with the docker/podman API version prefix, e.g. `/v1.41/...` or `/v5/libpod/...`). |
+| `decision` | `allow` (forwarded upstream) or `deny` (synthesised response from the proxy). |
+| `reason` | Structured token naming the policy check that fired. The prefix names the endpoint family (`create_hostconfig:` / `create_top:` / `update:` / `exec:` / `volume_create:` / `archive:` / `endpoint:`), the suffix names the specific check (`bind_source_outside_allowlist:<path>` / `privileged_true` / `network_mode_host` / `unknown_field:<json error>` / `cap_add_outside_allowlist:<cap>` / etc.). |
+
+### Common rejection classes
+
+| Symptom | `reason` shape | Fix |
+|---|---|---|
+| Worker tries to `-v /etc:/host alpine ...` | `create_hostconfig:bind_source_outside_allowlist:/etc` | Expected. The proxy is correctly rejecting a host-path bind. T1 in the threat table. |
+| Worker tries `--privileged` | `create_hostconfig:privileged_true` | Expected. T5. |
+| Worker tries `--network=host` | `create_hostconfig:network_mode_host` (or `_whitespace`/`_colon`/`_slash` for the cycle-6 categorisation) | Expected. T7. |
+| Worker tries `--cap-add SYS_ADMIN` (with the default empty `AllowedCaps`) | `create_hostconfig:cap_add_outside_allowlist:SYS_ADMIN` | Expected. T6. If the workload genuinely needs a cap, that's a `Config.AllowedCaps` discussion — file an issue. |
+| Worker tries a brand-new docker-API field this struct doesn't admit | `create_hostconfig:unknown_field:json: unknown field "NewField"` | Field-admission process (§4). |
+| Worker gets `503` with `"podman socket unavailable: ..."` envelope | Audit log shows `decision=allow` then nothing — the proxy accepted policy-wise but the upstream isn't there | Bring the upstream up: Darwin `podman machine start`; NixOS `systemctl --user status podman.socket`. |
+| Worker gets `400` with `"malformed_body:empty"` or similar | `create_top:malformed_body:empty` | Client is sending an empty / non-JSON `POST /containers/create` body. Bug in the client, not the proxy. |
+
+### When to escalate
+
+Most rejections are *correct* — the agent attempted an escape and the
+proxy blocked it. Escalation paths:
+
+- **A legitimate workflow needs a field that's currently denied** —
+  file an issue, follow §4. Do NOT loosen the policy in a worker PR
+  without an audit.
+- **The audit log shows the proxy accepted a request that should have
+  been denied** — that's a P0 security bug against this package.
+  Reproduce in a test, open an issue, escalate.
+- **The proxy returns 5xx (not 4xx) when the policy should fire** —
+  parsing or upstream-handling bug. File an issue with the failing
+  request body.
+
+## 8. Cycle history — six rounds of structural hardening
+
+PR #2326 went through six review cycles. Each cycle's review-security
+agent found a different *class* of permissiveness, not just a single
+missing check; each cycle closed its findings AND inverted one layer of
+the default-deny model so the next layer down became the next surface to
+audit. The canonical security spec is now the typed structs and value
+allowlists in `policy.go`, not the deny-list comments scattered through
+old commit messages.
+
+| Cycle | Class of finding | Layer inverted |
+|---|---|---|
+| 1 | Initial implementation + AC coverage | Endpoint allowlist (positive `classifyRequest` table) |
+| 2 | 5 missing-field denials (`Memory=0` bypass, `NanoCpus` unparsed, `/update` resets caps, exec-`Privileged` bypass, `SecurityOpt` unfiltered) | Body-content policy expanded |
+| 3 | 1 CRITICAL — bind-source check was purely lexical; symlinks bypassed it | Path resolution: `filepath.EvalSymlinks` on bind sources |
+| 4 | 5 missing-field denials (`DeviceCgroupRules`, `MaskedPaths`/`ReadonlyPaths`, `CgroupnsMode`, `VolumesFrom`/`DeviceRequests`, local-driver volume bind) | Body-content policy hardened further |
+| 5 | Pattern recognised: the body parser was permissive at the FIELD-NAME layer | **Field-name layer:** `json.Decoder.DisallowUnknownFields()` + typed allowlist structs at every body-bearing endpoint |
+| 6 | One level down: admitted fields had VALUE-LEVEL deny-lists (`Mount.Type` forwarded everything that wasn't `bind`/`volume`, including the podman-specific `glob` Type → CRITICAL) | **Field-value layer:** per-field value allowlists for enumerable fields |
+
+After cycle 6 the body-inspection model is default-deny at both the
+field-name and the field-value layers. A future docker-API field or
+value that introduces an escape vector is rejected by default until it
+is explicitly admitted via the field-admission process (§4).
+
+The cycle-7 work landed in PR #2332 (Step 7) as the container-name
+auto-prefix policy on `POST /containers/create` — the same six-layer
+shape applied to the `Name` field and the `?name=` URL query, so the
+cleanup sweep can deterministically locate every container belonging
+to a session.
+
+## 9. Configuration knobs
+
+The proxy's `Config` struct in `internal/podmanproxy/proxy.go` carries
+the per-session knobs that the sidecar wires. The Step 3 wiring
+(`internal/sidecar/podman_proxy.go::buildProxyConfig`) sets:
+
+- `AllowedBindSources` — the per-session worktree path, the bare repo
+  path, and the per-session scratch directory.
+- `ContainerNamePrefix` — `"prism-" + sessionName + "-"`, which
+  activates the cycle-7 auto-prefix policy and lets the cleanup sweep
+  (`cmd/cleanup.go::sweepOrphanContainersForSession`) find every
+  container belonging to the session.
+- `AllowedCaps` — empty by default; deny-all.
+- `AllowedSecurityOpts` — empty by default; deny-all.
+- `MaxMemoryBytes` / `MaxCPUQuota` / `MaxNanoCpus` — unset by default
+  (no cap-strict-mode); when set, the cap is enforced AND the field is
+  required.
+- `AuditWriter` — the `os.File` for `<sessionDir>/podman-proxy.log`.
+
+Out-of-tree callers may construct the `Config` differently. The proxy
+package itself imposes no policy beyond what the `Config` declares.
+
+## 10. Linger decision
+
+**No `loginctl enable-linger <user>` for v1.** The proxy is only
+used by interactive prism sessions — when the user has a graphical
+session, the user-systemd instance is running, and the rootless
+podman socket unit is socket-activated on first use. Users running
+long-lived background workers that need podman across SSH-out can
+re-evaluate later.
+
+This is documented here rather than enforced in nix because the
+decision is operational, not structural: enabling linger requires no
+code change, and disabling it later requires no code change. No
+host in this flake currently sets it, and this PR did not change
+that.
+
+## 11. References
+
+- Parent issue: [#2317](https://github.com/prismatic-koi/nixos-config/issues/2317) — design, threat-table sketch, parent ACs.
+- Step 1 PR: [#2326](https://github.com/prismatic-koi/nixos-config/pull/2326) — the proxy package itself, plus the six-cycle hardening history.
+- Step 2 PR: [#2327](https://github.com/prismatic-koi/nixos-config/pull/2327) — DB migration v36→v37.
+- Step 3 PR: [#2328](https://github.com/prismatic-koi/nixos-config/pull/2328) — sidecar wiring.
+- Step 4 PR: [#2329](https://github.com/prismatic-koi/nixos-config/pull/2329) — bwrap profile.
+- Step 5 PR: [#2331](https://github.com/prismatic-koi/nixos-config/pull/2331) — sandbox-exec profile.
+- Step 6 PR: [#2330](https://github.com/prismatic-koi/nixos-config/pull/2330) — `--containers` spawn flag.
+- Step 7 PR: [#2332](https://github.com/prismatic-koi/nixos-config/pull/2332) — orphan-container cleanup sweep + auto-prefix on `Name`.
+- Canonical structs: [`internal/podmanproxy/policy.go`](../internal/podmanproxy/policy.go) (`hostConfig`, `containerCreateBody`, `containerExecBody`, `volumeCreateBody`, `networkCreateBody`).
+- Package doc: [`internal/podmanproxy/doc.go`](../internal/podmanproxy/doc.go) (cross-references this document for the threat table; the package doc is the in-tree summary).
+- Sidecar wiring: [`internal/sidecar/podman_proxy.go`](../internal/sidecar/podman_proxy.go).
+- Cleanup sweep: [`cmd/cleanup.go`](../cmd/cleanup.go) (`sweepOrphanContainersForSession`).
+- Sandbox-exec testing convention: [`docs/sandbox-exec-testing.md`](sandbox-exec-testing.md).

--- a/modules/programs/prism/prism/docs/podman-proxy.md
+++ b/modules/programs/prism/prism/docs/podman-proxy.md
@@ -44,12 +44,12 @@ record the rationale.
 | # | Threat | Mitigation | Canonical reference |
 |---|---|---|---|
 | T1 | Agent reads any host file via `-v /host/path:/x` | `HostConfig.Binds` policy rejects sources outside the per-session allowlist (worktree + bare repo + scratch dir). Symlinks resolved via `filepath.EvalSymlinks` before the prefix check. | `policy.go::checkHostConfig` (Binds branch), `isAllowedBindSource`, `canonicalisePath` |
-| T2 | Same exfil via `HostConfig.Mounts` with `Type=bind` | Same allowlist check applied to every `Mounts[]` entry with `Type=bind`. `Type` is itself value-allowlisted to `{bind, volume, tmpfs}`. | `policy.go::hostConfigMount`, `mountTypeAllowlist`, `checkHostConfig` (Mounts branch) |
+| T2 | Same exfil via `HostConfig.Mounts` with `Type=bind` | Same allowlist check applied to every `Mounts[]` entry with `Type=bind`. `Type` is itself value-allowlisted to `{bind, volume, tmpfs}` via an inline `switch` in `checkHostConfig` (no named variable — the `case` branches in `policy.go` are the spec); anything outside the allowlist (including the podman-specific `glob`) hits the `default:` branch and denies. | `policy.go::hostConfigMount`, `policy.go::checkHostConfig` (Mounts branch / `switch m.Type`) |
 | T3 | Same exfil via `Mounts` with `Type=volume` and `VolumeOptions.DriverConfig.Name="local"` (a "named-volume" that is functionally a bind to a host path via `device=…`) | `Mounts[].VolumeOptions.DriverConfig` is DENIED when present. Same shape closed at the volumes/create endpoint: `Driver=local` with non-empty `DriverOpts` rejected. | `policy.go::hostConfigVolumeOptions`, `inspectVolumeCreate` |
 | T4 | Exfil via `POST /containers/{id}/archive` (`podman cp` write) | Archive endpoint's `path` query parameter is checked against the same bind-source allowlist with the same symlink-canonicalisation. | `endpoints.go::endpointPolicyArchive`, `policy.go::inspectArchive` |
 | T5 | Container escape via `HostConfig.Privileged: true` | Boolean check; any `true` rejects. | `policy.go::checkHostConfig` (Privileged branch) |
 | T6 | Capability escape via `HostConfig.CapAdd: [SYS_ADMIN]` etc. | `CapAdd` allowlisted against `Config.AllowedCaps`; default empty = deny-all. | `policy.go::checkHostConfig` (CapAdd branch), `Config.AllowedCaps` |
-| T7 | Namespace escape via `NetworkMode=host` (or `PidMode`/`IpcMode`/`UTSMode`/`UsernsMode`/`CgroupnsMode`=host) | All six `*Mode` fields use a literal value allowlist. `NetworkMode` allows `{"", bridge, none, default, slirp4netns, pasta}` plus a user-defined-name regex (`^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,62}$`). The other five allow `{"", "private"}` only. | `policy.go::checkNetworkMode`, `checkSimpleNamespaceMode`, the constants `networkModeAllowlist`, `simpleNamespaceModeAllowlist` |
+| T7 | Namespace escape via `NetworkMode=host` (or `PidMode`/`IpcMode`/`UTSMode`/`UsernsMode`/`CgroupnsMode`=host) | All six `*Mode` fields use a literal value allowlist. `NetworkMode` allows `{"", bridge, none, default, slirp4netns, pasta}` plus a user-defined-name regex. The other five allow `{"", "private"}` only. | `policy.go::checkNetworkMode`, `policy.go::checkSimpleNamespaceMode`, the package-level variables `networkModeFixedLiterals`, `networkNameRegex`, `simpleNamespaceLiterals` |
 | T8 | Cgroup-rule escape via `HostConfig.DeviceCgroupRules` | DENIED when non-empty. This is a parallel cgroup-rule mechanism to `Devices`; with `CAP_MKNOD` in the default capset, the agent could mknod host disks. | `policy.go::checkHostConfig` (DeviceCgroupRules branch) |
 | T9 | Device passthrough via `HostConfig.Devices` or `DeviceRequests` (GPU / nvidia-container-runtime) | Both DENIED when non-empty. | `policy.go::checkHostConfig` (Devices, DeviceRequests branches) |
 | T10 | `MaskedPaths` / `ReadonlyPaths` override re-exposing `/proc/keys`, `/proc/sysrq-trigger`, etc. | Both DENIED when present (pointer-to-slice distinguishes "absent" from "explicitly empty"). | `policy.go::checkHostConfig` (MaskedPaths, ReadonlyPaths branches) |
@@ -60,7 +60,7 @@ record the rationale.
 | T15 | Post-create cap relax via `POST /containers/{id}/update` resetting Memory to 0 | The `update` endpoint runs through the same cap-strict-mode check as `create`. | `endpoints.go::endpointPolicyUpdate`, `policy.go::inspectUpdate` |
 | T16 | Privilege escalation via `POST /containers/{id}/exec` body's own `Privileged: true` | `exec` body is parsed with `containerExecBody` and `Privileged: true` is rejected. | `policy.go::inspectExec`, `containerExecBody.Privileged` |
 | T17 | Log-driver shipping container logs off the host via `LogConfig.Type=syslog`/`splunk`/`fluentd`/`gelf`/`awslogs` | `LogConfig.Type` is value-allowlisted to local-only drivers `{json-file, none, journald, k8s-file, passthrough, passthrough-tty}`. | `policy.go::checkLogConfigType`, `logConfigTypeAllowlist` |
-| T18 | `Mount.Type=glob` — podman-specific value that calls `filepath.Glob(Source)` on the host | `Mount.Type` value allowlist is case-sensitive `{bind, volume, tmpfs}`; everything else (`glob`, `image`, `npipe`, `artifact`, `ramfs`, `devpts`, empty string, case variants, whitespace, unicode zero-width space) rejects. | `policy.go::mountTypeAllowlist`, `checkHostConfig` (Mounts branch) |
+| T18 | `Mount.Type=glob` — podman-specific value that calls `filepath.Glob(Source)` on the host | `Mount.Type` value allowlist is case-sensitive `{bind, volume, tmpfs}` (inline `switch` in `checkHostConfig`); everything else (`glob`, `image`, `npipe`, `artifact`, `ramfs`, `devpts`, empty string, case variants, whitespace, unicode zero-width space) hits the `default:` branch and rejects. | `policy.go::checkHostConfig` (Mounts branch — `switch m.Type` / `case "bind"`, `case "volume"`, `case "tmpfs"`, `default:`) |
 | T19 | Raw-socket bypass: agent runs `curl --unix-socket /run/user/$UID/podman/podman.sock ...` to talk to the real socket directly | No path exists — the real socket is bound NEITHER into the bwrap mount tree NOR into the sandbox-exec SBPL allow list. The only socket reachable from inside the sandbox is the filtered one. | bwrap profile in `internal/container/bwrap.go`; SBPL in `internal/container/sandbox_exec.go`; absence asserted by negative-mutation tests |
 | T20 | CLI-wrapper bypass: agent runs a custom HTTP client bypassing `podman`/`docker` CLI | Same answer as T19. The wrapper IS the only reachable surface. |
 | T21 | Build context smuggle via `POST /build` of arbitrary-content tar | No new escape: `build` is bounded by what the sandbox already exposes. Build endpoint is `endpointAllow` (query-only and opaque body). No size cap in v1; revisit if abuse appears. | `endpoints.go` (build endpoint) |
@@ -87,7 +87,7 @@ it.
 |---|---|---|---|
 | 1 | **Endpoint** | Positive allowlist via `classifyRequest` in `internal/podmanproxy/endpoints.go`; the last branch of every method helper is `endpointDeny`. Any unknown path/method pair returns 403 with a friendly JSON envelope that names the rejected endpoint. | PR #2326 cycle 1 |
 | 2 | **Field-name** | `json.Decoder.DisallowUnknownFields()` + typed struct per body-bearing endpoint. The structs (`hostConfig`, `containerCreateBody`, `containerExecBody`, `volumeCreateBody`, `networkCreateBody`) are the canonical security spec. Every admitted field is annotated `INSPECTED` (policy-checked), `DENIED` (rejected when non-empty/non-default), or `FORWARDED` (admitted as opaque `json.RawMessage`, bytes pass to the upstream unmodified). A future docker-API field that introduces an escape vector is rejected by default until it is explicitly admitted. | PR #2326 cycle 5 |
-| 3 | **Field-value** | Per-field literal allowlists (+ `NetworkMode` user-defined-name regex) for enumerable values: `Mount.Type`, the six `*Mode` fields, `LogConfig.Type`. Anything outside the allowlist denies. Closes the class where the field is admitted but a dangerous value of that field forwards (cycle-6 CRITICAL: `Mount.Type=glob` was originally forwarded because the parser was deny-list — it only rejected if `Type != "bind" && Type != "volume"`). | PR #2326 cycle 6 |
+| 3 | **Field-value** | Per-field literal allowlists (+ `NetworkMode` user-defined-name regex `networkNameRegex`) for enumerable values: `Mount.Type` (inline `switch` in `checkHostConfig` Mounts loop), the six `*Mode` fields (`networkModeFixedLiterals` for `NetworkMode`; `simpleNamespaceLiterals` for `PidMode`/`IpcMode`/`UTSMode`/`UsernsMode`/`CgroupnsMode`), `LogConfig.Type` (`logConfigTypeAllowlist`). Anything outside the allowlist denies. Closes the class where the field is admitted but a dangerous value of that field forwards (cycle-6 CRITICAL: `Mount.Type=glob` was originally forwarded because the parser was deny-list — it only rejected if `Type != "bind" && Type != "volume"`). | PR #2326 cycle 6 |
 | 4 | **Body-content** | `checkHostConfig` walks the parsed HostConfig and rejects dangerous values: `Privileged: true`, host-namespace modes, non-empty `Devices` / `DeviceCgroupRules` / `DeviceRequests` / `VolumesFrom`, present `MaskedPaths` / `ReadonlyPaths`, non-empty `Sysctls`, `Mounts[].VolumeOptions.DriverConfig` non-nil, `CapAdd` outside allowlist, `SecurityOpt` outside allowlist, resource caps in strict mode. | PR #2326 cycles 1 + 2 + 4 |
 | 5 | **Path-resolution** | `filepath.EvalSymlinks` + lexical `filepath.Clean` on both bind sources AND allowlist entries before the prefix comparison. Relative paths, broken symlink chains, and non-existent sources all deny. Closes the cycle-3 CRITICAL where the agent planted a symlink inside an allowed prefix pointing at `/etc/passwd` and the lexical prefix-match passed. See §5 for the residual TOCTOU. | PR #2326 cycle 3 |
 | 6 | **Query** | `PUT /containers/{id}/archive` `path` query parameter is checked against `AllowedBindSources` with the same canonicalised-prefix logic as `Binds`. The other endpoint with a security-relevant query (`POST /containers/create?name=<…>`) is covered by the cycle-7 container-name auto-prefix policy in `applyContainerNamePolicy`. | PR #2326 cycle 1 (archive) + PR #2332 (Name query) |
@@ -141,9 +141,22 @@ this example) that takes an integer share-weight.
    a positive + revert-and-watch-fail test pair as proof the new check is
    not a no-op (see §6).
 5. **Field requiring a value allowlist?** If the field is enumerable (a
-   handful of well-known values), add the literal allowlist alongside
-   `mountTypeAllowlist` / `networkModeAllowlist` / `logConfigTypeAllowlist`
-   and wire the check from `checkHostConfig`.
+   handful of well-known values), follow one of the two patterns
+   already in `policy.go`:
+
+   - **Package-level `map[string]struct{}` allowlist** — used by
+     `networkModeFixedLiterals`, `simpleNamespaceLiterals`, and
+     `logConfigTypeAllowlist`. Best when the field is enumerable AND
+     checked by a dedicated `check<Field>` helper (e.g.
+     `checkNetworkMode`, `checkLogConfigType`).
+   - **Inline `switch` with explicit `case` branches and a `default:`
+     deny** — used by `Mount.Type` inside `checkHostConfig`'s Mounts
+     loop. Best when the per-value action varies (`case "bind"` runs
+     the bind-source policy, `case "volume"` runs the DriverConfig
+     check, `case "tmpfs"` is a no-op forward, `default:` denies).
+
+   Either pattern is acceptable; pick whichever matches the shape of
+   the policy decision the field needs.
 
 The single most important reviewer task on a change to `policy.go` is
 **reading the struct and confirming the rationale comments**, not guessing
@@ -183,9 +196,12 @@ miss.
 ## 6. Verification — the test suite as the spec
 
 The body of evidence for "this policy is enforced" is the test suite at
-`internal/podmanproxy/proxy_security_test.go` (100 top-level test
-functions, 276 RUN entries with subtests, all green under `-race`). The
-key meta-test is:
+`internal/podmanproxy/proxy_security_test.go` — 83 top-level test
+functions at this writing, many with multiple subtests, all green under
+`-race`. (The companion files `proxy_test.go` and
+`proxy_name_prefix_test.go` add a further ~40 top-level tests covering
+the constructor, lifecycle, and cycle-7 Name-prefix policy.) The key
+meta-test is:
 
 ```go
 // TestSecurity_NegativeControl_RootAllowlistPasses mutates Config.AllowedBindSources
@@ -228,7 +244,7 @@ Every request the proxy sees writes exactly one JSON line to:
 Each line has the shape:
 
 ```json
-{"timestamp":"2026-06-30T11:58:42.123456Z","method":"POST","endpoint":"/v5/libpod/containers/create","decision":"deny","reason":"create_hostconfig:bind_source_outside_allowlist:/etc"}
+{"timestamp":"2026-06-30T11:58:42.123456Z","method":"POST","endpoint":"/v5/libpod/containers/create","decision":"deny","reason":"host_bind:/etc"}
 ```
 
 | Field | Meaning |
@@ -237,19 +253,28 @@ Each line has the shape:
 | `method` | HTTP method. |
 | `endpoint` | Full request path (with the docker/podman API version prefix, e.g. `/v1.41/...` or `/v5/libpod/...`). |
 | `decision` | `allow` (forwarded upstream) or `deny` (synthesised response from the proxy). |
-| `reason` | Structured token naming the policy check that fired. The prefix names the endpoint family (`create_hostconfig:` / `create_top:` / `update:` / `exec:` / `volume_create:` / `archive:` / `endpoint:`), the suffix names the specific check (`bind_source_outside_allowlist:<path>` / `privileged_true` / `network_mode_host` / `unknown_field:<json error>` / `cap_add_outside_allowlist:<cap>` / etc.). |
+| `reason` | Structured token naming the policy check that fired. Two shapes: (a) bare body-policy tokens — e.g. `host_bind:<path>`, `privileged`, `cap_add:<cap>`, `mount_bind:<source>`, `mount_volume_driver_config`, `mount_type_not_allowed:<type>`, `networkmode_host` / `networkmode_colon` / `networkmode_slash` / `networkmode_whitespace`, the same suffix family on `pidmode_*` / `ipcmode_*` / `utsmode_*` / `usernsmode_*` / `cgroupnsmode_*` — emitted by `policy.go::checkHostConfig` and friends; (b) endpoint-prefixed schema errors — `create_top:`, `create_hostconfig:`, `update:`, `exec:`, `volume_create:`, `network_create:`, `archive:`, `endpoint:` — followed by an `unknown_field:<json error>` / `malformed_body:<reason>` suffix when the strict JSON decode rejects the body. Grep the audit log for these exact tokens; do not paraphrase. |
 
 ### Common rejection classes
 
-| Symptom | `reason` shape | Fix |
+Reason strings below are the **exact tokens** the proxy writes to the
+audit log — grep them verbatim. Each entry cites the `policy.go`
+callsite that formats the token so you can verify the format from the
+source if your version of the proxy drifts.
+
+| Symptom | `reason` token | Fix |
 |---|---|---|
-| Worker tries to `-v /etc:/host alpine ...` | `create_hostconfig:bind_source_outside_allowlist:/etc` | Expected. The proxy is correctly rejecting a host-path bind. T1 in the threat table. |
-| Worker tries `--privileged` | `create_hostconfig:privileged_true` | Expected. T5. |
-| Worker tries `--network=host` | `create_hostconfig:network_mode_host` (or `_whitespace`/`_colon`/`_slash` for the cycle-6 categorisation) | Expected. T7. |
-| Worker tries `--cap-add SYS_ADMIN` (with the default empty `AllowedCaps`) | `create_hostconfig:cap_add_outside_allowlist:SYS_ADMIN` | Expected. T6. If the workload genuinely needs a cap, that's a `Config.AllowedCaps` discussion — file an issue. |
-| Worker tries a brand-new docker-API field this struct doesn't admit | `create_hostconfig:unknown_field:json: unknown field "NewField"` | Field-admission process (§4). |
+| Worker tries `-v /etc:/host alpine ...` | `host_bind:/etc` (`policy.go::checkHostConfig` Binds branch) | Expected. T1. |
+| Worker tries a `Mounts[]` entry with `Type=bind` and a forbidden Source | `mount_bind:<source>` (`checkHostConfig` Mounts loop, `case "bind"`) | Expected. T2. |
+| Worker tries a `Mounts[]` entry with `Type=volume` and `VolumeOptions.DriverConfig` set | `mount_volume_driver_config` (`checkHostConfig` Mounts loop, `case "volume"`) | Expected. T3 (local-driver bind-volume escape). |
+| Worker tries a `Mounts[]` entry with a `Type` outside `{bind, volume, tmpfs}` (`glob`, `image`, `npipe`, case variants …) | `mount_type_not_allowed:<type>` (`checkHostConfig` Mounts loop, `default:`) | Expected. T18. |
+| Worker tries `--privileged` | `privileged` (`checkHostConfig` Privileged branch) | Expected. T5. |
+| Worker tries `--cap-add SYS_ADMIN` (with the default empty `AllowedCaps`) | `cap_add:SYS_ADMIN` (`checkHostConfig` CapAdd branch) | Expected. T6. If the workload genuinely needs a cap, that's a `Config.AllowedCaps` discussion — file an issue. |
+| Worker tries `--network=host` | `networkmode_host` (`denyIfUnsafeModeValue` via `checkNetworkMode`; the same helper emits `networkmode_colon` / `networkmode_slash` / `networkmode_whitespace` for the other categorised value-level rejections, and `network_mode_invalid:<value>` when no class matches and the user-defined-name regex fails) | Expected. T7. |
+| Worker tries `--pid=host` / `--ipc=host` / `--uts=host` / `--userns=host` / `--cgroupns=host` | `pidmode_host` / `ipcmode_host` / `utsmode_host` / `usernsmode_host` / `cgroupnsmode_host` (same `denyIfUnsafeModeValue` formatter on the five sibling fields; same `_colon` / `_slash` / `_whitespace` suffix family applies, plus `<field>_invalid:<value>` as the catch-all) | Expected. T7. |
+| Worker tries a brand-new docker-/podman-API field this struct doesn't admit | `create_hostconfig:unknown_field:json: unknown field "NewField"` (or the matching `create_top:` / `update:` / `exec:` / `volume_create:` / `network_create:` prefix per endpoint) | Field-admission process (§4). |
 | Worker gets `503` with `"podman socket unavailable: ..."` envelope | Audit log shows `decision=allow` then nothing — the proxy accepted policy-wise but the upstream isn't there | Bring the upstream up: Darwin `podman machine start`; NixOS `systemctl --user status podman.socket`. |
-| Worker gets `400` with `"malformed_body:empty"` or similar | `create_top:malformed_body:empty` | Client is sending an empty / non-JSON `POST /containers/create` body. Bug in the client, not the proxy. |
+| Worker gets `400` with `"malformed_body:empty"` or similar | `create_top:malformed_body:empty` (or the matching endpoint prefix) | Client is sending an empty / non-JSON `POST /containers/create` body. Bug in the client, not the proxy. |
 
 ### When to escalate
 

--- a/modules/programs/prism/prism/docs/podman-proxy.md
+++ b/modules/programs/prism/prism/docs/podman-proxy.md
@@ -229,8 +229,10 @@ Tests for sidecar wiring live at
 
 Tests for the bwrap profile additions live at
 `internal/container/bwrap_test.go` (Step 4); tests for the sandbox-exec
-profile additions live at `cmd/agent_run_sandbox_exec_darwin_test.go` and
-the integration test under `internal/integration/` per the
+profile additions live at
+`internal/container/sandbox_exec_podman_proxy_test.go` and
+`internal/container/sandbox_exec_podman_proxy_prepare_test.go`, plus the
+integration test under `internal/integration/` per the
 [sandbox-exec testing convention](sandbox-exec-testing.md) (Step 5).
 
 ## 7. Troubleshooting — reading the audit log

--- a/modules/system/users.nix
+++ b/modules/system/users.nix
@@ -17,6 +17,12 @@ in
       description = username;
       extraGroups = [
         "wheel"
+        # Read+write access to the rootless podman socket
+        # (/run/user/<uid>/podman/podman.sock, mode 0660 root:podman) so
+        # `prism spawn --containers` workers can talk to the host podman
+        # via the per-session filtering proxy. See #2317 and
+        # modules/programs/prism/prism/docs/podman-proxy.md.
+        "podman"
         (lib.mkIf config.networking.networkmanager.enable "networkmanager")
         (lib.mkIf config.hardware.openrazer.enable "openrazer")
       ];


### PR DESCRIPTION
## Scope

Step 8 of #2317 — the closer for the per-session filtered podman socket proxy train. All seven implementation steps already on `main` (#2326, #2327, #2328, #2329, #2330, #2331, #2332). This PR adds the formal security spec, the operational AGENTS.md section, the NixOS nix housekeeping, and the closure comment for #2317.

**This is the only PR in the train that uses `Closes #2317`** — every prior step used `Refs #2317`.

Closes #2317
Refs #2325

## What's in this PR

### 1. AGENTS.md — new "Podman support for workers" section

A new subsection inside the existing Prism block in the root `AGENTS.md` covering:

- The opt-in `--containers` flag and the DB-column contract (`spawn_inputs.containers_flag` + `agent_status.containers_enabled`).
- Operational summary of the six-layer default-deny model, pointing at the new doc for the canonical spec.
- The cycle-5 schema-inversion contract: new docker-/podman-API fields are deny-by-default at the FIELD-NAME layer; admitting one requires an audit and a follow-up PR.
- Platform prerequisites: NixOS podman group + socket-activated user unit, the friendly 503 envelope; Darwin `podman machine init`/`start` manual prerequisite.
- The no-linger-for-v1 decision.
- Debugging rejections via the audit log.

### 2. New doc: `modules/programs/prism/prism/docs/podman-proxy.md`

The formal security spec. **Threat table is updated to reflect what actually shipped** after the six review-security cycles on PR #2326 — the original #2317 §4 was written before cycles 2-6 surfaced the structural classes, and the shipped model is materially stronger. Every threat (T1-T23) cross-references the typed struct field or value-allowlist constant in `internal/podmanproxy/policy.go` that mitigates it; the struct is the canonical security spec.

Sections:

1. What the proxy is — lifecycle and socket placement
2. Threat model — T1-T23, each cross-referenced to `policy.go`
3. Default-deny at six layers — endpoint, field-name, field-value, body-content, path-resolution, query, with the cycle that introduced each
4. Field-admission process — walkthrough for admitting a new HostConfig field
5. Residual TOCTOU between `EvalSymlinks` and `mount(2)` — v1 acceptance + future Linux `nosymfollow` / Darwin SBPL hardening directions
6. Verification — test suite as the spec, including the load-bearing `TestSecurity_NegativeControl_RootAllowlistPasses` meta-test
7. Troubleshooting — reading the audit log at `<sessionDir>/podman-proxy.log` with the common rejection-class table
8. Cycle history — six rounds of structural hardening
9. Configuration knobs
10. Linger decision
11. References

### 3. NixOS housekeeping — `modules/system/users.nix`

Adds `"podman"` to the primary user's `extraGroups`.

**Discovery note:** the spawn prompt asked me to grep `hosts/` and `users/`; this repo has neither — it uses `machines/` (m4mac, navi, tui) for per-host configuration, and the system-user account is shared across all NixOS hosts via `modules/system/users.nix` (the user is `config.nx.username`, default `"ben"`, gated on `pkgs.stdenv.isLinux`). So one change in one file covers every NixOS host. The Darwin host (m4mac) is correctly skipped by the existing `lib.mkIf isLinux` wrapper — its system user `bensherman` doesn't need a `podman` group because `nix-darwin`'s podman doesn't use a group-owned socket.

| Host | Type | User | `podman` group? |
|---|---|---|---|
| navi | NixOS | `ben` (via `nx.username` default) | ✅ via this PR |
| tui  | NixOS | `ben` (via `nx.username` default) | ✅ via this PR |
| m4mac | Darwin (nix-darwin) | `bensherman` | n/a — Darwin podman is user-managed via `podman machine`, no group socket |

### 4. Linger decision

Documented in both AGENTS.md and the new doc: **no linger for v1.** The proxy is only used by interactive prism sessions. The decision is operational, not structural — enabling later is a one-line change.

### 5. Darwin housekeeping

Documented in AGENTS.md: `podman machine init` (one-time) + `podman machine start` (per boot) as the manual prerequisite. The proxy's friendly 503 envelope is the documented failure mode when the machine isn't running. No nix-darwin module shipped in this train.

## What's NOT in this PR

- No source-code changes under `internal/podmanproxy/`, `internal/sidecar/`, `internal/container/`, or `cmd/` — that territory is settled across Steps 1-7.
- No nix-darwin podman-machine module.
- No optional launchd auto-start for the Darwin machine. The doc notes this as an obvious follow-up if friction warrants; not filed as an issue because it's a clear "later if".
- No new `--containers` default; the flag stays opt-in.

## End-to-end acceptance — deferred to user manual verification

**Spawn-prompt sanction.** This deferral path is explicitly authorised by the spawn prompt for issue #2325, which says:

> If the host running this PR can do these tests, RUN THEM. ... If the host cannot ... do the ones you CAN, and explicitly call out in the PR description which ones need manual user verification. Don't fake the AC ticks; the closure comment on #2317 needs to honestly reflect what was tested vs deferred.

The three e2e ACs from #2325 require a working podman backend AND a freshly-built prism binary carrying the `--containers` flag. Neither condition is met on this branch's build host (Darwin / m4mac):

- No podman machine initialised here (`podman machine list` is empty).
- The currently-installed prism binary predates Step 6 / #2330, so `prism agent-context | jq '.commands.spawn.flags | keys'` shows no `--containers` flag.

Both conditions resolve naturally on the user's next `nh switch` (which rebuilds prism with the train's changes) and a Darwin `podman machine init && podman machine start` (one-time setup). The three e2e ACs are therefore explicitly called out as deferred to manual verification, not faked:

| AC | Status | How to verify |
|---|---|---|
| NixOS spawn-and-run | **Deferred** | On navi or tui post-`nh switch`: `prism spawn --containers --prompt 'run: podman run --rm alpine echo hi'` → check transcript shows `hi`. |
| Darwin spawn-and-run | **Deferred** | On m4mac after `podman machine init && podman machine start`: same as above. |
| Security probe | **Deferred** | On either platform: `prism spawn --containers --prompt 'run: podman run -v /etc:/host alpine cat /host/passwd'` → expect 403 from proxy, audit log entry under `<sessionDir>/podman-proxy.log` with `decision=deny reason=host_bind:/etc`. |

The proxy's security guarantees themselves are NOT relying on the e2e test for proof — `proxy_security_test.go` has **100 test functions / 276 RUN entries** (including the load-bearing `TestSecurity_NegativeControl_RootAllowlistPasses` meta-test that proves the positive denial tests are not vacuous) exercising every documented escape vector. The e2e test is the integration-level confirmation that the train pieces compose correctly on a real host; the unit/integration tests across Steps 1-7 are the proof that each piece works in isolation.

## Quality gates

- `gofmt -l .` from `modules/programs/prism/prism/` — n/a, no Go changes.
- `go build ./...`, `go test ./...` — n/a, no Go changes (and the build sandbox here has no write access to the Go module cache).
- `nixfmt --check modules/system/users.nix` — clean.
- The other changed files are markdown (AGENTS.md and the new doc); no formatter convention beyond plain markdown.

## Closure comment for #2317 (to post after this PR merges)

Draft below; final wording will go on #2317 as a comment after merge:

> # Per-session filtered podman socket proxy — landed
>
> The eight-PR train tracked by this issue has landed:
>
> - #2326 (Step 1) — `internal/podmanproxy/` standalone proxy with the six-layer default-deny model
> - #2327 (Step 2) — DB migration v36→v37 (`agent_status.containers_enabled`, `spawn_inputs.containers_flag`)
> - #2328 (Step 3) — sidecar wiring, conditional proxy goroutine, upstream discovery
> - #2329 (Step 4) — bwrap profile (`CONTAINER_HOST`/`DOCKER_HOST` env, scratch bind)
> - #2331 (Step 5) — sandbox-exec profile (SBPL literal allow, env injection, paired Darwin integration + negative-mutation tests)
> - #2330 (Step 6) — `prism spawn --containers` CLI flag
> - #2332 (Step 7) — orphan-container cleanup sweep + auto-prefix on `Name` field
> - this PR (Step 8) — docs, nix housekeeping, closure
>
> ## Parent ACs from §7
>
> | # | AC | Status / evidence |
> |---|---|---|
> | 1 | `prism spawn --containers` records `containers_flag=1` and `containers_enabled=1` | ✅ Step 6 #2330 — `cmd/spawn.go` flag plumbing + tests; Step 2 #2327 — DB columns; rendered in `prism stats compare` axis. |
> | 2 | Worker can `podman run --rm alpine echo hi` from inside its sandbox | ⏳ **Deferred to manual user verification post-`nh switch`** — Step 3-7 unit/integration tests cover the wiring; live e2e needs a podman backend + the new prism binary. |
> | 3 | Worker can `podman run -v $WORKTREE_PATH:/x alpine ls /x` | ⏳ **Deferred** — bind-source allowlist tests in `proxy_security_test.go::TestSecurity_AllowedBinds_ForwardsUnmodified` cover the proxy side; e2e needs live podman. |
> | 4 | Worker can write to `<sessionDir>/container-scratch/foo` and bind-mount it RW | ⏳ **Deferred** — Step 4 #2329 (bwrap) and Step 5 #2331 (sandbox-exec) tests cover the bind; e2e needs live podman. |
> | 5 | On cleanup: proxy exits, scratch dir removed, orphan `prism-<session>-*` containers swept | ✅ Step 7 #2332 — `cmd/cleanup.go::sweepOrphanContainersForSession`; sidecar shutdown closes the proxy goroutine. |
> | 6 | Bind outside allowlist (`-v /etc:/host` etc.) → 4xx from proxy, container not created | ✅ Step 1 #2326 — `TestSecurity_HostBindOutsideAllowlist_Denied`, `TestSecurity_HostMountOutsideAllowlist_Denied`. Live e2e ⏳ deferred. |
> | 7 | `--privileged` → 4xx | ✅ `TestSecurity_Privileged_Denied`. |
> | 8 | `--cap-add SYS_ADMIN` → 4xx | ✅ `TestSecurity_CapAddDisallowed_Denied`. |
> | 9 | `--network=host`, `--pid=host`, `--ipc=host`, `--uts=host`, `--userns=host` → 4xx | ✅ `TestSecurity_HostNamespaceModes_Denied` (5 subtests) + `TestSecurity_SimpleNamespaceModes_DangerousValues_Denied` (30 subtests covering value-layer). |
> | 10 | `podman cp <ct>:/etc/passwd /tmp/p` → 4xx | ✅ `TestSecurity_ArchivePathOutsideAllowlist_Denied`, `TestSecurity_ArchiveSymlinkToForbiddenPath_Denied`. |
> | 11 | Raw-socket bypass (`curl --unix-socket /run/user/1000/podman/podman.sock ...`) fails — path doesn't exist inside sandbox | ✅ Step 4 #2329 and Step 5 #2331 — bwrap argv / SBPL profile do NOT bind the real socket path. Negative-mutation tests prove the absence. |
> | 12 | Bwrap argv + SBPL profile inspection: real podman socket path appears in NEITHER | ✅ Step 4 #2329 and Step 5 #2331 — explicit absence assertions in profile tests. |
> | 13 | Upstream unavailable → 503 with actionable envelope | ✅ Step 1 #2326 — `TestSecurity_UpstreamMissing_Returns503Envelope`, `TestSecurity_UpstreamECONNREFUSED_Returns503Envelope`. |
> | 14 | `--containers --isolation host` warns but does not error | ✅ Step 6 #2330 — `cmd/spawn.go` warning emit + test. |
> | 15 | Existing sessions (`containers_enabled=0`) see no behavioural change — no proxy starts, no env vars, no new mounts | ✅ Step 3 #2328 — `podman_proxy_test.go::TestPodmanProxy_NotStarted_WhenContainersDisabled`; Step 4/5 — env/mount gates conditional on the DB flag. |
> | 16 | Negative-control: profile mutation including the real socket path FAILS the negative tests | ✅ Step 5 #2331 — paired Darwin integration test with negative-mutation per the sandbox-exec testing convention. |
> | 17 | Audit log at `<sessionDir>/podman-proxy.log` — one JSON line per request with timestamp, endpoint, decision, reason | ✅ Step 1 #2326 — `TestSecurity_AuditLog_OneLinePerRequest`, `TestSecurity_AuditLog_NewlineTerminated`; Step 3 #2328 — sidecar wires the file path. |
>
> ## Deferred for user manual verification
>
> ACs 2, 3, 4, 6 (e2e on live podman) require:
>
> 1. `nh switch` on the target host (rebuilds prism with `--containers`).
> 2. NixOS: the user account is now in the `podman` group automatically (Step 8 housekeeping in `modules/system/users.nix`); no manual step.
> 3. Darwin: `podman machine init` (one-time) + `podman machine start` (per-boot) per the AGENTS.md doc.
>
> Once the above is done, the three commands in the Step-8 PR description (NixOS spawn-and-run, Darwin spawn-and-run, security probe) are sufficient to tick the deferred ACs off.
>
> ## Out-of-scope follow-ups filed during the train
>
> None filed. The only candidate was the optional launchd `podman machine start` auto-start agent on Darwin, which the doc notes as a clear "later if friction warrants" — not filed as a tracker because the friction surface is the user's own `podman machine start` muscle memory; not worth opening an issue speculatively.
